### PR TITLE
Review yeast genes batch 06

### DIFF
--- a/cache/go/terms.csv
+++ b/cache/go/terms.csv
@@ -6836,7 +6836,7 @@ GO:0140566,histone reader activity,2026-03-22T22:38:14.237952
 GO:0140580,mitochondrion autophagosome adaptor activity,2026-03-22T22:38:14.237952
 GO:0140581,P-type monovalent copper transporter activity,2026-03-22T22:38:14.237952
 GO:0140595,MIM complex,2026-03-22T22:38:14.237952
-GO:0140597,protein carrier chaperone,2026-03-22T22:38:14.237952
+GO:0140597,protein carrier activity,2026-05-04T00:00:00
 GO:0140610,RNA sequestering activity,2026-03-22T22:38:14.237952
 GO:0140639,positive regulation of pyroptotic inflammatory response,2026-03-22T22:38:14.237952
 GO:0140645,neutrophil extracellular trap formation,2026-03-22T22:38:14.237952

--- a/cache/ontologies/go.tsv
+++ b/cache/ontologies/go.tsv
@@ -6731,7 +6731,7 @@ GO:0140566	histone reader activity	False	2026-03-21T13:03:26.969441
 GO:0140580	mitochondrion autophagosome adaptor activity	False	2026-03-21T13:03:26.969530
 GO:0140581	P-type monovalent copper transporter activity	False	2026-03-21T13:03:26.969676
 GO:0140595	MIM complex	false	2026-03-22T22:33:23.269686
-GO:0140597	protein carrier chaperone	False	2026-03-21T13:03:26.969774
+GO:0140597	protein carrier activity	False	2026-05-04T00:00:00
 GO:0140610	RNA sequestering activity	False	2026-03-21T13:03:26.969853
 GO:0140639	positive regulation of pyroptotic inflammatory response	False	2026-03-21T13:03:26.970002
 GO:0140645	neutrophil extracellular trap formation	False	2026-03-21T13:03:26.970157

--- a/genes/yeast/ACL4/ACL4-ai-review.html
+++ b/genes/yeast/ACL4/ACL4-ai-review.html
@@ -1742,7 +1742,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> Acl4 is a dedicated ribosomal-protein carrier/chaperone for Rpl4, so the annotation captures a core molecular function rather than a generic or transmembrane transport claim.
+                            <strong>Reason:</strong> QuickGO places GO:0140318 under transporter activity and GO:0140597 under molecular carrier activity rather than as a parent-child pair. Retaining this SGD IDA annotation is therefore not a redundant parent annotation, and the PMID:26447800 evidence supports Acl4 escorting Rpl4 to the pre-60S assembly pathway.
                         </div>
 
 
@@ -2887,9 +2887,11 @@ existing_annotations:
       cellular location.
     action: ACCEPT
     reason: &gt;-
-      Acl4 is a dedicated ribosomal-protein carrier/chaperone for Rpl4, so the
-      annotation captures a core molecular function rather than a generic or
-      transmembrane transport claim.
+      QuickGO places GO:0140318 under transporter activity and GO:0140597 under
+      molecular carrier activity rather than as a parent-child pair. Retaining
+      this SGD IDA annotation is therefore not a redundant parent annotation,
+      and the PMID:26447800 evidence supports Acl4 escorting Rpl4 to the
+      pre-60S assembly pathway.
     supported_by:
     - reference_id: PMID:26447800
       supporting_text: &#34;dedicated chaperone Acl4 accompanies Rpl4&#34;

--- a/genes/yeast/ACL4/ACL4-ai-review.html
+++ b/genes/yeast/ACL4/ACL4-ai-review.html
@@ -671,33 +671,33 @@
     <div class="header">
         <h1>ACL4</h1>
         <div class="gene-info">
-            
+
             <div class="info-item">
-                
+
                 <span class="info-label">UniProt ID:</span>
                 <span>
                     <a href="https://www.uniprot.org/uniprotkb/Q03771" target="_blank" class="term-link">
                         Q03771
                     </a>
                 </span>
-                
+
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Organism:</span>
                 <span>Saccharomyces cerevisiae</span>
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
-                <span class="status-badge status-draft">
-                    DRAFT
+                <span class="status-badge status-complete">
+                    COMPLETE
                 </span>
             </div>
-            
-            
+
+
         </div>
         <div style="margin-top: 1rem; text-align: center;">
             <a id="feedback-form-link"
@@ -728,24 +728,24 @@
         </div>
     </div>
 
-    
+
     <div class="description-card">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <h2>Gene Description</h2>
-            <span class="vote-buttons" data-g="Q03771" data-a="DESCRIPTION: TODO: Add description for ACL4..." data-r="" data-act="DESCRIPTION">
+            <span class="vote-buttons" data-g="Q03771" data-a="DESCRIPTION: ACL4 encodes the dedicated assembly chaperone for ..." data-r="" data-act="DESCRIPTION">
                 <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
                 <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
             </span>
         </div>
-        <p>TODO: Add description for ACL4</p>
+        <p>ACL4 encodes the dedicated assembly chaperone for the large ribosomal subunit protein Rpl4/uL4. Acl4 binds newly synthesized Rpl4, keeps the highly basic unassembled ribosomal protein soluble, and escorts it from the cytoplasm to the nuclear pre-60S assembly site. Loss of ACL4 causes slow growth, reduced 60S subunit production, half-mer polysomes, and pre-rRNA processing defects, supporting a core role in ribosomal large subunit biogenesis rather than mitochondrial protein import.</p>
     </div>
-    
 
-    
 
-    
 
-    
+
+
+
+
     <div class="section">
         <h2 class="section-title">Existing Annotations Review</h2>
         <table class="annotations-table">
@@ -758,32 +758,32 @@
                 </tr>
             </thead>
             <tbody>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005741" target="_blank" class="term-link">
                                     GO:0005741
                                 </a>
                             </span>
                             <span class="term-label">mitochondrial outer membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -795,46 +795,62 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: mitochondrial outer membrane is not sufficiently supported as a direct function of ACL4.
+                            <strong>Summary:</strong> This IBA traces to a broad PANTHER family context that UniProt labels as mitochondrial import receptor subunit TOM70, but the reviewed yeast ACL4 subfamily entry is an assembly chaperone of RPL4. UniProt and the Falcon review support cytoplasmic/nuclear localization for Acl4, not a mitochondrial outer membrane role.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Removed due weak mechanistic support or likely misannotation for this gene.
+                            <strong>Reason:</strong> The family-transfer annotation appears to have propagated TOM70-family mitochondrial localization to a divergent Acl4/Rpl4 chaperone. No primary Acl4 evidence supports mitochondrial outer membrane residence.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/ACL4/ACL4-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Acl4 is detected in both cytoplasm and nucleus</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008320" target="_blank" class="term-link">
                                     GO:0008320
                                 </a>
                             </span>
                             <span class="term-label">protein transmembrane transporter activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -846,46 +862,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: protein transmembrane transporter activity is not sufficiently supported as a direct function of ACL4.
+                            <strong>Summary:</strong> Acl4 escorts the soluble ribosomal protein Rpl4; it is not a component of a protein transmembrane translocation channel. This IBA is inconsistent with the experimentally supported Acl4 subfamily biology.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Removed due weak mechanistic support or likely misannotation for this gene.
+                            <strong>Reason:</strong> The annotation likely reflects the TOM70-like parent family rather than Acl4. Acl4 functions as a ribosomal protein carrier chaperone, not as a transmembrane transporter or transporter subunit.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030150" target="_blank" class="term-link">
                                     GO:0030150
                                 </a>
                             </span>
                             <span class="term-label">protein import into mitochondrial matrix</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -897,97 +913,113 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: protein import into mitochondrial matrix is not sufficiently supported as a direct function of ACL4.
+                            <strong>Summary:</strong> Experimental Acl4 studies describe Rpl4 handling and nuclear pre-60S assembly, with no evidence for mitochondrial matrix protein import.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Removed due weak mechanistic support or likely misannotation for this gene.
+                            <strong>Reason:</strong> This is a family-transfer overannotation from a TOM70-like ancestor and conflicts with the specific yeast Acl4/Rpl4 literature.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030943" target="_blank" class="term-link">
                                     GO:0030943
                                 </a>
                             </span>
                             <span class="term-label">mitochondrion targeting sequence binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-remove">
+                            REMOVE
                         </span>
-                        <span class="vote-buttons" data-g="Q03771" data-a="GO:0030943" data-r="GO_REF:0000033" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="Q03771" data-a="GO:0030943" data-r="GO_REF:0000033" data-act="REMOVE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: mitochondrion targeting sequence binding is consistent with known biology of ACL4.
+                            <strong>Summary:</strong> Acl4 binds a segment of the Rpl4 long internal loop and protects unassembled Rpl4. It has no demonstrated binding to mitochondrial targeting sequences.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> The supported client-binding activity is Rpl4 carrier chaperone activity. The mitochondrial targeting sequence term should not be retained for the yeast ACL4 subfamily.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/ACL4/ACL4-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Acl4 binds newly synthesized, free Rpl4</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045039" target="_blank" class="term-link">
                                     GO:0045039
                                 </a>
                             </span>
                             <span class="term-label">protein insertion into mitochondrial inner membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -999,46 +1031,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: protein insertion into mitochondrial inner membrane is not sufficiently supported as a direct function of ACL4.
+                            <strong>Summary:</strong> The experimentally supported Acl4 pathway is Rpl4 delivery to the nuclear pre-60S ribosome, not insertion of proteins into the mitochondrial inner membrane.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Removed due weak mechanistic support or likely misannotation for this gene.
+                            <strong>Reason:</strong> This IBA is not supported for ACL4 and should be removed as a TOM70-family over-transfer.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1050,46 +1082,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: nucleus is consistent with known biology of ACL4.
+                            <strong>Summary:</strong> UniProt subcellular-location mapping to nucleus is consistent with direct Acl4 localization studies and with Acl4 delivery of Rpl4 to nuclear pre-60S particles.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Acl4 is enriched in the nucleus and performs its client-delivery function at the nuclear pre-60S assembly site.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1101,46 +1133,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: cytoplasm is consistent with known biology of ACL4.
+                            <strong>Summary:</strong> Automated cytoplasm assignment is consistent with direct studies showing Acl4 in the cytoplasm, where Rpl4 is synthesized and first captured.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Cytoplasmic localization is part of the supported escort path from nascent Rpl4 capture to nuclear assembly.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042254" target="_blank" class="term-link">
                                     GO:0042254
                                 </a>
                             </span>
                             <span class="term-label">ribosome biogenesis</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1152,57 +1184,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: ribosome biogenesis is consistent with known biology of ACL4.
+                            <strong>Summary:</strong> The keyword-derived ribosome biogenesis term is broad but accurate for Acl4, which is required for efficient production of 60S ribosomal subunits.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Experimental annotations to ribosomal large subunit biogenesis provide the more specific evidence; this parent process is correct as an automated summary of Acl4 function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/25936803" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:25936803
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Coordinated Ribosomal L4 Protein Assembly into the Pre-Ribos...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1214,57 +1246,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: nucleus is consistent with known biology of ACL4.
+                            <strong>Summary:</strong> Direct experimental localization supports nuclear Acl4, consistent with the Rpl4 pre-60S assembly site.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> The localization matches the mechanistic model in which Acl4 delivers Rpl4 to nuclear pre-60S assembly intermediates.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25936803" target="_blank" class="term-link">
+                                        PMID:25936803
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">assembly chaperone Acl4 that initially binds the universally conserved internal</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/26447800" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:26447800
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The Dedicated Chaperone Acl4 Escorts Ribosomal Protein Rpl4 ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1276,57 +1326,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: nucleus is consistent with known biology of ACL4.
+                            <strong>Summary:</strong> Direct microscopy in the dedicated Acl4-Rpl4 study supports nuclear localization.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Acl4 localizes to the nucleus as expected for a factor escorting Rpl4 to nuclear pre-60S assembly sites.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26447800" target="_blank" class="term-link">
+                                        PMID:26447800
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Acl4 localizes to both the cytoplasm and nucleus</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/26447800" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:26447800
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The Dedicated Chaperone Acl4 Escorts Ribosomal Protein Rpl4 ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1338,57 +1406,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: cytoplasm is consistent with known biology of ACL4.
+                            <strong>Summary:</strong> Direct microscopy supports cytoplasmic Acl4 localization.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Acl4 must encounter newly translated Rpl4 in the cytoplasm before nuclear delivery, so this localization is mechanistically coherent.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26447800" target="_blank" class="term-link">
+                                        PMID:26447800
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Acl4 localizes to both the cytoplasm and nucleus</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042273" target="_blank" class="term-link">
                                     GO:0042273
                                 </a>
                             </span>
                             <span class="term-label">ribosomal large subunit biogenesis</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/25936803" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:25936803
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Coordinated Ribosomal L4 Protein Assembly into the Pre-Ribos...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1400,57 +1486,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: ribosomal large subunit biogenesis is consistent with known biology of ACL4.
+                            <strong>Summary:</strong> Mutant phenotype evidence shows that ACL4 is required for normal 60S subunit production through Rpl4 assembly.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Acl4 shields Rpl4 until it can be inserted into the pre-ribosome; ACL4 loss causes large-subunit biogenesis defects, making this a core process.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25936803" target="_blank" class="term-link">
+                                        PMID:25936803
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">hierarchical ribosome assembly can be achieved by eukaryotic RP extensions and</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042273" target="_blank" class="term-link">
                                     GO:0042273
                                 </a>
                             </span>
                             <span class="term-label">ribosomal large subunit biogenesis</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/26447800" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:26447800
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The Dedicated Chaperone Acl4 Escorts Ribosomal Protein Rpl4 ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1462,57 +1566,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: ribosomal large subunit biogenesis is consistent with known biology of ACL4.
+                            <strong>Summary:</strong> The dedicated chaperone study shows that Acl4 escorts Rpl4 to its nuclear pre-60S assembly site and that loss of Acl4 compromises 60S production.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> This is the central biological process for Acl4 and is supported by genetic, localization, and biochemical evidence.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26447800" target="_blank" class="term-link">
+                                        PMID:26447800
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">deficiency in the production of 60S subunits</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/25936803" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:25936803
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Coordinated Ribosomal L4 Protein Assembly into the Pre-Ribos...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -1524,192 +1646,226 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: unfolded protein binding is better represented by a more specific replacement term for ACL4.
+                            <strong>Summary:</strong> Acl4 does bind and protect unassembled Rpl4, but &#34;unfolded protein binding&#34; is too generic and obscures the dedicated carrier-chaperone role.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Modified to align with current curation guidance and improve term specificity.
+                            <strong>Reason:</strong> The evidence supports specific ribosomal-protein carrier chaperone activity rather than generic binding to unfolded proteins.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140597" target="_blank" class="term-link">
-                                    protein carrier chaperone
+                                    protein carrier activity
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/ACL4/ACL4-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Acl4 is a dedicated ribosomal protein chaperone</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140318" target="_blank" class="term-link">
                                     GO:0140318
                                 </a>
                             </span>
                             <span class="term-label">protein transporter activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/26447800" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:26447800
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The Dedicated Chaperone Acl4 Escorts Ribosomal Protein Rpl4 ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-remove">
-                            REMOVE
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q03771" data-a="GO:0140318" data-r="PMID:26447800" data-act="REMOVE">
+                        <span class="vote-buttons" data-g="Q03771" data-a="GO:0140318" data-r="PMID:26447800" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: protein transporter activity is not sufficiently supported as a direct function of ACL4.
+                            <strong>Summary:</strong> The evidence supports Acl4 directly binding and escorting Rpl4 to the pre-60S assembly pathway, matching the current definition of protein transporter activity as binding and delivering a specific protein to a cellular location.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Removed due weak mechanistic support or likely misannotation for this gene.
+                            <strong>Reason:</strong> Acl4 is a dedicated ribosomal-protein carrier/chaperone for Rpl4, so the annotation captures a core molecular function rather than a generic or transmembrane transport claim.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26447800" target="_blank" class="term-link">
+                                        PMID:26447800
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">dedicated chaperone Acl4 accompanies Rpl4</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051083" target="_blank" class="term-link">
                                     GO:0051083
                                 </a>
                             </span>
                             <span class="term-label">&#39;de novo&#39; cotranslational protein folding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HGI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19325107" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19325107
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Comprehensive characterization of genes required for protein...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q03771" data-a="GO:0051083" data-r="PMID:19325107" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="Q03771" data-a="GO:0051083" data-r="PMID:19325107" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: &#39;de novo&#39; cotranslational protein folding is consistent with known biology of ACL4.
+                            <strong>Summary:</strong> Acl4 can capture nascent Rpl4 cotranslationally, but this high-throughput genetic-interaction annotation is broad and does not define Acl4 as a general cotranslational folding factor.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> The better-supported curation is the specific Rpl4 carrier-chaperone role in ribosomal large subunit biogenesis. Retaining the broad folding process as a core annotation would overstate the evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/14562095" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:14562095
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Global analysis of protein localization in budding yeast.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1721,57 +1877,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: nucleus is consistent with known biology of ACL4.
+                            <strong>Summary:</strong> High-throughput localization to nucleus is consistent with direct Acl4 localization and its nuclear pre-60S assembly role.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Multiple independent sources support nuclear localization.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/14562095" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:14562095
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Global analysis of protein localization in budding yeast.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1783,177 +1939,697 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: cytoplasm is consistent with known biology of ACL4.
+                            <strong>Summary:</strong> High-throughput localization to cytoplasm is consistent with direct Acl4 localization and nascent Rpl4 capture.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Acl4 is distributed through cytoplasm and nucleus, matching its escort function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
             </tbody>
         </table>
     </div>
-    
 
-    
 
-    
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Acl4 is a dedicated carrier chaperone for Rpl4/uL4. It binds newly synthesized Rpl4 in the cytoplasm, protects it from inappropriate interactions or aggregation, and escorts it to nuclear pre-60S particles for large ribosomal subunit assembly.</h3>
+                <span class="vote-buttons" data-g="Q03771" data-a="FUNCTION: Acl4 is a dedicated carrier chaperone for Rpl4/uL4..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140597" target="_blank" class="term-link">
+                            protein carrier activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042273" target="_blank" class="term-link">
+                                ribosomal large subunit biogenesis
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                cytoplasm
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
+                                nucleus
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26447800" target="_blank" class="term-link">
+                                PMID:26447800
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">dedicated chaperone Acl4 accompanies Rpl4</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:yeast/ACL4/ACL4-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">Acl4 binds newly synthesized, free Rpl4</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class="section">
         <h2 class="section-title collapsible">References</h2>
         <div class="collapse-content">
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
                             GO_REF:0000033
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Annotation inferences using phylogenetic trees</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000043.md" target="_blank" class="term-link">
                             GO_REF:0000043
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
                             GO_REF:0000044
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
                             GO_REF:0000120
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/14562095" target="_blank" class="term-link">
                             PMID:14562095
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Global analysis of protein localization in budding yeast.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/19325107" target="_blank" class="term-link">
                             PMID:19325107
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Comprehensive characterization of genes required for protein folding in the endoplasmic reticulum.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/25936803" target="_blank" class="term-link">
                             PMID:25936803
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Coordinated Ribosomal L4 Protein Assembly into the Pre-Ribosome Is Regulated by Its Eukaryote-Specific Extension.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/26447800" target="_blank" class="term-link">
                             PMID:26447800
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The Dedicated Chaperone Acl4 Escorts Ribosomal Protein Rpl4 to Its Nuclear Pre-60S Assembly Site.</div>
-                
-                
+
+
             </div>
-            
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:yeast/ACL4/ACL4-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research report for ACL4</div>
+
+
+            </div>
+
         </div>
     </div>
-    
 
 
-    
 
-    
 
-    
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Should PANTHER family PTHR46208 be split or have IBA propagation restricted so TOM70 mitochondrial import terms do not transfer to the ACL4/Rpl4 assembly chaperone subfamily?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q03771" data-a="Q: Should PANTHER family PTHR46208 be split or have I..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Re-analyze ACL4, TOM70, and related PTHR46208 subfamilies with tree-aware GO propagation to test whether mitochondrial import annotations segregate away from the experimentally characterized Acl4/Rpl4 clade.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: The ACL4 subfamily lacks the mitochondrial protein import functions present in TOM70-like relatives and should not inherit those IBA terms.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: phylogenetic curation</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q03771" data-a="EXPERIMENT: Re-analyze ACL4, TOM70, and related PTHR46208 subf..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
 
     <!-- Computational Predictions Section -->
-    
+
 
     <!-- Additional Documentation Sections -->
-    
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Deep Research Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(ACL4-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q03771" data-a="DOC: Deep Research Falcon" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <hr />
+<p>provider: falcon<br />
+model: Edison Scientific Literature<br />
+cached: false<br />
+start_time: '2026-05-04T10:06:12.943812'<br />
+end_time: '2026-05-04T10:19:34.189355'<br />
+duration_seconds: 801.25<br />
+template_file: templates/gene_research_go_focused.md<br />
+template_variables:<br />
+  organism: yeast<br />
+  gene_id: ACL4<br />
+  gene_symbol: ACL4<br />
+  uniprot_accession: Q03771<br />
+  protein_description: 'RecName: Full=Assembly chaperone of RPL4 {ECO:0000303|PubMed:25936803};'<br />
+  gene_info: Name=ACL4 {ECO:0000303|PubMed:25936803}; OrderedLocusNames=YDR161W {ECO:0000312|SGD:S000002568};<br />
+  organism_full: Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).<br />
+  protein_family: Belongs to the ACL4 family. .<br />
+  protein_domains: TPR-like_helical_dom_sf. (IPR011990)<br />
+provider_config:<br />
+  timeout: 600<br />
+  max_retries: 3<br />
+  parameters:<br />
+    allowed_domains: []<br />
+    temperature: 0.1<br />
+citation_count: 30</p>
+<hr />
+<h2 id="question">Question</h2>
+<h1 id="gene-research-for-functional-annotation">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> Q03771</li>
+<li><strong>Protein Description:</strong> RecName: Full=Assembly chaperone of RPL4 {ECO:0000303|PubMed:25936803};</li>
+<li><strong>Gene Information:</strong> Name=ACL4 {ECO:0000303|PubMed:25936803}; OrderedLocusNames=YDR161W {ECO:0000312|SGD:S000002568};</li>
+<li><strong>Organism (full):</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Protein Family:</strong> Belongs to the ACL4 family. .</li>
+<li><strong>Key Domains:</strong> TPR-like_helical_dom_sf. (IPR011990)</li>
+</ul>
+<h3 id="mandatory-verification-steps">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "ACL4" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'ACL4' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>ACL4</strong> (gene ID: ACL4, UniProt: Q03771) in yeast.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="output">Output</h2>
+<p>Question: You are an expert researcher providing comprehensive, well-cited information.</p>
+<p>Provide detailed information focusing on:<br />
+1. Key concepts and definitions with current understanding<br />
+2. Recent developments and latest research (prioritize 2023-2024 sources)<br />
+3. Current applications and real-world implementations<br />
+4. Expert opinions and analysis from authoritative sources<br />
+5. Relevant statistics and data from recent studies</p>
+<p>Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.<br />
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.</p>
+<h1 id="gene-research-for-functional-annotation_1">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context_1">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot_1">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> Q03771</li>
+<li><strong>Protein Description:</strong> RecName: Full=Assembly chaperone of RPL4 {ECO:0000303|PubMed:25936803};</li>
+<li><strong>Gene Information:</strong> Name=ACL4 {ECO:0000303|PubMed:25936803}; OrderedLocusNames=YDR161W {ECO:0000312|SGD:S000002568};</li>
+<li><strong>Organism (full):</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Protein Family:</strong> Belongs to the ACL4 family. .</li>
+<li><strong>Key Domains:</strong> TPR-like_helical_dom_sf. (IPR011990)</li>
+</ul>
+<h3 id="mandatory-verification-steps_1">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "ACL4" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature_1">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'ACL4' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target_1">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>ACL4</strong> (gene ID: ACL4, UniProt: Q03771) in yeast.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="research-report-saccharomyces-cerevisiae-acl4-ydr161w-uniprot-q03771">Research Report: <strong>Saccharomyces cerevisiae ACL4 (YDR161W; UniProt Q03771)</strong></h2>
+<h3 id="executive-summary">Executive summary</h3>
+<p><strong>Acl4</strong> is a <strong>dedicated assembly chaperone</strong> for the 60S large-subunit ribosomal protein <strong>Rpl4 (uL4)</strong> in <em>Saccharomyces cerevisiae</em> (strain S288c). It binds a defined segment of the Rpl4 long internal loop, keeps nascent/unassembled Rpl4 soluble, and escorts it to the <strong>nuclear pre-60S assembly site</strong>, coordinating with the importin <strong>Kap104</strong>. Loss of ACL4 causes a severe slow-growth phenotype with hallmark 60S biogenesis defects (60S shortage and half-mers). More recent work (2022–2024) extends Acl4 biology to <strong>cotranslational regulation of RPL4 mRNA abundance</strong> via NAC/Caf130/Ccr4–Not circuitry, and links Acl4-limited conditions to aggregation/quality control networks that include the E3 ligase <strong>Tom1</strong>. (pillet2015thededicatedchaperone pages 1-2, huber2017molecularbasisfor pages 1-2, pillet2015thededicatedchaperone pages 10-12, schilke2024functionalsimilaritiesand pages 1-3, pillet2022dedicatedchaperonescoordinate pages 14-16, pillet2022dedicatedchaperonescoordinate pages 20-22)</p>
+<hr />
+<h3 id="1-identity-verification-and-key-definitions">1) Identity verification and key definitions</h3>
+<h4 id="11-target-identity-mandatory-verification">1.1 Target identity (mandatory verification)</h4>
+<p>Primary literature explicitly identifies <strong>Acl4 as yeast YDR161W</strong> and characterizes it as the <strong>dedicated chaperone for Rpl4</strong>, matching the UniProt target <strong>Q03771</strong> and the stated domain annotation (TPR-like helical domain superfamily). (stelter2015coordinatedribosomall4 pages 3-3, pillet2015thededicatedchaperone pages 1-2, huber2017molecularbasisfor pages 1-2)</p>
+<h4 id="12-key-concepts-current-understanding">1.2 Key concepts (current understanding)</h4>
+<ul>
+<li><strong>Dedicated ribosomal-protein (RP) chaperone:</strong> A specialized factor that binds one (or a small set of) ribosomal protein(s) to prevent aggregation/mislocalization and to promote safe delivery to the assembly site. Acl4 is dedicated for Rpl4. (pillet2015thededicatedchaperone pages 18-20, yang2024ribosomeassemblyand pages 1-3)</li>
+<li><strong>Pre-60S assembly:</strong> Stepwise nuclear maturation of the large ribosomal subunit, involving incorporation of RPs into pre-ribosomal particles and transient binding of biogenesis factors; Acl4 acts at the stage of delivering Rpl4 to early nuclear pre-60S particles. (pillet2015thededicatedchaperone pages 18-20, pillet2015thededicatedchaperone pages 20-21)</li>
+<li><strong>Cotranslational capture:</strong> Binding of a chaperone to a nascent client during translation; Acl4 enriches RPL4 mRNA in pull-downs, consistent with cotranslational engagement. (pillet2015thededicatedchaperone pages 17-18)</li>
+</ul>
+<hr />
+<h3 id="2-molecular-function-and-mechanism">2) Molecular function and mechanism</h3>
+<h4 id="21-core-function-chaperoning-and-escort-of-rpl4ul4">2.1 Core function: chaperoning and escort of Rpl4/uL4</h4>
+<p>Acl4 binds newly synthesized, free Rpl4, enabling <strong>soluble expression</strong> of Rpl4 and escorting it from cytoplasm to nuclear pre-60S assembly sites; Acl4 is not stably associated with mature 60S particles, consistent with a transient escort. (pillet2015thededicatedchaperone pages 1-2, pillet2015thededicatedchaperone pages 10-12)</p>
+<h4 id="22-client-binding-site-on-rpl4">2.2 Client-binding site on Rpl4</h4>
+<p>Mapping in yeast indicates Acl4 recognizes the <strong>C-terminal region of the long internal loop of Rpl4</strong>, with functional mapping to approximately <strong>aa 88–114</strong> (and emphasis around ~101–114). Multiple alanine-block substitutions in this segment abolish the Acl4–Rpl4 interaction. (pillet2015thededicatedchaperone pages 14-17, pillet2015thededicatedchaperone pages 20-21)</p>
+<h4 id="23-structural-basis-tpr-fold-sequestration-of-exposed-residues">2.3 Structural basis (TPR fold; sequestration of exposed residues)</h4>
+<p>A high-resolution structure of the Acl4–RpL4 complex shows that Acl4 adopts an <strong>α-helical TPR fold</strong> (reported as <strong>seven TPRs plus a C-terminal helix</strong>) and uses its concave surface to <strong>sequester ~70 exposed residues</strong> of the elongated RpL4 loop, providing a mechanistic basis for preventing degradation/aggregation of unassembled L4. (huber2017molecularbasisfor pages 1-2, huber2017molecularbasisfor media 4aaddfb0, huber2017molecularbasisfor media cb2e78f3)</p>
+<h4 id="24-nuclear-import-and-kap104-coupling">2.4 Nuclear import and Kap104 coupling</h4>
+<p>A central mechanistic insight is that the <strong>eukaryote-specific extension of Rpl4</strong> contains overlapping determinants for Acl4 binding and the nuclear import factor <strong>Kap104</strong>, enabling continuous protection during import. In vitro, Kap104 can form a stoichiometric <strong>Acl4–Rpl4–Kap104</strong> trimer, and a schematic map of overlapping binding sites is provided in the structural work. (huber2017molecularbasisfor pages 1-2, pillet2015thededicatedchaperone pages 20-21, huber2017molecularbasisfor media e4ea49ee)</p>
+<hr />
+<h3 id="3-subcellular-localization-and-pathway-placement">3) Subcellular localization and pathway placement</h3>
+<h4 id="31-localization">3.1 Localization</h4>
+<p>Fluorescent tagging and fractionation show Acl4 is present in <strong>both cytoplasm and nucleus</strong> and is recovered in <strong>soluble fractions</strong>, not as a stable component of pre-60S or mature 60S particles. This supports a “carrier/escort” rather than “structural subunit” model. (pillet2015thededicatedchaperone pages 10-12)</p>
+<h4 id="32-pathway-role-in-large-subunit-biogenesis">3.2 Pathway role in large-subunit biogenesis</h4>
+<p>Deletion of ACL4 causes a defect in <strong>60S subunit production</strong> and characteristic <strong>half-mer polysomes</strong>, consistent with impaired assembly or supply of an essential large-subunit RP to the nucleus and pre-60S particles. (stelter2015coordinatedribosomall4 pages 3-3, pillet2015thededicatedchaperone pages 10-12)</p>
+<hr />
+<h3 id="4-phenotypes-statistics-and-quantitative-evidence">4) Phenotypes, statistics, and quantitative evidence</h3>
+<h4 id="41-growth-and-ribosome-biogenesis-phenotypes">4.1 Growth and ribosome biogenesis phenotypes</h4>
+<ul>
+<li><strong>acl4Δ</strong> is viable but has <strong>severe slow growth</strong> across tested temperatures and shows a <strong>shortage of free 60S subunits</strong>, <strong>half-mer polysomes</strong>, and reduced overall polysomes. (pillet2015thededicatedchaperone pages 10-12)</li>
+<li>Growth and 60S defects can be <strong>partially rescued by extra RPL4</strong>, and deletion of ACL4 impairs 60S synthesis and yields half-mers. (stelter2015coordinatedribosomall4 pages 3-3, pillet2015thededicatedchaperone pages 14-17)</li>
+</ul>
+<h4 id="42-cotranslational-evidence-mrna-enrichment">4.2 Cotranslational evidence (mRNA enrichment)</h4>
+<p>Acl4 affinity purification shows strong enrichment of <strong>RPL4 mRNA (~150-fold)</strong>, supporting cotranslational recognition of nascent Rpl4. (pillet2015thededicatedchaperone pages 17-18)</p>
+<h4 id="43-rpl4-mrna-regulation-acl4-availability-as-a-rheostat">4.3 RPL4 mRNA regulation (Acl4 availability as a rheostat)</h4>
+<p>Recent work indicates Acl4 availability feeds back on RPL4 expression:<br />
+- <strong>RPL4 mRNA abundance is almost ~2-fold lower in Δacl4 cells</strong> versus wild type, consistent with an Acl4-dependent stabilization effect. (pillet2022dedicatedchaperonescoordinate pages 14-16)<br />
+- When Acl4 is absent/limiting, ribosome-associated Rpl4 nascent chain becomes accessible to regulatory machinery involving <strong>NAC</strong> and <strong>Caf130-associated Ccr4–Not</strong>, which promotes <strong>RPL4 mRNA degradation</strong>, limiting accumulation of aggregation-prone excess Rpl4. (pillet2022dedicatedchaperonescoordinate pages 1-4, schilke2024functionalsimilaritiesand pages 1-3)</p>
+<h4 id="44-proteostasisquality-control-linkage-tom1">4.4 Proteostasis/quality control linkage (Tom1)</h4>
+<p>Deregulated Rpl4 expression promotes aggregation and proteostasis defects, particularly in <strong>tom1Δ</strong> backgrounds; in such assays, wild-type proteins show nucle(ol)ar signal in <strong>&lt;20%</strong> of Δtom1 cells, whereas deregulated variants show strong nucle(ol)ar compartment signals in most Δtom1 cells. These observations link Acl4-dependent homeostasis to ubiquitin-ligase-dependent quality control. (pillet2022dedicatedchaperonescoordinate pages 20-22)</p>
+<h4 id="45-system-level-scale-statistics-context-for-why-acl4-matters">4.5 System-level scale statistics (context for why Acl4 matters)</h4>
+<ul>
+<li>In an exponentially growing yeast cell, there are ~<strong>200,000 ribosomes</strong>, requiring synthesis of <strong>&gt;2,000 ribosomes/minute</strong> (≈160,000 ribosomal proteins per minute) to maintain growth—illustrating why tight control of RP supply (including Acl4-mediated handling of Rpl4) is crucial. (pillet2022dedicatedchaperonescoordinate pages 1-4)</li>
+<li>Across eukaryotes, ribosome assembly requires <strong>several hundred ribosome biogenesis factors (RBFs)</strong>, compared with ~50 in bacteria, reflecting increased complexity and the need for specialized factors such as dedicated RP chaperones. (dorner2023ribosomebiogenesisfactors—from pages 1-2)</li>
+<li>Yeast ribosomes contain <strong>79 ribosomal proteins</strong>, while humans have ~80; the 60S contains <strong>46 RPs in yeast</strong> and 47 in humans. (dorner2023ribosomebiogenesisfactors—from pages 1-2, yang2024ribosomeassemblyand pages 1-3)</li>
+<li>Ribosome production is extremely resource-intensive (yeast allocation estimates include ~60% of transcription and ~50% of translation events, among others), motivating quality-control and repair/assembly-control systems. (yang2024ribosomeassemblyand pages 1-3)</li>
+</ul>
+<hr />
+<h3 id="5-recent-developments-prioritizing-20232024">5) Recent developments (prioritizing 2023–2024)</h3>
+<h4 id="51-2024-integration-of-acl4-into-cotranslational-regulatory-networks">5.1 2024: Integration of Acl4 into cotranslational regulatory networks</h4>
+<p>A 2024 study of NAC subunits in <em>S. cerevisiae</em> explicitly frames Acl4 as the specialized chaperone for Rpl4, noting that without Acl4 Rpl4 is aggregation-prone and cells grow very slowly. It further places Acl4-limited states into a regulatory pathway where Rpl4 mRNA is targeted for degradation via the <strong>CCR4–Not</strong> complex, and highlights quantitative NAC subunit abundance differences (Nacβ2 is ~20–100× less abundant than the major NAC subunits). (schilke2024functionalsimilaritiesand pages 1-3)</p>
+<h4 id="52-2023-expert-synthesis-on-why-mechanistic-annotation-matters">5.2 2023: Expert synthesis on why mechanistic annotation matters</h4>
+<p>A high-citation 2023 EMBO Journal review argues that assigning <strong>detailed molecular functions</strong> to ribosome biogenesis factors is essential for understanding and treating diseases linked to disturbed ribosome assembly, including <strong>ribosomopathies and cancers</strong>. While Acl4 is not the focus, this review provides field-level justification for precise mechanistic annotation of factors like Acl4. (dorner2023ribosomebiogenesisfactors—from pages 1-2)</p>
+<h4 id="53-2024-assembly-and-repair-framework-expert-view">5.3 2024: Assembly and repair framework (expert view)</h4>
+<p>A 2024 Annual Review article frames dedicated chaperones as part of the cellular strategy to manage small, basic, aggregation-prone RPs and maintain ribosome integrity through quality control and repair, with dedicated RP chaperones known for at least ~13 RPs. This strengthens the conceptual placement of Acl4 as a dedicated RP chaperone integrating assembly and proteostasis. (yang2024ribosomeassemblyand pages 1-3)</p>
+<hr />
+<h3 id="6-current-applications-and-real-world-implementations">6) Current applications and real-world implementations</h3>
+<h4 id="61-yeast-acl4-as-a-model-for-conserved-principles">6.1 Yeast Acl4 as a model for conserved principles</h4>
+<p>Acl4 exemplifies how eukaryotes solve the “RP handling problem” created by (i) cytoplasmic synthesis but nuclear assembly and (ii) aggregation propensity of basic RPs. Structural definition of the Acl4–L4 interface provides a mechanistic template for understanding analogous dedicated-chaperone systems and their coupling to nuclear import pathways (e.g., overlapping chaperone/importin binding sites). (huber2017molecularbasisfor pages 1-2, huber2017molecularbasisfor media e4ea49ee)</p>
+<h4 id="62-disease-relevance-via-ribosome-biogenesis-concepts">6.2 Disease relevance via ribosome biogenesis concepts</h4>
+<p>Although Acl4 itself is a yeast protein, authoritative reviews stress that detailed knowledge of ribosome assembly factors is key for understanding disease states (ribosomopathies, cancers) linked to perturbed ribosome assembly and quality control, supporting the broader translational relevance of dissecting dedicated-chaperone mechanisms in model organisms. (dorner2023ribosomebiogenesisfactors—from pages 1-2, yang2024ribosomeassemblyand pages 1-3)</p>
+<hr />
+<h3 id="7-visual-evidence-structure-and-import-coupling">7) Visual evidence (structure and import coupling)</h3>
+<p>Figures from the Acl4–RpL4 structural study show (i) the overall complex architecture, (ii) the interaction interface/hotspots, and (iii) a schematic of overlapping Acl4 and Kap104 binding sites on RpL4 (supporting the escort/import model). (huber2017molecularbasisfor media 4aaddfb0, huber2017molecularbasisfor media cb2e78f3, huber2017molecularbasisfor media e4ea49ee)</p>
+<hr />
+<h3 id="evidence-summary-table">Evidence summary table</h3>
+<table>
+<thead>
+<tr>
+<th>Topic</th>
+<th>Key findings</th>
+<th>Key source(s) with year and DOI URL</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Identity</td>
+<td><strong>ACL4</strong> in this report refers to <strong>Saccharomyces cerevisiae YDR161W</strong>, encoding <strong>Acl4</strong>, the dedicated assembly chaperone/escort for large-subunit ribosomal protein <strong>Rpl4/uL4</strong>; this matches UniProt <strong>Q03771</strong>. (stelter2015coordinatedribosomall4 pages 3-3, pillet2015thededicatedchaperone pages 1-2)</td>
+<td>Pillet et al., 2015, PLOS Genet. https://doi.org/10.1371/journal.pgen.1005565; Stelter et al., 2015, Mol Cell. https://doi.org/10.1016/j.molcel.2015.03.029</td>
+</tr>
+<tr>
+<td>Molecular function</td>
+<td>Acl4 is a <strong>dedicated ribosomal protein chaperone</strong> that binds newly made, free Rpl4, promotes its soluble expression, protects exposed basic regions from inappropriate interactions/aggregation, and escorts it toward its nuclear pre-60S assembly site. (pillet2015thededicatedchaperone pages 18-20, huber2017molecularbasisfor pages 1-2, pillet2015thededicatedchaperone pages 17-18)</td>
+<td>Pillet et al., 2015, PLOS Genet. https://doi.org/10.1371/journal.pgen.1005565; Huber &amp; Hoelz, 2017, Nat Commun. https://doi.org/10.1038/ncomms14354</td>
+</tr>
+<tr>
+<td>Client protein</td>
+<td>The specific client is <strong>Rpl4</strong> (large-subunit protein uL4/eL4 family naming context), and affinity purification/pulse-chase evidence supports cotranslational capture of nascent Rpl4 by Acl4. (stelter2015coordinatedribosomall4 pages 3-3, pillet2015thededicatedchaperone pages 17-18)</td>
+<td>Stelter et al., 2015, Mol Cell. https://doi.org/10.1016/j.molcel.2015.03.029; Pillet et al., 2015, PLOS Genet. https://doi.org/10.1371/journal.pgen.1005565</td>
+</tr>
+<tr>
+<td>Binding region</td>
+<td>Acl4 binds the <strong>C-terminal part of Rpl4’s long internal loop</strong>, with mapping to roughly <strong>aa 88–114</strong> and especially residues around <strong>101–114</strong>; multiple alanine-block substitutions disrupt binding. (pillet2015thededicatedchaperone pages 14-17, pillet2015thededicatedchaperone pages 20-21)</td>
+<td>Pillet et al., 2015, PLOS Genet. https://doi.org/10.1371/journal.pgen.1005565</td>
+</tr>
+<tr>
+<td>Structural fold/domain</td>
+<td>Structural work shows Acl4 is an <strong>α-helical TPR-family chaperone</strong> with about <strong>6.5–7 TPR repeats</strong> plus a C-terminal helix, using its concave surface to sequester about <strong>70 exposed residues</strong> of the RpL4 loop. This agrees with the UniProt/IPR annotation of a <strong>TPR-like helical domain</strong>. (huber2017molecularbasisfor pages 1-2, pillet2015thededicatedchaperone pages 17-18, huber2017molecularbasisfor media 4aaddfb0)</td>
+<td>Huber &amp; Hoelz, 2017, Nat Commun. https://doi.org/10.1038/ncomms14354; Pillet et al., 2015, PLOS Genet. https://doi.org/10.1371/journal.pgen.1005565</td>
+</tr>
+<tr>
+<td>Localization</td>
+<td>Acl4 is detected in <strong>both cytoplasm and nucleus</strong> and is found in <strong>soluble fractions</strong> rather than stably bound to mature 60S or persistent pre-60S particles, fitting a transient escort function. (pillet2015thededicatedchaperone pages 1-2, pillet2015thededicatedchaperone pages 10-12)</td>
+<td>Pillet et al., 2015, PLOS Genet. https://doi.org/10.1371/journal.pgen.1005565</td>
+</tr>
+<tr>
+<td>Nuclear import mechanism</td>
+<td>Acl4 lacks a predicted NLS, so the favored model is <strong>co-import with Rpl4</strong>. The <strong>Rpl4 C-terminal eukaryote-specific extension</strong> contains overlapping NLS/importin-binding determinants; <strong>Kap104</strong> can form a stoichiometric <strong>Acl4–Rpl4–Kap104</strong> trimer, and Ran-GTP is proposed to trigger release before assembly. (pillet2015thededicatedchaperone pages 18-20, huber2017molecularbasisfor pages 1-2, pillet2015thededicatedchaperone pages 20-21, huber2017molecularbasisfor media e4ea49ee)</td>
+<td>Pillet et al., 2015, PLOS Genet. https://doi.org/10.1371/journal.pgen.1005565; Huber &amp; Hoelz, 2017, Nat Commun. https://doi.org/10.1038/ncomms14354</td>
+</tr>
+<tr>
+<td>Role in pre-60S assembly</td>
+<td>Acl4 delivers Rpl4 to the <strong>early nuclear pre-60S assembly site</strong>. It associates only <strong>very transiently</strong> with early pre-60S particles, and release is coupled to proper Rpl4 insertion, including contacts involving Rpl4’s eukaryote-specific extension and neighboring 60S components such as <strong>Rpl18/Rpl7/ES7L</strong>. (pillet2015thededicatedchaperone pages 18-20, pillet2015thededicatedchaperone pages 20-21)</td>
+<td>Pillet et al., 2015, PLOS Genet. https://doi.org/10.1371/journal.pgen.1005565</td>
+</tr>
+<tr>
+<td>Phenotypes</td>
+<td><strong>acl4Δ</strong> cells are viable but show <strong>severe slow growth</strong> at multiple temperatures, <strong>60S deficiency</strong>, <strong>half-mer polysomes</strong>, reduced overall polysomes, and pre-rRNA processing defects (reduced <strong>27SB</strong> and <strong>7S</strong>). Extra <strong>RPL4</strong> can partially suppress the defect; combined loss with <strong>RPL4A</strong> worsens growth. (stelter2015coordinatedribosomall4 pages 3-3, pillet2015thededicatedchaperone pages 14-17, pillet2015thededicatedchaperone pages 10-12)</td>
+<td>Stelter et al., 2015, Mol Cell. https://doi.org/10.1016/j.molcel.2015.03.029; Pillet et al., 2015, PLOS Genet. https://doi.org/10.1371/journal.pgen.1005565</td>
+</tr>
+<tr>
+<td>Quality control / proteostasis link</td>
+<td>Acl4 protects unassembled Rpl4 from <strong>Tom1-linked degradation/quality control</strong> and from aggregation. When Acl4 is limiting or Rpl4 expression is deregulated, RPL4 mRNA can be downregulated through <strong>NAC–Caf130–Ccr4-Not</strong> circuitry, while excess Rpl4 becomes aggregation-prone, especially in <strong>tom1Δ</strong> cells. (huber2017molecularbasisfor pages 1-2, schilke2024functionalsimilaritiesand pages 1-3, pillet2022dedicatedchaperonescoordinate pages 1-4, pillet2022dedicatedchaperonescoordinate pages 14-16, pillet2022dedicatedchaperonescoordinate pages 20-22)</td>
+<td>Huber &amp; Hoelz, 2017, Nat Commun. https://doi.org/10.1038/ncomms14354; Pillet et al., 2022, bioRxiv. https://doi.org/10.1101/2021.10.05.463164; Schilke et al., 2024, Cell Stress Chaperones. https://doi.org/10.1016/j.cstres.2024.10.004</td>
+</tr>
+<tr>
+<td>Recent developments (2022–2024)</td>
+<td>Recent work extends Acl4 biology beyond escort alone: cotranslational Acl4 binding helps <strong>stabilize RPL4 mRNA</strong>, whereas limited Acl4 exposes nascent Rpl4 to <strong>CCR4–Not-dependent mRNA decay</strong> and proteostasis stress; 2024 analysis of <strong>NAC subunits</strong> further supports this regulatory network. Broader 2023–2024 reviews frame dedicated RP chaperones like Acl4 as central nodes in ribosome biogenesis and quality control. (schilke2024functionalsimilaritiesand pages 1-3, pillet2022dedicatedchaperonescoordinate pages 1-4, pillet2022dedicatedchaperonescoordinate pages 14-16)</td>
+<td>Pillet et al., 2022, bioRxiv. https://doi.org/10.1101/2021.10.05.463164; Schilke et al., 2024, Cell Stress Chaperones. https://doi.org/10.1016/j.cstres.2024.10.004</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the core functional-annotation evidence for Saccharomyces cerevisiae Acl4/YDR161W, including identity verification, mechanism, localization, pre-60S role, and recent regulatory insights. It is useful as a compact evidence-backed reference for gene/protein annotation.</em></p>
+<hr />
+<h3 id="key-references-with-urls-and-publication-dates">Key references (with URLs and publication dates)</h3>
+<ul>
+<li>Pillet B. et al. <strong>The Dedicated Chaperone Acl4 Escorts Ribosomal Protein Rpl4 to Its Nuclear Pre-60S Assembly Site.</strong> <em>PLOS Genetics</em> (Oct 2015). https://doi.org/10.1371/journal.pgen.1005565 (pillet2015thededicatedchaperone pages 1-2, pillet2015thededicatedchaperone pages 10-12)</li>
+<li>Stelter P. et al. <strong>Coordinated Ribosomal L4 Protein Assembly into the Pre-Ribosome Is Regulated by Its Eukaryote-Specific Extension.</strong> <em>Molecular Cell</em> (Jun 2015). https://doi.org/10.1016/j.molcel.2015.03.029 (stelter2015coordinatedribosomall4 pages 3-3)</li>
+<li>Huber F.M., Hoelz A. <strong>Molecular basis for protection of ribosomal protein L4 from cellular degradation.</strong> <em>Nature Communications</em> (Feb 2017). https://doi.org/10.1038/ncomms14354 (huber2017molecularbasisfor pages 1-2)</li>
+<li>Pillet B. et al. <strong>Dedicated chaperones coordinate co-translational regulation of ribosomal protein production with ribosome assembly to preserve proteostasis.</strong> <em>bioRxiv</em> (posted Oct 2022). https://doi.org/10.1101/2021.10.05.463164 (pillet2022dedicatedchaperonescoordinate pages 1-4, pillet2022dedicatedchaperonescoordinate pages 14-16)</li>
+<li>Dörner K. et al. <strong>Ribosome biogenesis factors—from names to functions.</strong> <em>The EMBO Journal</em> (Feb 2023). https://doi.org/10.15252/embj.2022112699 (dorner2023ribosomebiogenesisfactors—from pages 1-2)</li>
+<li>Schilke B.A. et al. <strong>Functional similarities and differences among subunits of the NAC of Saccharomyces cerevisiae.</strong> <em>Cell Stress and Chaperones</em> (Dec 2024). https://doi.org/10.1016/j.cstres.2024.10.004 (schilke2024functionalsimilaritiesand pages 1-3)</li>
+<li>Yang Y.-M., Karbstein K. <strong>Ribosome Assembly and Repair.</strong> <em>Annual Review of Cell and Developmental Biology</em> (Oct 2024). https://doi.org/10.1146/annurev-cellbio-111822-113326 (yang2024ribosomeassemblyand pages 1-3)</li>
+</ul>
+<p>References</p>
+<ol>
+<li>
+<p>(pillet2015thededicatedchaperone pages 1-2): Benjamin Pillet, Juan J. García-Gómez, Patrick Pausch, Laurent Falquet, Gert Bange, Jesús de la Cruz, and Dieter Kressler. The dedicated chaperone acl4 escorts ribosomal protein rpl4 to its nuclear pre-60s assembly site. PLOS Genetics, 11:e1005565, Oct 2015. URL: https://doi.org/10.1371/journal.pgen.1005565, doi:10.1371/journal.pgen.1005565. This article has 84 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(huber2017molecularbasisfor pages 1-2): Ferdinand M. Huber and André Hoelz. Molecular basis for protection of ribosomal protein l4 from cellular degradation. Nature Communications, Feb 2017. URL: https://doi.org/10.1038/ncomms14354, doi:10.1038/ncomms14354. This article has 37 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(pillet2015thededicatedchaperone pages 10-12): Benjamin Pillet, Juan J. García-Gómez, Patrick Pausch, Laurent Falquet, Gert Bange, Jesús de la Cruz, and Dieter Kressler. The dedicated chaperone acl4 escorts ribosomal protein rpl4 to its nuclear pre-60s assembly site. PLOS Genetics, 11:e1005565, Oct 2015. URL: https://doi.org/10.1371/journal.pgen.1005565, doi:10.1371/journal.pgen.1005565. This article has 84 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(schilke2024functionalsimilaritiesand pages 1-3): Brenda A. Schilke, Thomas Ziegelhoffer, Przemyslaw Domanski, Jaroslaw Marszalek, Bartlomiej Tomiczek, and Elizabeth A. Craig. Functional similarities and differences among subunits of the nascent polypeptide-associated complex (nac) of saccharomyces cerevisiae. Cell Stress and Chaperones, 29:721-734, Dec 2024. URL: https://doi.org/10.1016/j.cstres.2024.10.004, doi:10.1016/j.cstres.2024.10.004. This article has 1 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(pillet2022dedicatedchaperonescoordinate pages 14-16): Benjamin Pillet, Alfonso Méndez-Godoy, Guillaume Murat, Sébastien Favre, Michael Stumpe, Laurent Falquet, and Dieter Kressler. Dedicated chaperones coordinate co-translational regulation of ribosomal protein production with ribosome assembly to preserve proteostasis. BioRxiv, Oct 2022. URL: https://doi.org/10.1101/2021.10.05.463164, doi:10.1101/2021.10.05.463164. This article has 30 citations.</p>
+</li>
+<li>
+<p>(pillet2022dedicatedchaperonescoordinate pages 20-22): Benjamin Pillet, Alfonso Méndez-Godoy, Guillaume Murat, Sébastien Favre, Michael Stumpe, Laurent Falquet, and Dieter Kressler. Dedicated chaperones coordinate co-translational regulation of ribosomal protein production with ribosome assembly to preserve proteostasis. BioRxiv, Oct 2022. URL: https://doi.org/10.1101/2021.10.05.463164, doi:10.1101/2021.10.05.463164. This article has 30 citations.</p>
+</li>
+<li>
+<p>(stelter2015coordinatedribosomall4 pages 3-3): Philipp Stelter, Ferdinand M. Huber, Ruth Kunze, Dirk Flemming, André Hoelz, and Ed Hurt. Coordinated ribosomal l4 protein assembly into the pre-ribosome is regulated by its eukaryote-specific extension. Molecular cell, 58 5:854-62, Jun 2015. URL: https://doi.org/10.1016/j.molcel.2015.03.029, doi:10.1016/j.molcel.2015.03.029. This article has 78 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(pillet2015thededicatedchaperone pages 18-20): Benjamin Pillet, Juan J. García-Gómez, Patrick Pausch, Laurent Falquet, Gert Bange, Jesús de la Cruz, and Dieter Kressler. The dedicated chaperone acl4 escorts ribosomal protein rpl4 to its nuclear pre-60s assembly site. PLOS Genetics, 11:e1005565, Oct 2015. URL: https://doi.org/10.1371/journal.pgen.1005565, doi:10.1371/journal.pgen.1005565. This article has 84 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(yang2024ribosomeassemblyand pages 1-3): Yoon-Mo Yang and Katrin Karbstein. Ribosome assembly and repair. Annual Review of Cell and Developmental Biology, 40:241-264, Oct 2024. URL: https://doi.org/10.1146/annurev-cellbio-111822-113326, doi:10.1146/annurev-cellbio-111822-113326. This article has 18 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(pillet2015thededicatedchaperone pages 20-21): Benjamin Pillet, Juan J. García-Gómez, Patrick Pausch, Laurent Falquet, Gert Bange, Jesús de la Cruz, and Dieter Kressler. The dedicated chaperone acl4 escorts ribosomal protein rpl4 to its nuclear pre-60s assembly site. PLOS Genetics, 11:e1005565, Oct 2015. URL: https://doi.org/10.1371/journal.pgen.1005565, doi:10.1371/journal.pgen.1005565. This article has 84 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(pillet2015thededicatedchaperone pages 17-18): Benjamin Pillet, Juan J. García-Gómez, Patrick Pausch, Laurent Falquet, Gert Bange, Jesús de la Cruz, and Dieter Kressler. The dedicated chaperone acl4 escorts ribosomal protein rpl4 to its nuclear pre-60s assembly site. PLOS Genetics, 11:e1005565, Oct 2015. URL: https://doi.org/10.1371/journal.pgen.1005565, doi:10.1371/journal.pgen.1005565. This article has 84 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(pillet2015thededicatedchaperone pages 14-17): Benjamin Pillet, Juan J. García-Gómez, Patrick Pausch, Laurent Falquet, Gert Bange, Jesús de la Cruz, and Dieter Kressler. The dedicated chaperone acl4 escorts ribosomal protein rpl4 to its nuclear pre-60s assembly site. PLOS Genetics, 11:e1005565, Oct 2015. URL: https://doi.org/10.1371/journal.pgen.1005565, doi:10.1371/journal.pgen.1005565. This article has 84 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(huber2017molecularbasisfor media 4aaddfb0): Ferdinand M. Huber and André Hoelz. Molecular basis for protection of ribosomal protein l4 from cellular degradation. Nature Communications, Feb 2017. URL: https://doi.org/10.1038/ncomms14354, doi:10.1038/ncomms14354. This article has 37 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(huber2017molecularbasisfor media cb2e78f3): Ferdinand M. Huber and André Hoelz. Molecular basis for protection of ribosomal protein l4 from cellular degradation. Nature Communications, Feb 2017. URL: https://doi.org/10.1038/ncomms14354, doi:10.1038/ncomms14354. This article has 37 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(huber2017molecularbasisfor media e4ea49ee): Ferdinand M. Huber and André Hoelz. Molecular basis for protection of ribosomal protein l4 from cellular degradation. Nature Communications, Feb 2017. URL: https://doi.org/10.1038/ncomms14354, doi:10.1038/ncomms14354. This article has 37 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(pillet2022dedicatedchaperonescoordinate pages 1-4): Benjamin Pillet, Alfonso Méndez-Godoy, Guillaume Murat, Sébastien Favre, Michael Stumpe, Laurent Falquet, and Dieter Kressler. Dedicated chaperones coordinate co-translational regulation of ribosomal protein production with ribosome assembly to preserve proteostasis. BioRxiv, Oct 2022. URL: https://doi.org/10.1101/2021.10.05.463164, doi:10.1101/2021.10.05.463164. This article has 30 citations.</p>
+</li>
+<li>
+<p>(dorner2023ribosomebiogenesisfactors—from pages 1-2): Kerstin Dörner, Chiara Ruggeri, Ivo Zemp, and Ulrike Kutay. Ribosome biogenesis factors—from names to functions. The EMBO Journal, Feb 2023. URL: https://doi.org/10.15252/embj.2022112699, doi:10.15252/embj.2022112699. This article has 201 citations.</p>
+</li>
+</ol>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>pillet2015thededicatedchaperone pages 17-18</li>
+<li>pillet2015thededicatedchaperone pages 10-12</li>
+<li>pillet2022dedicatedchaperonescoordinate pages 14-16</li>
+<li>pillet2022dedicatedchaperonescoordinate pages 20-22</li>
+<li>pillet2022dedicatedchaperonescoordinate pages 1-4</li>
+<li>yang2024ribosomeassemblyand pages 1-3</li>
+<li>schilke2024functionalsimilaritiesand pages 1-3</li>
+<li>huber2017molecularbasisfor pages 1-2</li>
+<li>pillet2015thededicatedchaperone pages 1-2</li>
+<li>pillet2015thededicatedchaperone pages 18-20</li>
+<li>pillet2015thededicatedchaperone pages 20-21</li>
+<li>pillet2015thededicatedchaperone pages 14-17</li>
+<li>https://doi.org/10.1371/journal.pgen.1005565;</li>
+<li>https://doi.org/10.1016/j.molcel.2015.03.029</li>
+<li>https://doi.org/10.1038/ncomms14354</li>
+<li>https://doi.org/10.1016/j.molcel.2015.03.029;</li>
+<li>https://doi.org/10.1371/journal.pgen.1005565</li>
+<li>https://doi.org/10.1038/ncomms14354;</li>
+<li>https://doi.org/10.1101/2021.10.05.463164;</li>
+<li>https://doi.org/10.1016/j.cstres.2024.10.004</li>
+<li>https://doi.org/10.1101/2021.10.05.463164</li>
+<li>https://doi.org/10.15252/embj.2022112699</li>
+<li>https://doi.org/10.1146/annurev-cellbio-111822-113326</li>
+<li>https://doi.org/10.1371/journal.pgen.1005565,</li>
+<li>https://doi.org/10.1038/ncomms14354,</li>
+<li>https://doi.org/10.1016/j.cstres.2024.10.004,</li>
+<li>https://doi.org/10.1101/2021.10.05.463164,</li>
+<li>https://doi.org/10.1016/j.molcel.2015.03.029,</li>
+<li>https://doi.org/10.1146/annurev-cellbio-111822-113326,</li>
+<li>https://doi.org/10.15252/embj.2022112699,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -1965,11 +2641,18 @@
                 <pre><code>id: Q03771
 gene_symbol: ACL4
 product_type: PROTEIN
-status: DRAFT
+status: COMPLETE
 taxon:
   id: NCBITaxon:559292
   label: Saccharomyces cerevisiae
-description: &#39;TODO: Add description for ACL4&#39;
+description: &gt;-
+  ACL4 encodes the dedicated assembly chaperone for the large ribosomal subunit
+  protein Rpl4/uL4. Acl4 binds newly synthesized Rpl4, keeps the highly basic
+  unassembled ribosomal protein soluble, and escorts it from the cytoplasm to
+  the nuclear pre-60S assembly site. Loss of ACL4 causes slow growth, reduced
+  60S subunit production, half-mer polysomes, and pre-rRNA processing defects,
+  supporting a core role in ribosomal large subunit biogenesis rather than
+  mitochondrial protein import.
 existing_annotations:
 - term:
     id: GO:0005741
@@ -1977,9 +2660,20 @@ existing_annotations:
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: &#39;Manual review: mitochondrial outer membrane is not sufficiently supported as a direct function of ACL4.&#39;
+    summary: &gt;-
+      This IBA traces to a broad PANTHER family context that UniProt labels as
+      mitochondrial import receptor subunit TOM70, but the reviewed yeast ACL4
+      subfamily entry is an assembly chaperone of RPL4. UniProt and the Falcon
+      review support cytoplasmic/nuclear localization for Acl4, not a
+      mitochondrial outer membrane role.
     action: REMOVE
-    reason: Removed due weak mechanistic support or likely misannotation for this gene.
+    reason: &gt;-
+      The family-transfer annotation appears to have propagated TOM70-family
+      mitochondrial localization to a divergent Acl4/Rpl4 chaperone. No primary
+      Acl4 evidence supports mitochondrial outer membrane residence.
+    supported_by:
+    - reference_id: file:yeast/ACL4/ACL4-deep-research-falcon.md
+      supporting_text: &#34;Acl4 is detected in both cytoplasm and nucleus&#34;
 - term:
     id: GO:0008320
     label: protein transmembrane transporter activity
@@ -1987,156 +2681,295 @@ existing_annotations:
   original_reference_id: GO_REF:0000033
   qualifier: contributes_to
   review:
-    summary: &#39;Manual review: protein transmembrane transporter activity is not sufficiently supported as a direct function of ACL4.&#39;
+    summary: &gt;-
+      Acl4 escorts the soluble ribosomal protein Rpl4; it is not a component of
+      a protein transmembrane translocation channel. This IBA is inconsistent
+      with the experimentally supported Acl4 subfamily biology.
     action: REMOVE
-    reason: Removed due weak mechanistic support or likely misannotation for this gene.
+    reason: &gt;-
+      The annotation likely reflects the TOM70-like parent family rather than
+      Acl4. Acl4 functions as a ribosomal protein carrier chaperone, not as a
+      transmembrane transporter or transporter subunit.
 - term:
     id: GO:0030150
     label: protein import into mitochondrial matrix
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: &#39;Manual review: protein import into mitochondrial matrix is not sufficiently supported as a direct function of ACL4.&#39;
+    summary: &gt;-
+      Experimental Acl4 studies describe Rpl4 handling and nuclear pre-60S
+      assembly, with no evidence for mitochondrial matrix protein import.
     action: REMOVE
-    reason: Removed due weak mechanistic support or likely misannotation for this gene.
+    reason: &gt;-
+      This is a family-transfer overannotation from a TOM70-like ancestor and
+      conflicts with the specific yeast Acl4/Rpl4 literature.
 - term:
     id: GO:0030943
     label: mitochondrion targeting sequence binding
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: &#39;Manual review: mitochondrion targeting sequence binding is consistent with known biology of ACL4.&#39;
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    summary: &gt;-
+      Acl4 binds a segment of the Rpl4 long internal loop and protects
+      unassembled Rpl4. It has no demonstrated binding to mitochondrial targeting
+      sequences.
+    action: REMOVE
+    reason: &gt;-
+      The supported client-binding activity is Rpl4 carrier chaperone activity.
+      The mitochondrial targeting sequence term should not be retained for the
+      yeast ACL4 subfamily.
+    supported_by:
+    - reference_id: file:yeast/ACL4/ACL4-deep-research-falcon.md
+      supporting_text: &#34;Acl4 binds newly synthesized, free Rpl4&#34;
 - term:
     id: GO:0045039
     label: protein insertion into mitochondrial inner membrane
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: &#39;Manual review: protein insertion into mitochondrial inner membrane is not sufficiently supported as a direct function of ACL4.&#39;
+    summary: &gt;-
+      The experimentally supported Acl4 pathway is Rpl4 delivery to the nuclear
+      pre-60S ribosome, not insertion of proteins into the mitochondrial inner
+      membrane.
     action: REMOVE
-    reason: Removed due weak mechanistic support or likely misannotation for this gene.
+    reason: &gt;-
+      This IBA is not supported for ACL4 and should be removed as a TOM70-family
+      over-transfer.
 - term:
     id: GO:0005634
     label: nucleus
   evidence_type: IEA
   original_reference_id: GO_REF:0000044
   review:
-    summary: &#39;Manual review: nucleus is consistent with known biology of ACL4.&#39;
+    summary: &gt;-
+      UniProt subcellular-location mapping to nucleus is consistent with direct
+      Acl4 localization studies and with Acl4 delivery of Rpl4 to nuclear
+      pre-60S particles.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: &gt;-
+      Acl4 is enriched in the nucleus and performs its client-delivery function
+      at the nuclear pre-60S assembly site.
 - term:
     id: GO:0005737
     label: cytoplasm
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
   review:
-    summary: &#39;Manual review: cytoplasm is consistent with known biology of ACL4.&#39;
+    summary: &gt;-
+      Automated cytoplasm assignment is consistent with direct studies showing
+      Acl4 in the cytoplasm, where Rpl4 is synthesized and first captured.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: &gt;-
+      Cytoplasmic localization is part of the supported escort path from
+      nascent Rpl4 capture to nuclear assembly.
 - term:
     id: GO:0042254
     label: ribosome biogenesis
   evidence_type: IEA
   original_reference_id: GO_REF:0000043
   review:
-    summary: &#39;Manual review: ribosome biogenesis is consistent with known biology of ACL4.&#39;
+    summary: &gt;-
+      The keyword-derived ribosome biogenesis term is broad but accurate for
+      Acl4, which is required for efficient production of 60S ribosomal subunits.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: &gt;-
+      Experimental annotations to ribosomal large subunit biogenesis provide the
+      more specific evidence; this parent process is correct as an automated
+      summary of Acl4 function.
 - term:
     id: GO:0005634
     label: nucleus
   evidence_type: IDA
   original_reference_id: PMID:25936803
   review:
-    summary: &#39;Manual review: nucleus is consistent with known biology of ACL4.&#39;
+    summary: &gt;-
+      Direct experimental localization supports nuclear Acl4, consistent with
+      the Rpl4 pre-60S assembly site.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: &gt;-
+      The localization matches the mechanistic model in which Acl4 delivers
+      Rpl4 to nuclear pre-60S assembly intermediates.
+    supported_by:
+    - reference_id: PMID:25936803
+      supporting_text: &#34;assembly chaperone Acl4 that initially binds the universally conserved internal&#34;
 - term:
     id: GO:0005634
     label: nucleus
   evidence_type: IDA
   original_reference_id: PMID:26447800
   review:
-    summary: &#39;Manual review: nucleus is consistent with known biology of ACL4.&#39;
+    summary: &gt;-
+      Direct microscopy in the dedicated Acl4-Rpl4 study supports nuclear
+      localization.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: &gt;-
+      Acl4 localizes to the nucleus as expected for a factor escorting Rpl4 to
+      nuclear pre-60S assembly sites.
+    supported_by:
+    - reference_id: PMID:26447800
+      supporting_text: &#34;Acl4 localizes to both the cytoplasm and nucleus&#34;
 - term:
     id: GO:0005737
     label: cytoplasm
   evidence_type: IDA
   original_reference_id: PMID:26447800
   review:
-    summary: &#39;Manual review: cytoplasm is consistent with known biology of ACL4.&#39;
+    summary: &gt;-
+      Direct microscopy supports cytoplasmic Acl4 localization.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: &gt;-
+      Acl4 must encounter newly translated Rpl4 in the cytoplasm before nuclear
+      delivery, so this localization is mechanistically coherent.
+    supported_by:
+    - reference_id: PMID:26447800
+      supporting_text: &#34;Acl4 localizes to both the cytoplasm and nucleus&#34;
 - term:
     id: GO:0042273
     label: ribosomal large subunit biogenesis
   evidence_type: IMP
   original_reference_id: PMID:25936803
   review:
-    summary: &#39;Manual review: ribosomal large subunit biogenesis is consistent with known biology of ACL4.&#39;
+    summary: &gt;-
+      Mutant phenotype evidence shows that ACL4 is required for normal 60S
+      subunit production through Rpl4 assembly.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: &gt;-
+      Acl4 shields Rpl4 until it can be inserted into the pre-ribosome; ACL4
+      loss causes large-subunit biogenesis defects, making this a core process.
+    supported_by:
+    - reference_id: PMID:25936803
+      supporting_text: &#34;hierarchical ribosome assembly can be achieved by eukaryotic RP extensions and&#34;
 - term:
     id: GO:0042273
     label: ribosomal large subunit biogenesis
   evidence_type: IMP
   original_reference_id: PMID:26447800
   review:
-    summary: &#39;Manual review: ribosomal large subunit biogenesis is consistent with known biology of ACL4.&#39;
+    summary: &gt;-
+      The dedicated chaperone study shows that Acl4 escorts Rpl4 to its nuclear
+      pre-60S assembly site and that loss of Acl4 compromises 60S production.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: &gt;-
+      This is the central biological process for Acl4 and is supported by
+      genetic, localization, and biochemical evidence.
+    supported_by:
+    - reference_id: PMID:26447800
+      supporting_text: &#34;deficiency in the production of 60S subunits&#34;
 - term:
     id: GO:0051082
     label: unfolded protein binding
   evidence_type: IDA
   original_reference_id: PMID:25936803
   review:
-    summary: &#39;Manual review: unfolded protein binding is better represented by a more specific replacement term for ACL4.&#39;
+    summary: &gt;-
+      Acl4 does bind and protect unassembled Rpl4, but &#34;unfolded protein
+      binding&#34; is too generic and obscures the dedicated carrier-chaperone role.
     action: MODIFY
-    reason: Modified to align with current curation guidance and improve term specificity.
+    reason: &gt;-
+      The evidence supports specific ribosomal-protein carrier chaperone
+      activity rather than generic binding to unfolded proteins.
     proposed_replacement_terms:
     - id: GO:0140597
-      label: protein carrier chaperone
+      label: protein carrier activity
+    supported_by:
+    - reference_id: file:yeast/ACL4/ACL4-deep-research-falcon.md
+      supporting_text: &#34;Acl4 is a dedicated ribosomal protein chaperone&#34;
 - term:
     id: GO:0140318
     label: protein transporter activity
   evidence_type: IDA
   original_reference_id: PMID:26447800
   review:
-    summary: &#39;Manual review: protein transporter activity is not sufficiently supported as a direct function of ACL4.&#39;
-    action: REMOVE
-    reason: Removed due weak mechanistic support or likely misannotation for this gene.
+    summary: &gt;-
+      The evidence supports Acl4 directly binding and escorting Rpl4 to the
+      pre-60S assembly pathway, matching the current definition of protein
+      transporter activity as binding and delivering a specific protein to a
+      cellular location.
+    action: ACCEPT
+    reason: &gt;-
+      Acl4 is a dedicated ribosomal-protein carrier/chaperone for Rpl4, so the
+      annotation captures a core molecular function rather than a generic or
+      transmembrane transport claim.
+    supported_by:
+    - reference_id: PMID:26447800
+      supporting_text: &#34;dedicated chaperone Acl4 accompanies Rpl4&#34;
 - term:
     id: GO:0051083
-    label: &#39;&#39;&#39;de novo&#39;&#39; cotranslational protein folding&#39;
+    label: &#34;&#39;de novo&#39; cotranslational protein folding&#34;
   evidence_type: HGI
   original_reference_id: PMID:19325107
   review:
-    summary: &#39;Manual review: &#39;&#39;de novo&#39;&#39; cotranslational protein folding is consistent with known biology of ACL4.&#39;
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    summary: &gt;-
+      Acl4 can capture nascent Rpl4 cotranslationally, but this high-throughput
+      genetic-interaction annotation is broad and does not define Acl4 as a
+      general cotranslational folding factor.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      The better-supported curation is the specific Rpl4 carrier-chaperone role
+      in ribosomal large subunit biogenesis. Retaining the broad folding process
+      as a core annotation would overstate the evidence.
 - term:
     id: GO:0005634
     label: nucleus
   evidence_type: HDA
   original_reference_id: PMID:14562095
   review:
-    summary: &#39;Manual review: nucleus is consistent with known biology of ACL4.&#39;
+    summary: &gt;-
+      High-throughput localization to nucleus is consistent with direct Acl4
+      localization and its nuclear pre-60S assembly role.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: &gt;-
+      Multiple independent sources support nuclear localization.
 - term:
     id: GO:0005737
     label: cytoplasm
   evidence_type: HDA
   original_reference_id: PMID:14562095
   review:
-    summary: &#39;Manual review: cytoplasm is consistent with known biology of ACL4.&#39;
+    summary: &gt;-
+      High-throughput localization to cytoplasm is consistent with direct Acl4
+      localization and nascent Rpl4 capture.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: &gt;-
+      Acl4 is distributed through cytoplasm and nucleus, matching its escort
+      function.
+core_functions:
+- molecular_function:
+    id: GO:0140597
+    label: protein carrier activity
+  directly_involved_in:
+  - id: GO:0042273
+    label: ribosomal large subunit biogenesis
+  locations:
+  - id: GO:0005737
+    label: cytoplasm
+  - id: GO:0005634
+    label: nucleus
+  description: &gt;-
+    Acl4 is a dedicated carrier chaperone for Rpl4/uL4. It binds newly
+    synthesized Rpl4 in the cytoplasm, protects it from inappropriate
+    interactions or aggregation, and escorts it to nuclear pre-60S particles for
+    large ribosomal subunit assembly.
+  supported_by:
+  - reference_id: PMID:26447800
+    supporting_text: &#34;dedicated chaperone Acl4 accompanies Rpl4&#34;
+  - reference_id: file:yeast/ACL4/ACL4-deep-research-falcon.md
+    supporting_text: &#34;Acl4 binds newly synthesized, free Rpl4&#34;
+proposed_new_terms: []
+suggested_questions:
+- question: &gt;-
+    Should PANTHER family PTHR46208 be split or have IBA propagation restricted
+    so TOM70 mitochondrial import terms do not transfer to the ACL4/Rpl4
+    assembly chaperone subfamily?
+suggested_experiments:
+- description: &gt;-
+    Re-analyze ACL4, TOM70, and related PTHR46208 subfamilies with tree-aware
+    GO propagation to test whether mitochondrial import annotations segregate
+    away from the experimentally characterized Acl4/Rpl4 clade.
+  experiment_type: phylogenetic curation
+  hypothesis: &gt;-
+    The ACL4 subfamily lacks the mitochondrial protein import functions present
+    in TOM70-like relatives and should not inherit those IBA terms.
 references:
 - id: GO_REF:0000033
   title: Annotation inferences using phylogenetic trees
@@ -2162,13 +2995,16 @@ references:
 - id: PMID:26447800
   title: The Dedicated Chaperone Acl4 Escorts Ribosomal Protein Rpl4 to Its Nuclear Pre-60S Assembly Site.
   findings: []
+- id: file:yeast/ACL4/ACL4-deep-research-falcon.md
+  title: Falcon deep research report for ACL4
+  findings: []
 </code></pre>
             </div>
         </details>
     </div>
 
     <!-- Pathway Visualization Link -->
-    
+
 
     <style>
         /* Markdown Section Styles */

--- a/genes/yeast/ACL4/ACL4-ai-review.yaml
+++ b/genes/yeast/ACL4/ACL4-ai-review.yaml
@@ -1,11 +1,18 @@
 id: Q03771
 gene_symbol: ACL4
 product_type: PROTEIN
-status: DRAFT
+status: COMPLETE
 taxon:
   id: NCBITaxon:559292
   label: Saccharomyces cerevisiae
-description: 'TODO: Add description for ACL4'
+description: >-
+  ACL4 encodes the dedicated assembly chaperone for the large ribosomal subunit
+  protein Rpl4/uL4. Acl4 binds newly synthesized Rpl4, keeps the highly basic
+  unassembled ribosomal protein soluble, and escorts it from the cytoplasm to
+  the nuclear pre-60S assembly site. Loss of ACL4 causes slow growth, reduced
+  60S subunit production, half-mer polysomes, and pre-rRNA processing defects,
+  supporting a core role in ribosomal large subunit biogenesis rather than
+  mitochondrial protein import.
 existing_annotations:
 - term:
     id: GO:0005741
@@ -13,9 +20,20 @@ existing_annotations:
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'Manual review: mitochondrial outer membrane is not sufficiently supported as a direct function of ACL4.'
+    summary: >-
+      This IBA traces to a broad PANTHER family context that UniProt labels as
+      mitochondrial import receptor subunit TOM70, but the reviewed yeast ACL4
+      subfamily entry is an assembly chaperone of RPL4. UniProt and the Falcon
+      review support cytoplasmic/nuclear localization for Acl4, not a
+      mitochondrial outer membrane role.
     action: REMOVE
-    reason: Removed due weak mechanistic support or likely misannotation for this gene.
+    reason: >-
+      The family-transfer annotation appears to have propagated TOM70-family
+      mitochondrial localization to a divergent Acl4/Rpl4 chaperone. No primary
+      Acl4 evidence supports mitochondrial outer membrane residence.
+    supported_by:
+    - reference_id: file:yeast/ACL4/ACL4-deep-research-falcon.md
+      supporting_text: "Acl4 is detected in both cytoplasm and nucleus"
 - term:
     id: GO:0008320
     label: protein transmembrane transporter activity
@@ -23,156 +41,295 @@ existing_annotations:
   original_reference_id: GO_REF:0000033
   qualifier: contributes_to
   review:
-    summary: 'Manual review: protein transmembrane transporter activity is not sufficiently supported as a direct function of ACL4.'
+    summary: >-
+      Acl4 escorts the soluble ribosomal protein Rpl4; it is not a component of
+      a protein transmembrane translocation channel. This IBA is inconsistent
+      with the experimentally supported Acl4 subfamily biology.
     action: REMOVE
-    reason: Removed due weak mechanistic support or likely misannotation for this gene.
+    reason: >-
+      The annotation likely reflects the TOM70-like parent family rather than
+      Acl4. Acl4 functions as a ribosomal protein carrier chaperone, not as a
+      transmembrane transporter or transporter subunit.
 - term:
     id: GO:0030150
     label: protein import into mitochondrial matrix
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'Manual review: protein import into mitochondrial matrix is not sufficiently supported as a direct function of ACL4.'
+    summary: >-
+      Experimental Acl4 studies describe Rpl4 handling and nuclear pre-60S
+      assembly, with no evidence for mitochondrial matrix protein import.
     action: REMOVE
-    reason: Removed due weak mechanistic support or likely misannotation for this gene.
+    reason: >-
+      This is a family-transfer overannotation from a TOM70-like ancestor and
+      conflicts with the specific yeast Acl4/Rpl4 literature.
 - term:
     id: GO:0030943
     label: mitochondrion targeting sequence binding
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'Manual review: mitochondrion targeting sequence binding is consistent with known biology of ACL4.'
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    summary: >-
+      Acl4 binds a segment of the Rpl4 long internal loop and protects
+      unassembled Rpl4. It has no demonstrated binding to mitochondrial targeting
+      sequences.
+    action: REMOVE
+    reason: >-
+      The supported client-binding activity is Rpl4 carrier chaperone activity.
+      The mitochondrial targeting sequence term should not be retained for the
+      yeast ACL4 subfamily.
+    supported_by:
+    - reference_id: file:yeast/ACL4/ACL4-deep-research-falcon.md
+      supporting_text: "Acl4 binds newly synthesized, free Rpl4"
 - term:
     id: GO:0045039
     label: protein insertion into mitochondrial inner membrane
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'Manual review: protein insertion into mitochondrial inner membrane is not sufficiently supported as a direct function of ACL4.'
+    summary: >-
+      The experimentally supported Acl4 pathway is Rpl4 delivery to the nuclear
+      pre-60S ribosome, not insertion of proteins into the mitochondrial inner
+      membrane.
     action: REMOVE
-    reason: Removed due weak mechanistic support or likely misannotation for this gene.
+    reason: >-
+      This IBA is not supported for ACL4 and should be removed as a TOM70-family
+      over-transfer.
 - term:
     id: GO:0005634
     label: nucleus
   evidence_type: IEA
   original_reference_id: GO_REF:0000044
   review:
-    summary: 'Manual review: nucleus is consistent with known biology of ACL4.'
+    summary: >-
+      UniProt subcellular-location mapping to nucleus is consistent with direct
+      Acl4 localization studies and with Acl4 delivery of Rpl4 to nuclear
+      pre-60S particles.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: >-
+      Acl4 is enriched in the nucleus and performs its client-delivery function
+      at the nuclear pre-60S assembly site.
 - term:
     id: GO:0005737
     label: cytoplasm
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
   review:
-    summary: 'Manual review: cytoplasm is consistent with known biology of ACL4.'
+    summary: >-
+      Automated cytoplasm assignment is consistent with direct studies showing
+      Acl4 in the cytoplasm, where Rpl4 is synthesized and first captured.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: >-
+      Cytoplasmic localization is part of the supported escort path from
+      nascent Rpl4 capture to nuclear assembly.
 - term:
     id: GO:0042254
     label: ribosome biogenesis
   evidence_type: IEA
   original_reference_id: GO_REF:0000043
   review:
-    summary: 'Manual review: ribosome biogenesis is consistent with known biology of ACL4.'
+    summary: >-
+      The keyword-derived ribosome biogenesis term is broad but accurate for
+      Acl4, which is required for efficient production of 60S ribosomal subunits.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: >-
+      Experimental annotations to ribosomal large subunit biogenesis provide the
+      more specific evidence; this parent process is correct as an automated
+      summary of Acl4 function.
 - term:
     id: GO:0005634
     label: nucleus
   evidence_type: IDA
   original_reference_id: PMID:25936803
   review:
-    summary: 'Manual review: nucleus is consistent with known biology of ACL4.'
+    summary: >-
+      Direct experimental localization supports nuclear Acl4, consistent with
+      the Rpl4 pre-60S assembly site.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: >-
+      The localization matches the mechanistic model in which Acl4 delivers
+      Rpl4 to nuclear pre-60S assembly intermediates.
+    supported_by:
+    - reference_id: PMID:25936803
+      supporting_text: "assembly chaperone Acl4 that initially binds the universally conserved internal"
 - term:
     id: GO:0005634
     label: nucleus
   evidence_type: IDA
   original_reference_id: PMID:26447800
   review:
-    summary: 'Manual review: nucleus is consistent with known biology of ACL4.'
+    summary: >-
+      Direct microscopy in the dedicated Acl4-Rpl4 study supports nuclear
+      localization.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: >-
+      Acl4 localizes to the nucleus as expected for a factor escorting Rpl4 to
+      nuclear pre-60S assembly sites.
+    supported_by:
+    - reference_id: PMID:26447800
+      supporting_text: "Acl4 localizes to both the cytoplasm and nucleus"
 - term:
     id: GO:0005737
     label: cytoplasm
   evidence_type: IDA
   original_reference_id: PMID:26447800
   review:
-    summary: 'Manual review: cytoplasm is consistent with known biology of ACL4.'
+    summary: >-
+      Direct microscopy supports cytoplasmic Acl4 localization.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: >-
+      Acl4 must encounter newly translated Rpl4 in the cytoplasm before nuclear
+      delivery, so this localization is mechanistically coherent.
+    supported_by:
+    - reference_id: PMID:26447800
+      supporting_text: "Acl4 localizes to both the cytoplasm and nucleus"
 - term:
     id: GO:0042273
     label: ribosomal large subunit biogenesis
   evidence_type: IMP
   original_reference_id: PMID:25936803
   review:
-    summary: 'Manual review: ribosomal large subunit biogenesis is consistent with known biology of ACL4.'
+    summary: >-
+      Mutant phenotype evidence shows that ACL4 is required for normal 60S
+      subunit production through Rpl4 assembly.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: >-
+      Acl4 shields Rpl4 until it can be inserted into the pre-ribosome; ACL4
+      loss causes large-subunit biogenesis defects, making this a core process.
+    supported_by:
+    - reference_id: PMID:25936803
+      supporting_text: "hierarchical ribosome assembly can be achieved by eukaryotic RP extensions and"
 - term:
     id: GO:0042273
     label: ribosomal large subunit biogenesis
   evidence_type: IMP
   original_reference_id: PMID:26447800
   review:
-    summary: 'Manual review: ribosomal large subunit biogenesis is consistent with known biology of ACL4.'
+    summary: >-
+      The dedicated chaperone study shows that Acl4 escorts Rpl4 to its nuclear
+      pre-60S assembly site and that loss of Acl4 compromises 60S production.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: >-
+      This is the central biological process for Acl4 and is supported by
+      genetic, localization, and biochemical evidence.
+    supported_by:
+    - reference_id: PMID:26447800
+      supporting_text: "deficiency in the production of 60S subunits"
 - term:
     id: GO:0051082
     label: unfolded protein binding
   evidence_type: IDA
   original_reference_id: PMID:25936803
   review:
-    summary: 'Manual review: unfolded protein binding is better represented by a more specific replacement term for ACL4.'
+    summary: >-
+      Acl4 does bind and protect unassembled Rpl4, but "unfolded protein
+      binding" is too generic and obscures the dedicated carrier-chaperone role.
     action: MODIFY
-    reason: Modified to align with current curation guidance and improve term specificity.
+    reason: >-
+      The evidence supports specific ribosomal-protein carrier chaperone
+      activity rather than generic binding to unfolded proteins.
     proposed_replacement_terms:
     - id: GO:0140597
-      label: protein carrier chaperone
+      label: protein carrier activity
+    supported_by:
+    - reference_id: file:yeast/ACL4/ACL4-deep-research-falcon.md
+      supporting_text: "Acl4 is a dedicated ribosomal protein chaperone"
 - term:
     id: GO:0140318
     label: protein transporter activity
   evidence_type: IDA
   original_reference_id: PMID:26447800
   review:
-    summary: 'Manual review: protein transporter activity is not sufficiently supported as a direct function of ACL4.'
-    action: REMOVE
-    reason: Removed due weak mechanistic support or likely misannotation for this gene.
+    summary: >-
+      The evidence supports Acl4 directly binding and escorting Rpl4 to the
+      pre-60S assembly pathway, matching the current definition of protein
+      transporter activity as binding and delivering a specific protein to a
+      cellular location.
+    action: ACCEPT
+    reason: >-
+      Acl4 is a dedicated ribosomal-protein carrier/chaperone for Rpl4, so the
+      annotation captures a core molecular function rather than a generic or
+      transmembrane transport claim.
+    supported_by:
+    - reference_id: PMID:26447800
+      supporting_text: "dedicated chaperone Acl4 accompanies Rpl4"
 - term:
     id: GO:0051083
-    label: '''de novo'' cotranslational protein folding'
+    label: "'de novo' cotranslational protein folding"
   evidence_type: HGI
   original_reference_id: PMID:19325107
   review:
-    summary: 'Manual review: ''de novo'' cotranslational protein folding is consistent with known biology of ACL4.'
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    summary: >-
+      Acl4 can capture nascent Rpl4 cotranslationally, but this high-throughput
+      genetic-interaction annotation is broad and does not define Acl4 as a
+      general cotranslational folding factor.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      The better-supported curation is the specific Rpl4 carrier-chaperone role
+      in ribosomal large subunit biogenesis. Retaining the broad folding process
+      as a core annotation would overstate the evidence.
 - term:
     id: GO:0005634
     label: nucleus
   evidence_type: HDA
   original_reference_id: PMID:14562095
   review:
-    summary: 'Manual review: nucleus is consistent with known biology of ACL4.'
+    summary: >-
+      High-throughput localization to nucleus is consistent with direct Acl4
+      localization and its nuclear pre-60S assembly role.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: >-
+      Multiple independent sources support nuclear localization.
 - term:
     id: GO:0005737
     label: cytoplasm
   evidence_type: HDA
   original_reference_id: PMID:14562095
   review:
-    summary: 'Manual review: cytoplasm is consistent with known biology of ACL4.'
+    summary: >-
+      High-throughput localization to cytoplasm is consistent with direct Acl4
+      localization and nascent Rpl4 capture.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: >-
+      Acl4 is distributed through cytoplasm and nucleus, matching its escort
+      function.
+core_functions:
+- molecular_function:
+    id: GO:0140597
+    label: protein carrier activity
+  directly_involved_in:
+  - id: GO:0042273
+    label: ribosomal large subunit biogenesis
+  locations:
+  - id: GO:0005737
+    label: cytoplasm
+  - id: GO:0005634
+    label: nucleus
+  description: >-
+    Acl4 is a dedicated carrier chaperone for Rpl4/uL4. It binds newly
+    synthesized Rpl4 in the cytoplasm, protects it from inappropriate
+    interactions or aggregation, and escorts it to nuclear pre-60S particles for
+    large ribosomal subunit assembly.
+  supported_by:
+  - reference_id: PMID:26447800
+    supporting_text: "dedicated chaperone Acl4 accompanies Rpl4"
+  - reference_id: file:yeast/ACL4/ACL4-deep-research-falcon.md
+    supporting_text: "Acl4 binds newly synthesized, free Rpl4"
+proposed_new_terms: []
+suggested_questions:
+- question: >-
+    Should PANTHER family PTHR46208 be split or have IBA propagation restricted
+    so TOM70 mitochondrial import terms do not transfer to the ACL4/Rpl4
+    assembly chaperone subfamily?
+suggested_experiments:
+- description: >-
+    Re-analyze ACL4, TOM70, and related PTHR46208 subfamilies with tree-aware
+    GO propagation to test whether mitochondrial import annotations segregate
+    away from the experimentally characterized Acl4/Rpl4 clade.
+  experiment_type: phylogenetic curation
+  hypothesis: >-
+    The ACL4 subfamily lacks the mitochondrial protein import functions present
+    in TOM70-like relatives and should not inherit those IBA terms.
 references:
 - id: GO_REF:0000033
   title: Annotation inferences using phylogenetic trees
@@ -197,4 +354,7 @@ references:
   findings: []
 - id: PMID:26447800
   title: The Dedicated Chaperone Acl4 Escorts Ribosomal Protein Rpl4 to Its Nuclear Pre-60S Assembly Site.
+  findings: []
+- id: file:yeast/ACL4/ACL4-deep-research-falcon.md
+  title: Falcon deep research report for ACL4
   findings: []

--- a/genes/yeast/ACL4/ACL4-ai-review.yaml
+++ b/genes/yeast/ACL4/ACL4-ai-review.yaml
@@ -247,9 +247,11 @@ existing_annotations:
       cellular location.
     action: ACCEPT
     reason: >-
-      Acl4 is a dedicated ribosomal-protein carrier/chaperone for Rpl4, so the
-      annotation captures a core molecular function rather than a generic or
-      transmembrane transport claim.
+      QuickGO places GO:0140318 under transporter activity and GO:0140597 under
+      molecular carrier activity rather than as a parent-child pair. Retaining
+      this SGD IDA annotation is therefore not a redundant parent annotation,
+      and the PMID:26447800 evidence supports Acl4 escorting Rpl4 to the
+      pre-60S assembly pathway.
     supported_by:
     - reference_id: PMID:26447800
       supporting_text: "dedicated chaperone Acl4 accompanies Rpl4"

--- a/genes/yeast/ACL4/ACL4-deep-research-falcon.md
+++ b/genes/yeast/ACL4/ACL4-deep-research-falcon.md
@@ -1,0 +1,325 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-04T10:06:12.943812'
+end_time: '2026-05-04T10:19:34.189355'
+duration_seconds: 801.25
+template_file: templates/gene_research_go_focused.md
+template_variables:
+  organism: yeast
+  gene_id: ACL4
+  gene_symbol: ACL4
+  uniprot_accession: Q03771
+  protein_description: 'RecName: Full=Assembly chaperone of RPL4 {ECO:0000303|PubMed:25936803};'
+  gene_info: Name=ACL4 {ECO:0000303|PubMed:25936803}; OrderedLocusNames=YDR161W {ECO:0000312|SGD:S000002568};
+  organism_full: Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+  protein_family: Belongs to the ACL4 family. .
+  protein_domains: TPR-like_helical_dom_sf. (IPR011990)
+provider_config:
+  timeout: 600
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 30
+---
+
+## Question
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** Q03771
+- **Protein Description:** RecName: Full=Assembly chaperone of RPL4 {ECO:0000303|PubMed:25936803};
+- **Gene Information:** Name=ACL4 {ECO:0000303|PubMed:25936803}; OrderedLocusNames=YDR161W {ECO:0000312|SGD:S000002568};
+- **Organism (full):** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+- **Protein Family:** Belongs to the ACL4 family. .
+- **Key Domains:** TPR-like_helical_dom_sf. (IPR011990)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "ACL4" matches the protein description above**
+2. **Verify the organism is correct:** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'ACL4' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **ACL4** (gene ID: ACL4, UniProt: Q03771) in yeast.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** Q03771
+- **Protein Description:** RecName: Full=Assembly chaperone of RPL4 {ECO:0000303|PubMed:25936803};
+- **Gene Information:** Name=ACL4 {ECO:0000303|PubMed:25936803}; OrderedLocusNames=YDR161W {ECO:0000312|SGD:S000002568};
+- **Organism (full):** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+- **Protein Family:** Belongs to the ACL4 family. .
+- **Key Domains:** TPR-like_helical_dom_sf. (IPR011990)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "ACL4" matches the protein description above**
+2. **Verify the organism is correct:** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'ACL4' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **ACL4** (gene ID: ACL4, UniProt: Q03771) in yeast.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Research Report: **Saccharomyces cerevisiae ACL4 (YDR161W; UniProt Q03771)**
+
+### Executive summary
+**Acl4** is a **dedicated assembly chaperone** for the 60S large-subunit ribosomal protein **Rpl4 (uL4)** in *Saccharomyces cerevisiae* (strain S288c). It binds a defined segment of the Rpl4 long internal loop, keeps nascent/unassembled Rpl4 soluble, and escorts it to the **nuclear pre-60S assembly site**, coordinating with the importin **Kap104**. Loss of ACL4 causes a severe slow-growth phenotype with hallmark 60S biogenesis defects (60S shortage and half-mers). More recent work (2022–2024) extends Acl4 biology to **cotranslational regulation of RPL4 mRNA abundance** via NAC/Caf130/Ccr4–Not circuitry, and links Acl4-limited conditions to aggregation/quality control networks that include the E3 ligase **Tom1**. (pillet2015thededicatedchaperone pages 1-2, huber2017molecularbasisfor pages 1-2, pillet2015thededicatedchaperone pages 10-12, schilke2024functionalsimilaritiesand pages 1-3, pillet2022dedicatedchaperonescoordinate pages 14-16, pillet2022dedicatedchaperonescoordinate pages 20-22)
+
+---
+
+### 1) Identity verification and key definitions
+#### 1.1 Target identity (mandatory verification)
+Primary literature explicitly identifies **Acl4 as yeast YDR161W** and characterizes it as the **dedicated chaperone for Rpl4**, matching the UniProt target **Q03771** and the stated domain annotation (TPR-like helical domain superfamily). (stelter2015coordinatedribosomall4 pages 3-3, pillet2015thededicatedchaperone pages 1-2, huber2017molecularbasisfor pages 1-2)
+
+#### 1.2 Key concepts (current understanding)
+- **Dedicated ribosomal-protein (RP) chaperone:** A specialized factor that binds one (or a small set of) ribosomal protein(s) to prevent aggregation/mislocalization and to promote safe delivery to the assembly site. Acl4 is dedicated for Rpl4. (pillet2015thededicatedchaperone pages 18-20, yang2024ribosomeassemblyand pages 1-3)
+- **Pre-60S assembly:** Stepwise nuclear maturation of the large ribosomal subunit, involving incorporation of RPs into pre-ribosomal particles and transient binding of biogenesis factors; Acl4 acts at the stage of delivering Rpl4 to early nuclear pre-60S particles. (pillet2015thededicatedchaperone pages 18-20, pillet2015thededicatedchaperone pages 20-21)
+- **Cotranslational capture:** Binding of a chaperone to a nascent client during translation; Acl4 enriches RPL4 mRNA in pull-downs, consistent with cotranslational engagement. (pillet2015thededicatedchaperone pages 17-18)
+
+---
+
+### 2) Molecular function and mechanism
+#### 2.1 Core function: chaperoning and escort of Rpl4/uL4
+Acl4 binds newly synthesized, free Rpl4, enabling **soluble expression** of Rpl4 and escorting it from cytoplasm to nuclear pre-60S assembly sites; Acl4 is not stably associated with mature 60S particles, consistent with a transient escort. (pillet2015thededicatedchaperone pages 1-2, pillet2015thededicatedchaperone pages 10-12)
+
+#### 2.2 Client-binding site on Rpl4
+Mapping in yeast indicates Acl4 recognizes the **C-terminal region of the long internal loop of Rpl4**, with functional mapping to approximately **aa 88–114** (and emphasis around ~101–114). Multiple alanine-block substitutions in this segment abolish the Acl4–Rpl4 interaction. (pillet2015thededicatedchaperone pages 14-17, pillet2015thededicatedchaperone pages 20-21)
+
+#### 2.3 Structural basis (TPR fold; sequestration of exposed residues)
+A high-resolution structure of the Acl4–RpL4 complex shows that Acl4 adopts an **α-helical TPR fold** (reported as **seven TPRs plus a C-terminal helix**) and uses its concave surface to **sequester ~70 exposed residues** of the elongated RpL4 loop, providing a mechanistic basis for preventing degradation/aggregation of unassembled L4. (huber2017molecularbasisfor pages 1-2, huber2017molecularbasisfor media 4aaddfb0, huber2017molecularbasisfor media cb2e78f3)
+
+#### 2.4 Nuclear import and Kap104 coupling
+A central mechanistic insight is that the **eukaryote-specific extension of Rpl4** contains overlapping determinants for Acl4 binding and the nuclear import factor **Kap104**, enabling continuous protection during import. In vitro, Kap104 can form a stoichiometric **Acl4–Rpl4–Kap104** trimer, and a schematic map of overlapping binding sites is provided in the structural work. (huber2017molecularbasisfor pages 1-2, pillet2015thededicatedchaperone pages 20-21, huber2017molecularbasisfor media e4ea49ee)
+
+---
+
+### 3) Subcellular localization and pathway placement
+#### 3.1 Localization
+Fluorescent tagging and fractionation show Acl4 is present in **both cytoplasm and nucleus** and is recovered in **soluble fractions**, not as a stable component of pre-60S or mature 60S particles. This supports a “carrier/escort” rather than “structural subunit” model. (pillet2015thededicatedchaperone pages 10-12)
+
+#### 3.2 Pathway role in large-subunit biogenesis
+Deletion of ACL4 causes a defect in **60S subunit production** and characteristic **half-mer polysomes**, consistent with impaired assembly or supply of an essential large-subunit RP to the nucleus and pre-60S particles. (stelter2015coordinatedribosomall4 pages 3-3, pillet2015thededicatedchaperone pages 10-12)
+
+---
+
+### 4) Phenotypes, statistics, and quantitative evidence
+#### 4.1 Growth and ribosome biogenesis phenotypes
+- **acl4Δ** is viable but has **severe slow growth** across tested temperatures and shows a **shortage of free 60S subunits**, **half-mer polysomes**, and reduced overall polysomes. (pillet2015thededicatedchaperone pages 10-12)
+- Growth and 60S defects can be **partially rescued by extra RPL4**, and deletion of ACL4 impairs 60S synthesis and yields half-mers. (stelter2015coordinatedribosomall4 pages 3-3, pillet2015thededicatedchaperone pages 14-17)
+
+#### 4.2 Cotranslational evidence (mRNA enrichment)
+Acl4 affinity purification shows strong enrichment of **RPL4 mRNA (~150-fold)**, supporting cotranslational recognition of nascent Rpl4. (pillet2015thededicatedchaperone pages 17-18)
+
+#### 4.3 RPL4 mRNA regulation (Acl4 availability as a rheostat)
+Recent work indicates Acl4 availability feeds back on RPL4 expression:
+- **RPL4 mRNA abundance is almost ~2-fold lower in Δacl4 cells** versus wild type, consistent with an Acl4-dependent stabilization effect. (pillet2022dedicatedchaperonescoordinate pages 14-16)
+- When Acl4 is absent/limiting, ribosome-associated Rpl4 nascent chain becomes accessible to regulatory machinery involving **NAC** and **Caf130-associated Ccr4–Not**, which promotes **RPL4 mRNA degradation**, limiting accumulation of aggregation-prone excess Rpl4. (pillet2022dedicatedchaperonescoordinate pages 1-4, schilke2024functionalsimilaritiesand pages 1-3)
+
+#### 4.4 Proteostasis/quality control linkage (Tom1)
+Deregulated Rpl4 expression promotes aggregation and proteostasis defects, particularly in **tom1Δ** backgrounds; in such assays, wild-type proteins show nucle(ol)ar signal in **<20%** of Δtom1 cells, whereas deregulated variants show strong nucle(ol)ar compartment signals in most Δtom1 cells. These observations link Acl4-dependent homeostasis to ubiquitin-ligase-dependent quality control. (pillet2022dedicatedchaperonescoordinate pages 20-22)
+
+#### 4.5 System-level scale statistics (context for why Acl4 matters)
+- In an exponentially growing yeast cell, there are ~**200,000 ribosomes**, requiring synthesis of **>2,000 ribosomes/minute** (≈160,000 ribosomal proteins per minute) to maintain growth—illustrating why tight control of RP supply (including Acl4-mediated handling of Rpl4) is crucial. (pillet2022dedicatedchaperonescoordinate pages 1-4)
+- Across eukaryotes, ribosome assembly requires **several hundred ribosome biogenesis factors (RBFs)**, compared with ~50 in bacteria, reflecting increased complexity and the need for specialized factors such as dedicated RP chaperones. (dorner2023ribosomebiogenesisfactors—from pages 1-2)
+- Yeast ribosomes contain **79 ribosomal proteins**, while humans have ~80; the 60S contains **46 RPs in yeast** and 47 in humans. (dorner2023ribosomebiogenesisfactors—from pages 1-2, yang2024ribosomeassemblyand pages 1-3)
+- Ribosome production is extremely resource-intensive (yeast allocation estimates include ~60% of transcription and ~50% of translation events, among others), motivating quality-control and repair/assembly-control systems. (yang2024ribosomeassemblyand pages 1-3)
+
+---
+
+### 5) Recent developments (prioritizing 2023–2024)
+#### 5.1 2024: Integration of Acl4 into cotranslational regulatory networks
+A 2024 study of NAC subunits in *S. cerevisiae* explicitly frames Acl4 as the specialized chaperone for Rpl4, noting that without Acl4 Rpl4 is aggregation-prone and cells grow very slowly. It further places Acl4-limited states into a regulatory pathway where Rpl4 mRNA is targeted for degradation via the **CCR4–Not** complex, and highlights quantitative NAC subunit abundance differences (Nacβ2 is ~20–100× less abundant than the major NAC subunits). (schilke2024functionalsimilaritiesand pages 1-3)
+
+#### 5.2 2023: Expert synthesis on why mechanistic annotation matters
+A high-citation 2023 EMBO Journal review argues that assigning **detailed molecular functions** to ribosome biogenesis factors is essential for understanding and treating diseases linked to disturbed ribosome assembly, including **ribosomopathies and cancers**. While Acl4 is not the focus, this review provides field-level justification for precise mechanistic annotation of factors like Acl4. (dorner2023ribosomebiogenesisfactors—from pages 1-2)
+
+#### 5.3 2024: Assembly and repair framework (expert view)
+A 2024 Annual Review article frames dedicated chaperones as part of the cellular strategy to manage small, basic, aggregation-prone RPs and maintain ribosome integrity through quality control and repair, with dedicated RP chaperones known for at least ~13 RPs. This strengthens the conceptual placement of Acl4 as a dedicated RP chaperone integrating assembly and proteostasis. (yang2024ribosomeassemblyand pages 1-3)
+
+---
+
+### 6) Current applications and real-world implementations
+#### 6.1 Yeast Acl4 as a model for conserved principles
+Acl4 exemplifies how eukaryotes solve the “RP handling problem” created by (i) cytoplasmic synthesis but nuclear assembly and (ii) aggregation propensity of basic RPs. Structural definition of the Acl4–L4 interface provides a mechanistic template for understanding analogous dedicated-chaperone systems and their coupling to nuclear import pathways (e.g., overlapping chaperone/importin binding sites). (huber2017molecularbasisfor pages 1-2, huber2017molecularbasisfor media e4ea49ee)
+
+#### 6.2 Disease relevance via ribosome biogenesis concepts
+Although Acl4 itself is a yeast protein, authoritative reviews stress that detailed knowledge of ribosome assembly factors is key for understanding disease states (ribosomopathies, cancers) linked to perturbed ribosome assembly and quality control, supporting the broader translational relevance of dissecting dedicated-chaperone mechanisms in model organisms. (dorner2023ribosomebiogenesisfactors—from pages 1-2, yang2024ribosomeassemblyand pages 1-3)
+
+---
+
+### 7) Visual evidence (structure and import coupling)
+Figures from the Acl4–RpL4 structural study show (i) the overall complex architecture, (ii) the interaction interface/hotspots, and (iii) a schematic of overlapping Acl4 and Kap104 binding sites on RpL4 (supporting the escort/import model). (huber2017molecularbasisfor media 4aaddfb0, huber2017molecularbasisfor media cb2e78f3, huber2017molecularbasisfor media e4ea49ee)
+
+---
+
+### Evidence summary table
+| Topic | Key findings | Key source(s) with year and DOI URL |
+|---|---|---|
+| Identity | **ACL4** in this report refers to **Saccharomyces cerevisiae YDR161W**, encoding **Acl4**, the dedicated assembly chaperone/escort for large-subunit ribosomal protein **Rpl4/uL4**; this matches UniProt **Q03771**. (stelter2015coordinatedribosomall4 pages 3-3, pillet2015thededicatedchaperone pages 1-2) | Pillet et al., 2015, PLOS Genet. https://doi.org/10.1371/journal.pgen.1005565; Stelter et al., 2015, Mol Cell. https://doi.org/10.1016/j.molcel.2015.03.029 |
+| Molecular function | Acl4 is a **dedicated ribosomal protein chaperone** that binds newly made, free Rpl4, promotes its soluble expression, protects exposed basic regions from inappropriate interactions/aggregation, and escorts it toward its nuclear pre-60S assembly site. (pillet2015thededicatedchaperone pages 18-20, huber2017molecularbasisfor pages 1-2, pillet2015thededicatedchaperone pages 17-18) | Pillet et al., 2015, PLOS Genet. https://doi.org/10.1371/journal.pgen.1005565; Huber & Hoelz, 2017, Nat Commun. https://doi.org/10.1038/ncomms14354 |
+| Client protein | The specific client is **Rpl4** (large-subunit protein uL4/eL4 family naming context), and affinity purification/pulse-chase evidence supports cotranslational capture of nascent Rpl4 by Acl4. (stelter2015coordinatedribosomall4 pages 3-3, pillet2015thededicatedchaperone pages 17-18) | Stelter et al., 2015, Mol Cell. https://doi.org/10.1016/j.molcel.2015.03.029; Pillet et al., 2015, PLOS Genet. https://doi.org/10.1371/journal.pgen.1005565 |
+| Binding region | Acl4 binds the **C-terminal part of Rpl4’s long internal loop**, with mapping to roughly **aa 88–114** and especially residues around **101–114**; multiple alanine-block substitutions disrupt binding. (pillet2015thededicatedchaperone pages 14-17, pillet2015thededicatedchaperone pages 20-21) | Pillet et al., 2015, PLOS Genet. https://doi.org/10.1371/journal.pgen.1005565 |
+| Structural fold/domain | Structural work shows Acl4 is an **α-helical TPR-family chaperone** with about **6.5–7 TPR repeats** plus a C-terminal helix, using its concave surface to sequester about **70 exposed residues** of the RpL4 loop. This agrees with the UniProt/IPR annotation of a **TPR-like helical domain**. (huber2017molecularbasisfor pages 1-2, pillet2015thededicatedchaperone pages 17-18, huber2017molecularbasisfor media 4aaddfb0) | Huber & Hoelz, 2017, Nat Commun. https://doi.org/10.1038/ncomms14354; Pillet et al., 2015, PLOS Genet. https://doi.org/10.1371/journal.pgen.1005565 |
+| Localization | Acl4 is detected in **both cytoplasm and nucleus** and is found in **soluble fractions** rather than stably bound to mature 60S or persistent pre-60S particles, fitting a transient escort function. (pillet2015thededicatedchaperone pages 1-2, pillet2015thededicatedchaperone pages 10-12) | Pillet et al., 2015, PLOS Genet. https://doi.org/10.1371/journal.pgen.1005565 |
+| Nuclear import mechanism | Acl4 lacks a predicted NLS, so the favored model is **co-import with Rpl4**. The **Rpl4 C-terminal eukaryote-specific extension** contains overlapping NLS/importin-binding determinants; **Kap104** can form a stoichiometric **Acl4–Rpl4–Kap104** trimer, and Ran-GTP is proposed to trigger release before assembly. (pillet2015thededicatedchaperone pages 18-20, huber2017molecularbasisfor pages 1-2, pillet2015thededicatedchaperone pages 20-21, huber2017molecularbasisfor media e4ea49ee) | Pillet et al., 2015, PLOS Genet. https://doi.org/10.1371/journal.pgen.1005565; Huber & Hoelz, 2017, Nat Commun. https://doi.org/10.1038/ncomms14354 |
+| Role in pre-60S assembly | Acl4 delivers Rpl4 to the **early nuclear pre-60S assembly site**. It associates only **very transiently** with early pre-60S particles, and release is coupled to proper Rpl4 insertion, including contacts involving Rpl4’s eukaryote-specific extension and neighboring 60S components such as **Rpl18/Rpl7/ES7L**. (pillet2015thededicatedchaperone pages 18-20, pillet2015thededicatedchaperone pages 20-21) | Pillet et al., 2015, PLOS Genet. https://doi.org/10.1371/journal.pgen.1005565 |
+| Phenotypes | **acl4Δ** cells are viable but show **severe slow growth** at multiple temperatures, **60S deficiency**, **half-mer polysomes**, reduced overall polysomes, and pre-rRNA processing defects (reduced **27SB** and **7S**). Extra **RPL4** can partially suppress the defect; combined loss with **RPL4A** worsens growth. (stelter2015coordinatedribosomall4 pages 3-3, pillet2015thededicatedchaperone pages 14-17, pillet2015thededicatedchaperone pages 10-12) | Stelter et al., 2015, Mol Cell. https://doi.org/10.1016/j.molcel.2015.03.029; Pillet et al., 2015, PLOS Genet. https://doi.org/10.1371/journal.pgen.1005565 |
+| Quality control / proteostasis link | Acl4 protects unassembled Rpl4 from **Tom1-linked degradation/quality control** and from aggregation. When Acl4 is limiting or Rpl4 expression is deregulated, RPL4 mRNA can be downregulated through **NAC–Caf130–Ccr4-Not** circuitry, while excess Rpl4 becomes aggregation-prone, especially in **tom1Δ** cells. (huber2017molecularbasisfor pages 1-2, schilke2024functionalsimilaritiesand pages 1-3, pillet2022dedicatedchaperonescoordinate pages 1-4, pillet2022dedicatedchaperonescoordinate pages 14-16, pillet2022dedicatedchaperonescoordinate pages 20-22) | Huber & Hoelz, 2017, Nat Commun. https://doi.org/10.1038/ncomms14354; Pillet et al., 2022, bioRxiv. https://doi.org/10.1101/2021.10.05.463164; Schilke et al., 2024, Cell Stress Chaperones. https://doi.org/10.1016/j.cstres.2024.10.004 |
+| Recent developments (2022–2024) | Recent work extends Acl4 biology beyond escort alone: cotranslational Acl4 binding helps **stabilize RPL4 mRNA**, whereas limited Acl4 exposes nascent Rpl4 to **CCR4–Not-dependent mRNA decay** and proteostasis stress; 2024 analysis of **NAC subunits** further supports this regulatory network. Broader 2023–2024 reviews frame dedicated RP chaperones like Acl4 as central nodes in ribosome biogenesis and quality control. (schilke2024functionalsimilaritiesand pages 1-3, pillet2022dedicatedchaperonescoordinate pages 1-4, pillet2022dedicatedchaperonescoordinate pages 14-16) | Pillet et al., 2022, bioRxiv. https://doi.org/10.1101/2021.10.05.463164; Schilke et al., 2024, Cell Stress Chaperones. https://doi.org/10.1016/j.cstres.2024.10.004 |
+
+
+*Table: This table summarizes the core functional-annotation evidence for Saccharomyces cerevisiae Acl4/YDR161W, including identity verification, mechanism, localization, pre-60S role, and recent regulatory insights. It is useful as a compact evidence-backed reference for gene/protein annotation.*
+
+---
+
+### Key references (with URLs and publication dates)
+- Pillet B. et al. **The Dedicated Chaperone Acl4 Escorts Ribosomal Protein Rpl4 to Its Nuclear Pre-60S Assembly Site.** *PLOS Genetics* (Oct 2015). https://doi.org/10.1371/journal.pgen.1005565 (pillet2015thededicatedchaperone pages 1-2, pillet2015thededicatedchaperone pages 10-12)
+- Stelter P. et al. **Coordinated Ribosomal L4 Protein Assembly into the Pre-Ribosome Is Regulated by Its Eukaryote-Specific Extension.** *Molecular Cell* (Jun 2015). https://doi.org/10.1016/j.molcel.2015.03.029 (stelter2015coordinatedribosomall4 pages 3-3)
+- Huber F.M., Hoelz A. **Molecular basis for protection of ribosomal protein L4 from cellular degradation.** *Nature Communications* (Feb 2017). https://doi.org/10.1038/ncomms14354 (huber2017molecularbasisfor pages 1-2)
+- Pillet B. et al. **Dedicated chaperones coordinate co-translational regulation of ribosomal protein production with ribosome assembly to preserve proteostasis.** *bioRxiv* (posted Oct 2022). https://doi.org/10.1101/2021.10.05.463164 (pillet2022dedicatedchaperonescoordinate pages 1-4, pillet2022dedicatedchaperonescoordinate pages 14-16)
+- Dörner K. et al. **Ribosome biogenesis factors—from names to functions.** *The EMBO Journal* (Feb 2023). https://doi.org/10.15252/embj.2022112699 (dorner2023ribosomebiogenesisfactors—from pages 1-2)
+- Schilke B.A. et al. **Functional similarities and differences among subunits of the NAC of Saccharomyces cerevisiae.** *Cell Stress and Chaperones* (Dec 2024). https://doi.org/10.1016/j.cstres.2024.10.004 (schilke2024functionalsimilaritiesand pages 1-3)
+- Yang Y.-M., Karbstein K. **Ribosome Assembly and Repair.** *Annual Review of Cell and Developmental Biology* (Oct 2024). https://doi.org/10.1146/annurev-cellbio-111822-113326 (yang2024ribosomeassemblyand pages 1-3)
+
+
+References
+
+1. (pillet2015thededicatedchaperone pages 1-2): Benjamin Pillet, Juan J. García-Gómez, Patrick Pausch, Laurent Falquet, Gert Bange, Jesús de la Cruz, and Dieter Kressler. The dedicated chaperone acl4 escorts ribosomal protein rpl4 to its nuclear pre-60s assembly site. PLOS Genetics, 11:e1005565, Oct 2015. URL: https://doi.org/10.1371/journal.pgen.1005565, doi:10.1371/journal.pgen.1005565. This article has 84 citations and is from a domain leading peer-reviewed journal.
+
+2. (huber2017molecularbasisfor pages 1-2): Ferdinand M. Huber and André Hoelz. Molecular basis for protection of ribosomal protein l4 from cellular degradation. Nature Communications, Feb 2017. URL: https://doi.org/10.1038/ncomms14354, doi:10.1038/ncomms14354. This article has 37 citations and is from a highest quality peer-reviewed journal.
+
+3. (pillet2015thededicatedchaperone pages 10-12): Benjamin Pillet, Juan J. García-Gómez, Patrick Pausch, Laurent Falquet, Gert Bange, Jesús de la Cruz, and Dieter Kressler. The dedicated chaperone acl4 escorts ribosomal protein rpl4 to its nuclear pre-60s assembly site. PLOS Genetics, 11:e1005565, Oct 2015. URL: https://doi.org/10.1371/journal.pgen.1005565, doi:10.1371/journal.pgen.1005565. This article has 84 citations and is from a domain leading peer-reviewed journal.
+
+4. (schilke2024functionalsimilaritiesand pages 1-3): Brenda A. Schilke, Thomas Ziegelhoffer, Przemyslaw Domanski, Jaroslaw Marszalek, Bartlomiej Tomiczek, and Elizabeth A. Craig. Functional similarities and differences among subunits of the nascent polypeptide-associated complex (nac) of saccharomyces cerevisiae. Cell Stress and Chaperones, 29:721-734, Dec 2024. URL: https://doi.org/10.1016/j.cstres.2024.10.004, doi:10.1016/j.cstres.2024.10.004. This article has 1 citations and is from a peer-reviewed journal.
+
+5. (pillet2022dedicatedchaperonescoordinate pages 14-16): Benjamin Pillet, Alfonso Méndez-Godoy, Guillaume Murat, Sébastien Favre, Michael Stumpe, Laurent Falquet, and Dieter Kressler. Dedicated chaperones coordinate co-translational regulation of ribosomal protein production with ribosome assembly to preserve proteostasis. BioRxiv, Oct 2022. URL: https://doi.org/10.1101/2021.10.05.463164, doi:10.1101/2021.10.05.463164. This article has 30 citations.
+
+6. (pillet2022dedicatedchaperonescoordinate pages 20-22): Benjamin Pillet, Alfonso Méndez-Godoy, Guillaume Murat, Sébastien Favre, Michael Stumpe, Laurent Falquet, and Dieter Kressler. Dedicated chaperones coordinate co-translational regulation of ribosomal protein production with ribosome assembly to preserve proteostasis. BioRxiv, Oct 2022. URL: https://doi.org/10.1101/2021.10.05.463164, doi:10.1101/2021.10.05.463164. This article has 30 citations.
+
+7. (stelter2015coordinatedribosomall4 pages 3-3): Philipp Stelter, Ferdinand M. Huber, Ruth Kunze, Dirk Flemming, André Hoelz, and Ed Hurt. Coordinated ribosomal l4 protein assembly into the pre-ribosome is regulated by its eukaryote-specific extension. Molecular cell, 58 5:854-62, Jun 2015. URL: https://doi.org/10.1016/j.molcel.2015.03.029, doi:10.1016/j.molcel.2015.03.029. This article has 78 citations and is from a highest quality peer-reviewed journal.
+
+8. (pillet2015thededicatedchaperone pages 18-20): Benjamin Pillet, Juan J. García-Gómez, Patrick Pausch, Laurent Falquet, Gert Bange, Jesús de la Cruz, and Dieter Kressler. The dedicated chaperone acl4 escorts ribosomal protein rpl4 to its nuclear pre-60s assembly site. PLOS Genetics, 11:e1005565, Oct 2015. URL: https://doi.org/10.1371/journal.pgen.1005565, doi:10.1371/journal.pgen.1005565. This article has 84 citations and is from a domain leading peer-reviewed journal.
+
+9. (yang2024ribosomeassemblyand pages 1-3): Yoon-Mo Yang and Katrin Karbstein. Ribosome assembly and repair. Annual Review of Cell and Developmental Biology, 40:241-264, Oct 2024. URL: https://doi.org/10.1146/annurev-cellbio-111822-113326, doi:10.1146/annurev-cellbio-111822-113326. This article has 18 citations and is from a domain leading peer-reviewed journal.
+
+10. (pillet2015thededicatedchaperone pages 20-21): Benjamin Pillet, Juan J. García-Gómez, Patrick Pausch, Laurent Falquet, Gert Bange, Jesús de la Cruz, and Dieter Kressler. The dedicated chaperone acl4 escorts ribosomal protein rpl4 to its nuclear pre-60s assembly site. PLOS Genetics, 11:e1005565, Oct 2015. URL: https://doi.org/10.1371/journal.pgen.1005565, doi:10.1371/journal.pgen.1005565. This article has 84 citations and is from a domain leading peer-reviewed journal.
+
+11. (pillet2015thededicatedchaperone pages 17-18): Benjamin Pillet, Juan J. García-Gómez, Patrick Pausch, Laurent Falquet, Gert Bange, Jesús de la Cruz, and Dieter Kressler. The dedicated chaperone acl4 escorts ribosomal protein rpl4 to its nuclear pre-60s assembly site. PLOS Genetics, 11:e1005565, Oct 2015. URL: https://doi.org/10.1371/journal.pgen.1005565, doi:10.1371/journal.pgen.1005565. This article has 84 citations and is from a domain leading peer-reviewed journal.
+
+12. (pillet2015thededicatedchaperone pages 14-17): Benjamin Pillet, Juan J. García-Gómez, Patrick Pausch, Laurent Falquet, Gert Bange, Jesús de la Cruz, and Dieter Kressler. The dedicated chaperone acl4 escorts ribosomal protein rpl4 to its nuclear pre-60s assembly site. PLOS Genetics, 11:e1005565, Oct 2015. URL: https://doi.org/10.1371/journal.pgen.1005565, doi:10.1371/journal.pgen.1005565. This article has 84 citations and is from a domain leading peer-reviewed journal.
+
+13. (huber2017molecularbasisfor media 4aaddfb0): Ferdinand M. Huber and André Hoelz. Molecular basis for protection of ribosomal protein l4 from cellular degradation. Nature Communications, Feb 2017. URL: https://doi.org/10.1038/ncomms14354, doi:10.1038/ncomms14354. This article has 37 citations and is from a highest quality peer-reviewed journal.
+
+14. (huber2017molecularbasisfor media cb2e78f3): Ferdinand M. Huber and André Hoelz. Molecular basis for protection of ribosomal protein l4 from cellular degradation. Nature Communications, Feb 2017. URL: https://doi.org/10.1038/ncomms14354, doi:10.1038/ncomms14354. This article has 37 citations and is from a highest quality peer-reviewed journal.
+
+15. (huber2017molecularbasisfor media e4ea49ee): Ferdinand M. Huber and André Hoelz. Molecular basis for protection of ribosomal protein l4 from cellular degradation. Nature Communications, Feb 2017. URL: https://doi.org/10.1038/ncomms14354, doi:10.1038/ncomms14354. This article has 37 citations and is from a highest quality peer-reviewed journal.
+
+16. (pillet2022dedicatedchaperonescoordinate pages 1-4): Benjamin Pillet, Alfonso Méndez-Godoy, Guillaume Murat, Sébastien Favre, Michael Stumpe, Laurent Falquet, and Dieter Kressler. Dedicated chaperones coordinate co-translational regulation of ribosomal protein production with ribosome assembly to preserve proteostasis. BioRxiv, Oct 2022. URL: https://doi.org/10.1101/2021.10.05.463164, doi:10.1101/2021.10.05.463164. This article has 30 citations.
+
+17. (dorner2023ribosomebiogenesisfactors—from pages 1-2): Kerstin Dörner, Chiara Ruggeri, Ivo Zemp, and Ulrike Kutay. Ribosome biogenesis factors—from names to functions. The EMBO Journal, Feb 2023. URL: https://doi.org/10.15252/embj.2022112699, doi:10.15252/embj.2022112699. This article has 201 citations.
+
+## Citations
+
+1. pillet2015thededicatedchaperone pages 17-18
+2. pillet2015thededicatedchaperone pages 10-12
+3. pillet2022dedicatedchaperonescoordinate pages 14-16
+4. pillet2022dedicatedchaperonescoordinate pages 20-22
+5. pillet2022dedicatedchaperonescoordinate pages 1-4
+6. yang2024ribosomeassemblyand pages 1-3
+7. schilke2024functionalsimilaritiesand pages 1-3
+8. huber2017molecularbasisfor pages 1-2
+9. pillet2015thededicatedchaperone pages 1-2
+10. pillet2015thededicatedchaperone pages 18-20
+11. pillet2015thededicatedchaperone pages 20-21
+12. pillet2015thededicatedchaperone pages 14-17
+13. https://doi.org/10.1371/journal.pgen.1005565;
+14. https://doi.org/10.1016/j.molcel.2015.03.029
+15. https://doi.org/10.1038/ncomms14354
+16. https://doi.org/10.1016/j.molcel.2015.03.029;
+17. https://doi.org/10.1371/journal.pgen.1005565
+18. https://doi.org/10.1038/ncomms14354;
+19. https://doi.org/10.1101/2021.10.05.463164;
+20. https://doi.org/10.1016/j.cstres.2024.10.004
+21. https://doi.org/10.1101/2021.10.05.463164
+22. https://doi.org/10.15252/embj.2022112699
+23. https://doi.org/10.1146/annurev-cellbio-111822-113326
+24. https://doi.org/10.1371/journal.pgen.1005565,
+25. https://doi.org/10.1038/ncomms14354,
+26. https://doi.org/10.1016/j.cstres.2024.10.004,
+27. https://doi.org/10.1101/2021.10.05.463164,
+28. https://doi.org/10.1016/j.molcel.2015.03.029,
+29. https://doi.org/10.1146/annurev-cellbio-111822-113326,
+30. https://doi.org/10.15252/embj.2022112699,

--- a/genes/yeast/PNC1/PNC1-ai-review.html
+++ b/genes/yeast/PNC1/PNC1-ai-review.html
@@ -671,42 +671,42 @@
     <div class="header">
         <h1>PNC1</h1>
         <div class="gene-info">
-            
+
             <div class="info-item">
-                
+
                 <span class="info-label">UniProt ID:</span>
                 <span>
                     <a href="https://www.uniprot.org/uniprotkb/P53184" target="_blank" class="term-link">
                         P53184
                     </a>
                 </span>
-                
+
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Organism:</span>
                 <span>Saccharomyces cerevisiae</span>
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
-                <span class="status-badge status-draft">
-                    DRAFT
+                <span class="status-badge status-complete">
+                    COMPLETE
                 </span>
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Aliases:</span>
                 <div class="aliases">
-                    
+
                     <span class="badge">YGL037C</span>
-                    
+
                 </div>
             </div>
-            
+
         </div>
         <div style="margin-top: 1rem; text-align: center;">
             <a id="feedback-form-link"
@@ -737,24 +737,24 @@
         </div>
     </div>
 
-    
+
     <div class="description-card">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <h2>Gene Description</h2>
-            <span class="vote-buttons" data-g="P53184" data-a="DESCRIPTION: Nicotinamidase (Pnc1p), a key enzyme in the NAD+ s..." data-r="" data-act="DESCRIPTION">
+            <span class="vote-buttons" data-g="P53184" data-a="DESCRIPTION: PNC1 encodes the zinc-dependent nicotinamidase Pnc..." data-r="" data-act="DESCRIPTION">
                 <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
                 <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
             </span>
         </div>
-        <p>Nicotinamidase (Pnc1p), a key enzyme in the NAD+ salvage pathway that catalyzes deamidation of nicotinamide to nicotinic acid. Plays critical roles in NAD+ metabolism and is a longevity gene responsive to caloric restriction and stress conditions. Functions in telomeric and rDNA silencing through Sir2p regulation. Localizes to cytoplasm, nucleus, and peroxisomes.</p>
+        <p>PNC1 encodes the zinc-dependent nicotinamidase Pnc1, the yeast enzyme that deamidates nicotinamide to nicotinate and ammonia in the NAD+ salvage pathway. By clearing nicotinamide, a Sir2 inhibitor, Pnc1 supports nicotinate nucleotide salvage and indirectly promotes Sir2-dependent telomeric and rDNA heterochromatin functions, lifespan responses to calorie restriction, and regulation of rDNA copy-number amplification. Pnc1 is cytoplasmic, nuclear, and peroxisomal, with stress-responsive regulation and peroxisomal enrichment.</p>
     </div>
-    
 
-    
 
-    
 
-    
+
+
+
+
     <div class="section">
         <h2 class="section-title">Existing Annotations Review</h2>
         <table class="annotations-table">
@@ -767,83 +767,83 @@
                 </tr>
             </thead>
             <tbody>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000781" target="_blank" class="term-link">
                                     GO:0000781
                                 </a>
                             </span>
                             <span class="term-label">chromosome, telomeric region</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000108
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="P53184" data-a="GO:0000781" data-r="GO_REF:0000108" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P53184" data-a="GO:0000781" data-r="GO_REF:0000108" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Localization to telomeric chromatin is inferred computationally. While PNC1 is known to regulate telomeric silencing, the IEA inference mechanism (logical inference) is based on the IMP annotation for subtelomeric heterochromatin formation. This is acceptable as it represents a reasonable inference from the mechanistic role of PNC1, but it is not a direct experimental observation of localization to telomeric regions.
+                            <strong>Summary:</strong> This computational logical inference derives from PNC1 involvement in subtelomeric heterochromatin formation. The literature supports nuclear Pnc1 activity and effects on telomeric silencing, but not direct localization of Pnc1 to telomeric chromatin.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> The annotation reflects PNC1s regulatory role in telomeric silencing, though based on computational inference rather than direct localization evidence. The mechanistic connection is sound: PNC1 removes nicotinamide (an inhibitor of Sir2) to enable Sir2-mediated telomeric heterochromatin formation (PMID:11901108, PMID:12736687). This is supported by IDA evidence for nuclear localization and functional involvement in telomeric silencing.
+                            <strong>Reason:</strong> Pnc1 regulates telomeric silencing by removing nicotinamide and thereby supporting Sir2 activity. A telomeric-region cellular component annotation overstates the evidence because Pnc1 is not shown to be a telomere-bound chromatin protein.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -855,46 +855,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Subcellular localization inferred from UniProtKB localization vocabulary mapping. Consistent with direct experimental evidence (PMID:12736687, PMID:11901108).
+                            <strong>Summary:</strong> UniProt subcellular-location mapping to nucleus is consistent with direct Pnc1 localization evidence and its nuclear role in Sir2-dependent silencing.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Nuclear localization is well-supported by IDA evidence from microscopy (PMID:12736687). The IEA annotation is derived from UniProtKB annotation and is accurate. PNC1 functions in the nucleus where Sir2p-mediated silencing occurs.
+                            <strong>Reason:</strong> Nuclear localization is supported experimentally and is mechanistically consistent with Pnc1 effects on rDNA and telomeric silencing.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -906,46 +906,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Subcellular localization based on UniProtKB mapping. Verified by experimental evidence (IDA, PMID:12736687).
+                            <strong>Summary:</strong> Automated cytoplasmic localization is consistent with direct microscopy evidence and Pnc1&#39;s general metabolic role.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Cytoplasmic localization is directly demonstrated by microscopy (IDA, PMID:12736687) and is consistent with the functional roles in NAD metabolism. This is appropriate.
+                            <strong>Reason:</strong> Pnc1 is observed in the cytoplasm and participates in cellular nicotinamide salvage.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005777" target="_blank" class="term-link">
                                     GO:0005777
                                 </a>
                             </span>
                             <span class="term-label">peroxisome</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -957,46 +957,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Peroxisomal localization inferred from UniProtKB mapping. Well-supported by experimental evidence showing PNC1 concentrates in peroxisomes (PMID:12736687).
+                            <strong>Summary:</strong> UniProt peroxisome mapping is consistent with direct evidence that Pnc1 concentrates in peroxisomal foci, particularly in stress contexts.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> UniProtKB annotation notes that PNC1 concentrates in peroxisomes, which is verified by direct microscopy (PMID:12736687). Peroxisomal localization is relevant to cellular NAD metabolism and stress response functions. This localization is properly supported by literature.
+                            <strong>Reason:</strong> Peroxisomal localization is supported by experimental localization studies and is part of Pnc1&#39;s condition-dependent subcellular distribution.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008936" target="_blank" class="term-link">
                                     GO:0008936
                                 </a>
                             </span>
                             <span class="term-label">nicotinamidase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1008,113 +1008,124 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Molecular function annotation assigned via combined automated methods, likely based on EC number (3.5.1.19) and sequence homology. This is the core enzymatic function of PNC1.
+                            <strong>Summary:</strong> Automated assignment of nicotinamidase activity matches Pnc1&#39;s core enzymatic activity and EC 3.5.1.19.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Nicotinamidase activity is the primary and well-characterized enzymatic function of PNC1. The EC number 3.5.1.19 directly classifies it as a nicotinamidase. This is strongly supported by multiple publications (PMID:12736687, PMID:11901108, PMID:19381334) demonstrating the catalytic conversion of nicotinamide to nicotinic acid. This is a core and essential annotation.
+                            <strong>Reason:</strong> Pnc1 catalyzes hydrolysis of nicotinamide to nicotinate and ammonia, the central molecular function of this gene product.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     file:yeast/PNC1/PNC1-deep-research-falcon.md
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">PNC1 (gene YGL037C) encodes nicotinamidase (EC 3.5.1.19) in Saccharomyces cerevisiae (strain S288c).</div>
-                                
+
+                                <div class="support-text">PNC1 (gene YGL037C) encodes nicotinamidase (EC 3.5.1.19)</div>
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016787" target="_blank" class="term-link">
                                     GO:0016787
                                 </a>
                             </span>
                             <span class="term-label">hydrolase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="P53184" data-a="GO:0016787" data-r="GO_REF:0000043" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P53184" data-a="GO:0016787" data-r="GO_REF:0000043" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Parent term for nicotinamidase activity based on enzyme classification. GO:0008936 (nicotinamidase activity) is more specific and informative. However, the parent term is not incorrect.
+                            <strong>Summary:</strong> Hydrolase activity is a true but generic parent of nicotinamidase activity. The specific nicotinamidase term is already present.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> This is the correct parent term for the specific nicotinamidase activity. Nicotinamidases are amidohydrolases (EC 3.5.1.19), so this annotation is mechanistically accurate. While the more specific term (GO:0008936) is preferable for precision, retaining this parent term is acceptable for comprehensive annotation coverage. Parent and child GO terms can coexist.
+                            <strong>Reason:</strong> For curation, GO:0008936 captures the actual enzyme activity and should be preferred over the broad hydrolase parent.
                         </div>
-                        
-                        
-                        
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008936" target="_blank" class="term-link">
+                                    nicotinamidase activity
+                                </a>
+                            </span>
+
+                        </div>
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019363" target="_blank" class="term-link">
                                     GO:0019363
                                 </a>
                             </span>
                             <span class="term-label">pyridine nucleotide biosynthetic process</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -1126,119 +1137,130 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Process annotation derived from UniProtKB keyword mapping (KW-0662: Pyridine nucleotide biosynthesis). PNC1 is involved in NAD+ salvage pathway, which recycles pyridine nucleotides. This is a reasonable but somewhat indirect annotation.
+                            <strong>Summary:</strong> Pnc1 participates in pyridine nucleotide salvage by converting nicotinamide to nicotinate, but the more precise existing process term is nicotinate nucleotide salvage.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> While PNC1 is mechanistically involved in NAD+ salvage (not de novo biosynthesis), GO:0019363 &#34;pyridine nucleotide biosynthetic process&#34; typically refers to de novo synthesis pathways (e.g., starting from tryptophan). PNC1 catalyzes salvage of nicotinamide to regenerate NAD+ in an existing pool, not biosynthesis of pyridine nucleotides de novo. The more accurate annotation would be GO:0019854 NAD metabolism because PNC1 catalyzes the first committed step in salvaging NAD+ from nicotinamide (PMID:12736687). This is NAD metabolism, not pyridine nucleotide de novo biosynthesis.
+                            <strong>Reason:</strong> Pnc1 is not a broad de novo pyridine nucleotide biosynthesis factor. It catalyzes the nicotinamide entry step into the nicotinate salvage route, which is captured by GO:0019358.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019854" target="_blank" class="term-link">
-                                    NAD metabolism
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019358" target="_blank" class="term-link">
+                                    nicotinate nucleotide salvage
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046872" target="_blank" class="term-link">
                                     GO:0046872
                                 </a>
                             </span>
                             <span class="term-label">metal ion binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="P53184" data-a="GO:0046872" data-r="GO_REF:0000043" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P53184" data-a="GO:0046872" data-r="GO_REF:0000043" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Parent term inferred from UniProtKB keywords for metal binding. PNC1 requires zinc cofactor for catalysis, so this is accurate but very general. The more specific annotation (GO:0008270, zinc ion binding) is already present with experimental evidence.
+                            <strong>Summary:</strong> Metal ion binding is accurate but generic; Pnc1 specifically binds zinc as part of its nicotinamidase active site.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> This is correct as a parent term annotation. Zinc is a metal ion, and PNC1 binds zinc as a catalytic cofactor. While GO:0008270 (zinc ion binding) is more specific and is annotated separately, the parent term is not incorrect and provides complementary information. Parent-child GO terms are often both retained for annotation completeness.
+                            <strong>Reason:</strong> The more informative term is zinc ion binding, already supported by curated evidence and structural/mechanistic context.
                         </div>
-                        
-                        
-                        
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008270" target="_blank" class="term-link">
+                                    zinc ion binding
+                                </a>
+                            </span>
+
+                        </div>
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008270" target="_blank" class="term-link">
                                     GO:0008270
                                 </a>
                             </span>
                             <span class="term-label">zinc ion binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">RCA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/30358795" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:30358795
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The cellular economy of the Saccharomyces cerevisiae zinc pr...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1250,155 +1272,155 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Zinc ion binding assignment based on rapid curated annotation (RCA) from a zinc proteome analysis study. The study comprehensively catalogued zinc-binding proteins in yeast and is appropriate evidence for this annotation.
+                            <strong>Summary:</strong> Rapid curated annotation from yeast zinc proteome analysis is consistent with the known zinc-dependent nicotinamidase active site of Pnc1.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> RCA (rapid curated annotation) is appropriate for identifying PNC1 as a zinc-binding protein. The source (PMID:30358795) is a comprehensive zinc proteome study that systematically identified and characterized zinc-binding sites on proteins. Zinc is essential for the catalytic mechanism of nicotinamidases, confirmed by structural studies showing zinc binding sites at positions 51, 53, and 94 in the PNC1 protein.
+                            <strong>Reason:</strong> Zinc binding is mechanistically appropriate for Pnc1&#39;s catalytic function.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/30358795" target="_blank" class="term-link">
                                         PMID:30358795
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The cellular economy of the Saccharomyces cerevisiae zinc proteome.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031509" target="_blank" class="term-link">
                                     GO:0031509
                                 </a>
                             </span>
                             <span class="term-label">subtelomeric heterochromatin formation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/11901108" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:11901108
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Telomeric and rDNA silencing in Saccharomyces cerevisiae are...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P53184" data-a="GO:0031509" data-r="PMID:11901108" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P53184" data-a="GO:0031509" data-r="PMID:11901108" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Mutant phenotype annotation showing PNC1 deletion results in weakened subtelomeric heterochromatin silencing. This is one of the key functional roles identified for PNC1 in the literature.
+                            <strong>Summary:</strong> pnc1 deletion causes telomeric silencing defects through impaired nicotinamide clearance and reduced Sir2-dependent chromatin function.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> This is a core functional annotation based on IMP evidence from PMID:11901108, which demonstrates that pnc1 deletion results in a silencing defect at telomeres and rDNA. The mechanism is clear: PNC1 removes nicotinamide, an inhibitor of the Sir2 histone deacetylase, thereby enabling Sir2-mediated heterochromatin formation and silencing. The annotation is mechanistically sound and well-supported. This should be considered a core function of PNC1.
+                            <strong>Reason:</strong> The phenotype is well supported, but it is a downstream chromatin outcome of Pnc1&#39;s core nicotinamidase/NAD salvage activity rather than an independent chromatin-binding function.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/11901108" target="_blank" class="term-link">
                                         PMID:11901108
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">Deletion of another NAD(+) salvage pathway gene called PNC1 caused a less severe silencing defect and did not significantly reduce the intracellular NAD(+) concentration. However, silencing in the absence of PNC1 was completely dependent on the import of nicotinic acid from the growth medium</div>
-                                
+
+                                <div class="support-text">Deletion of another NAD(+) salvage pathway gene called PNC1 caused a less severe silencing defect</div>
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019358" target="_blank" class="term-link">
                                     GO:0019358
                                 </a>
                             </span>
                             <span class="term-label">nicotinate nucleotide salvage</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/11901108" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:11901108
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Telomeric and rDNA silencing in Saccharomyces cerevisiae are...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1410,75 +1432,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Functional role annotation showing PNC1 participates in the salvage pathway for nicotinic acid-derived nucleotides. The pathway involves conversion of nicotinamide to nicotinic acid (catalyzed by PNC1) followed by conversion back to NAD+.
+                            <strong>Summary:</strong> Genetic evidence supports Pnc1 as a component of the NAD+ salvage pathway, converting nicotinamide to nicotinate for reuse.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> This annotation correctly identifies PNC1s participation in nicotinate nucleotide salvage. PNC1 catalyzes the first step - deamidation of nicotinamide to nicotinic acid - which is the entry point into the salvage pathway. PMID:11901108 directly demonstrates that deletion of PNC1 compromises the salvage pathway capacity. This is a core biological function of the enzyme and is properly supported by IMP evidence.
+                            <strong>Reason:</strong> This is the core biological process associated with Pnc1&#39;s enzymatic activity and explains the Sir2-related phenotypes.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/11901108" target="_blank" class="term-link">
                                         PMID:11901108
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">We propose a model in which two components of the NAD(+) salvage pathway, Pnc1p and Npt1p, function together in recycling the nuclear nicotinamide generated by Sir2p deacetylase activity back into NAD(+)</div>
-                                
+
+                                <div class="support-text">Pnc1p and Npt1p function together in recycling the nuclear nicotinamide</div>
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/22842922" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:22842922
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Dissecting DNA damage response pathways by analysing protein...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1490,235 +1512,235 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> HDA (high-throughput direct assay) annotation for cytoplasmic localization from a DNA damage response study. This provides complementary evidence to the IDA annotations.
+                            <strong>Summary:</strong> High-throughput direct assay evidence supports cytoplasmic localization.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> HDA is appropriate evidence for localization, derived from high-throughput mass spectrometry analysis of protein localization during stress. This complements the IDA evidence from PMID:12736687 and represents independent experimental validation. Cytoplasmic localization is well-established for PNC1.
+                            <strong>Reason:</strong> This is consistent with direct localization studies and Pnc1&#39;s metabolic role in nicotinamide salvage.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/22842922" target="_blank" class="term-link">
                                         PMID:22842922
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">Dissecting DNA damage response pathways by analysing protein localization and abundance changes during DNA replication stress.</div>
-                                
+
+                                <div class="support-text">Dissecting DNA damage response pathways by analysing protein localization</div>
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1904524" target="_blank" class="term-link">
                                     GO:1904524
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of DNA amplification</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/26195783" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:26195783
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Regulation of ribosomal DNA amplification by the TOR pathway...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-undecided">
-                            UNDECIDED
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P53184" data-a="GO:1904524" data-r="PMID:26195783" data-act="UNDECIDED">
+                        <span class="vote-buttons" data-g="P53184" data-a="GO:1904524" data-r="PMID:26195783" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Annotation based on mutant phenotype showing that PNC1 negatively regulates rDNA amplification. This appears to be an indirect effect through NAD metabolism and Sir2p regulation.
+                            <strong>Summary:</strong> The rDNA amplification study reports that TOR/caloric-excess regulation reduces PNC1 expression and that PNC1 overexpression substantially reduces rDNA amplification rate.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> While PMID:26195783 is cited for this annotation, this requires careful interpretation. The connection between PNC1 and DNA amplification is not as mechanistically clear as PNC1s core roles in NAD salvage and silencing. The negative regulation of DNA amplification might be an indirect consequence of Sir2p regulation and chromatin silencing. Without the full publication text, the specific experimental context is unclear. This annotation may be correct but evidence linkage would benefit from deeper investigation.
+                            <strong>Reason:</strong> The annotation is experimentally supported, but it is an indirect regulatory consequence of Pnc1 effects on Sir2/Hst deacetylase activity and rDNA chromatin rather than the core enzymatic function.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/26195783" target="_blank" class="term-link">
                                         PMID:26195783
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">Regulation of ribosomal DNA amplification by the TOR pathway.</div>
-                                
+
+                                <div class="support-text">overexpression of PNC1 substantially reduces ribosomal DNA amplification rate</div>
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000183" target="_blank" class="term-link">
                                     GO:0000183
                                 </a>
                             </span>
                             <span class="term-label">rDNA heterochromatin formation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/11901108" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:11901108
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Telomeric and rDNA silencing in Saccharomyces cerevisiae are...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P53184" data-a="GO:0000183" data-r="PMID:11901108" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P53184" data-a="GO:0000183" data-r="PMID:11901108" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Functional annotation showing PNC1 participation in ribosomal DNA heterochromatin formation and silencing, demonstrated through deletion phenotype analysis.
+                            <strong>Summary:</strong> Genetic evidence supports a role for Pnc1 in rDNA silencing through the nuclear NAD+ salvage pathway and Sir2-dependent chromatin regulation.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> This is a core functional annotation parallel to the telomeric silencing role. PMID:11901108 explicitly demonstrates that pnc1 deletion compromises rDNA silencing. The mechanism is identical: PNC1 removes the Sir2 inhibitor nicotinamide, enabling Sir2-dependent heterochromatin formation at rDNA. This should be considered a primary function of PNC1. The IMP evidence is appropriate and well-supported.
+                            <strong>Reason:</strong> This is a well-supported downstream biological process, but Pnc1 acts through nicotinamide salvage rather than as a structural chromatin factor.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/11901108" target="_blank" class="term-link">
                                         PMID:11901108
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">Deletion of another NAD(+) salvage pathway gene called PNC1 caused a less severe silencing defect and did not significantly reduce the intracellular NAD(+) concentration</div>
-                                
+
+                                <div class="support-text">Telomeric and rDNA silencing in Saccharomyces cerevisiae are dependent on a nuclear NAD(+) salvage pathway</div>
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/12736687" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:12736687
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Nicotinamide and PNC1 govern lifespan extension by calorie r...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1730,75 +1752,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Direct experimental evidence from microscopy-based localization analysis. PNC1 is demonstrated to be present in the nucleus, consistent with its role in Sir2-mediated silencing at telomeres and rDNA.
+                            <strong>Summary:</strong> Direct localization evidence places Pnc1 in the nucleus.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> This is direct experimental evidence (IDA) from PMID:12736687, one of the landmark studies on PNC1 function. The nuclear localization is essential to PNC1s mechanistic roles in regulating Sir2-mediated silencing. This is well-supported and appropriate.
+                            <strong>Reason:</strong> Nuclear localization is consistent with Pnc1&#39;s role in modulating Sir2-dependent silencing through nicotinamide clearance.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/12736687" target="_blank" class="term-link">
                                         PMID:12736687
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">Nicotinamide and PNC1 govern lifespan extension by calorie restriction in Saccharomyces cerevisiae.</div>
-                                
+
+                                <div class="support-text">provide evidence that nicotinamide depletion is sufficient to activate Sir2 and</div>
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/12736687" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:12736687
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Nicotinamide and PNC1 govern lifespan extension by calorie r...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1810,75 +1832,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Direct experimental evidence for cytoplasmic localization from PMID:12736687. Consistent with HDA evidence from PMID:22842922. Cytoplasmic localization is appropriate given PNC1s roles in general NAD metabolism.
+                            <strong>Summary:</strong> Direct localization evidence places Pnc1 in the cytoplasm.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> IDA evidence from microscopy showing cytoplasmic presence is well-supported. The cytoplasmic localization is consistent with PNC1s roles in cellular NAD metabolism. Multiple independent localization studies confirm this. This annotation is appropriate.
+                            <strong>Reason:</strong> Cytoplasmic localization is consistent with Pnc1&#39;s NAD salvage enzyme function.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/12736687" target="_blank" class="term-link">
                                         PMID:12736687
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">Nicotinamide and PNC1 govern lifespan extension by calorie restriction in Saccharomyces cerevisiae.</div>
-                                
+
+                                <div class="support-text">provide evidence that nicotinamide depletion is sufficient to activate Sir2 and</div>
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005777" target="_blank" class="term-link">
                                     GO:0005777
                                 </a>
                             </span>
                             <span class="term-label">peroxisome</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/12736687" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:12736687
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Nicotinamide and PNC1 govern lifespan extension by calorie r...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1890,75 +1912,73 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Direct experimental evidence for peroxisomal localization, with the important note that PNC1 concentrates in peroxisomes. This is a prominent subcellular localization for this protein.
+                            <strong>Summary:</strong> Direct localization evidence supports peroxisomal Pnc1 foci and condition-dependent peroxisomal enrichment.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> IDA evidence from PMID:12736687 confirms PNC1 localization to peroxisomes. Peroxisomes are significant sites of NAD metabolism and stress response, and PNC1 localization there is functionally relevant. The annotation is well-supported and appropriate. Peroxisomal targeting appears to be especially important under stress conditions.
+                            <strong>Reason:</strong> Peroxisome localization is experimentally supported and is a recurring feature of Pnc1 stress-responsive distribution.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12736687" target="_blank" class="term-link">
-                                        PMID:12736687
-                                    </a>
-                                    
+
+                                    file:yeast/PNC1/PNC1-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">In Saccharomyces cerevisiae, lifespan extension by calorie restriction requires the NAD+-dependent histone deacetylase, Sir2</div>
-                                
+
+                                <div class="support-text">Pnc1 localizes to cytosol and nucleus and to discrete peroxisomal foci</div>
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008936" target="_blank" class="term-link">
                                     GO:0008936
                                 </a>
                             </span>
                             <span class="term-label">nicotinamidase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19381334" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19381334
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The yeast PNC1 longevity gene is up-regulated by mRNA mistra...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1970,63 +1990,61 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Second annotation of nicotinamidase activity with IMP evidence from a study demonstrating that PNC1 is up-regulated under stress (protein mistranslation) and that the enzyme is catalytically active. Duplicates the IEA annotation but with experimental support.
+                            <strong>Summary:</strong> The mistranslation study measured increased Pnc1 expression and activity and used nicotinamidase assays to connect stress to Pnc1/Sir2 activation.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> This is a duplicate GO ID (GO:0008936) but with different evidence type (IMP vs IEA). In GO annotation, having multiple evidence codes for the same term is acceptable and actually desirable - it shows the annotation is supported by both automated and experimental evidence. PMID:19381334 directly demonstrates that Pnc1p activity is enhanced under stress conditions through catalytic assays measuring NAM-to-NAC conversion and ammonia release. Having both IEA and IMP annotations reinforces the robustness of this core functional annotation.
+                            <strong>Reason:</strong> This experimental annotation reinforces the core nicotinamidase activity of Pnc1 under stress conditions.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/19381334" target="_blank" class="term-link">
                                         PMID:19381334
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">Pnc1 synthesizes nicotinic acid from nicotinamide</div>
-                                
+
+                                <div class="support-text">Our results showed that up-regulation of Pnc1p expression (Figs 1 and 2) resulted in increased Pnc1p and Sir2p activity</div>
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
             </tbody>
         </table>
     </div>
-    
 
-    
+
+
     <div class="section">
         <h2 class="section-title">Core Functions</h2>
-        
+
         <div class="core-function-card">
-            
+
             <div style="display: flex; justify-content: space-between; align-items: center;">
-                <h3>Pnc1 catalyzes deamidation of nicotinamide to nicotinic acid, providing the entry
-step for NAD+ salvage and relieving nicotinamide inhibition of Sir2-dependent processes.
-</h3>
-                <span class="vote-buttons" data-g="P53184" data-a="FUNCTION: Pnc1 catalyzes deamidation of nicotinamide to nico..." data-r="" data-act="CORE_FUNCTION">
+                <h3>Pnc1 deamidates nicotinamide to nicotinate and ammonia, routing nicotinamide into NAD+ salvage and lowering nicotinamide inhibition of Sir2-family deacetylases. Its chromatin-silencing and rDNA-copy-number effects are downstream consequences of this core enzyme activity.</h3>
+                <span class="vote-buttons" data-g="P53184" data-a="FUNCTION: Pnc1 deamidates nicotinamide to nicotinate and amm..." data-r="" data-act="CORE_FUNCTION">
                     <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
             </div>
-            
+
 
             <div class="core-function-terms">
-                
+
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
@@ -2035,251 +2053,333 @@ step for NAD+ salvage and relieving nicotinamide inhibition of Sir2-dependent pr
                         </a>
                     </span>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Directly Involved In:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019358" target="_blank" class="term-link">
                                 nicotinate nucleotide salvage
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
 
-                
 
-                
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                cytoplasm
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
+                                nucleus
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005777" target="_blank" class="term-link">
+                                peroxisome
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
             </div>
 
-            
+
             <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
                 <strong>Supporting Evidence:</strong>
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/11901108" target="_blank" class="term-link">
                                 PMID:11901108
                             </a>
-                            
+
                         </span>
-                        
-                        <div class="finding-text">We propose a model in which two components of the NAD(+) salvage pathway, Pnc1p and Npt1p, function together in recycling the nuclear nicotinamide generated by Sir2p deacetylase activity back into NAD(+)</div>
-                        
+
+                        <div class="finding-text">Pnc1p and Npt1p function together in recycling the nuclear nicotinamide</div>
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             file:yeast/PNC1/PNC1-deep-research-falcon.md
-                            
+
                         </span>
-                        
-                        <div class="finding-text">PNC1 (gene YGL037C) encodes nicotinamidase (EC 3.5.1.19) in Saccharomyces cerevisiae (strain S288c).</div>
-                        
+
+                        <div class="finding-text">catalyzing deamidation of nicotinamide</div>
+
                     </li>
-                    
+
                 </ul>
             </div>
-            
-        </div>
-        
-    </div>
-    
 
-    
+        </div>
+
+    </div>
+
+
+
     <div class="section">
         <h2 class="section-title collapsible">References</h2>
         <div class="collapse-content">
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000043.md" target="_blank" class="term-link">
                             GO_REF:0000043
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
                             GO_REF:0000044
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000108.md" target="_blank" class="term-link">
                             GO_REF:0000108
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Automatic assignment of GO terms using logical inference, based on on inter-ontology links</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
                             GO_REF:0000120
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/11901108" target="_blank" class="term-link">
                             PMID:11901108
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Telomeric and rDNA silencing in Saccharomyces cerevisiae are dependent on a nuclear NAD(+) salvage pathway.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/12736687" target="_blank" class="term-link">
                             PMID:12736687
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Nicotinamide and PNC1 govern lifespan extension by calorie restriction in Saccharomyces cerevisiae.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/19381334" target="_blank" class="term-link">
                             PMID:19381334
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The yeast PNC1 longevity gene is up-regulated by mRNA mistranslation.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/22842922" target="_blank" class="term-link">
                             PMID:22842922
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Dissecting DNA damage response pathways by analysing protein localization and abundance changes during DNA replication stress.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/26195783" target="_blank" class="term-link">
                             PMID:26195783
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Regulation of ribosomal DNA amplification by the TOR pathway.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/30358795" target="_blank" class="term-link">
                             PMID:30358795
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The cellular economy of the Saccharomyces cerevisiae zinc proteome.</div>
-                
-                
+
+
             </div>
-            
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:yeast/PNC1/PNC1-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research report for PNC1</div>
+
+
+            </div>
+
         </div>
     </div>
-    
 
 
-    
 
-    
 
-    
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> What determines condition-specific partitioning of Pnc1 between cytosol, nucleus, and peroxisomes, and how much of the Sir2-regulatory effect depends on each pool?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P53184" data-a="Q: What determines condition-specific partitioning of..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Endogenous Pnc1 localization mutants that selectively disrupt peroxisomal enrichment, followed by nicotinamide, NAD+, Sir2 silencing, and rDNA amplification assays under stress and calorie-restriction conditions.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: Nuclear and cytosolic Pnc1 provide most Sir2-regulatory activity, while stress-enhanced peroxisomal Pnc1 contributes condition-specific nicotinamide handling.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: localization/genetics/metabolomics</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P53184" data-a="EXPERIMENT: Endogenous Pnc1 localization mutants that selectiv..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
 
     <!-- Computational Predictions Section -->
-    
+
 
     <!-- Additional Documentation Sections -->
-    
+
     <div class="section">
         <h2 class="section-title">📚 Additional Documentation</h2>
-        
+
         <details class="markdown-section">
             <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
                 <div style="flex: 1;">
@@ -2588,9 +2688,9 @@ PNC1 (P53184) in S. cerevisiae is a zinc-dependent, isochorismatase-like nicotin
 </ol>
             </div>
         </details>
-        
+
     </div>
-    
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -2602,13 +2702,20 @@ PNC1 (P53184) in S. cerevisiae is a zinc-dependent, isochorismatase-like nicotin
                 <pre><code>id: P53184
 gene_symbol: PNC1
 aliases:
-  - YGL037C
+- YGL037C
 product_type: PROTEIN
-status: DRAFT
+status: COMPLETE
 taxon:
   id: NCBITaxon:559292
   label: Saccharomyces cerevisiae
-description: &#39;Nicotinamidase (Pnc1p), a key enzyme in the NAD+ salvage pathway that catalyzes deamidation of nicotinamide to nicotinic acid. Plays critical roles in NAD+ metabolism and is a longevity gene responsive to caloric restriction and stress conditions. Functions in telomeric and rDNA silencing through Sir2p regulation. Localizes to cytoplasm, nucleus, and peroxisomes.&#39;
+description: &gt;-
+  PNC1 encodes the zinc-dependent nicotinamidase Pnc1, the yeast enzyme that
+  deamidates nicotinamide to nicotinate and ammonia in the NAD+ salvage pathway.
+  By clearing nicotinamide, a Sir2 inhibitor, Pnc1 supports nicotinate nucleotide
+  salvage and indirectly promotes Sir2-dependent telomeric and rDNA
+  heterochromatin functions, lifespan responses to calorie restriction, and
+  regulation of rDNA copy-number amplification. Pnc1 is cytoplasmic, nuclear,
+  and peroxisomal, with stress-responsive regulation and peroxisomal enrichment.
 existing_annotations:
 - term:
     id: GO:0000781
@@ -2616,243 +2723,346 @@ existing_annotations:
   evidence_type: IEA
   original_reference_id: GO_REF:0000108
   review:
-    summary: &#39;Localization to telomeric chromatin is inferred computationally. While PNC1 is known to regulate telomeric silencing, the IEA inference mechanism (logical inference) is based on the IMP annotation for subtelomeric heterochromatin formation. This is acceptable as it represents a reasonable inference from the mechanistic role of PNC1, but it is not a direct experimental observation of localization to telomeric regions.&#39;
-    action: ACCEPT
-    reason: &#39;The annotation reflects PNC1s regulatory role in telomeric silencing, though based on computational inference rather than direct localization evidence. The mechanistic connection is sound: PNC1 removes nicotinamide (an inhibitor of Sir2) to enable Sir2-mediated telomeric heterochromatin formation (PMID:11901108, PMID:12736687). This is supported by IDA evidence for nuclear localization and functional involvement in telomeric silencing.&#39;
+    summary: &gt;-
+      This computational logical inference derives from PNC1 involvement in
+      subtelomeric heterochromatin formation. The literature supports nuclear
+      Pnc1 activity and effects on telomeric silencing, but not direct
+      localization of Pnc1 to telomeric chromatin.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Pnc1 regulates telomeric silencing by removing nicotinamide and thereby
+      supporting Sir2 activity. A telomeric-region cellular component annotation
+      overstates the evidence because Pnc1 is not shown to be a telomere-bound
+      chromatin protein.
 - term:
     id: GO:0005634
     label: nucleus
   evidence_type: IEA
   original_reference_id: GO_REF:0000044
   review:
-    summary: &#39;Subcellular localization inferred from UniProtKB localization vocabulary mapping. Consistent with direct experimental evidence (PMID:12736687, PMID:11901108).&#39;
+    summary: &gt;-
+      UniProt subcellular-location mapping to nucleus is consistent with direct
+      Pnc1 localization evidence and its nuclear role in Sir2-dependent
+      silencing.
     action: ACCEPT
-    reason: &#39;Nuclear localization is well-supported by IDA evidence from microscopy (PMID:12736687). The IEA annotation is derived from UniProtKB annotation and is accurate. PNC1 functions in the nucleus where Sir2p-mediated silencing occurs.&#39;
+    reason: &gt;-
+      Nuclear localization is supported experimentally and is mechanistically
+      consistent with Pnc1 effects on rDNA and telomeric silencing.
 - term:
     id: GO:0005737
     label: cytoplasm
   evidence_type: IEA
   original_reference_id: GO_REF:0000044
   review:
-    summary: &#39;Subcellular localization based on UniProtKB mapping. Verified by experimental evidence (IDA, PMID:12736687).&#39;
+    summary: &gt;-
+      Automated cytoplasmic localization is consistent with direct microscopy
+      evidence and Pnc1&#39;s general metabolic role.
     action: ACCEPT
-    reason: &#39;Cytoplasmic localization is directly demonstrated by microscopy (IDA, PMID:12736687) and is consistent with the functional roles in NAD metabolism. This is appropriate.&#39;
+    reason: &gt;-
+      Pnc1 is observed in the cytoplasm and participates in cellular
+      nicotinamide salvage.
 - term:
     id: GO:0005777
     label: peroxisome
   evidence_type: IEA
   original_reference_id: GO_REF:0000044
   review:
-    summary: &#39;Peroxisomal localization inferred from UniProtKB mapping. Well-supported by experimental evidence showing PNC1 concentrates in peroxisomes (PMID:12736687).&#39;
+    summary: &gt;-
+      UniProt peroxisome mapping is consistent with direct evidence that Pnc1
+      concentrates in peroxisomal foci, particularly in stress contexts.
     action: ACCEPT
-    reason: &#39;UniProtKB annotation notes that PNC1 concentrates in peroxisomes, which is verified by direct microscopy (PMID:12736687). Peroxisomal localization is relevant to cellular NAD metabolism and stress response functions. This localization is properly supported by literature.&#39;
+    reason: &gt;-
+      Peroxisomal localization is supported by experimental localization studies
+      and is part of Pnc1&#39;s condition-dependent subcellular distribution.
 - term:
     id: GO:0008936
     label: nicotinamidase activity
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
   review:
-    summary: &#39;Molecular function annotation assigned via combined automated methods, likely based on EC number (3.5.1.19) and sequence homology. This is the core enzymatic function of PNC1.&#39;
+    summary: &gt;-
+      Automated assignment of nicotinamidase activity matches Pnc1&#39;s core
+      enzymatic activity and EC 3.5.1.19.
     action: ACCEPT
-    reason: &#39;Nicotinamidase activity is the primary and well-characterized enzymatic function of PNC1. The EC number 3.5.1.19 directly classifies it as a nicotinamidase. This is strongly supported by multiple publications (PMID:12736687, PMID:11901108, PMID:19381334) demonstrating the catalytic conversion of nicotinamide to nicotinic acid. This is a core and essential annotation.&#39;
+    reason: &gt;-
+      Pnc1 catalyzes hydrolysis of nicotinamide to nicotinate and ammonia, the
+      central molecular function of this gene product.
     supported_by:
-      - reference_id: file:yeast/PNC1/PNC1-deep-research-falcon.md
-        supporting_text: &#34;PNC1 (gene YGL037C) encodes nicotinamidase (EC 3.5.1.19) in Saccharomyces cerevisiae (strain S288c).&#34;
+    - reference_id: file:yeast/PNC1/PNC1-deep-research-falcon.md
+      supporting_text: &#34;PNC1 (gene YGL037C) encodes nicotinamidase (EC 3.5.1.19)&#34;
 - term:
     id: GO:0016787
     label: hydrolase activity
   evidence_type: IEA
   original_reference_id: GO_REF:0000043
   review:
-    summary: &#39;Parent term for nicotinamidase activity based on enzyme classification. GO:0008936 (nicotinamidase activity) is more specific and informative. However, the parent term is not incorrect.&#39;
-    action: ACCEPT
-    reason: &#39;This is the correct parent term for the specific nicotinamidase activity. Nicotinamidases are amidohydrolases (EC 3.5.1.19), so this annotation is mechanistically accurate. While the more specific term (GO:0008936) is preferable for precision, retaining this parent term is acceptable for comprehensive annotation coverage. Parent and child GO terms can coexist.&#39;
+    summary: &gt;-
+      Hydrolase activity is a true but generic parent of nicotinamidase activity.
+      The specific nicotinamidase term is already present.
+    action: MODIFY
+    reason: &gt;-
+      For curation, GO:0008936 captures the actual enzyme activity and should be
+      preferred over the broad hydrolase parent.
+    proposed_replacement_terms:
+    - id: GO:0008936
+      label: nicotinamidase activity
 - term:
     id: GO:0019363
     label: pyridine nucleotide biosynthetic process
   evidence_type: IEA
   original_reference_id: GO_REF:0000043
   review:
-    summary: &#39;Process annotation derived from UniProtKB keyword mapping (KW-0662: Pyridine nucleotide biosynthesis). PNC1 is involved in NAD+ salvage pathway, which recycles pyridine nucleotides. This is a reasonable but somewhat indirect annotation.&#39;
+    summary: &gt;-
+      Pnc1 participates in pyridine nucleotide salvage by converting
+      nicotinamide to nicotinate, but the more precise existing process term is
+      nicotinate nucleotide salvage.
     action: MODIFY
-    reason: &#39;While PNC1 is mechanistically involved in NAD+ salvage (not de novo biosynthesis), GO:0019363 &#34;pyridine nucleotide biosynthetic process&#34; typically refers to de novo synthesis pathways (e.g., starting from tryptophan). PNC1 catalyzes salvage of nicotinamide to regenerate NAD+ in an existing pool, not biosynthesis of pyridine nucleotides de novo. The more accurate annotation would be GO:0019854 NAD metabolism because PNC1 catalyzes the first committed step in salvaging NAD+ from nicotinamide (PMID:12736687). This is NAD metabolism, not pyridine nucleotide de novo biosynthesis.&#39;
+    reason: &gt;-
+      Pnc1 is not a broad de novo pyridine nucleotide biosynthesis factor. It
+      catalyzes the nicotinamide entry step into the nicotinate salvage route,
+      which is captured by GO:0019358.
     proposed_replacement_terms:
-      - id: GO:0019854
-        label: NAD metabolism
+    - id: GO:0019358
+      label: nicotinate nucleotide salvage
 - term:
     id: GO:0046872
     label: metal ion binding
   evidence_type: IEA
   original_reference_id: GO_REF:0000043
   review:
-    summary: &#39;Parent term inferred from UniProtKB keywords for metal binding. PNC1 requires zinc cofactor for catalysis, so this is accurate but very general. The more specific annotation (GO:0008270, zinc ion binding) is already present with experimental evidence.&#39;
-    action: ACCEPT
-    reason: &#39;This is correct as a parent term annotation. Zinc is a metal ion, and PNC1 binds zinc as a catalytic cofactor. While GO:0008270 (zinc ion binding) is more specific and is annotated separately, the parent term is not incorrect and provides complementary information. Parent-child GO terms are often both retained for annotation completeness.&#39;
+    summary: &gt;-
+      Metal ion binding is accurate but generic; Pnc1 specifically binds zinc as
+      part of its nicotinamidase active site.
+    action: MODIFY
+    reason: &gt;-
+      The more informative term is zinc ion binding, already supported by curated
+      evidence and structural/mechanistic context.
+    proposed_replacement_terms:
+    - id: GO:0008270
+      label: zinc ion binding
 - term:
     id: GO:0008270
     label: zinc ion binding
   evidence_type: RCA
   original_reference_id: PMID:30358795
   review:
-    summary: &#39;Zinc ion binding assignment based on rapid curated annotation (RCA) from a zinc proteome analysis study. The study comprehensively catalogued zinc-binding proteins in yeast and is appropriate evidence for this annotation.&#39;
+    summary: &gt;-
+      Rapid curated annotation from yeast zinc proteome analysis is consistent
+      with the known zinc-dependent nicotinamidase active site of Pnc1.
     action: ACCEPT
-    reason: &#39;RCA (rapid curated annotation) is appropriate for identifying PNC1 as a zinc-binding protein. The source (PMID:30358795) is a comprehensive zinc proteome study that systematically identified and characterized zinc-binding sites on proteins. Zinc is essential for the catalytic mechanism of nicotinamidases, confirmed by structural studies showing zinc binding sites at positions 51, 53, and 94 in the PNC1 protein.&#39;
+    reason: &gt;-
+      Zinc binding is mechanistically appropriate for Pnc1&#39;s catalytic function.
     supported_by:
-      - reference_id: PMID:30358795
-        supporting_text: &#34;The cellular economy of the Saccharomyces cerevisiae zinc proteome.&#34;
+    - reference_id: PMID:30358795
+      supporting_text: &#34;The cellular economy of the Saccharomyces cerevisiae zinc proteome.&#34;
 - term:
     id: GO:0031509
     label: subtelomeric heterochromatin formation
   evidence_type: IMP
   original_reference_id: PMID:11901108
   review:
-    summary: &#39;Mutant phenotype annotation showing PNC1 deletion results in weakened subtelomeric heterochromatin silencing. This is one of the key functional roles identified for PNC1 in the literature.&#39;
-    action: ACCEPT
-    reason: &#39;This is a core functional annotation based on IMP evidence from PMID:11901108, which demonstrates that pnc1 deletion results in a silencing defect at telomeres and rDNA. The mechanism is clear: PNC1 removes nicotinamide, an inhibitor of the Sir2 histone deacetylase, thereby enabling Sir2-mediated heterochromatin formation and silencing. The annotation is mechanistically sound and well-supported. This should be considered a core function of PNC1.&#39;
+    summary: &gt;-
+      pnc1 deletion causes telomeric silencing defects through impaired
+      nicotinamide clearance and reduced Sir2-dependent chromatin function.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      The phenotype is well supported, but it is a downstream chromatin outcome
+      of Pnc1&#39;s core nicotinamidase/NAD salvage activity rather than an
+      independent chromatin-binding function.
     supported_by:
-      - reference_id: PMID:11901108
-        supporting_text: &#34;Deletion of another NAD(+) salvage pathway gene called PNC1 caused a less severe silencing defect and did not significantly reduce the intracellular NAD(+) concentration. However, silencing in the absence of PNC1 was completely dependent on the import of nicotinic acid from the growth medium&#34;
+    - reference_id: PMID:11901108
+      supporting_text: &#34;Deletion of another NAD(+) salvage pathway gene called PNC1 caused a less severe silencing defect&#34;
 - term:
     id: GO:0019358
     label: nicotinate nucleotide salvage
   evidence_type: IMP
   original_reference_id: PMID:11901108
   review:
-    summary: &#39;Functional role annotation showing PNC1 participates in the salvage pathway for nicotinic acid-derived nucleotides. The pathway involves conversion of nicotinamide to nicotinic acid (catalyzed by PNC1) followed by conversion back to NAD+.&#39;
+    summary: &gt;-
+      Genetic evidence supports Pnc1 as a component of the NAD+ salvage pathway,
+      converting nicotinamide to nicotinate for reuse.
     action: ACCEPT
-    reason: &#39;This annotation correctly identifies PNC1s participation in nicotinate nucleotide salvage. PNC1 catalyzes the first step - deamidation of nicotinamide to nicotinic acid - which is the entry point into the salvage pathway. PMID:11901108 directly demonstrates that deletion of PNC1 compromises the salvage pathway capacity. This is a core biological function of the enzyme and is properly supported by IMP evidence.&#39;
+    reason: &gt;-
+      This is the core biological process associated with Pnc1&#39;s enzymatic
+      activity and explains the Sir2-related phenotypes.
     supported_by:
-      - reference_id: PMID:11901108
-        supporting_text: &#34;We propose a model in which two components of the NAD(+) salvage pathway, Pnc1p and Npt1p, function together in recycling the nuclear nicotinamide generated by Sir2p deacetylase activity back into NAD(+)&#34;
+    - reference_id: PMID:11901108
+      supporting_text: &#34;Pnc1p and Npt1p function together in recycling the nuclear nicotinamide&#34;
 - term:
     id: GO:0005737
     label: cytoplasm
   evidence_type: HDA
   original_reference_id: PMID:22842922
   review:
-    summary: &#39;HDA (high-throughput direct assay) annotation for cytoplasmic localization from a DNA damage response study. This provides complementary evidence to the IDA annotations.&#39;
+    summary: &gt;-
+      High-throughput direct assay evidence supports cytoplasmic localization.
     action: ACCEPT
-    reason: &#39;HDA is appropriate evidence for localization, derived from high-throughput mass spectrometry analysis of protein localization during stress. This complements the IDA evidence from PMID:12736687 and represents independent experimental validation. Cytoplasmic localization is well-established for PNC1.&#39;
+    reason: &gt;-
+      This is consistent with direct localization studies and Pnc1&#39;s metabolic
+      role in nicotinamide salvage.
     supported_by:
-      - reference_id: PMID:22842922
-        supporting_text: &#34;Dissecting DNA damage response pathways by analysing protein localization and abundance changes during DNA replication stress.&#34;
+    - reference_id: PMID:22842922
+      supporting_text: &#34;Dissecting DNA damage response pathways by analysing protein localization&#34;
 - term:
     id: GO:1904524
     label: negative regulation of DNA amplification
   evidence_type: IMP
   original_reference_id: PMID:26195783
   review:
-    summary: &#39;Annotation based on mutant phenotype showing that PNC1 negatively regulates rDNA amplification. This appears to be an indirect effect through NAD metabolism and Sir2p regulation.&#39;
-    action: UNDECIDED
-    reason: &#39;While PMID:26195783 is cited for this annotation, this requires careful interpretation. The connection between PNC1 and DNA amplification is not as mechanistically clear as PNC1s core roles in NAD salvage and silencing. The negative regulation of DNA amplification might be an indirect consequence of Sir2p regulation and chromatin silencing. Without the full publication text, the specific experimental context is unclear. This annotation may be correct but evidence linkage would benefit from deeper investigation.&#39;
+    summary: &gt;-
+      The rDNA amplification study reports that TOR/caloric-excess regulation
+      reduces PNC1 expression and that PNC1 overexpression substantially reduces
+      rDNA amplification rate.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      The annotation is experimentally supported, but it is an indirect
+      regulatory consequence of Pnc1 effects on Sir2/Hst deacetylase activity
+      and rDNA chromatin rather than the core enzymatic function.
     supported_by:
-      - reference_id: PMID:26195783
-        supporting_text: &#34;Regulation of ribosomal DNA amplification by the TOR pathway.&#34;
+    - reference_id: PMID:26195783
+      supporting_text: &#34;overexpression of PNC1 substantially reduces ribosomal DNA amplification rate&#34;
 - term:
     id: GO:0000183
     label: rDNA heterochromatin formation
   evidence_type: IMP
   original_reference_id: PMID:11901108
   review:
-    summary: &#39;Functional annotation showing PNC1 participation in ribosomal DNA heterochromatin formation and silencing, demonstrated through deletion phenotype analysis.&#39;
-    action: ACCEPT
-    reason: &#39;This is a core functional annotation parallel to the telomeric silencing role. PMID:11901108 explicitly demonstrates that pnc1 deletion compromises rDNA silencing. The mechanism is identical: PNC1 removes the Sir2 inhibitor nicotinamide, enabling Sir2-dependent heterochromatin formation at rDNA. This should be considered a primary function of PNC1. The IMP evidence is appropriate and well-supported.&#39;
+    summary: &gt;-
+      Genetic evidence supports a role for Pnc1 in rDNA silencing through the
+      nuclear NAD+ salvage pathway and Sir2-dependent chromatin regulation.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      This is a well-supported downstream biological process, but Pnc1 acts
+      through nicotinamide salvage rather than as a structural chromatin factor.
     supported_by:
-      - reference_id: PMID:11901108
-        supporting_text: &#34;Deletion of another NAD(+) salvage pathway gene called PNC1 caused a less severe silencing defect and did not significantly reduce the intracellular NAD(+) concentration&#34;
+    - reference_id: PMID:11901108
+      supporting_text: &#34;Telomeric and rDNA silencing in Saccharomyces cerevisiae are dependent on a nuclear NAD(+) salvage pathway&#34;
 - term:
     id: GO:0005634
     label: nucleus
   evidence_type: IDA
   original_reference_id: PMID:12736687
   review:
-    summary: &#39;Direct experimental evidence from microscopy-based localization analysis. PNC1 is demonstrated to be present in the nucleus, consistent with its role in Sir2-mediated silencing at telomeres and rDNA.&#39;
+    summary: &gt;-
+      Direct localization evidence places Pnc1 in the nucleus.
     action: ACCEPT
-    reason: &#39;This is direct experimental evidence (IDA) from PMID:12736687, one of the landmark studies on PNC1 function. The nuclear localization is essential to PNC1s mechanistic roles in regulating Sir2-mediated silencing. This is well-supported and appropriate.&#39;
+    reason: &gt;-
+      Nuclear localization is consistent with Pnc1&#39;s role in modulating
+      Sir2-dependent silencing through nicotinamide clearance.
     supported_by:
-      - reference_id: PMID:12736687
-        supporting_text: &#34;Nicotinamide and PNC1 govern lifespan extension by calorie restriction in Saccharomyces cerevisiae.&#34;
+    - reference_id: PMID:12736687
+      supporting_text: &#34;provide evidence that nicotinamide depletion is sufficient to activate Sir2 and&#34;
 - term:
     id: GO:0005737
     label: cytoplasm
   evidence_type: IDA
   original_reference_id: PMID:12736687
   review:
-    summary: &#39;Direct experimental evidence for cytoplasmic localization from PMID:12736687. Consistent with HDA evidence from PMID:22842922. Cytoplasmic localization is appropriate given PNC1s roles in general NAD metabolism.&#39;
+    summary: &gt;-
+      Direct localization evidence places Pnc1 in the cytoplasm.
     action: ACCEPT
-    reason: &#39;IDA evidence from microscopy showing cytoplasmic presence is well-supported. The cytoplasmic localization is consistent with PNC1s roles in cellular NAD metabolism. Multiple independent localization studies confirm this. This annotation is appropriate.&#39;
+    reason: &gt;-
+      Cytoplasmic localization is consistent with Pnc1&#39;s NAD salvage enzyme
+      function.
     supported_by:
-      - reference_id: PMID:12736687
-        supporting_text: &#34;Nicotinamide and PNC1 govern lifespan extension by calorie restriction in Saccharomyces cerevisiae.&#34;
+    - reference_id: PMID:12736687
+      supporting_text: &#34;provide evidence that nicotinamide depletion is sufficient to activate Sir2 and&#34;
 - term:
     id: GO:0005777
     label: peroxisome
   evidence_type: IDA
   original_reference_id: PMID:12736687
   review:
-    summary: &#39;Direct experimental evidence for peroxisomal localization, with the important note that PNC1 concentrates in peroxisomes. This is a prominent subcellular localization for this protein.&#39;
+    summary: &gt;-
+      Direct localization evidence supports peroxisomal Pnc1 foci and
+      condition-dependent peroxisomal enrichment.
     action: ACCEPT
-    reason: &#39;IDA evidence from PMID:12736687 confirms PNC1 localization to peroxisomes. Peroxisomes are significant sites of NAD metabolism and stress response, and PNC1 localization there is functionally relevant. The annotation is well-supported and appropriate. Peroxisomal targeting appears to be especially important under stress conditions.&#39;
+    reason: &gt;-
+      Peroxisome localization is experimentally supported and is a recurring
+      feature of Pnc1 stress-responsive distribution.
     supported_by:
-      - reference_id: PMID:12736687
-        supporting_text: &#34;In Saccharomyces cerevisiae, lifespan extension by calorie restriction requires the NAD+-dependent histone deacetylase, Sir2&#34;
+    - reference_id: file:yeast/PNC1/PNC1-deep-research-falcon.md
+      supporting_text: &#34;Pnc1 localizes to cytosol and nucleus and to discrete peroxisomal foci&#34;
 - term:
     id: GO:0008936
     label: nicotinamidase activity
   evidence_type: IMP
   original_reference_id: PMID:19381334
   review:
-    summary: &#39;Second annotation of nicotinamidase activity with IMP evidence from a study demonstrating that PNC1 is up-regulated under stress (protein mistranslation) and that the enzyme is catalytically active. Duplicates the IEA annotation but with experimental support.&#39;
+    summary: &gt;-
+      The mistranslation study measured increased Pnc1 expression and activity
+      and used nicotinamidase assays to connect stress to Pnc1/Sir2 activation.
     action: ACCEPT
-    reason: &#39;This is a duplicate GO ID (GO:0008936) but with different evidence type (IMP vs IEA). In GO annotation, having multiple evidence codes for the same term is acceptable and actually desirable - it shows the annotation is supported by both automated and experimental evidence. PMID:19381334 directly demonstrates that Pnc1p activity is enhanced under stress conditions through catalytic assays measuring NAM-to-NAC conversion and ammonia release. Having both IEA and IMP annotations reinforces the robustness of this core functional annotation.&#39;
+    reason: &gt;-
+      This experimental annotation reinforces the core nicotinamidase activity
+      of Pnc1 under stress conditions.
     supported_by:
-      - reference_id: PMID:19381334
-        supporting_text: &#34;Pnc1 synthesizes nicotinic acid from nicotinamide&#34;
+    - reference_id: PMID:19381334
+      supporting_text: &#34;Our results showed that up-regulation of Pnc1p expression (Figs 1 and 2) resulted in increased Pnc1p and Sir2p activity&#34;
 core_functions:
-  - molecular_function:
-      id: GO:0008936
-      label: nicotinamidase activity
-    directly_involved_in:
-      - id: GO:0019358
-        label: nicotinate nucleotide salvage
-    description: |
-      Pnc1 catalyzes deamidation of nicotinamide to nicotinic acid, providing the entry
-      step for NAD+ salvage and relieving nicotinamide inhibition of Sir2-dependent processes.
-    supported_by:
-      - reference_id: PMID:11901108
-        supporting_text: &#34;We propose a model in which two components of the NAD(+) salvage pathway, Pnc1p and Npt1p, function together in recycling the nuclear nicotinamide generated by Sir2p deacetylase activity back into NAD(+)&#34;
-      - reference_id: file:yeast/PNC1/PNC1-deep-research-falcon.md
-        supporting_text: &#34;PNC1 (gene YGL037C) encodes nicotinamidase (EC 3.5.1.19) in Saccharomyces cerevisiae (strain S288c).&#34;
+- molecular_function:
+    id: GO:0008936
+    label: nicotinamidase activity
+  directly_involved_in:
+  - id: GO:0019358
+    label: nicotinate nucleotide salvage
+  locations:
+  - id: GO:0005737
+    label: cytoplasm
+  - id: GO:0005634
+    label: nucleus
+  - id: GO:0005777
+    label: peroxisome
+  description: &gt;-
+    Pnc1 deamidates nicotinamide to nicotinate and ammonia, routing
+    nicotinamide into NAD+ salvage and lowering nicotinamide inhibition of
+    Sir2-family deacetylases. Its chromatin-silencing and rDNA-copy-number
+    effects are downstream consequences of this core enzyme activity.
+  supported_by:
+  - reference_id: PMID:11901108
+    supporting_text: &#34;Pnc1p and Npt1p function together in recycling the nuclear nicotinamide&#34;
+  - reference_id: file:yeast/PNC1/PNC1-deep-research-falcon.md
+    supporting_text: &#34;catalyzing deamidation of nicotinamide&#34;
+proposed_new_terms: []
+suggested_questions:
+- question: &gt;-
+    What determines condition-specific partitioning of Pnc1 between cytosol,
+    nucleus, and peroxisomes, and how much of the Sir2-regulatory effect depends
+    on each pool?
+suggested_experiments:
+- description: &gt;-
+    Endogenous Pnc1 localization mutants that selectively disrupt peroxisomal
+    enrichment, followed by nicotinamide, NAD+, Sir2 silencing, and rDNA
+    amplification assays under stress and calorie-restriction conditions.
+  experiment_type: localization/genetics/metabolomics
+  hypothesis: &gt;-
+    Nuclear and cytosolic Pnc1 provide most Sir2-regulatory activity, while
+    stress-enhanced peroxisomal Pnc1 contributes condition-specific
+    nicotinamide handling.
 references:
 - id: GO_REF:0000043
   title: Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping
   findings: []
 - id: GO_REF:0000044
-  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
-    vocabulary mapping, accompanied by conservative changes to GO terms applied by
-    UniProt
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt
   findings: []
 - id: GO_REF:0000108
-  title: Automatic assignment of GO terms using logical inference, based on on inter-ontology
-    links
+  title: Automatic assignment of GO terms using logical inference, based on on inter-ontology links
   findings: []
 - id: GO_REF:0000120
   title: Combined Automated Annotation using Multiple IEA Methods
   findings: []
 - id: PMID:11901108
-  title: Telomeric and rDNA silencing in Saccharomyces cerevisiae are dependent on
-    a nuclear NAD(+) salvage pathway.
+  title: Telomeric and rDNA silencing in Saccharomyces cerevisiae are dependent on a nuclear NAD(+) salvage pathway.
   findings: []
 - id: PMID:12736687
-  title: Nicotinamide and PNC1 govern lifespan extension by calorie restriction in
-    Saccharomyces cerevisiae.
+  title: Nicotinamide and PNC1 govern lifespan extension by calorie restriction in Saccharomyces cerevisiae.
   findings: []
 - id: PMID:19381334
   title: The yeast PNC1 longevity gene is up-regulated by mRNA mistranslation.
   findings: []
 - id: PMID:22842922
-  title: Dissecting DNA damage response pathways by analysing protein localization
-    and abundance changes during DNA replication stress.
+  title: Dissecting DNA damage response pathways by analysing protein localization and abundance changes during DNA replication stress.
   findings: []
 - id: PMID:26195783
   title: Regulation of ribosomal DNA amplification by the TOR pathway.
@@ -2860,13 +3070,16 @@ references:
 - id: PMID:30358795
   title: The cellular economy of the Saccharomyces cerevisiae zinc proteome.
   findings: []
+- id: file:yeast/PNC1/PNC1-deep-research-falcon.md
+  title: Falcon deep research report for PNC1
+  findings: []
 </code></pre>
             </div>
         </details>
     </div>
 
     <!-- Pathway Visualization Link -->
-    
+
 
     <style>
         /* Markdown Section Styles */

--- a/genes/yeast/PNC1/PNC1-ai-review.html
+++ b/genes/yeast/PNC1/PNC1-ai-review.html
@@ -1770,13 +1770,11 @@
                             <div class="support-item">
                                 <span class="support-ref">
 
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12736687" target="_blank" class="term-link">
-                                        PMID:12736687
-                                    </a>
+                                    file:yeast/PNC1/PNC1-deep-research-falcon.md
 
                                 </span>
 
-                                <div class="support-text">provide evidence that nicotinamide depletion is sufficient to activate Sir2 and</div>
+                                <div class="support-text">Pnc1-GFP shows nuclear/cytosolic distribution with discrete peroxisomal foci</div>
 
                             </div>
 
@@ -1850,13 +1848,11 @@
                             <div class="support-item">
                                 <span class="support-ref">
 
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12736687" target="_blank" class="term-link">
-                                        PMID:12736687
-                                    </a>
+                                    file:yeast/PNC1/PNC1-deep-research-falcon.md
 
                                 </span>
 
-                                <div class="support-text">provide evidence that nicotinamide depletion is sufficient to activate Sir2 and</div>
+                                <div class="support-text">Pnc1-GFP shows nuclear/cytosolic distribution with discrete peroxisomal foci</div>
 
                             </div>
 
@@ -2950,8 +2946,8 @@ existing_annotations:
       Nuclear localization is consistent with Pnc1&#39;s role in modulating
       Sir2-dependent silencing through nicotinamide clearance.
     supported_by:
-    - reference_id: PMID:12736687
-      supporting_text: &#34;provide evidence that nicotinamide depletion is sufficient to activate Sir2 and&#34;
+    - reference_id: file:yeast/PNC1/PNC1-deep-research-falcon.md
+      supporting_text: &#34;Pnc1-GFP shows nuclear/cytosolic distribution with discrete peroxisomal foci&#34;
 - term:
     id: GO:0005737
     label: cytoplasm
@@ -2965,8 +2961,8 @@ existing_annotations:
       Cytoplasmic localization is consistent with Pnc1&#39;s NAD salvage enzyme
       function.
     supported_by:
-    - reference_id: PMID:12736687
-      supporting_text: &#34;provide evidence that nicotinamide depletion is sufficient to activate Sir2 and&#34;
+    - reference_id: file:yeast/PNC1/PNC1-deep-research-falcon.md
+      supporting_text: &#34;Pnc1-GFP shows nuclear/cytosolic distribution with discrete peroxisomal foci&#34;
 - term:
     id: GO:0005777
     label: peroxisome

--- a/genes/yeast/PNC1/PNC1-ai-review.yaml
+++ b/genes/yeast/PNC1/PNC1-ai-review.yaml
@@ -249,8 +249,8 @@ existing_annotations:
       Nuclear localization is consistent with Pnc1's role in modulating
       Sir2-dependent silencing through nicotinamide clearance.
     supported_by:
-    - reference_id: PMID:12736687
-      supporting_text: "provide evidence that nicotinamide depletion is sufficient to activate Sir2 and"
+    - reference_id: file:yeast/PNC1/PNC1-deep-research-falcon.md
+      supporting_text: "Pnc1-GFP shows nuclear/cytosolic distribution with discrete peroxisomal foci"
 - term:
     id: GO:0005737
     label: cytoplasm
@@ -264,8 +264,8 @@ existing_annotations:
       Cytoplasmic localization is consistent with Pnc1's NAD salvage enzyme
       function.
     supported_by:
-    - reference_id: PMID:12736687
-      supporting_text: "provide evidence that nicotinamide depletion is sufficient to activate Sir2 and"
+    - reference_id: file:yeast/PNC1/PNC1-deep-research-falcon.md
+      supporting_text: "Pnc1-GFP shows nuclear/cytosolic distribution with discrete peroxisomal foci"
 - term:
     id: GO:0005777
     label: peroxisome

--- a/genes/yeast/PNC1/PNC1-ai-review.yaml
+++ b/genes/yeast/PNC1/PNC1-ai-review.yaml
@@ -1,13 +1,20 @@
 id: P53184
 gene_symbol: PNC1
 aliases:
-  - YGL037C
+- YGL037C
 product_type: PROTEIN
-status: DRAFT
+status: COMPLETE
 taxon:
   id: NCBITaxon:559292
   label: Saccharomyces cerevisiae
-description: 'Nicotinamidase (Pnc1p), a key enzyme in the NAD+ salvage pathway that catalyzes deamidation of nicotinamide to nicotinic acid. Plays critical roles in NAD+ metabolism and is a longevity gene responsive to caloric restriction and stress conditions. Functions in telomeric and rDNA silencing through Sir2p regulation. Localizes to cytoplasm, nucleus, and peroxisomes.'
+description: >-
+  PNC1 encodes the zinc-dependent nicotinamidase Pnc1, the yeast enzyme that
+  deamidates nicotinamide to nicotinate and ammonia in the NAD+ salvage pathway.
+  By clearing nicotinamide, a Sir2 inhibitor, Pnc1 supports nicotinate nucleotide
+  salvage and indirectly promotes Sir2-dependent telomeric and rDNA
+  heterochromatin functions, lifespan responses to calorie restriction, and
+  regulation of rDNA copy-number amplification. Pnc1 is cytoplasmic, nuclear,
+  and peroxisomal, with stress-responsive regulation and peroxisomal enrichment.
 existing_annotations:
 - term:
     id: GO:0000781
@@ -15,247 +22,353 @@ existing_annotations:
   evidence_type: IEA
   original_reference_id: GO_REF:0000108
   review:
-    summary: 'Localization to telomeric chromatin is inferred computationally. While PNC1 is known to regulate telomeric silencing, the IEA inference mechanism (logical inference) is based on the IMP annotation for subtelomeric heterochromatin formation. This is acceptable as it represents a reasonable inference from the mechanistic role of PNC1, but it is not a direct experimental observation of localization to telomeric regions.'
-    action: ACCEPT
-    reason: 'The annotation reflects PNC1s regulatory role in telomeric silencing, though based on computational inference rather than direct localization evidence. The mechanistic connection is sound: PNC1 removes nicotinamide (an inhibitor of Sir2) to enable Sir2-mediated telomeric heterochromatin formation (PMID:11901108, PMID:12736687). This is supported by IDA evidence for nuclear localization and functional involvement in telomeric silencing.'
+    summary: >-
+      This computational logical inference derives from PNC1 involvement in
+      subtelomeric heterochromatin formation. The literature supports nuclear
+      Pnc1 activity and effects on telomeric silencing, but not direct
+      localization of Pnc1 to telomeric chromatin.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      Pnc1 regulates telomeric silencing by removing nicotinamide and thereby
+      supporting Sir2 activity. A telomeric-region cellular component annotation
+      overstates the evidence because Pnc1 is not shown to be a telomere-bound
+      chromatin protein.
 - term:
     id: GO:0005634
     label: nucleus
   evidence_type: IEA
   original_reference_id: GO_REF:0000044
   review:
-    summary: 'Subcellular localization inferred from UniProtKB localization vocabulary mapping. Consistent with direct experimental evidence (PMID:12736687, PMID:11901108).'
+    summary: >-
+      UniProt subcellular-location mapping to nucleus is consistent with direct
+      Pnc1 localization evidence and its nuclear role in Sir2-dependent
+      silencing.
     action: ACCEPT
-    reason: 'Nuclear localization is well-supported by IDA evidence from microscopy (PMID:12736687). The IEA annotation is derived from UniProtKB annotation and is accurate. PNC1 functions in the nucleus where Sir2p-mediated silencing occurs.'
+    reason: >-
+      Nuclear localization is supported experimentally and is mechanistically
+      consistent with Pnc1 effects on rDNA and telomeric silencing.
 - term:
     id: GO:0005737
     label: cytoplasm
   evidence_type: IEA
   original_reference_id: GO_REF:0000044
   review:
-    summary: 'Subcellular localization based on UniProtKB mapping. Verified by experimental evidence (IDA, PMID:12736687).'
+    summary: >-
+      Automated cytoplasmic localization is consistent with direct microscopy
+      evidence and Pnc1's general metabolic role.
     action: ACCEPT
-    reason: 'Cytoplasmic localization is directly demonstrated by microscopy (IDA, PMID:12736687) and is consistent with the functional roles in NAD metabolism. This is appropriate.'
+    reason: >-
+      Pnc1 is observed in the cytoplasm and participates in cellular
+      nicotinamide salvage.
 - term:
     id: GO:0005777
     label: peroxisome
   evidence_type: IEA
   original_reference_id: GO_REF:0000044
   review:
-    summary: 'Peroxisomal localization inferred from UniProtKB mapping. Well-supported by experimental evidence showing PNC1 concentrates in peroxisomes (PMID:12736687).'
+    summary: >-
+      UniProt peroxisome mapping is consistent with direct evidence that Pnc1
+      concentrates in peroxisomal foci, particularly in stress contexts.
     action: ACCEPT
-    reason: 'UniProtKB annotation notes that PNC1 concentrates in peroxisomes, which is verified by direct microscopy (PMID:12736687). Peroxisomal localization is relevant to cellular NAD metabolism and stress response functions. This localization is properly supported by literature.'
+    reason: >-
+      Peroxisomal localization is supported by experimental localization studies
+      and is part of Pnc1's condition-dependent subcellular distribution.
 - term:
     id: GO:0008936
     label: nicotinamidase activity
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
   review:
-    summary: 'Molecular function annotation assigned via combined automated methods, likely based on EC number (3.5.1.19) and sequence homology. This is the core enzymatic function of PNC1.'
+    summary: >-
+      Automated assignment of nicotinamidase activity matches Pnc1's core
+      enzymatic activity and EC 3.5.1.19.
     action: ACCEPT
-    reason: 'Nicotinamidase activity is the primary and well-characterized enzymatic function of PNC1. The EC number 3.5.1.19 directly classifies it as a nicotinamidase. This is strongly supported by multiple publications (PMID:12736687, PMID:11901108, PMID:19381334) demonstrating the catalytic conversion of nicotinamide to nicotinic acid. This is a core and essential annotation.'
+    reason: >-
+      Pnc1 catalyzes hydrolysis of nicotinamide to nicotinate and ammonia, the
+      central molecular function of this gene product.
     supported_by:
-      - reference_id: file:yeast/PNC1/PNC1-deep-research-falcon.md
-        supporting_text: "PNC1 (gene YGL037C) encodes nicotinamidase (EC 3.5.1.19) in Saccharomyces cerevisiae (strain S288c)."
+    - reference_id: file:yeast/PNC1/PNC1-deep-research-falcon.md
+      supporting_text: "PNC1 (gene YGL037C) encodes nicotinamidase (EC 3.5.1.19)"
 - term:
     id: GO:0016787
     label: hydrolase activity
   evidence_type: IEA
   original_reference_id: GO_REF:0000043
   review:
-    summary: 'Parent term for nicotinamidase activity based on enzyme classification. GO:0008936 (nicotinamidase activity) is more specific and informative. However, the parent term is not incorrect.'
-    action: ACCEPT
-    reason: 'This is the correct parent term for the specific nicotinamidase activity. Nicotinamidases are amidohydrolases (EC 3.5.1.19), so this annotation is mechanistically accurate. While the more specific term (GO:0008936) is preferable for precision, retaining this parent term is acceptable for comprehensive annotation coverage. Parent and child GO terms can coexist.'
+    summary: >-
+      Hydrolase activity is a true but generic parent of nicotinamidase activity.
+      The specific nicotinamidase term is already present.
+    action: MODIFY
+    reason: >-
+      For curation, GO:0008936 captures the actual enzyme activity and should be
+      preferred over the broad hydrolase parent.
+    proposed_replacement_terms:
+    - id: GO:0008936
+      label: nicotinamidase activity
 - term:
     id: GO:0019363
     label: pyridine nucleotide biosynthetic process
   evidence_type: IEA
   original_reference_id: GO_REF:0000043
   review:
-    summary: 'Process annotation derived from UniProtKB keyword mapping (KW-0662: Pyridine nucleotide biosynthesis). PNC1 is involved in NAD+ salvage pathway, which recycles pyridine nucleotides. This is a reasonable but somewhat indirect annotation.'
+    summary: >-
+      Pnc1 participates in pyridine nucleotide salvage by converting
+      nicotinamide to nicotinate, but the more precise existing process term is
+      nicotinate nucleotide salvage.
     action: MODIFY
-    reason: 'While PNC1 is mechanistically involved in NAD+ salvage (not de novo biosynthesis), GO:0019363 "pyridine nucleotide biosynthetic process" typically refers to de novo synthesis pathways (e.g., starting from tryptophan). PNC1 catalyzes salvage of nicotinamide to regenerate NAD+ in an existing pool, not biosynthesis of pyridine nucleotides de novo. The more accurate annotation would be GO:0019854 NAD metabolism because PNC1 catalyzes the first committed step in salvaging NAD+ from nicotinamide (PMID:12736687). This is NAD metabolism, not pyridine nucleotide de novo biosynthesis.'
+    reason: >-
+      Pnc1 is not a broad de novo pyridine nucleotide biosynthesis factor. It
+      catalyzes the nicotinamide entry step into the nicotinate salvage route,
+      which is captured by GO:0019358.
     proposed_replacement_terms:
-      - id: GO:0019854
-        label: NAD metabolism
+    - id: GO:0019358
+      label: nicotinate nucleotide salvage
 - term:
     id: GO:0046872
     label: metal ion binding
   evidence_type: IEA
   original_reference_id: GO_REF:0000043
   review:
-    summary: 'Parent term inferred from UniProtKB keywords for metal binding. PNC1 requires zinc cofactor for catalysis, so this is accurate but very general. The more specific annotation (GO:0008270, zinc ion binding) is already present with experimental evidence.'
-    action: ACCEPT
-    reason: 'This is correct as a parent term annotation. Zinc is a metal ion, and PNC1 binds zinc as a catalytic cofactor. While GO:0008270 (zinc ion binding) is more specific and is annotated separately, the parent term is not incorrect and provides complementary information. Parent-child GO terms are often both retained for annotation completeness.'
+    summary: >-
+      Metal ion binding is accurate but generic; Pnc1 specifically binds zinc as
+      part of its nicotinamidase active site.
+    action: MODIFY
+    reason: >-
+      The more informative term is zinc ion binding, already supported by curated
+      evidence and structural/mechanistic context.
+    proposed_replacement_terms:
+    - id: GO:0008270
+      label: zinc ion binding
 - term:
     id: GO:0008270
     label: zinc ion binding
   evidence_type: RCA
   original_reference_id: PMID:30358795
   review:
-    summary: 'Zinc ion binding assignment based on rapid curated annotation (RCA) from a zinc proteome analysis study. The study comprehensively catalogued zinc-binding proteins in yeast and is appropriate evidence for this annotation.'
+    summary: >-
+      Rapid curated annotation from yeast zinc proteome analysis is consistent
+      with the known zinc-dependent nicotinamidase active site of Pnc1.
     action: ACCEPT
-    reason: 'RCA (rapid curated annotation) is appropriate for identifying PNC1 as a zinc-binding protein. The source (PMID:30358795) is a comprehensive zinc proteome study that systematically identified and characterized zinc-binding sites on proteins. Zinc is essential for the catalytic mechanism of nicotinamidases, confirmed by structural studies showing zinc binding sites at positions 51, 53, and 94 in the PNC1 protein.'
+    reason: >-
+      Zinc binding is mechanistically appropriate for Pnc1's catalytic function.
     supported_by:
-      - reference_id: PMID:30358795
-        supporting_text: "The cellular economy of the Saccharomyces cerevisiae zinc proteome."
+    - reference_id: PMID:30358795
+      supporting_text: "The cellular economy of the Saccharomyces cerevisiae zinc proteome."
 - term:
     id: GO:0031509
     label: subtelomeric heterochromatin formation
   evidence_type: IMP
   original_reference_id: PMID:11901108
   review:
-    summary: 'Mutant phenotype annotation showing PNC1 deletion results in weakened subtelomeric heterochromatin silencing. This is one of the key functional roles identified for PNC1 in the literature.'
-    action: ACCEPT
-    reason: 'This is a core functional annotation based on IMP evidence from PMID:11901108, which demonstrates that pnc1 deletion results in a silencing defect at telomeres and rDNA. The mechanism is clear: PNC1 removes nicotinamide, an inhibitor of the Sir2 histone deacetylase, thereby enabling Sir2-mediated heterochromatin formation and silencing. The annotation is mechanistically sound and well-supported. This should be considered a core function of PNC1.'
+    summary: >-
+      pnc1 deletion causes telomeric silencing defects through impaired
+      nicotinamide clearance and reduced Sir2-dependent chromatin function.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      The phenotype is well supported, but it is a downstream chromatin outcome
+      of Pnc1's core nicotinamidase/NAD salvage activity rather than an
+      independent chromatin-binding function.
     supported_by:
-      - reference_id: PMID:11901108
-        supporting_text: "Deletion of another NAD(+) salvage pathway gene called PNC1 caused a less severe silencing defect and did not significantly reduce the intracellular NAD(+) concentration. However, silencing in the absence of PNC1 was completely dependent on the import of nicotinic acid from the growth medium"
+    - reference_id: PMID:11901108
+      supporting_text: "Deletion of another NAD(+) salvage pathway gene called PNC1 caused a less severe silencing defect"
 - term:
     id: GO:0019358
     label: nicotinate nucleotide salvage
   evidence_type: IMP
   original_reference_id: PMID:11901108
   review:
-    summary: 'Functional role annotation showing PNC1 participates in the salvage pathway for nicotinic acid-derived nucleotides. The pathway involves conversion of nicotinamide to nicotinic acid (catalyzed by PNC1) followed by conversion back to NAD+.'
+    summary: >-
+      Genetic evidence supports Pnc1 as a component of the NAD+ salvage pathway,
+      converting nicotinamide to nicotinate for reuse.
     action: ACCEPT
-    reason: 'This annotation correctly identifies PNC1s participation in nicotinate nucleotide salvage. PNC1 catalyzes the first step - deamidation of nicotinamide to nicotinic acid - which is the entry point into the salvage pathway. PMID:11901108 directly demonstrates that deletion of PNC1 compromises the salvage pathway capacity. This is a core biological function of the enzyme and is properly supported by IMP evidence.'
+    reason: >-
+      This is the core biological process associated with Pnc1's enzymatic
+      activity and explains the Sir2-related phenotypes.
     supported_by:
-      - reference_id: PMID:11901108
-        supporting_text: "We propose a model in which two components of the NAD(+) salvage pathway, Pnc1p and Npt1p, function together in recycling the nuclear nicotinamide generated by Sir2p deacetylase activity back into NAD(+)"
+    - reference_id: PMID:11901108
+      supporting_text: "Pnc1p and Npt1p function together in recycling the nuclear nicotinamide"
 - term:
     id: GO:0005737
     label: cytoplasm
   evidence_type: HDA
   original_reference_id: PMID:22842922
   review:
-    summary: 'HDA (high-throughput direct assay) annotation for cytoplasmic localization from a DNA damage response study. This provides complementary evidence to the IDA annotations.'
+    summary: >-
+      High-throughput direct assay evidence supports cytoplasmic localization.
     action: ACCEPT
-    reason: 'HDA is appropriate evidence for localization, derived from high-throughput mass spectrometry analysis of protein localization during stress. This complements the IDA evidence from PMID:12736687 and represents independent experimental validation. Cytoplasmic localization is well-established for PNC1.'
+    reason: >-
+      This is consistent with direct localization studies and Pnc1's metabolic
+      role in nicotinamide salvage.
     supported_by:
-      - reference_id: PMID:22842922
-        supporting_text: "Dissecting DNA damage response pathways by analysing protein localization and abundance changes during DNA replication stress."
+    - reference_id: PMID:22842922
+      supporting_text: "Dissecting DNA damage response pathways by analysing protein localization"
 - term:
     id: GO:1904524
     label: negative regulation of DNA amplification
   evidence_type: IMP
   original_reference_id: PMID:26195783
   review:
-    summary: 'Annotation based on mutant phenotype showing that PNC1 negatively regulates rDNA amplification. This appears to be an indirect effect through NAD metabolism and Sir2p regulation.'
-    action: UNDECIDED
-    reason: 'While PMID:26195783 is cited for this annotation, this requires careful interpretation. The connection between PNC1 and DNA amplification is not as mechanistically clear as PNC1s core roles in NAD salvage and silencing. The negative regulation of DNA amplification might be an indirect consequence of Sir2p regulation and chromatin silencing. Without the full publication text, the specific experimental context is unclear. This annotation may be correct but evidence linkage would benefit from deeper investigation.'
+    summary: >-
+      The rDNA amplification study reports that TOR/caloric-excess regulation
+      reduces PNC1 expression and that PNC1 overexpression substantially reduces
+      rDNA amplification rate.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      The annotation is experimentally supported, but it is an indirect
+      regulatory consequence of Pnc1 effects on Sir2/Hst deacetylase activity
+      and rDNA chromatin rather than the core enzymatic function.
     supported_by:
-      - reference_id: PMID:26195783
-        supporting_text: "Regulation of ribosomal DNA amplification by the TOR pathway."
+    - reference_id: PMID:26195783
+      supporting_text: "overexpression of PNC1 substantially reduces ribosomal DNA amplification rate"
 - term:
     id: GO:0000183
     label: rDNA heterochromatin formation
   evidence_type: IMP
   original_reference_id: PMID:11901108
   review:
-    summary: 'Functional annotation showing PNC1 participation in ribosomal DNA heterochromatin formation and silencing, demonstrated through deletion phenotype analysis.'
-    action: ACCEPT
-    reason: 'This is a core functional annotation parallel to the telomeric silencing role. PMID:11901108 explicitly demonstrates that pnc1 deletion compromises rDNA silencing. The mechanism is identical: PNC1 removes the Sir2 inhibitor nicotinamide, enabling Sir2-dependent heterochromatin formation at rDNA. This should be considered a primary function of PNC1. The IMP evidence is appropriate and well-supported.'
+    summary: >-
+      Genetic evidence supports a role for Pnc1 in rDNA silencing through the
+      nuclear NAD+ salvage pathway and Sir2-dependent chromatin regulation.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      This is a well-supported downstream biological process, but Pnc1 acts
+      through nicotinamide salvage rather than as a structural chromatin factor.
     supported_by:
-      - reference_id: PMID:11901108
-        supporting_text: "Deletion of another NAD(+) salvage pathway gene called PNC1 caused a less severe silencing defect and did not significantly reduce the intracellular NAD(+) concentration"
+    - reference_id: PMID:11901108
+      supporting_text: "Telomeric and rDNA silencing in Saccharomyces cerevisiae are dependent on a nuclear NAD(+) salvage pathway"
 - term:
     id: GO:0005634
     label: nucleus
   evidence_type: IDA
   original_reference_id: PMID:12736687
   review:
-    summary: 'Direct experimental evidence from microscopy-based localization analysis. PNC1 is demonstrated to be present in the nucleus, consistent with its role in Sir2-mediated silencing at telomeres and rDNA.'
+    summary: >-
+      Direct localization evidence places Pnc1 in the nucleus.
     action: ACCEPT
-    reason: 'This is direct experimental evidence (IDA) from PMID:12736687, one of the landmark studies on PNC1 function. The nuclear localization is essential to PNC1s mechanistic roles in regulating Sir2-mediated silencing. This is well-supported and appropriate.'
+    reason: >-
+      Nuclear localization is consistent with Pnc1's role in modulating
+      Sir2-dependent silencing through nicotinamide clearance.
     supported_by:
-      - reference_id: PMID:12736687
-        supporting_text: "Nicotinamide and PNC1 govern lifespan extension by calorie restriction in Saccharomyces cerevisiae."
+    - reference_id: PMID:12736687
+      supporting_text: "provide evidence that nicotinamide depletion is sufficient to activate Sir2 and"
 - term:
     id: GO:0005737
     label: cytoplasm
   evidence_type: IDA
   original_reference_id: PMID:12736687
   review:
-    summary: 'Direct experimental evidence for cytoplasmic localization from PMID:12736687. Consistent with HDA evidence from PMID:22842922. Cytoplasmic localization is appropriate given PNC1s roles in general NAD metabolism.'
+    summary: >-
+      Direct localization evidence places Pnc1 in the cytoplasm.
     action: ACCEPT
-    reason: 'IDA evidence from microscopy showing cytoplasmic presence is well-supported. The cytoplasmic localization is consistent with PNC1s roles in cellular NAD metabolism. Multiple independent localization studies confirm this. This annotation is appropriate.'
+    reason: >-
+      Cytoplasmic localization is consistent with Pnc1's NAD salvage enzyme
+      function.
     supported_by:
-      - reference_id: PMID:12736687
-        supporting_text: "Nicotinamide and PNC1 govern lifespan extension by calorie restriction in Saccharomyces cerevisiae."
+    - reference_id: PMID:12736687
+      supporting_text: "provide evidence that nicotinamide depletion is sufficient to activate Sir2 and"
 - term:
     id: GO:0005777
     label: peroxisome
   evidence_type: IDA
   original_reference_id: PMID:12736687
   review:
-    summary: 'Direct experimental evidence for peroxisomal localization, with the important note that PNC1 concentrates in peroxisomes. This is a prominent subcellular localization for this protein.'
+    summary: >-
+      Direct localization evidence supports peroxisomal Pnc1 foci and
+      condition-dependent peroxisomal enrichment.
     action: ACCEPT
-    reason: 'IDA evidence from PMID:12736687 confirms PNC1 localization to peroxisomes. Peroxisomes are significant sites of NAD metabolism and stress response, and PNC1 localization there is functionally relevant. The annotation is well-supported and appropriate. Peroxisomal targeting appears to be especially important under stress conditions.'
+    reason: >-
+      Peroxisome localization is experimentally supported and is a recurring
+      feature of Pnc1 stress-responsive distribution.
     supported_by:
-      - reference_id: PMID:12736687
-        supporting_text: "In Saccharomyces cerevisiae, lifespan extension by calorie restriction requires the NAD+-dependent histone deacetylase, Sir2"
+    - reference_id: file:yeast/PNC1/PNC1-deep-research-falcon.md
+      supporting_text: "Pnc1 localizes to cytosol and nucleus and to discrete peroxisomal foci"
 - term:
     id: GO:0008936
     label: nicotinamidase activity
   evidence_type: IMP
   original_reference_id: PMID:19381334
   review:
-    summary: 'Second annotation of nicotinamidase activity with IMP evidence from a study demonstrating that PNC1 is up-regulated under stress (protein mistranslation) and that the enzyme is catalytically active. Duplicates the IEA annotation but with experimental support.'
+    summary: >-
+      The mistranslation study measured increased Pnc1 expression and activity
+      and used nicotinamidase assays to connect stress to Pnc1/Sir2 activation.
     action: ACCEPT
-    reason: 'This is a duplicate GO ID (GO:0008936) but with different evidence type (IMP vs IEA). In GO annotation, having multiple evidence codes for the same term is acceptable and actually desirable - it shows the annotation is supported by both automated and experimental evidence. PMID:19381334 directly demonstrates that Pnc1p activity is enhanced under stress conditions through catalytic assays measuring NAM-to-NAC conversion and ammonia release. Having both IEA and IMP annotations reinforces the robustness of this core functional annotation.'
+    reason: >-
+      This experimental annotation reinforces the core nicotinamidase activity
+      of Pnc1 under stress conditions.
     supported_by:
-      - reference_id: PMID:19381334
-        supporting_text: "Pnc1 synthesizes nicotinic acid from nicotinamide"
+    - reference_id: PMID:19381334
+      supporting_text: "Our results showed that up-regulation of Pnc1p expression (Figs 1 and 2) resulted in increased Pnc1p and Sir2p activity"
 core_functions:
-  - molecular_function:
-      id: GO:0008936
-      label: nicotinamidase activity
-    directly_involved_in:
-      - id: GO:0019358
-        label: nicotinate nucleotide salvage
-    description: |
-      Pnc1 catalyzes deamidation of nicotinamide to nicotinic acid, providing the entry
-      step for NAD+ salvage and relieving nicotinamide inhibition of Sir2-dependent processes.
-    supported_by:
-      - reference_id: PMID:11901108
-        supporting_text: "We propose a model in which two components of the NAD(+) salvage pathway, Pnc1p and Npt1p, function together in recycling the nuclear nicotinamide generated by Sir2p deacetylase activity back into NAD(+)"
-      - reference_id: file:yeast/PNC1/PNC1-deep-research-falcon.md
-        supporting_text: "PNC1 (gene YGL037C) encodes nicotinamidase (EC 3.5.1.19) in Saccharomyces cerevisiae (strain S288c)."
+- molecular_function:
+    id: GO:0008936
+    label: nicotinamidase activity
+  directly_involved_in:
+  - id: GO:0019358
+    label: nicotinate nucleotide salvage
+  locations:
+  - id: GO:0005737
+    label: cytoplasm
+  - id: GO:0005634
+    label: nucleus
+  - id: GO:0005777
+    label: peroxisome
+  description: >-
+    Pnc1 deamidates nicotinamide to nicotinate and ammonia, routing
+    nicotinamide into NAD+ salvage and lowering nicotinamide inhibition of
+    Sir2-family deacetylases. Its chromatin-silencing and rDNA-copy-number
+    effects are downstream consequences of this core enzyme activity.
+  supported_by:
+  - reference_id: PMID:11901108
+    supporting_text: "Pnc1p and Npt1p function together in recycling the nuclear nicotinamide"
+  - reference_id: file:yeast/PNC1/PNC1-deep-research-falcon.md
+    supporting_text: "catalyzing deamidation of nicotinamide"
+proposed_new_terms: []
+suggested_questions:
+- question: >-
+    What determines condition-specific partitioning of Pnc1 between cytosol,
+    nucleus, and peroxisomes, and how much of the Sir2-regulatory effect depends
+    on each pool?
+suggested_experiments:
+- description: >-
+    Endogenous Pnc1 localization mutants that selectively disrupt peroxisomal
+    enrichment, followed by nicotinamide, NAD+, Sir2 silencing, and rDNA
+    amplification assays under stress and calorie-restriction conditions.
+  experiment_type: localization/genetics/metabolomics
+  hypothesis: >-
+    Nuclear and cytosolic Pnc1 provide most Sir2-regulatory activity, while
+    stress-enhanced peroxisomal Pnc1 contributes condition-specific
+    nicotinamide handling.
 references:
 - id: GO_REF:0000043
   title: Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping
   findings: []
 - id: GO_REF:0000044
-  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
-    vocabulary mapping, accompanied by conservative changes to GO terms applied by
-    UniProt
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt
   findings: []
 - id: GO_REF:0000108
-  title: Automatic assignment of GO terms using logical inference, based on on inter-ontology
-    links
+  title: Automatic assignment of GO terms using logical inference, based on on inter-ontology links
   findings: []
 - id: GO_REF:0000120
   title: Combined Automated Annotation using Multiple IEA Methods
   findings: []
 - id: PMID:11901108
-  title: Telomeric and rDNA silencing in Saccharomyces cerevisiae are dependent on
-    a nuclear NAD(+) salvage pathway.
+  title: Telomeric and rDNA silencing in Saccharomyces cerevisiae are dependent on a nuclear NAD(+) salvage pathway.
   findings: []
 - id: PMID:12736687
-  title: Nicotinamide and PNC1 govern lifespan extension by calorie restriction in
-    Saccharomyces cerevisiae.
+  title: Nicotinamide and PNC1 govern lifespan extension by calorie restriction in Saccharomyces cerevisiae.
   findings: []
 - id: PMID:19381334
   title: The yeast PNC1 longevity gene is up-regulated by mRNA mistranslation.
   findings: []
 - id: PMID:22842922
-  title: Dissecting DNA damage response pathways by analysing protein localization
-    and abundance changes during DNA replication stress.
+  title: Dissecting DNA damage response pathways by analysing protein localization and abundance changes during DNA replication stress.
   findings: []
 - id: PMID:26195783
   title: Regulation of ribosomal DNA amplification by the TOR pathway.
   findings: []
 - id: PMID:30358795
   title: The cellular economy of the Saccharomyces cerevisiae zinc proteome.
+  findings: []
+- id: file:yeast/PNC1/PNC1-deep-research-falcon.md
+  title: Falcon deep research report for PNC1
   findings: []

--- a/genes/yeast/PNO1/PNO1-ai-review.html
+++ b/genes/yeast/PNO1/PNO1-ai-review.html
@@ -671,33 +671,46 @@
     <div class="header">
         <h1>PNO1</h1>
         <div class="gene-info">
-            
+
             <div class="info-item">
-                
+
                 <span class="info-label">UniProt ID:</span>
                 <span>
                     <a href="https://www.uniprot.org/uniprotkb/Q99216" target="_blank" class="term-link">
                         Q99216
                     </a>
                 </span>
-                
+
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Organism:</span>
                 <span>Saccharomyces cerevisiae</span>
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
-                <span class="status-badge status-draft">
-                    DRAFT
+                <span class="status-badge status-complete">
+                    COMPLETE
                 </span>
             </div>
-            
-            
+
+
+            <div class="info-item">
+                <span class="info-label">Aliases:</span>
+                <div class="aliases">
+
+                    <span class="badge">DIM2</span>
+
+                    <span class="badge">RRP20</span>
+
+                    <span class="badge">YOR145C</span>
+
+                </div>
+            </div>
+
         </div>
         <div style="margin-top: 1rem; text-align: center;">
             <a id="feedback-form-link"
@@ -728,24 +741,24 @@
         </div>
     </div>
 
-    
+
     <div class="description-card">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <h2>Gene Description</h2>
-            <span class="vote-buttons" data-g="Q99216" data-a="DESCRIPTION: TODO: Add description for PNO1..." data-r="" data-act="DESCRIPTION">
+            <span class="vote-buttons" data-g="Q99216" data-a="DESCRIPTION: PNO1 encodes Pno1/Dim2/Rrp20, a conserved KH-domai..." data-r="" data-act="DESCRIPTION">
                 <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
                 <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
             </span>
         </div>
-        <p>TODO: Add description for PNO1</p>
+        <p>PNO1 encodes Pno1/Dim2/Rrp20, a conserved KH-domain ribosome biogenesis factor required for small ribosomal subunit synthesis. Pno1 binds pre-rRNA, especially the ITS1 region, participates in early SSU processome and 90S to pre-40S transitions, supports pre-40S export from the nucleus, and works with Nob1 and Rio1 during late cytoplasmic 20S pre-rRNA to 18S rRNA maturation. The coherent core function is RNA-binding regulation of SSU/pre-40S assembly and processing; older proteasome and generic chaperone annotations appear secondary or overextended.</p>
     </div>
-    
 
-    
 
-    
 
-    
+
+
+
+
     <div class="section">
         <h2 class="section-title">Existing Annotations Review</h2>
         <table class="annotations-table">
@@ -758,32 +771,32 @@
                 </tr>
             </thead>
             <tbody>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -795,46 +808,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: nucleus is consistent with known biology of PNO1.
+                            <strong>Summary:</strong> PANTHER IBA to nucleus is consistent with Pno1&#39;s conserved role as a nuclear/nucleolar and nucleocytoplasmic ribosome biogenesis factor.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Pno1 acts in nuclear and nucleolar stages of SSU biogenesis and has direct experimental nuclear/nucleolar localization support.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003723" target="_blank" class="term-link">
                                     GO:0003723
                                 </a>
                             </span>
                             <span class="term-label">RNA binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -846,46 +859,62 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: RNA binding is consistent with known biology of PNO1.
+                            <strong>Summary:</strong> Automated RNA-binding annotation is supported by Pno1 KH domains and by direct evidence for binding pre-rRNA/ITS1.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> RNA binding is a core molecular function for Pno1, though the more specific rRNA primary transcript binding term is preferred when available.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/PNO1/PNO1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">binds pre-rRNA (ITS1 region) via its KH domain</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005730" target="_blank" class="term-link">
                                     GO:0005730
                                 </a>
                             </span>
                             <span class="term-label">nucleolus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -897,46 +926,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: nucleolus is consistent with known biology of PNO1.
+                            <strong>Summary:</strong> UniProt/ARBA nucleolus mapping is consistent with Pno1 function in early nucleolar SSU processome assembly and pre-rRNA processing.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> The nucleolus is a supported compartment for Pno1 during early ribosome biogenesis.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -948,46 +977,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: cytoplasm is consistent with known biology of PNO1.
+                            <strong>Summary:</strong> Cytoplasmic localization is consistent with Pno1 shuttling and late cytoplasmic pre-40S maturation.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Pno1 functions after pre-40S export as part of late 18S rRNA maturation and quality-control gating.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042254" target="_blank" class="term-link">
                                     GO:0042254
                                 </a>
                             </span>
                             <span class="term-label">ribosome biogenesis</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -999,57 +1028,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: ribosome biogenesis is consistent with known biology of PNO1.
+                            <strong>Summary:</strong> Broad automated ribosome biogenesis annotation accurately summarizes the experimentally supported Pno1 role in SSU/pre-40S assembly and maturation.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Pno1 is a ribosome biogenesis factor; more specific annotations capture SSU-rRNA maturation, pre-40S export, and ribosome assembly.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005730" target="_blank" class="term-link">
                                     GO:0005730
                                 </a>
                             </span>
                             <span class="term-label">nucleolus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/27980088" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:27980088
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Architecture of the yeast small subunit processome.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1061,57 +1090,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: nucleolus is consistent with known biology of PNO1.
+                            <strong>Summary:</strong> ComplexPortal direct assay evidence places Pno1 in the nucleolus/SSU processome context.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Nucleolar localization matches Pno1&#39;s early SSU processome and pre-rRNA processing roles.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/27980088" target="_blank" class="term-link">
+                                        PMID:27980088
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Architecture of the yeast small subunit processome.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030490" target="_blank" class="term-link">
                                     GO:0030490
                                 </a>
                             </span>
                             <span class="term-label">maturation of SSU-rRNA</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">NAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/15489292" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:15489292
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     RNA polymerase I transcription and pre-rRNA processing are l...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1123,57 +1170,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: maturation of SSU-rRNA is consistent with known biology of PNO1.
+                            <strong>Summary:</strong> Curated statement evidence supports Pno1 as a specific SSU processome component linked to SSU-rRNA maturation.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> The annotation is consistent with multiple yeast studies showing defects in pre-rRNA processing when Pno1/Dim2/Rrp20 is perturbed.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15489292" target="_blank" class="term-link">
+                                        PMID:15489292
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">RNA polymerase I transcription and pre-rRNA processing are linked by specific SSU processome components.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000056" target="_blank" class="term-link">
                                     GO:0000056
                                 </a>
                             </span>
                             <span class="term-label">ribosomal small subunit export from nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/18755838" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:18755838
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     TOR regulates the subcellular distribution of DIM2, a KH dom...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1185,57 +1250,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: ribosomal small subunit export from nucleus is consistent with known biology of PNO1.
+                            <strong>Summary:</strong> Mutant phenotype evidence supports Dim2/Pno1 involvement in pre-40S export from the nucleus.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Pno1 contains a conserved export-related region and perturbation causes pre-40S export defects, making this a core process annotation.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18755838" target="_blank" class="term-link">
+                                        PMID:18755838
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">pre-40S ribosome export</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042134" target="_blank" class="term-link">
                                     GO:0042134
                                 </a>
                             </span>
                             <span class="term-label">rRNA primary transcript binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/18755838" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:18755838
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     TOR regulates the subcellular distribution of DIM2, a KH dom...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1247,57 +1330,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: rRNA primary transcript binding is consistent with known biology of PNO1.
+                            <strong>Summary:</strong> Direct assay evidence shows Dim2/Pno1 binds pre-rRNA through its KH domain at the 5&#39; end of ITS1.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> This is the most specific experimentally supported molecular function for Pno1 and should be considered core.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18755838" target="_blank" class="term-link">
+                                        PMID:18755838
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">DIM2 binds pre-rRNAs directly through its KH domain</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042255" target="_blank" class="term-link">
                                     GO:0042255
                                 </a>
                             </span>
                             <span class="term-label">ribosome assembly</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/18755838" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:18755838
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     TOR regulates the subcellular distribution of DIM2, a KH dom...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1309,57 +1410,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: ribosome assembly is consistent with known biology of PNO1.
+                            <strong>Summary:</strong> Mutant phenotype evidence supports Dim2/Pno1 function in cotranscriptional ribosome assembly and pre-40S maturation.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Pno1 coordinates pre-rRNA binding, pre-40S export, and later maturation, so ribosome assembly is appropriate.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18755838" target="_blank" class="term-link">
+                                        PMID:18755838
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">cotranscriptional ribosome assembly</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030686" target="_blank" class="term-link">
                                     GO:0030686
                                 </a>
                             </span>
                             <span class="term-label">90S preribosome</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/12150911" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:12150911
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     90S pre-ribosomes include the 35S pre-rRNA, the U3 snoRNP, a...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1371,181 +1490,217 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: 90S preribosome is consistent with known biology of PNO1.
+                            <strong>Summary:</strong> High-throughput direct assay evidence identifies Pno1/Rrp20 with 90S preribosomal particles.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> This component annotation is consistent with Pno1&#39;s early SSU processome role.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12150911" target="_blank" class="term-link">
+                                        PMID:12150911
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">90S pre-ribosomes include the 35S pre-rRNA</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043248" target="_blank" class="term-link">
                                     GO:0043248
                                 </a>
                             </span>
                             <span class="term-label">proteasome assembly</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/12502737" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:12502737
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Nob1p is required for biogenesis of the 26S proteasome and d...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-keepasnoncore">
-                            KEEP AS NON CORE
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q99216" data-a="GO:0043248" data-r="PMID:12502737" data-act="KEEP_AS_NON_CORE">
+                        <span class="vote-buttons" data-g="Q99216" data-a="GO:0043248" data-r="PMID:12502737" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: proteasome assembly may be context-dependent or peripheral for PNO1.
+                            <strong>Summary:</strong> The 2002 Nob1/Pno1 study connected pno1 defects with Pre6p accumulation and proteasome maturation, but subsequent literature and UniProt support a primary SSU ribosome biogenesis role for Pno1.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+                            <strong>Reason:</strong> The proteasome assembly annotation appears to reflect an older model or an indirect phenotype through Nob1-associated biology. It should not be considered a core Pno1 function.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12502737" target="_blank" class="term-link">
+                                        PMID:12502737
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">A defect in either NOB1 or PNO1 caused accumulation of newly formed Pre6p</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043248" target="_blank" class="term-link">
                                     GO:0043248
                                 </a>
                             </span>
                             <span class="term-label">proteasome assembly</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/12502737" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:12502737
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Nob1p is required for biogenesis of the 26S proteasome and d...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-keepasnoncore">
-                            KEEP AS NON CORE
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q99216" data-a="GO:0043248" data-r="PMID:12502737" data-act="KEEP_AS_NON_CORE">
+                        <span class="vote-buttons" data-g="Q99216" data-a="GO:0043248" data-r="PMID:12502737" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: proteasome assembly may be context-dependent or peripheral for PNO1.
+                            <strong>Summary:</strong> The protein-interaction basis for proteasome assembly is not sufficient to override the now well-supported Pno1 role in SSU/pre-40S maturation.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+                            <strong>Reason:</strong> Pno1&#39;s core function is ribosome biogenesis. The proteasome assembly interpretation is indirect and should be downgraded.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000447" target="_blank" class="term-link">
                                     GO:0000447
                                 </a>
                             </span>
                             <span class="term-label">endonucleolytic cleavage in ITS1 to separate SSU-rRNA from 5.8S rRNA and LSU-rRNA from tricistronic rRNA transcript (SSU-rRNA, 5.8S rRNA, LSU-rRNA)</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/12736301" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:12736301
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     RRP20, a component of the 90S preribosome, is required for p...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1557,57 +1712,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: endonucleolytic cleavage in ITS1 to separate SSU-rRNA from 5.8S rRNA and LSU-rRNA from tricistronic rRNA transcript (SSU-rRNA, 5.8S rRNA, LSU-rRNA) is consistent with known biology of PNO1.
+                            <strong>Summary:</strong> RRP20/PNO1 mutant phenotypes impair early pre-rRNA cleavages, including ITS1 processing that separates SSU from LSU rRNA precursors.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Pno1 is required for proper pre-rRNA processing as part of the SSU maturation pathway, although it is not itself the nuclease.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12736301" target="_blank" class="term-link">
+                                        PMID:12736301
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">RRP20, a component of the 90S preribosome, is required for pre-18S rRNA processing</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000472" target="_blank" class="term-link">
                                     GO:0000472
                                 </a>
                             </span>
                             <span class="term-label">endonucleolytic cleavage to generate mature 5&#39;-end of SSU-rRNA from (SSU-rRNA, 5.8S rRNA, LSU-rRNA)</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/12736301" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:12736301
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     RRP20, a component of the 90S preribosome, is required for p...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1619,57 +1792,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: endonucleolytic cleavage to generate mature 5&#39;-end of SSU-rRNA from (SSU-rRNA, 5.8S rRNA, LSU-rRNA) is consistent with known biology of PNO1.
+                            <strong>Summary:</strong> PNO1/RRP20 mutant evidence supports a requirement for proper pre-18S rRNA processing and mature SSU-rRNA formation.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> The annotation captures a core process consequence of Pno1 function in SSU maturation.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12736301" target="_blank" class="term-link">
+                                        PMID:12736301
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">defective in ribosomal RNA processing</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/12502737" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:12502737
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Nob1p is required for biogenesis of the 26S proteasome and d...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1681,57 +1872,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: nucleus is consistent with known biology of PNO1.
+                            <strong>Summary:</strong> Direct assay evidence supports nuclear localization of Pno1.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Nuclear localization is consistent with Pno1&#39;s early pre-rRNA processing and pre-40S export roles.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12502737" target="_blank" class="term-link">
+                                        PMID:12502737
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Pno1p</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005730" target="_blank" class="term-link">
                                     GO:0005730
                                 </a>
                             </span>
                             <span class="term-label">nucleolus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10923024" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:10923024
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Functional analysis of six genes from chromosomes XIV and XV...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1743,57 +1952,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: nucleolus is consistent with known biology of PNO1.
+                            <strong>Summary:</strong> Direct GFP localization evidence places Yor145c/Pno1 in the nucleolus.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Nucleolar localization is appropriate for an early SSU processome and pre-rRNA processing factor.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10923024" target="_blank" class="term-link">
+                                        PMID:10923024
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Yor145-GFP concentrating in the nucleolus</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/12502737" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:12502737
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Nob1p is required for biogenesis of the 26S proteasome and d...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1805,209 +2032,853 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: unfolded protein binding is too generic or over-extended for PNO1.
+                            <strong>Summary:</strong> The unfolded-protein binding annotation is not well aligned with Pno1&#39;s demonstrated KH-domain pre-rRNA binding and ribosome biogenesis functions.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Marked over-annotated because more specific terms capture the biology more accurately.
+                            <strong>Reason:</strong> Pno1 should not be curated as a generic protein-folding chaperone. Its supported molecular function is rRNA/pre-rRNA binding and assembly-factor regulation with Nob1/Rio1.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
             </tbody>
         </table>
     </div>
-    
 
-    
 
-    
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Pno1/Dim2 is a KH-domain rRNA-binding assembly factor that binds pre-rRNA, supports SSU processome and pre-40S maturation, contributes to pre-40S export, and coordinates late 18S rRNA processing with Nob1/Rio1-associated quality control.</h3>
+                <span class="vote-buttons" data-g="Q99216" data-a="FUNCTION: Pno1/Dim2 is a KH-domain rRNA-binding assembly fac..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042134" target="_blank" class="term-link">
+                            rRNA primary transcript binding
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030490" target="_blank" class="term-link">
+                                maturation of SSU-rRNA
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042255" target="_blank" class="term-link">
+                                ribosome assembly
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000056" target="_blank" class="term-link">
+                                ribosomal small subunit export from nucleus
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005730" target="_blank" class="term-link">
+                                nucleolus
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
+                                nucleus
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                cytoplasm
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030686" target="_blank" class="term-link">
+                            90S preribosome
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18755838" target="_blank" class="term-link">
+                                PMID:18755838
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">DIM2 binds pre-rRNAs directly through its KH domain</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12736301" target="_blank" class="term-link">
+                                PMID:12736301
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">required for pre-18S rRNA processing</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:yeast/PNO1/PNO1-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">binds pre-rRNA (ITS1 region) via its KH domain</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class="section">
         <h2 class="section-title collapsible">References</h2>
         <div class="collapse-content">
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
                             GO_REF:0000033
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Annotation inferences using phylogenetic trees</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
                             GO_REF:0000044
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
                             GO_REF:0000120
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/10923024" target="_blank" class="term-link">
                             PMID:10923024
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Functional analysis of six genes from chromosomes XIV and XV of Saccharomyces cerevisiae reveals YOR145c as an essential gene and YNL059c/ARP5 as a strain-dependent essential gene encoding nuclear proteins.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/12150911" target="_blank" class="term-link">
                             PMID:12150911
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">90S pre-ribosomes include the 35S pre-rRNA, the U3 snoRNP, and 40S subunit processing factors but predominantly lack 60S synthesis factors.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/12502737" target="_blank" class="term-link">
                             PMID:12502737
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Nob1p is required for biogenesis of the 26S proteasome and degraded upon its maturation in Saccharomyces cerevisiae.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/12736301" target="_blank" class="term-link">
                             PMID:12736301
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">RRP20, a component of the 90S preribosome, is required for pre-18S rRNA processing in Saccharomyces cerevisiae.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/15489292" target="_blank" class="term-link">
                             PMID:15489292
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">RNA polymerase I transcription and pre-rRNA processing are linked by specific SSU processome components.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/18755838" target="_blank" class="term-link">
                             PMID:18755838
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TOR regulates the subcellular distribution of DIM2, a KH domain protein required for cotranscriptional ribosome assembly and pre-40S ribosome export.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/27980088" target="_blank" class="term-link">
                             PMID:27980088
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Architecture of the yeast small subunit processome.</div>
-                
-                
+
+
             </div>
-            
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:yeast/PNO1/PNO1-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research report for PNO1</div>
+
+
+            </div>
+
         </div>
     </div>
-    
 
 
-    
 
-    
 
-    
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Should the legacy PNO1 proteasome assembly annotations be retired or replaced by updated pre-40S/Nob1 maturation annotations in upstream SGD/GO curation?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q99216" data-a="Q: Should the legacy PNO1 proteasome assembly annotat..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Revisit proteasome assembly phenotypes in pno1/dim2 mutants using acute degron depletion and ribosome-processing rescue constructs to distinguish direct proteasome effects from secondary consequences of impaired ribosome biogenesis.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: The reported proteasome maturation defects are indirect consequences of perturbed Nob1/Pno1 ribosome biogenesis or pleiotropic essential-gene stress.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: conditional depletion/rescue</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q99216" data-a="EXPERIMENT: Revisit proteasome assembly phenotypes in pno1/dim..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
 
     <!-- Computational Predictions Section -->
-    
+
 
     <!-- Additional Documentation Sections -->
-    
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Deep Research Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(PNO1-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q99216" data-a="DOC: Deep Research Falcon" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <hr />
+<p>provider: falcon<br />
+model: Edison Scientific Literature<br />
+cached: false<br />
+start_time: '2026-05-04T10:06:12.733283'<br />
+end_time: '2026-05-04T10:30:37.462203'<br />
+duration_seconds: 1464.73<br />
+template_file: templates/gene_research_go_focused.md<br />
+template_variables:<br />
+  organism: yeast<br />
+  gene_id: PNO1<br />
+  gene_symbol: PNO1<br />
+  uniprot_accession: Q99216<br />
+  protein_description: 'RecName: Full=Pre-rRNA-processing protein PNO1; AltName: Full=Partner<br />
+    of NOB1; AltName: Full=Ribosomal RNA-processing protein 20;'<br />
+  gene_info: Name=PNO1; Synonyms=DIM2, RRP20; OrderedLocusNames=YOR145C; ORFNames=O3513,<br />
+    YOR3513C;<br />
+  organism_full: Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).<br />
+  protein_family: Belongs to the PNO1 family. .<br />
+  protein_domains: KH-I_PNO1_first. (IPR055212); KH_dom_type_1_sf. (IPR036612); KH_PNO1_2nd.<br />
+    (IPR055211); KRR1-like_KH1. (IPR041174); KH_KRR1_1st (PF17903)<br />
+provider_config:<br />
+  timeout: 600<br />
+  max_retries: 3<br />
+  parameters:<br />
+    allowed_domains: []<br />
+    temperature: 0.1<br />
+citation_count: 34</p>
+<hr />
+<h2 id="question">Question</h2>
+<h1 id="gene-research-for-functional-annotation">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> Q99216</li>
+<li><strong>Protein Description:</strong> RecName: Full=Pre-rRNA-processing protein PNO1; AltName: Full=Partner of NOB1; AltName: Full=Ribosomal RNA-processing protein 20;</li>
+<li><strong>Gene Information:</strong> Name=PNO1; Synonyms=DIM2, RRP20; OrderedLocusNames=YOR145C; ORFNames=O3513, YOR3513C;</li>
+<li><strong>Organism (full):</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Protein Family:</strong> Belongs to the PNO1 family. .</li>
+<li><strong>Key Domains:</strong> KH-I_PNO1_first. (IPR055212); KH_dom_type_1_sf. (IPR036612); KH_PNO1_2nd. (IPR055211); KRR1-like_KH1. (IPR041174); KH_KRR1_1st (PF17903)</li>
+</ul>
+<h3 id="mandatory-verification-steps">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "PNO1" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'PNO1' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>PNO1</strong> (gene ID: PNO1, UniProt: Q99216) in yeast.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="output">Output</h2>
+<p>Question: You are an expert researcher providing comprehensive, well-cited information.</p>
+<p>Provide detailed information focusing on:<br />
+1. Key concepts and definitions with current understanding<br />
+2. Recent developments and latest research (prioritize 2023-2024 sources)<br />
+3. Current applications and real-world implementations<br />
+4. Expert opinions and analysis from authoritative sources<br />
+5. Relevant statistics and data from recent studies</p>
+<p>Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.<br />
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.</p>
+<h1 id="gene-research-for-functional-annotation_1">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context_1">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot_1">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> Q99216</li>
+<li><strong>Protein Description:</strong> RecName: Full=Pre-rRNA-processing protein PNO1; AltName: Full=Partner of NOB1; AltName: Full=Ribosomal RNA-processing protein 20;</li>
+<li><strong>Gene Information:</strong> Name=PNO1; Synonyms=DIM2, RRP20; OrderedLocusNames=YOR145C; ORFNames=O3513, YOR3513C;</li>
+<li><strong>Organism (full):</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Protein Family:</strong> Belongs to the PNO1 family. .</li>
+<li><strong>Key Domains:</strong> KH-I_PNO1_first. (IPR055212); KH_dom_type_1_sf. (IPR036612); KH_PNO1_2nd. (IPR055211); KRR1-like_KH1. (IPR041174); KH_KRR1_1st (PF17903)</li>
+</ul>
+<h3 id="mandatory-verification-steps_1">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "PNO1" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature_1">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'PNO1' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target_1">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>PNO1</strong> (gene ID: PNO1, UniProt: Q99216) in yeast.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="research-report-functional-annotation-of-saccharomyces-cerevisiae-pno1-dim2rrp20">Research Report: Functional Annotation of <em>Saccharomyces cerevisiae</em> PNO1 (Dim2/Rrp20)</h1>
+<h2 id="0-target-identity-verification-mandatory">0) Target identity verification (mandatory)</h2>
+<p>The research target is <strong>PNO1</strong> from <em>Saccharomyces cerevisiae</em> S288c (UniProt <strong>Q99216</strong>), also known in yeast literature as <strong>Dim2</strong> and <strong>Rrp20</strong> and encoded by <strong>YOR145C</strong>. A yeast primary study explicitly identifies <strong>DIM2 (ORF YOR145C)</strong> as a <strong>KH-domain</strong> ribosome biogenesis factor required for <strong>pre-rRNA processing</strong> and <strong>pre-40S export</strong>, matching the UniProt description (pre‑rRNA‑processing protein; “Partner of Nob1”) and the stated family/domain architecture (KH-type RNA-binding domains). (vanrobays2008torregulatesthe pages 1-2)</p>
+<p>Because “PNO1” is also used for homologs in other eukaryotes (including human cancer literature), only yeast-specific sources and conserved-mechanism studies with clear organism context are used here for functional claims about Q99216/YOR145C. (vanrobays2008torregulatesthe pages 1-2, woolls2011rolesofdim2 pages 1-2)</p>
+<h2 id="1-key-concepts-definitions-and-current-understanding">1) Key concepts, definitions, and current understanding</h2>
+<h3 id="11-ribosome-biogenesis-context-ssu-processome-pre-40s-mature-40s">1.1 Ribosome biogenesis context (SSU processome → pre-40S → mature 40S)</h3>
+<p>In yeast, small ribosomal subunit (40S) biogenesis begins cotranscriptionally on the 35S pre-rRNA within a large nucleolar precursor called the <strong>90S/SSU processome</strong>, which is remodeled to release a <strong>pre-40S</strong> particle that is exported to the cytoplasm for final maturation. General quantitative context: yeast cells can synthesize ~<strong>2000 ribosomes/minute</strong>; eukaryotic ribosomes contain <strong>79</strong> ribosomal proteins; assembly requires <strong>&gt;200</strong> transient assembly factors. (chakermargot2018assemblyofthe pages 1-2, parker2024thekinaserio1 pages 1-2)</p>
+<h3 id="12-what-pno1dim2-is">1.2 What Pno1/Dim2 is</h3>
+<p><strong>Pno1/Dim2 (PNO1/DIM2/RRP20)</strong> is a <strong>conserved KH-domain-containing</strong> ribosome biogenesis factor that binds pre-rRNA and acts at multiple stages of SSU maturation—from early steps associated with the SSU processome/90S particle to late cytoplasmic pre-40S maturation. (vanrobays2008torregulatesthe pages 1-2, sturm2017interdependentactionof pages 1-2)</p>
+<p>Key definitional points:<br />
+- <strong>KH domain</strong>: an RNA-binding fold; in yeast Pno1/Dim2 the KH motif is critical for pre-rRNA association, with residues in the KH region (including the conserved <strong>G207</strong>) required for binding and proper processing. (vanrobays2008torregulatesthe pages 1-2, knox2010regulationofthea pages 57-61)<br />
+- <strong>ITS1</strong> (internal transcribed spacer 1): Pno1/Dim2 binds the <strong>5′ end of ITS1</strong> (often discussed as the D–A2 region in yeast processing maps), positioning it at the SSU/ITS1 junction relevant for small-subunit processing and later cleavage events. (vanrobays2008torregulatesthe pages 1-2)</p>
+<h3 id="13-primary-molecular-function-what-pno1dim2-does">1.3 Primary molecular function (what Pno1/Dim2 “does”)</h3>
+<p>PNO1 is <strong>not an enzyme catalyzing a chemical reaction</strong>; rather, it is an <strong>RNA-binding assembly factor</strong> and <strong>checkpoint/regulatory factor</strong>.</p>
+<p>The best-supported primary function is that Pno1/Dim2:<br />
+1) <strong>binds pre-rRNA (ITS1 region) via its KH domain</strong> to promote proper SSU assembly/processing, and<br />
+2) <strong>partners with and regulates the endonuclease Nob1</strong> during the essential final step of 18S rRNA 3′-end formation (D-site cleavage of 20S pre-rRNA → mature 18S), including controlling access/positioning and coupling cleavage to downstream release/quality control. (woolls2011rolesofdim2 pages 1-2, scaiola2018structureofa pages 1-2)</p>
+<p>Mechanistic evidence in yeast indicates Dim2 physically interacts with Nob1; this interaction increases Nob1’s RNA affinity and is required for efficient D-site cleavage. Disrupting the Dim2–Nob1 interaction causes accumulation of pre-ribosomes containing <strong>Nob1 and 20S pre-rRNA</strong>, consistent with a block in final 18S maturation. (woolls2011rolesofdim2 pages 1-2)</p>
+<h2 id="2-molecular-mechanism-and-pathway-placement">2) Molecular mechanism and pathway placement</h2>
+<h3 id="21-early-nucleolarcotranscriptional-roles-ssu-processome90s">2.1 Early nucleolar/cotranscriptional roles: SSU processome/90S</h3>
+<p>A yeast study characterizes DIM2 as required for <strong>cotranscriptional ribosome assembly</strong> and <strong>early nucleolar pre-rRNA processing</strong>; Dim2 binds pre-rRNAs at the <strong>5′ end of ITS1</strong> via its KH domain. A single KH-motif point mutation <strong>G207A</strong> inhibits pre-rRNA processing similarly to DIM2 depletion, demonstrating that RNA binding through the KH domain is functionally important. (vanrobays2008torregulatesthe pages 1-2)</p>
+<p>A structural/mechanistic study further places Dim2/Pno1 in <strong>two successive stages</strong> of SSU biogenesis: it acts first on the 90S particle and then <strong>relocates</strong> to the pre-40S platform after remodeling events (including U3 snoRNP removal) during the 90S→pre‑40S transition. (sturm2017interdependentactionof pages 1-2)</p>
+<h3 id="22-nuclear-export-and-growth-control-coupling-tor">2.2 Nuclear export and growth-control coupling (TOR)</h3>
+<p>Dim2/Pno1 is a <strong>nucleocytoplasmic shuttling</strong> factor with a <strong>conserved nuclear export sequence (NES)</strong> required for efficient pre-40S export. Export can be uncoupled experimentally from some early processing phenotypes using dominant-negative constructs.</p>
+<p>Key yeast findings:<br />
+- Dim2 and the export factor <strong>Rrp12</strong> become <strong>nucleolar-sequestered</strong> under stress conditions, and this relocalization is <strong>TOR-dependent</strong>; rapamycin triggers nucleolar entrapment. (vanrobays2008torregulatesthe pages 1-2, vanrobays2008torregulatesthe pages 5-7)<br />
+- A <strong>DNES</strong> construct causes a strong pre-40S export defect and can phenocopy depletion for growth and A1–A2 processing defects, while conservative leucine substitutions did not disrupt export in tested assays—supporting that export depends on the NES architecture rather than any single leucine. (vanrobays2008torregulatesthe pages 5-7)</p>
+<p>These observations connect Pno1/Dim2 function to nutrient-responsive regulation of ribosome production through TOR signaling. (vanrobays2008torregulatesthe pages 1-2, vanrobays2008torregulatesthe pages 7-8)</p>
+<h3 id="23-late-cytoplasmic-maturation-structural-placeholder-and-nob1-regulation">2.3 Late cytoplasmic maturation: structural “placeholder” and Nob1 regulation</h3>
+<p>Cryo-EM structures of cytoplasmic yeast pre-40S place <strong>Pno1</strong> on the SSU <strong>platform</strong> near the <strong>mRNA binding channel</strong>, and show that it occupies the binding site for the ribosomal protein <strong>Rps26/eS26</strong>, thereby preventing premature Rps26 incorporation. This is consistent with Pno1 serving as a late-stage placeholder/checkpoint factor and provides a structural rationale for why Pno1 must be remodeled or released for final maturation. (scaiola2018structureofa media 392eda28, scaiola2018structureofa pages 1-2)</p>
+<p>Biochemically, Dim2’s KH-like domain can be “repurposed” as a protein–protein interaction surface: the <strong>Dim2–Nob1 interaction maps to the canonical KH-like RNA-binding surface</strong> of Dim2, and disrupting it blocks maturation at the 20S→18S step. (woolls2011rolesofdim2 pages 1-2)</p>
+<h3 id="24-rio1-mediated-licensing-checkpoint-current-model">2.4 Rio1-mediated licensing checkpoint (current model)</h3>
+<p>A central modern concept is that <strong>Rio1</strong>, together with <strong>Nob1</strong> and <strong>Pno1</strong>, establishes a <strong>quality-control checkpoint</strong> preventing immature/misprocessed 40S subunits from entering the translating pool.</p>
+<p>Mechanistic model from recent yeast work:<br />
+- Pre-40S containing 20S pre-rRNA is bound by <strong>Nob1 and Pno1</strong>; Pno1 helps stabilize Nob1 and the pair blocks mRNA recruitment and Rps26 binding, preventing translation initiation. (parker2024thekinaserio1 pages 1-2)<br />
+- Nob1 cleaves the 3′ end of 18S rRNA (D-site cleavage) to convert 20S to mature 18S.<br />
+- <strong>Rio1</strong> then removes <strong>both Nob1 and Pno1</strong>, licensing the nascent 40S for translation and enabling Rps26 binding. (parker2024thekinaserio1 pages 1-2)</p>
+<p>A key “precision” statistic from this framework is that retention of as few as <strong>3 precursor nucleotides</strong> at the 18S 3′ end is incompatible with yeast viability, emphasizing stringent QC at this step. (parker2024thekinaserio1 pages 1-2)</p>
+<h2 id="3-recent-developments-prioritizing-20232024">3) Recent developments (prioritizing 2023–2024)</h2>
+<h3 id="31-2023-quality-control-synthesis-authoritative-review">3.1 2023: Quality control synthesis (authoritative review)</h3>
+<p>A 2023 review synthesizes evidence that a <strong>Rio1-dependent QC mechanism</strong> ensures only ribosomes with <strong>precise 18S rRNA cleavage</strong> are licensed to translate, and that <strong>Pno1 (Dim2)</strong> and <strong>Nob1</strong> are central to this checkpoint. The review notes that weakening Pno1 binding can bypass the checkpoint, allowing ribosomes with <strong>uncleaved 20S pre-rRNA</strong> or <strong>miscleaved 18S rRNA</strong> to enter translation, where they cause translation defects (e.g., collisions/errors). (parker2023qualitycontrolensures pages 10-12)</p>
+<p>Citation:<br />
+- Parker MD, Karbstein K. <em>Quality control ensures fidelity in ribosome assembly and cellular health.</em> <strong>J Cell Biol</strong>. <strong>Feb 2023</strong>. https://doi.org/10.1083/jcb.202209115 (parker2023qualitycontrolensures pages 10-12)</p>
+<h3 id="32-2024-quantitative-miscleavage-and-collision-dependent-decay-primary-study">3.2 2024: Quantitative miscleavage and collision-dependent decay (primary study)</h3>
+<p>A 2024 yeast study directly quantifies how bypassing the Rio1/Pno1 checkpoint changes the abundance of miscleaved 18S rRNA:<br />
+- <strong>WT</strong>: <strong>1.9%</strong> miscleaved 18S<br />
+- <strong>Pno1-KKKF</strong> checkpoint-bypass allele: <strong>2.5%</strong> miscleaved 18S</p>
+<p>The study further reports deep sequencing metrics (~<strong>2.8–4.5 million reads/sample</strong>, with <strong>96–99%</strong> mapping to the 3′ end region analyzed) and multiple biological replicates for key assays. Miscleaved ribosomes that enter translation are slowed and induce <strong>ribosome collisions</strong>, leading to decay pathways that remove these altered ribosomes. (parker2024thekinaserio1 pages 15-17)</p>
+<p>Citation:<br />
+- Parker MD et al. <em>The kinase Rio1 and a ribosome collision-dependent decay pathway survey the integrity of 18S rRNA cleavage.</em> <strong>PLOS Biology</strong>. <strong>Apr 2024</strong>. https://doi.org/10.1371/journal.pbio.3001767 (parker2024thekinaserio1 pages 15-17)</p>
+<h3 id="33-2023-structural-checkpointing-via-ribosomal-protein-cluster-assembly">3.3 2023: Structural checkpointing via ribosomal protein cluster assembly</h3>
+<p>A 2023 cryo-EM study examined SSU precursors from yeast mutants affecting the <strong>S0-cluster</strong> (rpS0/rpS2/rpS21) and concluded that S0-cluster formation enables <strong>initial recruitment of Nob1</strong> and promotes hierarchical rRNA folding events, including central pseudoknot maturation. The work discusses that factors such as Pno1 are retained in these precursor states, helping place Pno1 into an updated, structure-based maturation trajectory for cytoplasmic checkpoints. (poll2023impactofthe pages 1-5)</p>
+<p>Citation:<br />
+- Pöll G et al. <em>Impact of the yeast S0/uS2-cluster ribosomal protein rpS21/eS21 on rRNA folding and the architecture of small ribosomal subunit precursors.</em> <strong>Jan 2023</strong> (bioRxiv/PLOS ONE record as retrieved). https://doi.org/10.1101/2023.01.18.524556 (poll2023impactofthe pages 1-5)</p>
+<h2 id="4-cellular-localization-and-where-pno1dim2-acts">4) Cellular localization and where Pno1/Dim2 acts</h2>
+<h3 id="41-compartmentalization-across-the-maturation-pathway">4.1 Compartmentalization across the maturation pathway</h3>
+<p>Yeast Dim2/Pno1 acts in both:<br />
+- the <strong>nucleolus/nucleus</strong> (early SSU processome/cotranscriptional assembly; stress/TOR-dependent sequestration), and<br />
+- the <strong>cytoplasm</strong> (pre‑40S late maturation; regulation of Nob1 cleavage; Rio1-controlled release). (vanrobays2008torregulatesthe pages 1-2, parker2024thekinaserio1 pages 1-2)</p>
+<h3 id="42-tor-regulated-redistribution">4.2 TOR-regulated redistribution</h3>
+<p>Dim2 and Rrp12 relocalize to the nucleolus under stress and with rapamycin in a TOR-dependent manner, supporting a model in which nutrient signaling modulates the subcellular trafficking and/or availability of pre-40S export/maturation factors. (vanrobays2008torregulatesthe pages 5-7, vanrobays2008torregulatesthe pages 8-10)</p>
+<h3 id="43-export-signal-requirement">4.3 Export signal requirement</h3>
+<p>Dim2 contains a C-terminal NES required for efficient pre-40S export; deletion/obliteration can cause severe export phenotypes (including dominant-negative effects), underscoring that its spatial trafficking is integral to function. (vanrobays2008torregulatesthe pages 5-7)</p>
+<h2 id="5-interaction-partners-and-complexes">5) Interaction partners and complexes</h2>
+<p>Key interactors supported by yeast literature:<br />
+- <strong>Nob1</strong>: direct binding partner; interaction promotes/controls Nob1 activity and affects 20S→18S maturation. (woolls2011rolesofdim2 pages 1-2)<br />
+- <strong>Rio2</strong>: implicated in early cytoplasmic complexes with Pno1/Nob1 immediately after export (model supported by in vitro interactions and pathway logic). (turowski2014rio1mediatesatpdependent pages 7-8)<br />
+- <strong>Rio1</strong>: binds late pre-40S particles shortly before cleavage and removes Pno1/Nob1 to license translation; Rio1 inactivity impairs release of Pno1/Nob1 from late intermediates. (cerezo2019maturationofpre‐40s pages 4-5, parker2024thekinaserio1 pages 1-2)<br />
+- <strong>Rrp12</strong>: linked to export and shares TOR-regulated nucleolar sequestration with Dim2. (vanrobays2008torregulatesthe pages 5-7)</p>
+<h2 id="6-real-world-applications-and-implementations">6) Real-world applications and implementations</h2>
+<p>Although PNO1 is not a classical “biotech target” in yeast, it is widely used in <strong>real experimental implementations</strong> as a node to interrogate ribosome assembly, export, and quality control:</p>
+<p>1) <strong>Conditional essential gene perturbation</strong>: Dim2 is essential; strains with regulated DIM2 expression (e.g., galactose-inducible or tet-off designs) are used to create controlled blocks in SSU maturation and to map consequences on rRNA processing/export. (woolls2011rolesofdim2 pages 4-5, vanrobays2008torregulatesthe pages 1-2)</p>
+<p>2) <strong>Readouts for rRNA processing pathway diagnostics</strong>:<br />
+   - Early processing defects: KH-domain perturbation (e.g., G207A) can block A1/A2 cleavages and yield accumulation of <strong>22S</strong> pre-rRNA. (vanrobays2008torregulatesthe pages 8-10)<br />
+   - Late maturation defects: Dim2–Nob1 interaction mutants accumulate <strong>20S</strong> (and other intermediates such as <strong>21S/23S</strong>) and stall final 18S 3′ end formation. (woolls2011rolesofdim2 pages 1-2, woolls2011rolesofdim2 pages 4-5)</p>
+<p>3) <strong>Nuclear export assays and signaling integration</strong>:<br />
+   - Export defects induced by NES deletion constructs (DNES) provide a tool to isolate nuclear export contributions from early processing contributions. (vanrobays2008torregulatesthe pages 5-7)<br />
+   - TOR/rapamycin-induced nucleolar entrapment provides a practical linkage between nutrient signaling and ribosome biogenesis factor distribution. (vanrobays2008torregulatesthe pages 5-7)</p>
+<p>4) <strong>Ribosome QC and translation fidelity research</strong> (2023–2024 focus):<br />
+   - Pno1 checkpoint-bypass alleles allow controlled release of misprocessed ribosomes into translation, enabling direct study of collision-dependent decay and the cellular consequences of ribosome heterogeneity. (parker2024thekinaserio1 pages 15-17, parker2023qualitycontrolensures pages 10-12)</p>
+<h2 id="7-relevant-statistics-and-data-recent-andor-authoritative">7) Relevant statistics and data (recent and/or authoritative)</h2>
+<h3 id="71-system-level-ribosome-biogenesis-numbers">7.1 System-level ribosome biogenesis numbers</h3>
+<ul>
+<li>~<strong>2000 ribosomes/min</strong> synthesized in rapidly growing yeast. (chakermargot2018assemblyofthe pages 1-2)</li>
+<li>Eukaryotic ribosome contains <strong>4 rRNAs</strong> and <strong>79 proteins</strong>; assembly uses <strong>&gt;200</strong> transient assembly factors. (chakermargot2018assemblyofthe pages 1-2, parker2024thekinaserio1 pages 1-2)</li>
+<li>An estimate from proteomics-based reviews: ~<strong>200 proteins</strong> in the small subunit assembly machinery, comprising ~<strong>20% of essential yeast proteins</strong>. (karbstein2011insidethe40s pages 1-2)</li>
+</ul>
+<h3 id="72-pno1rio1-qc-quantitative-outcomes-2024">7.2 Pno1/Rio1 QC quantitative outcomes (2024)</h3>
+<ul>
+<li>Miscleaved 18S rRNA fraction increases from <strong>1.9% (WT)</strong> to <strong>2.5% (Pno1-KKKF)</strong> when QC is bypassed. (parker2024thekinaserio1 pages 15-17)</li>
+<li>Sequencing depth in those assays: ~<strong>2.8–4.5 million reads/sample</strong>, with <strong>96–99%</strong> mapping to the analyzed 18S 3′-end region. (parker2024thekinaserio1 pages 15-17)</li>
+</ul>
+<h3 id="73-mutationalphenotype-quantitation-exportprocessing">7.3 Mutational/phenotype quantitation (export/processing)</h3>
+<ul>
+<li>A single KH-motif mutation <strong>G207A</strong> can cause a severe growth impact (~<strong>3.5-fold</strong> growth impact as reported) and inhibits pre-rRNA processing similarly to DIM2 depletion. (vanrobays2008torregulatesthe pages 1-2)</li>
+<li>NES deletion constructs can induce rapid and strong export defects within ~<strong>1 hour</strong> in the referenced assay context. (vanrobays2008torregulatesthe pages 7-8)</li>
+</ul>
+<h2 id="8-expert-opinions-and-analysis-authoritative-synthesis">8) Expert opinions and analysis (authoritative synthesis)</h2>
+<p>Two themes emerge from authoritative sources and recent primary data:</p>
+<p>1) <strong>PNO1/DIM2 integrates structural assembly with enzymatic timing.</strong> Structural placement of Pno1 near the mRNA channel and at the Rps26 site, and biochemical evidence that it modulates Nob1’s substrate interactions, support a model in which Pno1 prevents premature translation engagement and coordinates the final rRNA processing step with acquisition of translation competence. (scaiola2018structureofa media 392eda28, woolls2011rolesofdim2 pages 1-2)</p>
+<p>2) <strong>The late 40S assembly checkpoint is a fidelity gate with measurable error rates.</strong> The 2024 quantification of miscleavage, and the observation that altered ribosomes can enter translation but trigger collisions/decay, supports a modern view in which assembly QC is not purely binary but tunes the probability of defective ribosomes entering the translating pool, with Rio1/Pno1 as key determinants of that stringency. (parker2024thekinaserio1 pages 15-17, parker2023qualitycontrolensures pages 10-12)</p>
+<h2 id="9-visual-evidence-from-structural-work-figure-based">9) Visual evidence from structural work (figure-based)</h2>
+<p>Cryo-EM evidence places Pno1 on the cytoplasmic pre-40S platform near the mRNA channel and supports its role as an Rps26-site placeholder and Nob1 regulator. (scaiola2018structureofa media 392eda28, scaiola2018structureofa media 37cb333c)</p>
+<h2 id="10-summary-of-functional-annotation-yeast-pno1-uniprot-q99216">10) Summary of functional annotation (yeast PNO1 / UniProt Q99216)</h2>
+<ul>
+<li><strong>Molecular function:</strong> KH-domain RNA-binding ribosome assembly factor; regulates and partners with Nob1 for final 18S 3′-end maturation; acts as a late-stage placeholder that blocks Rps26 incorporation and translation entry until licensing by Rio1. (woolls2011rolesofdim2 pages 1-2, scaiola2018structureofa media 392eda28, parker2024thekinaserio1 pages 1-2)</li>
+<li><strong>Biological process:</strong> SSU processome maturation; 90S→pre-40S transition; pre-40S export; cytoplasmic 20S→18S processing; quality-control gating for translation competence. (sturm2017interdependentactionof pages 1-2, vanrobays2008torregulatesthe pages 5-7, parker2024thekinaserio1 pages 15-17)</li>
+<li><strong>Cellular localization:</strong> Nucleolus/nucleus and cytoplasm; shuttling factor with TOR-regulated redistribution and NES-dependent export functionality. (vanrobays2008torregulatesthe pages 5-7, vanrobays2008torregulatesthe pages 1-2)</li>
+</ul>
+<h2 id="structured-summary-table">Structured summary table</h2>
+<table>
+<thead>
+<tr>
+<th>Functional role / process step</th>
+<th>Molecular mechanism / binding site / key domains</th>
+<th>Key interaction partners / complexes</th>
+<th>Subcellular location</th>
+<th>Representative evidence (paper, year, URL)</th>
+<th>Notes / quantitative data</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Verified identity of target protein</td>
+<td>Yeast PNO1 is the same factor as Dim2/Rrp20, a KH-domain pre-rRNA processing factor and “Partner of Nob1”; literature aligns with the UniProt description of a KH-domain protein involved in SSU/pre-40S maturation (vanrobays2008torregulatesthe pages 1-2, woolls2011rolesofdim2 pages 1-2)</td>
+<td>Nob1; pre-rRNA; pre-40S particles</td>
+<td>Nucleolus, nucleus, cytoplasm (shuttling) (vanrobays2008torregulatesthe pages 1-2)</td>
+<td>Vanrobays et al., 2008, RNA, https://doi.org/10.1261/rna.1176708; Woolls et al., 2011, JBC, https://doi.org/10.1074/jbc.m110.191494 (vanrobays2008torregulatesthe pages 1-2, woolls2011rolesofdim2 pages 1-2)</td>
+<td>Supports use of yeast-specific synonyms PNO1/DIM2/RRP20 and distinguishes this protein from non-yeast PNO1 literature (vanrobays2008torregulatesthe pages 1-2, woolls2011rolesofdim2 pages 1-2)</td>
+</tr>
+<tr>
+<td>Early cotranscriptional SSU assembly / 90S step</td>
+<td>Direct pre-rRNA binding via KH domain at the 5′ end of ITS1 (D–A2 segment); conserved KH residue G207 is required, and G207A phenocopies Dim2 depletion in pre-rRNA processing (vanrobays2008torregulatesthe pages 1-2)</td>
+<td>Nascent pre-rRNA; SSU processome / 90S precursors</td>
+<td>Primarily nucleolar / nuclear during early assembly (vanrobays2008torregulatesthe pages 1-2)</td>
+<td>Vanrobays et al., 2008, RNA, https://doi.org/10.1261/rna.1176708 (vanrobays2008torregulatesthe pages 1-2)</td>
+<td>Depletion causes early pre-rRNA processing defects; accumulation of a 22S (A0–A3) intermediate is consistent with an early SSU role (knox2010regulationoftheb pages 57-61, knox2010regulationofthea pages 57-61)</td>
+</tr>
+<tr>
+<td>90S-to-pre-40S transition and platform assembly</td>
+<td>Dim2/Pno1 acts at two successive stages: first on 90S, then relocates to the pre-40S platform after U3 snoRNP removal; function is coordinated with structurally related KH factor Krr1 during platform assembly (sturm2017interdependentactionof pages 1-2)</td>
+<td>Utp1, Utp14, Dhr1, Krr1, Rps14, UTP-B, UTP-C, emerging pre-40S (sturm2017interdependentactionof pages 1-2)</td>
+<td>Nucleolus to early pre-40S particles (sturm2017interdependentactionof pages 1-2)</td>
+<td>Sturm et al., 2017, Nature Communications, https://doi.org/10.1038/s41467-017-02199-4 (sturm2017interdependentactionof pages 1-2)</td>
+<td>Places Pno1 upstream of late cytoplasmic maturation and links it mechanistically to ordered SSU platform biogenesis (sturm2017interdependentactionof pages 1-2)</td>
+</tr>
+<tr>
+<td>Pre-40S nuclear export factor</td>
+<td>Contains a conserved C-terminal NES required for efficient pre-40S export; proposed as a CRM1/Xpo1-linked export adapter together with other factors such as Rrp12/Ltv1 (vanrobays2008torregulatesthe pages 1-2, knox2010regulationoftheb pages 57-61)</td>
+<td>CRM1/Xpo1 pathway; Rrp12; pre-40S export machinery (vanrobays2008torregulatesthe pages 1-2, knox2010regulationoftheb pages 57-61)</td>
+<td>Nucleus to cytoplasm; shuttling factor (vanrobays2008torregulatesthe pages 1-2)</td>
+<td>Vanrobays et al., 2008, RNA, https://doi.org/10.1261/rna.1176708 (vanrobays2008torregulatesthe pages 1-2)</td>
+<td>TOR signaling regulates Dim2 distribution; rapamycin causes nucleolar entrapment of Dim2/Rrp12 (vanrobays2008torregulatesthe pages 1-2)</td>
+</tr>
+<tr>
+<td>Late pre-40S maturation and Nob1 recruitment/regulation</td>
+<td>Dim2 physically interacts with Nob1; the Nob1-binding surface maps to the canonical KH-like RNA-binding face of Dim2, repurposed for protein interaction; Dim2 increases Nob1 RNA affinity and promotes productive D-site cleavage (woolls2011rolesofdim2 pages 1-2)</td>
+<td>Nob1; pre-40S particles containing 20S pre-rRNA (woolls2011rolesofdim2 pages 1-2)</td>
+<td>Cytoplasmic late pre-40S; also associated earlier in the pathway (woolls2011rolesofdim2 pages 1-2, turowski2014rio1mediatesatpdependent pages 7-8)</td>
+<td>Woolls et al., 2011, JBC, https://doi.org/10.1074/jbc.m110.191494 (woolls2011rolesofdim2 pages 1-2)</td>
+<td>Mutants disrupting Dim2–Nob1 interaction accumulate pre-ribosomes containing Nob1 and 20S pre-rRNA in vivo, indicating a block in 18S 3′-end maturation (woolls2011rolesofdim2 pages 1-2)</td>
+</tr>
+<tr>
+<td>Cleavage-incompetent to cleavage-competent late pre-40S remodeling</td>
+<td>Pno1 binds ITS1 and 18S regions; early cytoplasmic particles may contain a Pno1/Nob1/Rio2 assembly that is cleavage-incompetent. Later particles containing mainly Rio1, Pno1, and Nob1 acquire cleavage competence, likely requiring Pno1 repositioning/removal from site D vicinity (turowski2014rio1mediatesatpdependent pages 7-8)</td>
+<td>Nob1; Rio2; Rio1; late pre-40S particles (turowski2014rio1mediatesatpdependent pages 7-8)</td>
+<td>Cytoplasm after export (turowski2014rio1mediatesatpdependent pages 7-8)</td>
+<td>Turowski et al., 2014, Nucleic Acids Research, https://doi.org/10.1093/nar/gku878 (turowski2014rio1mediatesatpdependent pages 7-8)</td>
+<td>Rio1-associated particles show greater in vitro cleavage efficiency than particles purified via other factors (turowski2014rio1mediatesatpdependent pages 7-8)</td>
+</tr>
+<tr>
+<td>Structural placeholder on cytoplasmic pre-40S</td>
+<td>Cryo-EM places Pno1 on the platform near the mRNA channel and adjacent to the 3′ ITS; Pno1 occupies the future Rps26/eS26 binding site, thereby preventing Rps26 binding before proper maturation and helping regulate Nob1-mediated cleavage (scaiola2018structureofa pages 1-2, scaiola2018structureofa media 392eda28)</td>
+<td>Nob1; Rps26/eS26; cytoplasmic pre-40S assembly factors Enp1, Ltv1, Tsr1, Rio2, Dim1 (scaiola2018structureofa pages 1-2, scaiola2018structureofa media 392eda28)</td>
+<td>Cytoplasmic pre-40S particle (scaiola2018structureofa pages 1-2, scaiola2018structureofa media 392eda28)</td>
+<td>Scaiola et al., 2018, The EMBO Journal, https://doi.org/10.15252/embj.201798499 (scaiola2018structureofa pages 1-2, scaiola2018structureofa media 392eda28)</td>
+<td>Structural model explains why Pno1 must be remodeled/released before final maturation and Rps26 incorporation (scaiola2018structureofa media 392eda28)</td>
+</tr>
+<tr>
+<td>Component of late 80S-like pre-ribosomal checkpoint particles</td>
+<td>Pno1/Dim2 is present with Rio1 and Nob1 in late cytoplasmic 80S-like particles; Rio1 ATPase activity promotes release of Pno1/Dim2, Nob1, and other factors from these particles (cerezo2019maturationofpre‐40s pages 4-5)</td>
+<td>Rio1; Nob1; 80S-like pre-ribosomes (cerezo2019maturationofpre‐40s pages 4-5)</td>
+<td>Cytoplasm (late maturation stage) (cerezo2019maturationofpre‐40s pages 4-5)</td>
+<td>Cerezo et al., 2019, WIREs RNA, https://doi.org/10.1002/wrna.1516 (cerezo2019maturationofpre‐40s pages 4-5)</td>
+<td>Review synthesizes structural and biochemical evidence but notes uncertainty over whether D-site cleavage occurs before or after 80S-like particle dissociation (cerezo2019maturationofpre‐40s pages 4-5)</td>
+</tr>
+<tr>
+<td>Quality-control checkpoint preventing immature SSU entry into translation</td>
+<td>Pno1 and Nob1 establish a Rio1-regulated QC checkpoint. Pno1 blocks mRNA recruitment and the Rps26 site until correct 18S 3′-end processing; Rio1 releases Nob1/Pno1 only from properly matured particles (parker2023qualitycontrolensures pages 10-12, parker2024thekinaserio1 pages 1-2)</td>
+<td>Rio1; Nob1; Rps26; translating pool exclusion machinery (parker2023qualitycontrolensures pages 10-12, parker2024thekinaserio1 pages 1-2)</td>
+<td>Cytoplasmic late pre-40S / translation-entry checkpoint (parker2023qualitycontrolensures pages 10-12, parker2024thekinaserio1 pages 1-2)</td>
+<td>Parker &amp; Karbstein, 2023, J Cell Biol, https://doi.org/10.1083/jcb.202209115; Parker et al., 2024, PLOS Biology, https://doi.org/10.1371/journal.pbio.3001767 (parker2023qualitycontrolensures pages 10-12, parker2024thekinaserio1 pages 1-2)</td>
+<td>Review notes that checkpoint-bypassing Pno1 mutants release particles with uncleaved 20S or miscleaved 18S into translation, causing translation errors/collisions; RIOK1 amplification is noted in 29% of cancers in the broader conserved context (parker2023qualitycontrolensures pages 10-12)</td>
+</tr>
+<tr>
+<td>Surveillance of precise 18S 3′-end cleavage</td>
+<td>Rio1 binds miscleaved 18S products less well; excess Pno1 increases accumulation of miscleaved rRNA, showing Pno1 dosage and release are part of the surveillance system for accurate cleavage (parker2024thekinaserio1 pages 15-17, parker2024thekinaserio1 pages 1-2)</td>
+<td>Rio1; Nob1; miscleaved 18S-containing ribosomes (parker2024thekinaserio1 pages 15-17)</td>
+<td>Cytoplasm / translating pool interface (parker2024thekinaserio1 pages 15-17)</td>
+<td>Parker et al., 2024, PLOS Biology, https://doi.org/10.1371/journal.pbio.3001767 (parker2024thekinaserio1 pages 15-17, parker2024thekinaserio1 pages 1-2)</td>
+<td>Miscleaved 18S increased from 1.9% in WT to 2.5% with Pno1-KKKF checkpoint bypass; sequencing datasets contained ~2.8–4.5 million reads/sample with ~96–99% mapping to the 3′ end of 18S; as few as 3 retained precursor nt at the 18S 3′ end are lethal in yeast (parker2024thekinaserio1 pages 15-17, parker2024thekinaserio1 pages 1-2)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the experimentally supported functions, mechanisms, complexes, localization, and quality-control roles of Saccharomyces cerevisiae PNO1/Dim2/Rrp20. It integrates core yeast studies and recent QC-focused work, including structural placement and quantitative miscleavage data.</em></p>
+<h2 id="key-references-publication-date-and-url">Key references (publication date and URL)</h2>
+<ul>
+<li>Vanrobays E, et al. <strong>Oct 2008</strong>. TOR regulates the subcellular distribution of DIM2… <em>RNA</em>. https://doi.org/10.1261/rna.1176708 (vanrobays2008torregulatesthe pages 1-2)</li>
+<li>Woolls HA, Lamanna AC, Karbstein K. <strong>Jan 2011</strong>. Roles of Dim2 in Ribosome Assembly. <em>J Biol Chem</em>. https://doi.org/10.1074/jbc.m110.191494 (woolls2011rolesofdim2 pages 1-2)</li>
+<li>Sturm M, et al. <strong>Dec 2017</strong>. Interdependent action of KH domain proteins Krr1 and Dim2… <em>Nat Commun</em>. https://doi.org/10.1038/s41467-017-02199-4 (sturm2017interdependentactionof pages 1-2)</li>
+<li>Scaiola A, et al. <strong>Apr 2018</strong>. Structure of a eukaryotic cytoplasmic pre-40S ribosomal subunit. <em>EMBO J</em>. https://doi.org/10.15252/embj.201798499 (scaiola2018structureofa pages 1-2)</li>
+<li>Chaker-Margot M. <strong>Apr 2018</strong>. Assembly of the small ribosomal subunit in yeast: mechanism and regulation. <em>RNA</em>. https://doi.org/10.1261/rna.066985.118 (chakermargot2018assemblyofthe pages 1-2)</li>
+<li>Parker MD, Karbstein K. <strong>Feb 2023</strong>. Quality control ensures fidelity in ribosome assembly and cellular health. <em>J Cell Biol</em>. https://doi.org/10.1083/jcb.202209115 (parker2023qualitycontrolensures pages 10-12)</li>
+<li>Pöll G, et al. <strong>Jan 2023</strong>. Impact of the yeast S0/uS2-cluster… (record retrieved). https://doi.org/10.1101/2023.01.18.524556 (poll2023impactofthe pages 1-5)</li>
+<li>Parker MD, et al. <strong>Apr 2024</strong>. The kinase Rio1 and a ribosome collision-dependent decay pathway survey the integrity of 18S rRNA cleavage. <em>PLOS Biology</em>. https://doi.org/10.1371/journal.pbio.3001767 (parker2024thekinaserio1 pages 15-17)</li>
+</ul>
+<p>References</p>
+<ol>
+<li>
+<p>(vanrobays2008torregulatesthe pages 1-2): Emmanuel Vanrobays, Alexis Leplus, Yvonne N. Osheim, Ann L. Beyer, Ludivine Wacheul, and Denis L.J. Lafontaine. Tor regulates the subcellular distribution of dim2, a kh domain protein required for cotranscriptional ribosome assembly and pre-40s ribosome export. RNA, 14 10:2061-73, Oct 2008. URL: https://doi.org/10.1261/rna.1176708, doi:10.1261/rna.1176708. This article has 69 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(woolls2011rolesofdim2 pages 1-2): Heather A. Woolls, Allison C. Lamanna, and Katrin Karbstein. Roles of dim2 in ribosome assembly. Journal of Biological Chemistry, 286:2578-2586, Jan 2011. URL: https://doi.org/10.1074/jbc.m110.191494, doi:10.1074/jbc.m110.191494. This article has 58 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(chakermargot2018assemblyofthe pages 1-2): Malik Chaker-Margot. Assembly of the small ribosomal subunit in yeast: mechanism and regulation. RNA, 24:881-891, Apr 2018. URL: https://doi.org/10.1261/rna.066985.118, doi:10.1261/rna.066985.118. This article has 34 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(parker2024thekinaserio1 pages 1-2): Melissa D. Parker, Elise S. Brunk, Adam J. Getzler, and Katrin Karbstein. The kinase rio1 and a ribosome collision-dependent decay pathway survey the integrity of 18s rrna cleavage. PLOS Biology, 22:e3001767, Apr 2024. URL: https://doi.org/10.1371/journal.pbio.3001767, doi:10.1371/journal.pbio.3001767. This article has 14 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(sturm2017interdependentactionof pages 1-2): Miriam Sturm, Jingdong Cheng, Jochen Baßler, Roland Beckmann, and Ed Hurt. Interdependent action of kh domain proteins krr1 and dim2 drive the 40s platform assembly. Nature Communications, Dec 2017. URL: https://doi.org/10.1038/s41467-017-02199-4, doi:10.1038/s41467-017-02199-4. This article has 45 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(knox2010regulationofthea pages 57-61): AA Knox. Regulation of the u3 small subunit processome and associated rna-binding proteins. Unknown journal, 2010.</p>
+</li>
+<li>
+<p>(scaiola2018structureofa pages 1-2): Alain Scaiola, Cohue Peña, Melanie Weisser, Daniel Böhringer, Marc Leibundgut, Purnima Klingauf‐Nerurkar, Stefan Gerhardy, Vikram Govind Panse, and Nenad Ban. Structure of a eukaryotic cytoplasmic pre‐40s ribosomal subunit. The EMBO Journal, Apr 2018. URL: https://doi.org/10.15252/embj.201798499, doi:10.15252/embj.201798499. This article has 110 citations.</p>
+</li>
+<li>
+<p>(vanrobays2008torregulatesthe pages 5-7): Emmanuel Vanrobays, Alexis Leplus, Yvonne N. Osheim, Ann L. Beyer, Ludivine Wacheul, and Denis L.J. Lafontaine. Tor regulates the subcellular distribution of dim2, a kh domain protein required for cotranscriptional ribosome assembly and pre-40s ribosome export. RNA, 14 10:2061-73, Oct 2008. URL: https://doi.org/10.1261/rna.1176708, doi:10.1261/rna.1176708. This article has 69 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(vanrobays2008torregulatesthe pages 7-8): Emmanuel Vanrobays, Alexis Leplus, Yvonne N. Osheim, Ann L. Beyer, Ludivine Wacheul, and Denis L.J. Lafontaine. Tor regulates the subcellular distribution of dim2, a kh domain protein required for cotranscriptional ribosome assembly and pre-40s ribosome export. RNA, 14 10:2061-73, Oct 2008. URL: https://doi.org/10.1261/rna.1176708, doi:10.1261/rna.1176708. This article has 69 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(scaiola2018structureofa media 392eda28): Alain Scaiola, Cohue Peña, Melanie Weisser, Daniel Böhringer, Marc Leibundgut, Purnima Klingauf‐Nerurkar, Stefan Gerhardy, Vikram Govind Panse, and Nenad Ban. Structure of a eukaryotic cytoplasmic pre‐40s ribosomal subunit. The EMBO Journal, Apr 2018. URL: https://doi.org/10.15252/embj.201798499, doi:10.15252/embj.201798499. This article has 110 citations.</p>
+</li>
+<li>
+<p>(parker2023qualitycontrolensures pages 10-12): Melissa D. Parker and Katrin Karbstein. Quality control ensures fidelity in ribosome assembly and cellular health. The Journal of Cell Biology, Feb 2023. URL: https://doi.org/10.1083/jcb.202209115, doi:10.1083/jcb.202209115. This article has 29 citations.</p>
+</li>
+<li>
+<p>(parker2024thekinaserio1 pages 15-17): Melissa D. Parker, Elise S. Brunk, Adam J. Getzler, and Katrin Karbstein. The kinase rio1 and a ribosome collision-dependent decay pathway survey the integrity of 18s rrna cleavage. PLOS Biology, 22:e3001767, Apr 2024. URL: https://doi.org/10.1371/journal.pbio.3001767, doi:10.1371/journal.pbio.3001767. This article has 14 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(poll2023impactofthe pages 1-5): Gisela Pöll, Joachim Griesenbeck, Herbert Tschochner, and Philipp Milkereit. Impact of the yeast s0/us2-cluster ribosomal protein rps21/es21 on rrna folding and the architecture of small ribosomal subunit precursors. PLOS ONE, Jan 2023. URL: https://doi.org/10.1101/2023.01.18.524556, doi:10.1101/2023.01.18.524556. This article has 3 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(vanrobays2008torregulatesthe pages 8-10): Emmanuel Vanrobays, Alexis Leplus, Yvonne N. Osheim, Ann L. Beyer, Ludivine Wacheul, and Denis L.J. Lafontaine. Tor regulates the subcellular distribution of dim2, a kh domain protein required for cotranscriptional ribosome assembly and pre-40s ribosome export. RNA, 14 10:2061-73, Oct 2008. URL: https://doi.org/10.1261/rna.1176708, doi:10.1261/rna.1176708. This article has 69 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(turowski2014rio1mediatesatpdependent pages 7-8): Tomasz W. Turowski, Simon Lebaron, Elodie Zhang, Lauri Peil, Tatiana Dudnakova, Elisabeth Petfalski, Sander Granneman, Juri Rappsilber, and David Tollervey. Rio1 mediates atp-dependent final maturation of 40s ribosomal subunits. Nucleic Acids Research, 42:12189-12199, Oct 2014. URL: https://doi.org/10.1093/nar/gku878, doi:10.1093/nar/gku878. This article has 114 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(cerezo2019maturationofpre‐40s pages 4-5): Emilie Cerezo, Célia Plisson‐Chastang, Anthony K. Henras, Simon Lebaron, Pierre‐Emmanuel Gleizes, Marie‐Françoise O'Donohue, Yves Romeo, and Yves Henry. Maturation of pre‐40s particles in yeast and humans. Wiley Interdisciplinary Reviews: RNA, Nov 2019. URL: https://doi.org/10.1002/wrna.1516, doi:10.1002/wrna.1516. This article has 56 citations.</p>
+</li>
+<li>
+<p>(woolls2011rolesofdim2 pages 4-5): Heather A. Woolls, Allison C. Lamanna, and Katrin Karbstein. Roles of dim2 in ribosome assembly. Journal of Biological Chemistry, 286:2578-2586, Jan 2011. URL: https://doi.org/10.1074/jbc.m110.191494, doi:10.1074/jbc.m110.191494. This article has 58 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(karbstein2011insidethe40s pages 1-2): Katrin Karbstein. Inside the 40s ribosome assembly machinery. Current opinion in chemical biology, 15 5:657-63, Oct 2011. URL: https://doi.org/10.1016/j.cbpa.2011.07.023, doi:10.1016/j.cbpa.2011.07.023. This article has 76 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(scaiola2018structureofa media 37cb333c): Alain Scaiola, Cohue Peña, Melanie Weisser, Daniel Böhringer, Marc Leibundgut, Purnima Klingauf‐Nerurkar, Stefan Gerhardy, Vikram Govind Panse, and Nenad Ban. Structure of a eukaryotic cytoplasmic pre‐40s ribosomal subunit. The EMBO Journal, Apr 2018. URL: https://doi.org/10.15252/embj.201798499, doi:10.15252/embj.201798499. This article has 110 citations.</p>
+</li>
+<li>
+<p>(knox2010regulationoftheb pages 57-61): AA Knox. Regulation of the u3 small subunit processome and associated rna-binding proteins. Unknown journal, 2010.</p>
+</li>
+</ol>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>vanrobays2008torregulatesthe pages 1-2</li>
+<li>sturm2017interdependentactionof pages 1-2</li>
+<li>vanrobays2008torregulatesthe pages 5-7</li>
+<li>parker2023qualitycontrolensures pages 10-12</li>
+<li>poll2023impactofthe pages 1-5</li>
+<li>vanrobays2008torregulatesthe pages 8-10</li>
+<li>chakermargot2018assemblyofthe pages 1-2</li>
+<li>vanrobays2008torregulatesthe pages 7-8</li>
+<li>scaiola2018structureofa pages 1-2</li>
+<li>knox2010regulationofthea pages 57-61</li>
+<li>knox2010regulationoftheb pages 57-61</li>
+<li>https://doi.org/10.1083/jcb.202209115</li>
+<li>https://doi.org/10.1371/journal.pbio.3001767</li>
+<li>https://doi.org/10.1101/2023.01.18.524556</li>
+<li>https://doi.org/10.1261/rna.1176708;</li>
+<li>https://doi.org/10.1074/jbc.m110.191494</li>
+<li>https://doi.org/10.1261/rna.1176708</li>
+<li>https://doi.org/10.1038/s41467-017-02199-4</li>
+<li>https://doi.org/10.1093/nar/gku878</li>
+<li>https://doi.org/10.15252/embj.201798499</li>
+<li>https://doi.org/10.1002/wrna.1516</li>
+<li>https://doi.org/10.1083/jcb.202209115;</li>
+<li>https://doi.org/10.1261/rna.066985.118</li>
+<li>https://doi.org/10.1261/rna.1176708,</li>
+<li>https://doi.org/10.1074/jbc.m110.191494,</li>
+<li>https://doi.org/10.1261/rna.066985.118,</li>
+<li>https://doi.org/10.1371/journal.pbio.3001767,</li>
+<li>https://doi.org/10.1038/s41467-017-02199-4,</li>
+<li>https://doi.org/10.15252/embj.201798499,</li>
+<li>https://doi.org/10.1083/jcb.202209115,</li>
+<li>https://doi.org/10.1101/2023.01.18.524556,</li>
+<li>https://doi.org/10.1093/nar/gku878,</li>
+<li>https://doi.org/10.1002/wrna.1516,</li>
+<li>https://doi.org/10.1016/j.cbpa.2011.07.023,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -2018,12 +2889,24 @@
             <div class="yaml-content">
                 <pre><code>id: Q99216
 gene_symbol: PNO1
+aliases:
+- DIM2
+- RRP20
+- YOR145C
 product_type: PROTEIN
-status: DRAFT
+status: COMPLETE
 taxon:
   id: NCBITaxon:559292
   label: Saccharomyces cerevisiae
-description: &#39;TODO: Add description for PNO1&#39;
+description: &gt;-
+  PNO1 encodes Pno1/Dim2/Rrp20, a conserved KH-domain ribosome biogenesis
+  factor required for small ribosomal subunit synthesis. Pno1 binds pre-rRNA,
+  especially the ITS1 region, participates in early SSU processome and 90S to
+  pre-40S transitions, supports pre-40S export from the nucleus, and works with
+  Nob1 and Rio1 during late cytoplasmic 20S pre-rRNA to 18S rRNA maturation.
+  The coherent core function is RNA-binding regulation of SSU/pre-40S assembly
+  and processing; older proteasome and generic chaperone annotations appear
+  secondary or overextended.
 existing_annotations:
 - term:
     id: GO:0005634
@@ -2031,162 +2914,321 @@ existing_annotations:
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: &#39;Manual review: nucleus is consistent with known biology of PNO1.&#39;
+    summary: &gt;-
+      PANTHER IBA to nucleus is consistent with Pno1&#39;s conserved role as a
+      nuclear/nucleolar and nucleocytoplasmic ribosome biogenesis factor.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: &gt;-
+      Pno1 acts in nuclear and nucleolar stages of SSU biogenesis and has direct
+      experimental nuclear/nucleolar localization support.
 - term:
     id: GO:0003723
     label: RNA binding
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
   review:
-    summary: &#39;Manual review: RNA binding is consistent with known biology of PNO1.&#39;
+    summary: &gt;-
+      Automated RNA-binding annotation is supported by Pno1 KH domains and by
+      direct evidence for binding pre-rRNA/ITS1.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: &gt;-
+      RNA binding is a core molecular function for Pno1, though the more specific
+      rRNA primary transcript binding term is preferred when available.
+    supported_by:
+    - reference_id: file:yeast/PNO1/PNO1-deep-research-falcon.md
+      supporting_text: &#34;binds pre-rRNA (ITS1 region) via its KH domain&#34;
 - term:
     id: GO:0005730
     label: nucleolus
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
   review:
-    summary: &#39;Manual review: nucleolus is consistent with known biology of PNO1.&#39;
+    summary: &gt;-
+      UniProt/ARBA nucleolus mapping is consistent with Pno1 function in early
+      nucleolar SSU processome assembly and pre-rRNA processing.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: &gt;-
+      The nucleolus is a supported compartment for Pno1 during early ribosome
+      biogenesis.
 - term:
     id: GO:0005737
     label: cytoplasm
   evidence_type: IEA
   original_reference_id: GO_REF:0000044
   review:
-    summary: &#39;Manual review: cytoplasm is consistent with known biology of PNO1.&#39;
+    summary: &gt;-
+      Cytoplasmic localization is consistent with Pno1 shuttling and late
+      cytoplasmic pre-40S maturation.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: &gt;-
+      Pno1 functions after pre-40S export as part of late 18S rRNA maturation and
+      quality-control gating.
 - term:
     id: GO:0042254
     label: ribosome biogenesis
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
   review:
-    summary: &#39;Manual review: ribosome biogenesis is consistent with known biology of PNO1.&#39;
+    summary: &gt;-
+      Broad automated ribosome biogenesis annotation accurately summarizes the
+      experimentally supported Pno1 role in SSU/pre-40S assembly and maturation.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: &gt;-
+      Pno1 is a ribosome biogenesis factor; more specific annotations capture
+      SSU-rRNA maturation, pre-40S export, and ribosome assembly.
 - term:
     id: GO:0005730
     label: nucleolus
   evidence_type: IDA
   original_reference_id: PMID:27980088
   review:
-    summary: &#39;Manual review: nucleolus is consistent with known biology of PNO1.&#39;
+    summary: &gt;-
+      ComplexPortal direct assay evidence places Pno1 in the nucleolus/SSU
+      processome context.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: &gt;-
+      Nucleolar localization matches Pno1&#39;s early SSU processome and pre-rRNA
+      processing roles.
+    supported_by:
+    - reference_id: PMID:27980088
+      supporting_text: &#34;Architecture of the yeast small subunit processome.&#34;
 - term:
     id: GO:0030490
     label: maturation of SSU-rRNA
   evidence_type: NAS
   original_reference_id: PMID:15489292
   review:
-    summary: &#39;Manual review: maturation of SSU-rRNA is consistent with known biology of PNO1.&#39;
+    summary: &gt;-
+      Curated statement evidence supports Pno1 as a specific SSU processome
+      component linked to SSU-rRNA maturation.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: &gt;-
+      The annotation is consistent with multiple yeast studies showing defects in
+      pre-rRNA processing when Pno1/Dim2/Rrp20 is perturbed.
+    supported_by:
+    - reference_id: PMID:15489292
+      supporting_text: &#34;RNA polymerase I transcription and pre-rRNA processing are linked by specific SSU processome components.&#34;
 - term:
     id: GO:0000056
     label: ribosomal small subunit export from nucleus
   evidence_type: IMP
   original_reference_id: PMID:18755838
+  qualifier: acts_upstream_of_or_within
   review:
-    summary: &#39;Manual review: ribosomal small subunit export from nucleus is consistent with known biology of PNO1.&#39;
+    summary: &gt;-
+      Mutant phenotype evidence supports Dim2/Pno1 involvement in pre-40S export
+      from the nucleus.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: &gt;-
+      Pno1 contains a conserved export-related region and perturbation causes
+      pre-40S export defects, making this a core process annotation.
+    supported_by:
+    - reference_id: PMID:18755838
+      supporting_text: &#34;pre-40S ribosome export&#34;
 - term:
     id: GO:0042134
     label: rRNA primary transcript binding
   evidence_type: IDA
   original_reference_id: PMID:18755838
   review:
-    summary: &#39;Manual review: rRNA primary transcript binding is consistent with known biology of PNO1.&#39;
+    summary: &gt;-
+      Direct assay evidence shows Dim2/Pno1 binds pre-rRNA through its KH domain
+      at the 5&#39; end of ITS1.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: &gt;-
+      This is the most specific experimentally supported molecular function for
+      Pno1 and should be considered core.
+    supported_by:
+    - reference_id: PMID:18755838
+      supporting_text: &#34;DIM2 binds pre-rRNAs directly through its KH domain&#34;
 - term:
     id: GO:0042255
     label: ribosome assembly
   evidence_type: IMP
   original_reference_id: PMID:18755838
   review:
-    summary: &#39;Manual review: ribosome assembly is consistent with known biology of PNO1.&#39;
+    summary: &gt;-
+      Mutant phenotype evidence supports Dim2/Pno1 function in cotranscriptional
+      ribosome assembly and pre-40S maturation.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: &gt;-
+      Pno1 coordinates pre-rRNA binding, pre-40S export, and later maturation, so
+      ribosome assembly is appropriate.
+    supported_by:
+    - reference_id: PMID:18755838
+      supporting_text: &#34;cotranscriptional ribosome assembly&#34;
 - term:
     id: GO:0030686
     label: 90S preribosome
   evidence_type: HDA
   original_reference_id: PMID:12150911
   review:
-    summary: &#39;Manual review: 90S preribosome is consistent with known biology of PNO1.&#39;
+    summary: &gt;-
+      High-throughput direct assay evidence identifies Pno1/Rrp20 with 90S
+      preribosomal particles.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: &gt;-
+      This component annotation is consistent with Pno1&#39;s early SSU processome
+      role.
+    supported_by:
+    - reference_id: PMID:12150911
+      supporting_text: &#34;90S pre-ribosomes include the 35S pre-rRNA&#34;
 - term:
     id: GO:0043248
     label: proteasome assembly
   evidence_type: IMP
   original_reference_id: PMID:12502737
   review:
-    summary: &#39;Manual review: proteasome assembly may be context-dependent or peripheral for PNO1.&#39;
-    action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    summary: &gt;-
+      The 2002 Nob1/Pno1 study connected pno1 defects with Pre6p accumulation
+      and proteasome maturation, but subsequent literature and UniProt support a
+      primary SSU ribosome biogenesis role for Pno1.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      The proteasome assembly annotation appears to reflect an older model or an
+      indirect phenotype through Nob1-associated biology. It should not be
+      considered a core Pno1 function.
+    supported_by:
+    - reference_id: PMID:12502737
+      supporting_text: &#34;A defect in either NOB1 or PNO1 caused accumulation of newly formed Pre6p&#34;
 - term:
     id: GO:0043248
     label: proteasome assembly
   evidence_type: IPI
   original_reference_id: PMID:12502737
   review:
-    summary: &#39;Manual review: proteasome assembly may be context-dependent or peripheral for PNO1.&#39;
-    action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    summary: &gt;-
+      The protein-interaction basis for proteasome assembly is not sufficient to
+      override the now well-supported Pno1 role in SSU/pre-40S maturation.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Pno1&#39;s core function is ribosome biogenesis. The proteasome assembly
+      interpretation is indirect and should be downgraded.
 - term:
     id: GO:0000447
     label: endonucleolytic cleavage in ITS1 to separate SSU-rRNA from 5.8S rRNA and LSU-rRNA from tricistronic rRNA transcript (SSU-rRNA, 5.8S rRNA, LSU-rRNA)
   evidence_type: IMP
   original_reference_id: PMID:12736301
   review:
-    summary: &#39;Manual review: endonucleolytic cleavage in ITS1 to separate SSU-rRNA from 5.8S rRNA and LSU-rRNA from tricistronic rRNA transcript (SSU-rRNA, 5.8S rRNA, LSU-rRNA) is consistent with known biology of PNO1.&#39;
+    summary: &gt;-
+      RRP20/PNO1 mutant phenotypes impair early pre-rRNA cleavages, including
+      ITS1 processing that separates SSU from LSU rRNA precursors.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: &gt;-
+      Pno1 is required for proper pre-rRNA processing as part of the SSU
+      maturation pathway, although it is not itself the nuclease.
+    supported_by:
+    - reference_id: PMID:12736301
+      supporting_text: &#34;RRP20, a component of the 90S preribosome, is required for pre-18S rRNA processing&#34;
 - term:
     id: GO:0000472
     label: endonucleolytic cleavage to generate mature 5&#39;-end of SSU-rRNA from (SSU-rRNA, 5.8S rRNA, LSU-rRNA)
   evidence_type: IMP
   original_reference_id: PMID:12736301
   review:
-    summary: &#39;Manual review: endonucleolytic cleavage to generate mature 5&#39;&#39;-end of SSU-rRNA from (SSU-rRNA, 5.8S rRNA, LSU-rRNA) is consistent with known biology of PNO1.&#39;
+    summary: &gt;-
+      PNO1/RRP20 mutant evidence supports a requirement for proper pre-18S rRNA
+      processing and mature SSU-rRNA formation.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: &gt;-
+      The annotation captures a core process consequence of Pno1 function in SSU
+      maturation.
+    supported_by:
+    - reference_id: PMID:12736301
+      supporting_text: &#34;defective in ribosomal RNA processing&#34;
 - term:
     id: GO:0005634
     label: nucleus
   evidence_type: IDA
   original_reference_id: PMID:12502737
   review:
-    summary: &#39;Manual review: nucleus is consistent with known biology of PNO1.&#39;
+    summary: &gt;-
+      Direct assay evidence supports nuclear localization of Pno1.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: &gt;-
+      Nuclear localization is consistent with Pno1&#39;s early pre-rRNA processing
+      and pre-40S export roles.
+    supported_by:
+    - reference_id: PMID:12502737
+      supporting_text: &#34;Pno1p&#34;
 - term:
     id: GO:0005730
     label: nucleolus
   evidence_type: IDA
   original_reference_id: PMID:10923024
   review:
-    summary: &#39;Manual review: nucleolus is consistent with known biology of PNO1.&#39;
+    summary: &gt;-
+      Direct GFP localization evidence places Yor145c/Pno1 in the nucleolus.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: &gt;-
+      Nucleolar localization is appropriate for an early SSU processome and
+      pre-rRNA processing factor.
+    supported_by:
+    - reference_id: PMID:10923024
+      supporting_text: &#34;Yor145-GFP concentrating in the nucleolus&#34;
 - term:
     id: GO:0051082
     label: unfolded protein binding
   evidence_type: IDA
   original_reference_id: PMID:12502737
   review:
-    summary: &#39;Manual review: unfolded protein binding is too generic or over-extended for PNO1.&#39;
+    summary: &gt;-
+      The unfolded-protein binding annotation is not well aligned with Pno1&#39;s
+      demonstrated KH-domain pre-rRNA binding and ribosome biogenesis functions.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Marked over-annotated because more specific terms capture the biology more accurately.
+    reason: &gt;-
+      Pno1 should not be curated as a generic protein-folding chaperone. Its
+      supported molecular function is rRNA/pre-rRNA binding and assembly-factor
+      regulation with Nob1/Rio1.
+core_functions:
+- molecular_function:
+    id: GO:0042134
+    label: rRNA primary transcript binding
+  directly_involved_in:
+  - id: GO:0030490
+    label: maturation of SSU-rRNA
+  - id: GO:0042255
+    label: ribosome assembly
+  - id: GO:0000056
+    label: ribosomal small subunit export from nucleus
+  locations:
+  - id: GO:0005730
+    label: nucleolus
+  - id: GO:0005634
+    label: nucleus
+  - id: GO:0005737
+    label: cytoplasm
+  in_complex:
+    id: GO:0030686
+    label: 90S preribosome
+  description: &gt;-
+    Pno1/Dim2 is a KH-domain rRNA-binding assembly factor that binds pre-rRNA,
+    supports SSU processome and pre-40S maturation, contributes to pre-40S
+    export, and coordinates late 18S rRNA processing with Nob1/Rio1-associated
+    quality control.
+  supported_by:
+  - reference_id: PMID:18755838
+    supporting_text: &#34;DIM2 binds pre-rRNAs directly through its KH domain&#34;
+  - reference_id: PMID:12736301
+    supporting_text: &#34;required for pre-18S rRNA processing&#34;
+  - reference_id: file:yeast/PNO1/PNO1-deep-research-falcon.md
+    supporting_text: &#34;binds pre-rRNA (ITS1 region) via its KH domain&#34;
+proposed_new_terms: []
+suggested_questions:
+- question: &gt;-
+    Should the legacy PNO1 proteasome assembly annotations be retired or
+    replaced by updated pre-40S/Nob1 maturation annotations in upstream SGD/GO
+    curation?
+suggested_experiments:
+- description: &gt;-
+    Revisit proteasome assembly phenotypes in pno1/dim2 mutants using acute
+    degron depletion and ribosome-processing rescue constructs to distinguish
+    direct proteasome effects from secondary consequences of impaired ribosome
+    biogenesis.
+  experiment_type: conditional depletion/rescue
+  hypothesis: &gt;-
+    The reported proteasome maturation defects are indirect consequences of
+    perturbed Nob1/Pno1 ribosome biogenesis or pleiotropic essential-gene stress.
 references:
 - id: GO_REF:0000033
   title: Annotation inferences using phylogenetic trees
@@ -2218,13 +3260,16 @@ references:
 - id: PMID:27980088
   title: Architecture of the yeast small subunit processome.
   findings: []
+- id: file:yeast/PNO1/PNO1-deep-research-falcon.md
+  title: Falcon deep research report for PNO1
+  findings: []
 </code></pre>
             </div>
         </details>
     </div>
 
     <!-- Pathway Visualization Link -->
-    
+
 
     <style>
         /* Markdown Section Styles */

--- a/genes/yeast/PNO1/PNO1-ai-review.html
+++ b/genes/yeast/PNO1/PNO1-ai-review.html
@@ -1577,7 +1577,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> The proteasome assembly annotation appears to reflect an older model or an indirect phenotype through Nob1-associated biology. It should not be considered a core Pno1 function.
+                            <strong>Reason:</strong> PMID:12502737 directly reports pno1 mutant proteasome maturation defects, but later Pno1/Dim2 literature supports ribosome biogenesis, pre-rRNA processing, and pre-40S maturation as the conserved core function. This proteasome assembly annotation is therefore retained only as a non-core/over-annotated phenotype from an older model.
                         </div>
 
 
@@ -1657,10 +1657,28 @@
 
 
                         <div>
-                            <strong>Reason:</strong> Pno1&#39;s core function is ribosome biogenesis. The proteasome assembly interpretation is indirect and should be downgraded.
+                            <strong>Reason:</strong> The original paper did observe proteasome assembly defects in pno1 mutants, but the current weight of evidence places Pno1 as a Dim2/Rrp20 ribosome biogenesis factor. The proteasome annotation should therefore be treated as an over-annotated non-core phenotype rather than a primary molecular role.
                         </div>
 
 
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12502737" target="_blank" class="term-link">
+                                        PMID:12502737
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">temperature-sensitive nob1 and pno1 mutants exhibited defects in the processing of the beta subunits and in the assembly of the 20S and the 26S proteasomes</div>
+
+                            </div>
+
+                        </div>
 
                     </td>
                 </tr>
@@ -1896,7 +1914,7 @@
 
                                 </span>
 
-                                <div class="support-text">Pno1p</div>
+                                <div class="support-text">Nob1p is a nuclear protein that forms a complex with the 19S regulatory particle of the 26S proteasome and with uncharacterized nuclear protein Pno1p</div>
 
                             </div>
 
@@ -3085,9 +3103,11 @@ existing_annotations:
       primary SSU ribosome biogenesis role for Pno1.
     action: MARK_AS_OVER_ANNOTATED
     reason: &gt;-
-      The proteasome assembly annotation appears to reflect an older model or an
-      indirect phenotype through Nob1-associated biology. It should not be
-      considered a core Pno1 function.
+      PMID:12502737 directly reports pno1 mutant proteasome maturation defects,
+      but later Pno1/Dim2 literature supports ribosome biogenesis, pre-rRNA
+      processing, and pre-40S maturation as the conserved core function. This
+      proteasome assembly annotation is therefore retained only as a
+      non-core/over-annotated phenotype from an older model.
     supported_by:
     - reference_id: PMID:12502737
       supporting_text: &#34;A defect in either NOB1 or PNO1 caused accumulation of newly formed Pre6p&#34;
@@ -3102,8 +3122,14 @@ existing_annotations:
       override the now well-supported Pno1 role in SSU/pre-40S maturation.
     action: MARK_AS_OVER_ANNOTATED
     reason: &gt;-
-      Pno1&#39;s core function is ribosome biogenesis. The proteasome assembly
-      interpretation is indirect and should be downgraded.
+      The original paper did observe proteasome assembly defects in pno1
+      mutants, but the current weight of evidence places Pno1 as a Dim2/Rrp20
+      ribosome biogenesis factor. The proteasome annotation should therefore be
+      treated as an over-annotated non-core phenotype rather than a primary
+      molecular role.
+    supported_by:
+    - reference_id: PMID:12502737
+      supporting_text: &#34;temperature-sensitive nob1 and pno1 mutants exhibited defects in the processing of the beta subunits and in the assembly of the 20S and the 26S proteasomes&#34;
 - term:
     id: GO:0000447
     label: endonucleolytic cleavage in ITS1 to separate SSU-rRNA from 5.8S rRNA and LSU-rRNA from tricistronic rRNA transcript (SSU-rRNA, 5.8S rRNA, LSU-rRNA)
@@ -3150,7 +3176,7 @@ existing_annotations:
       and pre-40S export roles.
     supported_by:
     - reference_id: PMID:12502737
-      supporting_text: &#34;Pno1p&#34;
+      supporting_text: &#34;Nob1p is a nuclear protein that forms a complex with the 19S regulatory particle of the 26S proteasome and with uncharacterized nuclear protein Pno1p&#34;
 - term:
     id: GO:0005730
     label: nucleolus

--- a/genes/yeast/PNO1/PNO1-ai-review.yaml
+++ b/genes/yeast/PNO1/PNO1-ai-review.yaml
@@ -196,9 +196,11 @@ existing_annotations:
       primary SSU ribosome biogenesis role for Pno1.
     action: MARK_AS_OVER_ANNOTATED
     reason: >-
-      The proteasome assembly annotation appears to reflect an older model or an
-      indirect phenotype through Nob1-associated biology. It should not be
-      considered a core Pno1 function.
+      PMID:12502737 directly reports pno1 mutant proteasome maturation defects,
+      but later Pno1/Dim2 literature supports ribosome biogenesis, pre-rRNA
+      processing, and pre-40S maturation as the conserved core function. This
+      proteasome assembly annotation is therefore retained only as a
+      non-core/over-annotated phenotype from an older model.
     supported_by:
     - reference_id: PMID:12502737
       supporting_text: "A defect in either NOB1 or PNO1 caused accumulation of newly formed Pre6p"
@@ -213,8 +215,14 @@ existing_annotations:
       override the now well-supported Pno1 role in SSU/pre-40S maturation.
     action: MARK_AS_OVER_ANNOTATED
     reason: >-
-      Pno1's core function is ribosome biogenesis. The proteasome assembly
-      interpretation is indirect and should be downgraded.
+      The original paper did observe proteasome assembly defects in pno1
+      mutants, but the current weight of evidence places Pno1 as a Dim2/Rrp20
+      ribosome biogenesis factor. The proteasome annotation should therefore be
+      treated as an over-annotated non-core phenotype rather than a primary
+      molecular role.
+    supported_by:
+    - reference_id: PMID:12502737
+      supporting_text: "temperature-sensitive nob1 and pno1 mutants exhibited defects in the processing of the beta subunits and in the assembly of the 20S and the 26S proteasomes"
 - term:
     id: GO:0000447
     label: endonucleolytic cleavage in ITS1 to separate SSU-rRNA from 5.8S rRNA and LSU-rRNA from tricistronic rRNA transcript (SSU-rRNA, 5.8S rRNA, LSU-rRNA)
@@ -261,7 +269,7 @@ existing_annotations:
       and pre-40S export roles.
     supported_by:
     - reference_id: PMID:12502737
-      supporting_text: "Pno1p"
+      supporting_text: "Nob1p is a nuclear protein that forms a complex with the 19S regulatory particle of the 26S proteasome and with uncharacterized nuclear protein Pno1p"
 - term:
     id: GO:0005730
     label: nucleolus

--- a/genes/yeast/PNO1/PNO1-ai-review.yaml
+++ b/genes/yeast/PNO1/PNO1-ai-review.yaml
@@ -1,11 +1,23 @@
 id: Q99216
 gene_symbol: PNO1
+aliases:
+- DIM2
+- RRP20
+- YOR145C
 product_type: PROTEIN
-status: DRAFT
+status: COMPLETE
 taxon:
   id: NCBITaxon:559292
   label: Saccharomyces cerevisiae
-description: 'TODO: Add description for PNO1'
+description: >-
+  PNO1 encodes Pno1/Dim2/Rrp20, a conserved KH-domain ribosome biogenesis
+  factor required for small ribosomal subunit synthesis. Pno1 binds pre-rRNA,
+  especially the ITS1 region, participates in early SSU processome and 90S to
+  pre-40S transitions, supports pre-40S export from the nucleus, and works with
+  Nob1 and Rio1 during late cytoplasmic 20S pre-rRNA to 18S rRNA maturation.
+  The coherent core function is RNA-binding regulation of SSU/pre-40S assembly
+  and processing; older proteasome and generic chaperone annotations appear
+  secondary or overextended.
 existing_annotations:
 - term:
     id: GO:0005634
@@ -13,162 +25,321 @@ existing_annotations:
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'Manual review: nucleus is consistent with known biology of PNO1.'
+    summary: >-
+      PANTHER IBA to nucleus is consistent with Pno1's conserved role as a
+      nuclear/nucleolar and nucleocytoplasmic ribosome biogenesis factor.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: >-
+      Pno1 acts in nuclear and nucleolar stages of SSU biogenesis and has direct
+      experimental nuclear/nucleolar localization support.
 - term:
     id: GO:0003723
     label: RNA binding
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
   review:
-    summary: 'Manual review: RNA binding is consistent with known biology of PNO1.'
+    summary: >-
+      Automated RNA-binding annotation is supported by Pno1 KH domains and by
+      direct evidence for binding pre-rRNA/ITS1.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: >-
+      RNA binding is a core molecular function for Pno1, though the more specific
+      rRNA primary transcript binding term is preferred when available.
+    supported_by:
+    - reference_id: file:yeast/PNO1/PNO1-deep-research-falcon.md
+      supporting_text: "binds pre-rRNA (ITS1 region) via its KH domain"
 - term:
     id: GO:0005730
     label: nucleolus
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
   review:
-    summary: 'Manual review: nucleolus is consistent with known biology of PNO1.'
+    summary: >-
+      UniProt/ARBA nucleolus mapping is consistent with Pno1 function in early
+      nucleolar SSU processome assembly and pre-rRNA processing.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: >-
+      The nucleolus is a supported compartment for Pno1 during early ribosome
+      biogenesis.
 - term:
     id: GO:0005737
     label: cytoplasm
   evidence_type: IEA
   original_reference_id: GO_REF:0000044
   review:
-    summary: 'Manual review: cytoplasm is consistent with known biology of PNO1.'
+    summary: >-
+      Cytoplasmic localization is consistent with Pno1 shuttling and late
+      cytoplasmic pre-40S maturation.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: >-
+      Pno1 functions after pre-40S export as part of late 18S rRNA maturation and
+      quality-control gating.
 - term:
     id: GO:0042254
     label: ribosome biogenesis
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
   review:
-    summary: 'Manual review: ribosome biogenesis is consistent with known biology of PNO1.'
+    summary: >-
+      Broad automated ribosome biogenesis annotation accurately summarizes the
+      experimentally supported Pno1 role in SSU/pre-40S assembly and maturation.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: >-
+      Pno1 is a ribosome biogenesis factor; more specific annotations capture
+      SSU-rRNA maturation, pre-40S export, and ribosome assembly.
 - term:
     id: GO:0005730
     label: nucleolus
   evidence_type: IDA
   original_reference_id: PMID:27980088
   review:
-    summary: 'Manual review: nucleolus is consistent with known biology of PNO1.'
+    summary: >-
+      ComplexPortal direct assay evidence places Pno1 in the nucleolus/SSU
+      processome context.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: >-
+      Nucleolar localization matches Pno1's early SSU processome and pre-rRNA
+      processing roles.
+    supported_by:
+    - reference_id: PMID:27980088
+      supporting_text: "Architecture of the yeast small subunit processome."
 - term:
     id: GO:0030490
     label: maturation of SSU-rRNA
   evidence_type: NAS
   original_reference_id: PMID:15489292
   review:
-    summary: 'Manual review: maturation of SSU-rRNA is consistent with known biology of PNO1.'
+    summary: >-
+      Curated statement evidence supports Pno1 as a specific SSU processome
+      component linked to SSU-rRNA maturation.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: >-
+      The annotation is consistent with multiple yeast studies showing defects in
+      pre-rRNA processing when Pno1/Dim2/Rrp20 is perturbed.
+    supported_by:
+    - reference_id: PMID:15489292
+      supporting_text: "RNA polymerase I transcription and pre-rRNA processing are linked by specific SSU processome components."
 - term:
     id: GO:0000056
     label: ribosomal small subunit export from nucleus
   evidence_type: IMP
   original_reference_id: PMID:18755838
+  qualifier: acts_upstream_of_or_within
   review:
-    summary: 'Manual review: ribosomal small subunit export from nucleus is consistent with known biology of PNO1.'
+    summary: >-
+      Mutant phenotype evidence supports Dim2/Pno1 involvement in pre-40S export
+      from the nucleus.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: >-
+      Pno1 contains a conserved export-related region and perturbation causes
+      pre-40S export defects, making this a core process annotation.
+    supported_by:
+    - reference_id: PMID:18755838
+      supporting_text: "pre-40S ribosome export"
 - term:
     id: GO:0042134
     label: rRNA primary transcript binding
   evidence_type: IDA
   original_reference_id: PMID:18755838
   review:
-    summary: 'Manual review: rRNA primary transcript binding is consistent with known biology of PNO1.'
+    summary: >-
+      Direct assay evidence shows Dim2/Pno1 binds pre-rRNA through its KH domain
+      at the 5' end of ITS1.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: >-
+      This is the most specific experimentally supported molecular function for
+      Pno1 and should be considered core.
+    supported_by:
+    - reference_id: PMID:18755838
+      supporting_text: "DIM2 binds pre-rRNAs directly through its KH domain"
 - term:
     id: GO:0042255
     label: ribosome assembly
   evidence_type: IMP
   original_reference_id: PMID:18755838
   review:
-    summary: 'Manual review: ribosome assembly is consistent with known biology of PNO1.'
+    summary: >-
+      Mutant phenotype evidence supports Dim2/Pno1 function in cotranscriptional
+      ribosome assembly and pre-40S maturation.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: >-
+      Pno1 coordinates pre-rRNA binding, pre-40S export, and later maturation, so
+      ribosome assembly is appropriate.
+    supported_by:
+    - reference_id: PMID:18755838
+      supporting_text: "cotranscriptional ribosome assembly"
 - term:
     id: GO:0030686
     label: 90S preribosome
   evidence_type: HDA
   original_reference_id: PMID:12150911
   review:
-    summary: 'Manual review: 90S preribosome is consistent with known biology of PNO1.'
+    summary: >-
+      High-throughput direct assay evidence identifies Pno1/Rrp20 with 90S
+      preribosomal particles.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: >-
+      This component annotation is consistent with Pno1's early SSU processome
+      role.
+    supported_by:
+    - reference_id: PMID:12150911
+      supporting_text: "90S pre-ribosomes include the 35S pre-rRNA"
 - term:
     id: GO:0043248
     label: proteasome assembly
   evidence_type: IMP
   original_reference_id: PMID:12502737
   review:
-    summary: 'Manual review: proteasome assembly may be context-dependent or peripheral for PNO1.'
-    action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    summary: >-
+      The 2002 Nob1/Pno1 study connected pno1 defects with Pre6p accumulation
+      and proteasome maturation, but subsequent literature and UniProt support a
+      primary SSU ribosome biogenesis role for Pno1.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      The proteasome assembly annotation appears to reflect an older model or an
+      indirect phenotype through Nob1-associated biology. It should not be
+      considered a core Pno1 function.
+    supported_by:
+    - reference_id: PMID:12502737
+      supporting_text: "A defect in either NOB1 or PNO1 caused accumulation of newly formed Pre6p"
 - term:
     id: GO:0043248
     label: proteasome assembly
   evidence_type: IPI
   original_reference_id: PMID:12502737
   review:
-    summary: 'Manual review: proteasome assembly may be context-dependent or peripheral for PNO1.'
-    action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    summary: >-
+      The protein-interaction basis for proteasome assembly is not sufficient to
+      override the now well-supported Pno1 role in SSU/pre-40S maturation.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      Pno1's core function is ribosome biogenesis. The proteasome assembly
+      interpretation is indirect and should be downgraded.
 - term:
     id: GO:0000447
     label: endonucleolytic cleavage in ITS1 to separate SSU-rRNA from 5.8S rRNA and LSU-rRNA from tricistronic rRNA transcript (SSU-rRNA, 5.8S rRNA, LSU-rRNA)
   evidence_type: IMP
   original_reference_id: PMID:12736301
   review:
-    summary: 'Manual review: endonucleolytic cleavage in ITS1 to separate SSU-rRNA from 5.8S rRNA and LSU-rRNA from tricistronic rRNA transcript (SSU-rRNA, 5.8S rRNA, LSU-rRNA) is consistent with known biology of PNO1.'
+    summary: >-
+      RRP20/PNO1 mutant phenotypes impair early pre-rRNA cleavages, including
+      ITS1 processing that separates SSU from LSU rRNA precursors.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: >-
+      Pno1 is required for proper pre-rRNA processing as part of the SSU
+      maturation pathway, although it is not itself the nuclease.
+    supported_by:
+    - reference_id: PMID:12736301
+      supporting_text: "RRP20, a component of the 90S preribosome, is required for pre-18S rRNA processing"
 - term:
     id: GO:0000472
     label: endonucleolytic cleavage to generate mature 5'-end of SSU-rRNA from (SSU-rRNA, 5.8S rRNA, LSU-rRNA)
   evidence_type: IMP
   original_reference_id: PMID:12736301
   review:
-    summary: 'Manual review: endonucleolytic cleavage to generate mature 5''-end of SSU-rRNA from (SSU-rRNA, 5.8S rRNA, LSU-rRNA) is consistent with known biology of PNO1.'
+    summary: >-
+      PNO1/RRP20 mutant evidence supports a requirement for proper pre-18S rRNA
+      processing and mature SSU-rRNA formation.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: >-
+      The annotation captures a core process consequence of Pno1 function in SSU
+      maturation.
+    supported_by:
+    - reference_id: PMID:12736301
+      supporting_text: "defective in ribosomal RNA processing"
 - term:
     id: GO:0005634
     label: nucleus
   evidence_type: IDA
   original_reference_id: PMID:12502737
   review:
-    summary: 'Manual review: nucleus is consistent with known biology of PNO1.'
+    summary: >-
+      Direct assay evidence supports nuclear localization of Pno1.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: >-
+      Nuclear localization is consistent with Pno1's early pre-rRNA processing
+      and pre-40S export roles.
+    supported_by:
+    - reference_id: PMID:12502737
+      supporting_text: "Pno1p"
 - term:
     id: GO:0005730
     label: nucleolus
   evidence_type: IDA
   original_reference_id: PMID:10923024
   review:
-    summary: 'Manual review: nucleolus is consistent with known biology of PNO1.'
+    summary: >-
+      Direct GFP localization evidence places Yor145c/Pno1 in the nucleolus.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: >-
+      Nucleolar localization is appropriate for an early SSU processome and
+      pre-rRNA processing factor.
+    supported_by:
+    - reference_id: PMID:10923024
+      supporting_text: "Yor145-GFP concentrating in the nucleolus"
 - term:
     id: GO:0051082
     label: unfolded protein binding
   evidence_type: IDA
   original_reference_id: PMID:12502737
   review:
-    summary: 'Manual review: unfolded protein binding is too generic or over-extended for PNO1.'
+    summary: >-
+      The unfolded-protein binding annotation is not well aligned with Pno1's
+      demonstrated KH-domain pre-rRNA binding and ribosome biogenesis functions.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Marked over-annotated because more specific terms capture the biology more accurately.
+    reason: >-
+      Pno1 should not be curated as a generic protein-folding chaperone. Its
+      supported molecular function is rRNA/pre-rRNA binding and assembly-factor
+      regulation with Nob1/Rio1.
+core_functions:
+- molecular_function:
+    id: GO:0042134
+    label: rRNA primary transcript binding
+  directly_involved_in:
+  - id: GO:0030490
+    label: maturation of SSU-rRNA
+  - id: GO:0042255
+    label: ribosome assembly
+  - id: GO:0000056
+    label: ribosomal small subunit export from nucleus
+  locations:
+  - id: GO:0005730
+    label: nucleolus
+  - id: GO:0005634
+    label: nucleus
+  - id: GO:0005737
+    label: cytoplasm
+  in_complex:
+    id: GO:0030686
+    label: 90S preribosome
+  description: >-
+    Pno1/Dim2 is a KH-domain rRNA-binding assembly factor that binds pre-rRNA,
+    supports SSU processome and pre-40S maturation, contributes to pre-40S
+    export, and coordinates late 18S rRNA processing with Nob1/Rio1-associated
+    quality control.
+  supported_by:
+  - reference_id: PMID:18755838
+    supporting_text: "DIM2 binds pre-rRNAs directly through its KH domain"
+  - reference_id: PMID:12736301
+    supporting_text: "required for pre-18S rRNA processing"
+  - reference_id: file:yeast/PNO1/PNO1-deep-research-falcon.md
+    supporting_text: "binds pre-rRNA (ITS1 region) via its KH domain"
+proposed_new_terms: []
+suggested_questions:
+- question: >-
+    Should the legacy PNO1 proteasome assembly annotations be retired or
+    replaced by updated pre-40S/Nob1 maturation annotations in upstream SGD/GO
+    curation?
+suggested_experiments:
+- description: >-
+    Revisit proteasome assembly phenotypes in pno1/dim2 mutants using acute
+    degron depletion and ribosome-processing rescue constructs to distinguish
+    direct proteasome effects from secondary consequences of impaired ribosome
+    biogenesis.
+  experiment_type: conditional depletion/rescue
+  hypothesis: >-
+    The reported proteasome maturation defects are indirect consequences of
+    perturbed Nob1/Pno1 ribosome biogenesis or pleiotropic essential-gene stress.
 references:
 - id: GO_REF:0000033
   title: Annotation inferences using phylogenetic trees
@@ -199,4 +370,7 @@ references:
   findings: []
 - id: PMID:27980088
   title: Architecture of the yeast small subunit processome.
+  findings: []
+- id: file:yeast/PNO1/PNO1-deep-research-falcon.md
+  title: Falcon deep research report for PNO1
   findings: []

--- a/genes/yeast/PNO1/PNO1-deep-research-falcon.md
+++ b/genes/yeast/PNO1/PNO1-deep-research-falcon.md
@@ -1,0 +1,417 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-04T10:06:12.733283'
+end_time: '2026-05-04T10:30:37.462203'
+duration_seconds: 1464.73
+template_file: templates/gene_research_go_focused.md
+template_variables:
+  organism: yeast
+  gene_id: PNO1
+  gene_symbol: PNO1
+  uniprot_accession: Q99216
+  protein_description: 'RecName: Full=Pre-rRNA-processing protein PNO1; AltName: Full=Partner
+    of NOB1; AltName: Full=Ribosomal RNA-processing protein 20;'
+  gene_info: Name=PNO1; Synonyms=DIM2, RRP20; OrderedLocusNames=YOR145C; ORFNames=O3513,
+    YOR3513C;
+  organism_full: Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+  protein_family: Belongs to the PNO1 family. .
+  protein_domains: KH-I_PNO1_first. (IPR055212); KH_dom_type_1_sf. (IPR036612); KH_PNO1_2nd.
+    (IPR055211); KRR1-like_KH1. (IPR041174); KH_KRR1_1st (PF17903)
+provider_config:
+  timeout: 600
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 34
+---
+
+## Question
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** Q99216
+- **Protein Description:** RecName: Full=Pre-rRNA-processing protein PNO1; AltName: Full=Partner of NOB1; AltName: Full=Ribosomal RNA-processing protein 20;
+- **Gene Information:** Name=PNO1; Synonyms=DIM2, RRP20; OrderedLocusNames=YOR145C; ORFNames=O3513, YOR3513C;
+- **Organism (full):** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+- **Protein Family:** Belongs to the PNO1 family. .
+- **Key Domains:** KH-I_PNO1_first. (IPR055212); KH_dom_type_1_sf. (IPR036612); KH_PNO1_2nd. (IPR055211); KRR1-like_KH1. (IPR041174); KH_KRR1_1st (PF17903)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "PNO1" matches the protein description above**
+2. **Verify the organism is correct:** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'PNO1' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **PNO1** (gene ID: PNO1, UniProt: Q99216) in yeast.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** Q99216
+- **Protein Description:** RecName: Full=Pre-rRNA-processing protein PNO1; AltName: Full=Partner of NOB1; AltName: Full=Ribosomal RNA-processing protein 20;
+- **Gene Information:** Name=PNO1; Synonyms=DIM2, RRP20; OrderedLocusNames=YOR145C; ORFNames=O3513, YOR3513C;
+- **Organism (full):** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+- **Protein Family:** Belongs to the PNO1 family. .
+- **Key Domains:** KH-I_PNO1_first. (IPR055212); KH_dom_type_1_sf. (IPR036612); KH_PNO1_2nd. (IPR055211); KRR1-like_KH1. (IPR041174); KH_KRR1_1st (PF17903)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "PNO1" matches the protein description above**
+2. **Verify the organism is correct:** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'PNO1' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **PNO1** (gene ID: PNO1, UniProt: Q99216) in yeast.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+# Research Report: Functional Annotation of *Saccharomyces cerevisiae* PNO1 (Dim2/Rrp20)
+
+## 0) Target identity verification (mandatory)
+
+The research target is **PNO1** from *Saccharomyces cerevisiae* S288c (UniProt **Q99216**), also known in yeast literature as **Dim2** and **Rrp20** and encoded by **YOR145C**. A yeast primary study explicitly identifies **DIM2 (ORF YOR145C)** as a **KH-domain** ribosome biogenesis factor required for **pre-rRNA processing** and **pre-40S export**, matching the UniProt description (pre‑rRNA‑processing protein; “Partner of Nob1”) and the stated family/domain architecture (KH-type RNA-binding domains). (vanrobays2008torregulatesthe pages 1-2)
+
+Because “PNO1” is also used for homologs in other eukaryotes (including human cancer literature), only yeast-specific sources and conserved-mechanism studies with clear organism context are used here for functional claims about Q99216/YOR145C. (vanrobays2008torregulatesthe pages 1-2, woolls2011rolesofdim2 pages 1-2)
+
+## 1) Key concepts, definitions, and current understanding
+
+### 1.1 Ribosome biogenesis context (SSU processome → pre-40S → mature 40S)
+
+In yeast, small ribosomal subunit (40S) biogenesis begins cotranscriptionally on the 35S pre-rRNA within a large nucleolar precursor called the **90S/SSU processome**, which is remodeled to release a **pre-40S** particle that is exported to the cytoplasm for final maturation. General quantitative context: yeast cells can synthesize ~**2000 ribosomes/minute**; eukaryotic ribosomes contain **79** ribosomal proteins; assembly requires **>200** transient assembly factors. (chakermargot2018assemblyofthe pages 1-2, parker2024thekinaserio1 pages 1-2)
+
+### 1.2 What Pno1/Dim2 is
+
+**Pno1/Dim2 (PNO1/DIM2/RRP20)** is a **conserved KH-domain-containing** ribosome biogenesis factor that binds pre-rRNA and acts at multiple stages of SSU maturation—from early steps associated with the SSU processome/90S particle to late cytoplasmic pre-40S maturation. (vanrobays2008torregulatesthe pages 1-2, sturm2017interdependentactionof pages 1-2)
+
+Key definitional points:
+- **KH domain**: an RNA-binding fold; in yeast Pno1/Dim2 the KH motif is critical for pre-rRNA association, with residues in the KH region (including the conserved **G207**) required for binding and proper processing. (vanrobays2008torregulatesthe pages 1-2, knox2010regulationofthea pages 57-61)
+- **ITS1** (internal transcribed spacer 1): Pno1/Dim2 binds the **5′ end of ITS1** (often discussed as the D–A2 region in yeast processing maps), positioning it at the SSU/ITS1 junction relevant for small-subunit processing and later cleavage events. (vanrobays2008torregulatesthe pages 1-2)
+
+### 1.3 Primary molecular function (what Pno1/Dim2 “does”)
+
+PNO1 is **not an enzyme catalyzing a chemical reaction**; rather, it is an **RNA-binding assembly factor** and **checkpoint/regulatory factor**.
+
+The best-supported primary function is that Pno1/Dim2:
+1) **binds pre-rRNA (ITS1 region) via its KH domain** to promote proper SSU assembly/processing, and
+2) **partners with and regulates the endonuclease Nob1** during the essential final step of 18S rRNA 3′-end formation (D-site cleavage of 20S pre-rRNA → mature 18S), including controlling access/positioning and coupling cleavage to downstream release/quality control. (woolls2011rolesofdim2 pages 1-2, scaiola2018structureofa pages 1-2)
+
+Mechanistic evidence in yeast indicates Dim2 physically interacts with Nob1; this interaction increases Nob1’s RNA affinity and is required for efficient D-site cleavage. Disrupting the Dim2–Nob1 interaction causes accumulation of pre-ribosomes containing **Nob1 and 20S pre-rRNA**, consistent with a block in final 18S maturation. (woolls2011rolesofdim2 pages 1-2)
+
+## 2) Molecular mechanism and pathway placement
+
+### 2.1 Early nucleolar/cotranscriptional roles: SSU processome/90S
+
+A yeast study characterizes DIM2 as required for **cotranscriptional ribosome assembly** and **early nucleolar pre-rRNA processing**; Dim2 binds pre-rRNAs at the **5′ end of ITS1** via its KH domain. A single KH-motif point mutation **G207A** inhibits pre-rRNA processing similarly to DIM2 depletion, demonstrating that RNA binding through the KH domain is functionally important. (vanrobays2008torregulatesthe pages 1-2)
+
+A structural/mechanistic study further places Dim2/Pno1 in **two successive stages** of SSU biogenesis: it acts first on the 90S particle and then **relocates** to the pre-40S platform after remodeling events (including U3 snoRNP removal) during the 90S→pre‑40S transition. (sturm2017interdependentactionof pages 1-2)
+
+### 2.2 Nuclear export and growth-control coupling (TOR)
+
+Dim2/Pno1 is a **nucleocytoplasmic shuttling** factor with a **conserved nuclear export sequence (NES)** required for efficient pre-40S export. Export can be uncoupled experimentally from some early processing phenotypes using dominant-negative constructs.
+
+Key yeast findings:
+- Dim2 and the export factor **Rrp12** become **nucleolar-sequestered** under stress conditions, and this relocalization is **TOR-dependent**; rapamycin triggers nucleolar entrapment. (vanrobays2008torregulatesthe pages 1-2, vanrobays2008torregulatesthe pages 5-7)
+- A **DNES** construct causes a strong pre-40S export defect and can phenocopy depletion for growth and A1–A2 processing defects, while conservative leucine substitutions did not disrupt export in tested assays—supporting that export depends on the NES architecture rather than any single leucine. (vanrobays2008torregulatesthe pages 5-7)
+
+These observations connect Pno1/Dim2 function to nutrient-responsive regulation of ribosome production through TOR signaling. (vanrobays2008torregulatesthe pages 1-2, vanrobays2008torregulatesthe pages 7-8)
+
+### 2.3 Late cytoplasmic maturation: structural “placeholder” and Nob1 regulation
+
+Cryo-EM structures of cytoplasmic yeast pre-40S place **Pno1** on the SSU **platform** near the **mRNA binding channel**, and show that it occupies the binding site for the ribosomal protein **Rps26/eS26**, thereby preventing premature Rps26 incorporation. This is consistent with Pno1 serving as a late-stage placeholder/checkpoint factor and provides a structural rationale for why Pno1 must be remodeled or released for final maturation. (scaiola2018structureofa media 392eda28, scaiola2018structureofa pages 1-2)
+
+Biochemically, Dim2’s KH-like domain can be “repurposed” as a protein–protein interaction surface: the **Dim2–Nob1 interaction maps to the canonical KH-like RNA-binding surface** of Dim2, and disrupting it blocks maturation at the 20S→18S step. (woolls2011rolesofdim2 pages 1-2)
+
+### 2.4 Rio1-mediated licensing checkpoint (current model)
+
+A central modern concept is that **Rio1**, together with **Nob1** and **Pno1**, establishes a **quality-control checkpoint** preventing immature/misprocessed 40S subunits from entering the translating pool.
+
+Mechanistic model from recent yeast work:
+- Pre-40S containing 20S pre-rRNA is bound by **Nob1 and Pno1**; Pno1 helps stabilize Nob1 and the pair blocks mRNA recruitment and Rps26 binding, preventing translation initiation. (parker2024thekinaserio1 pages 1-2)
+- Nob1 cleaves the 3′ end of 18S rRNA (D-site cleavage) to convert 20S to mature 18S.
+- **Rio1** then removes **both Nob1 and Pno1**, licensing the nascent 40S for translation and enabling Rps26 binding. (parker2024thekinaserio1 pages 1-2)
+
+A key “precision” statistic from this framework is that retention of as few as **3 precursor nucleotides** at the 18S 3′ end is incompatible with yeast viability, emphasizing stringent QC at this step. (parker2024thekinaserio1 pages 1-2)
+
+## 3) Recent developments (prioritizing 2023–2024)
+
+### 3.1 2023: Quality control synthesis (authoritative review)
+
+A 2023 review synthesizes evidence that a **Rio1-dependent QC mechanism** ensures only ribosomes with **precise 18S rRNA cleavage** are licensed to translate, and that **Pno1 (Dim2)** and **Nob1** are central to this checkpoint. The review notes that weakening Pno1 binding can bypass the checkpoint, allowing ribosomes with **uncleaved 20S pre-rRNA** or **miscleaved 18S rRNA** to enter translation, where they cause translation defects (e.g., collisions/errors). (parker2023qualitycontrolensures pages 10-12)
+
+Citation:
+- Parker MD, Karbstein K. *Quality control ensures fidelity in ribosome assembly and cellular health.* **J Cell Biol**. **Feb 2023**. https://doi.org/10.1083/jcb.202209115 (parker2023qualitycontrolensures pages 10-12)
+
+### 3.2 2024: Quantitative miscleavage and collision-dependent decay (primary study)
+
+A 2024 yeast study directly quantifies how bypassing the Rio1/Pno1 checkpoint changes the abundance of miscleaved 18S rRNA:
+- **WT**: **1.9%** miscleaved 18S
+- **Pno1-KKKF** checkpoint-bypass allele: **2.5%** miscleaved 18S
+
+The study further reports deep sequencing metrics (~**2.8–4.5 million reads/sample**, with **96–99%** mapping to the 3′ end region analyzed) and multiple biological replicates for key assays. Miscleaved ribosomes that enter translation are slowed and induce **ribosome collisions**, leading to decay pathways that remove these altered ribosomes. (parker2024thekinaserio1 pages 15-17)
+
+Citation:
+- Parker MD et al. *The kinase Rio1 and a ribosome collision-dependent decay pathway survey the integrity of 18S rRNA cleavage.* **PLOS Biology**. **Apr 2024**. https://doi.org/10.1371/journal.pbio.3001767 (parker2024thekinaserio1 pages 15-17)
+
+### 3.3 2023: Structural checkpointing via ribosomal protein cluster assembly
+
+A 2023 cryo-EM study examined SSU precursors from yeast mutants affecting the **S0-cluster** (rpS0/rpS2/rpS21) and concluded that S0-cluster formation enables **initial recruitment of Nob1** and promotes hierarchical rRNA folding events, including central pseudoknot maturation. The work discusses that factors such as Pno1 are retained in these precursor states, helping place Pno1 into an updated, structure-based maturation trajectory for cytoplasmic checkpoints. (poll2023impactofthe pages 1-5)
+
+Citation:
+- Pöll G et al. *Impact of the yeast S0/uS2-cluster ribosomal protein rpS21/eS21 on rRNA folding and the architecture of small ribosomal subunit precursors.* **Jan 2023** (bioRxiv/PLOS ONE record as retrieved). https://doi.org/10.1101/2023.01.18.524556 (poll2023impactofthe pages 1-5)
+
+## 4) Cellular localization and where Pno1/Dim2 acts
+
+### 4.1 Compartmentalization across the maturation pathway
+
+Yeast Dim2/Pno1 acts in both:
+- the **nucleolus/nucleus** (early SSU processome/cotranscriptional assembly; stress/TOR-dependent sequestration), and
+- the **cytoplasm** (pre‑40S late maturation; regulation of Nob1 cleavage; Rio1-controlled release). (vanrobays2008torregulatesthe pages 1-2, parker2024thekinaserio1 pages 1-2)
+
+### 4.2 TOR-regulated redistribution
+
+Dim2 and Rrp12 relocalize to the nucleolus under stress and with rapamycin in a TOR-dependent manner, supporting a model in which nutrient signaling modulates the subcellular trafficking and/or availability of pre-40S export/maturation factors. (vanrobays2008torregulatesthe pages 5-7, vanrobays2008torregulatesthe pages 8-10)
+
+### 4.3 Export signal requirement
+
+Dim2 contains a C-terminal NES required for efficient pre-40S export; deletion/obliteration can cause severe export phenotypes (including dominant-negative effects), underscoring that its spatial trafficking is integral to function. (vanrobays2008torregulatesthe pages 5-7)
+
+## 5) Interaction partners and complexes
+
+Key interactors supported by yeast literature:
+- **Nob1**: direct binding partner; interaction promotes/controls Nob1 activity and affects 20S→18S maturation. (woolls2011rolesofdim2 pages 1-2)
+- **Rio2**: implicated in early cytoplasmic complexes with Pno1/Nob1 immediately after export (model supported by in vitro interactions and pathway logic). (turowski2014rio1mediatesatpdependent pages 7-8)
+- **Rio1**: binds late pre-40S particles shortly before cleavage and removes Pno1/Nob1 to license translation; Rio1 inactivity impairs release of Pno1/Nob1 from late intermediates. (cerezo2019maturationofpre‐40s pages 4-5, parker2024thekinaserio1 pages 1-2)
+- **Rrp12**: linked to export and shares TOR-regulated nucleolar sequestration with Dim2. (vanrobays2008torregulatesthe pages 5-7)
+
+## 6) Real-world applications and implementations
+
+Although PNO1 is not a classical “biotech target” in yeast, it is widely used in **real experimental implementations** as a node to interrogate ribosome assembly, export, and quality control:
+
+1) **Conditional essential gene perturbation**: Dim2 is essential; strains with regulated DIM2 expression (e.g., galactose-inducible or tet-off designs) are used to create controlled blocks in SSU maturation and to map consequences on rRNA processing/export. (woolls2011rolesofdim2 pages 4-5, vanrobays2008torregulatesthe pages 1-2)
+
+2) **Readouts for rRNA processing pathway diagnostics**:
+   - Early processing defects: KH-domain perturbation (e.g., G207A) can block A1/A2 cleavages and yield accumulation of **22S** pre-rRNA. (vanrobays2008torregulatesthe pages 8-10)
+   - Late maturation defects: Dim2–Nob1 interaction mutants accumulate **20S** (and other intermediates such as **21S/23S**) and stall final 18S 3′ end formation. (woolls2011rolesofdim2 pages 1-2, woolls2011rolesofdim2 pages 4-5)
+
+3) **Nuclear export assays and signaling integration**:
+   - Export defects induced by NES deletion constructs (DNES) provide a tool to isolate nuclear export contributions from early processing contributions. (vanrobays2008torregulatesthe pages 5-7)
+   - TOR/rapamycin-induced nucleolar entrapment provides a practical linkage between nutrient signaling and ribosome biogenesis factor distribution. (vanrobays2008torregulatesthe pages 5-7)
+
+4) **Ribosome QC and translation fidelity research** (2023–2024 focus):
+   - Pno1 checkpoint-bypass alleles allow controlled release of misprocessed ribosomes into translation, enabling direct study of collision-dependent decay and the cellular consequences of ribosome heterogeneity. (parker2024thekinaserio1 pages 15-17, parker2023qualitycontrolensures pages 10-12)
+
+## 7) Relevant statistics and data (recent and/or authoritative)
+
+### 7.1 System-level ribosome biogenesis numbers
+
+- ~**2000 ribosomes/min** synthesized in rapidly growing yeast. (chakermargot2018assemblyofthe pages 1-2)
+- Eukaryotic ribosome contains **4 rRNAs** and **79 proteins**; assembly uses **>200** transient assembly factors. (chakermargot2018assemblyofthe pages 1-2, parker2024thekinaserio1 pages 1-2)
+- An estimate from proteomics-based reviews: ~**200 proteins** in the small subunit assembly machinery, comprising ~**20% of essential yeast proteins**. (karbstein2011insidethe40s pages 1-2)
+
+### 7.2 Pno1/Rio1 QC quantitative outcomes (2024)
+
+- Miscleaved 18S rRNA fraction increases from **1.9% (WT)** to **2.5% (Pno1-KKKF)** when QC is bypassed. (parker2024thekinaserio1 pages 15-17)
+- Sequencing depth in those assays: ~**2.8–4.5 million reads/sample**, with **96–99%** mapping to the analyzed 18S 3′-end region. (parker2024thekinaserio1 pages 15-17)
+
+### 7.3 Mutational/phenotype quantitation (export/processing)
+
+- A single KH-motif mutation **G207A** can cause a severe growth impact (~**3.5-fold** growth impact as reported) and inhibits pre-rRNA processing similarly to DIM2 depletion. (vanrobays2008torregulatesthe pages 1-2)
+- NES deletion constructs can induce rapid and strong export defects within ~**1 hour** in the referenced assay context. (vanrobays2008torregulatesthe pages 7-8)
+
+## 8) Expert opinions and analysis (authoritative synthesis)
+
+Two themes emerge from authoritative sources and recent primary data:
+
+1) **PNO1/DIM2 integrates structural assembly with enzymatic timing.** Structural placement of Pno1 near the mRNA channel and at the Rps26 site, and biochemical evidence that it modulates Nob1’s substrate interactions, support a model in which Pno1 prevents premature translation engagement and coordinates the final rRNA processing step with acquisition of translation competence. (scaiola2018structureofa media 392eda28, woolls2011rolesofdim2 pages 1-2)
+
+2) **The late 40S assembly checkpoint is a fidelity gate with measurable error rates.** The 2024 quantification of miscleavage, and the observation that altered ribosomes can enter translation but trigger collisions/decay, supports a modern view in which assembly QC is not purely binary but tunes the probability of defective ribosomes entering the translating pool, with Rio1/Pno1 as key determinants of that stringency. (parker2024thekinaserio1 pages 15-17, parker2023qualitycontrolensures pages 10-12)
+
+## 9) Visual evidence from structural work (figure-based)
+
+Cryo-EM evidence places Pno1 on the cytoplasmic pre-40S platform near the mRNA channel and supports its role as an Rps26-site placeholder and Nob1 regulator. (scaiola2018structureofa media 392eda28, scaiola2018structureofa media 37cb333c)
+
+## 10) Summary of functional annotation (yeast PNO1 / UniProt Q99216)
+
+- **Molecular function:** KH-domain RNA-binding ribosome assembly factor; regulates and partners with Nob1 for final 18S 3′-end maturation; acts as a late-stage placeholder that blocks Rps26 incorporation and translation entry until licensing by Rio1. (woolls2011rolesofdim2 pages 1-2, scaiola2018structureofa media 392eda28, parker2024thekinaserio1 pages 1-2)
+- **Biological process:** SSU processome maturation; 90S→pre-40S transition; pre-40S export; cytoplasmic 20S→18S processing; quality-control gating for translation competence. (sturm2017interdependentactionof pages 1-2, vanrobays2008torregulatesthe pages 5-7, parker2024thekinaserio1 pages 15-17)
+- **Cellular localization:** Nucleolus/nucleus and cytoplasm; shuttling factor with TOR-regulated redistribution and NES-dependent export functionality. (vanrobays2008torregulatesthe pages 5-7, vanrobays2008torregulatesthe pages 1-2)
+
+## Structured summary table
+
+| Functional role / process step | Molecular mechanism / binding site / key domains | Key interaction partners / complexes | Subcellular location | Representative evidence (paper, year, URL) | Notes / quantitative data |
+|---|---|---|---|---|---|
+| Verified identity of target protein | Yeast PNO1 is the same factor as Dim2/Rrp20, a KH-domain pre-rRNA processing factor and “Partner of Nob1”; literature aligns with the UniProt description of a KH-domain protein involved in SSU/pre-40S maturation (vanrobays2008torregulatesthe pages 1-2, woolls2011rolesofdim2 pages 1-2) | Nob1; pre-rRNA; pre-40S particles | Nucleolus, nucleus, cytoplasm (shuttling) (vanrobays2008torregulatesthe pages 1-2) | Vanrobays et al., 2008, RNA, https://doi.org/10.1261/rna.1176708; Woolls et al., 2011, JBC, https://doi.org/10.1074/jbc.m110.191494 (vanrobays2008torregulatesthe pages 1-2, woolls2011rolesofdim2 pages 1-2) | Supports use of yeast-specific synonyms PNO1/DIM2/RRP20 and distinguishes this protein from non-yeast PNO1 literature (vanrobays2008torregulatesthe pages 1-2, woolls2011rolesofdim2 pages 1-2) |
+| Early cotranscriptional SSU assembly / 90S step | Direct pre-rRNA binding via KH domain at the 5′ end of ITS1 (D–A2 segment); conserved KH residue G207 is required, and G207A phenocopies Dim2 depletion in pre-rRNA processing (vanrobays2008torregulatesthe pages 1-2) | Nascent pre-rRNA; SSU processome / 90S precursors | Primarily nucleolar / nuclear during early assembly (vanrobays2008torregulatesthe pages 1-2) | Vanrobays et al., 2008, RNA, https://doi.org/10.1261/rna.1176708 (vanrobays2008torregulatesthe pages 1-2) | Depletion causes early pre-rRNA processing defects; accumulation of a 22S (A0–A3) intermediate is consistent with an early SSU role (knox2010regulationoftheb pages 57-61, knox2010regulationofthea pages 57-61) |
+| 90S-to-pre-40S transition and platform assembly | Dim2/Pno1 acts at two successive stages: first on 90S, then relocates to the pre-40S platform after U3 snoRNP removal; function is coordinated with structurally related KH factor Krr1 during platform assembly (sturm2017interdependentactionof pages 1-2) | Utp1, Utp14, Dhr1, Krr1, Rps14, UTP-B, UTP-C, emerging pre-40S (sturm2017interdependentactionof pages 1-2) | Nucleolus to early pre-40S particles (sturm2017interdependentactionof pages 1-2) | Sturm et al., 2017, Nature Communications, https://doi.org/10.1038/s41467-017-02199-4 (sturm2017interdependentactionof pages 1-2) | Places Pno1 upstream of late cytoplasmic maturation and links it mechanistically to ordered SSU platform biogenesis (sturm2017interdependentactionof pages 1-2) |
+| Pre-40S nuclear export factor | Contains a conserved C-terminal NES required for efficient pre-40S export; proposed as a CRM1/Xpo1-linked export adapter together with other factors such as Rrp12/Ltv1 (vanrobays2008torregulatesthe pages 1-2, knox2010regulationoftheb pages 57-61) | CRM1/Xpo1 pathway; Rrp12; pre-40S export machinery (vanrobays2008torregulatesthe pages 1-2, knox2010regulationoftheb pages 57-61) | Nucleus to cytoplasm; shuttling factor (vanrobays2008torregulatesthe pages 1-2) | Vanrobays et al., 2008, RNA, https://doi.org/10.1261/rna.1176708 (vanrobays2008torregulatesthe pages 1-2) | TOR signaling regulates Dim2 distribution; rapamycin causes nucleolar entrapment of Dim2/Rrp12 (vanrobays2008torregulatesthe pages 1-2) |
+| Late pre-40S maturation and Nob1 recruitment/regulation | Dim2 physically interacts with Nob1; the Nob1-binding surface maps to the canonical KH-like RNA-binding face of Dim2, repurposed for protein interaction; Dim2 increases Nob1 RNA affinity and promotes productive D-site cleavage (woolls2011rolesofdim2 pages 1-2) | Nob1; pre-40S particles containing 20S pre-rRNA (woolls2011rolesofdim2 pages 1-2) | Cytoplasmic late pre-40S; also associated earlier in the pathway (woolls2011rolesofdim2 pages 1-2, turowski2014rio1mediatesatpdependent pages 7-8) | Woolls et al., 2011, JBC, https://doi.org/10.1074/jbc.m110.191494 (woolls2011rolesofdim2 pages 1-2) | Mutants disrupting Dim2–Nob1 interaction accumulate pre-ribosomes containing Nob1 and 20S pre-rRNA in vivo, indicating a block in 18S 3′-end maturation (woolls2011rolesofdim2 pages 1-2) |
+| Cleavage-incompetent to cleavage-competent late pre-40S remodeling | Pno1 binds ITS1 and 18S regions; early cytoplasmic particles may contain a Pno1/Nob1/Rio2 assembly that is cleavage-incompetent. Later particles containing mainly Rio1, Pno1, and Nob1 acquire cleavage competence, likely requiring Pno1 repositioning/removal from site D vicinity (turowski2014rio1mediatesatpdependent pages 7-8) | Nob1; Rio2; Rio1; late pre-40S particles (turowski2014rio1mediatesatpdependent pages 7-8) | Cytoplasm after export (turowski2014rio1mediatesatpdependent pages 7-8) | Turowski et al., 2014, Nucleic Acids Research, https://doi.org/10.1093/nar/gku878 (turowski2014rio1mediatesatpdependent pages 7-8) | Rio1-associated particles show greater in vitro cleavage efficiency than particles purified via other factors (turowski2014rio1mediatesatpdependent pages 7-8) |
+| Structural placeholder on cytoplasmic pre-40S | Cryo-EM places Pno1 on the platform near the mRNA channel and adjacent to the 3′ ITS; Pno1 occupies the future Rps26/eS26 binding site, thereby preventing Rps26 binding before proper maturation and helping regulate Nob1-mediated cleavage (scaiola2018structureofa pages 1-2, scaiola2018structureofa media 392eda28) | Nob1; Rps26/eS26; cytoplasmic pre-40S assembly factors Enp1, Ltv1, Tsr1, Rio2, Dim1 (scaiola2018structureofa pages 1-2, scaiola2018structureofa media 392eda28) | Cytoplasmic pre-40S particle (scaiola2018structureofa pages 1-2, scaiola2018structureofa media 392eda28) | Scaiola et al., 2018, The EMBO Journal, https://doi.org/10.15252/embj.201798499 (scaiola2018structureofa pages 1-2, scaiola2018structureofa media 392eda28) | Structural model explains why Pno1 must be remodeled/released before final maturation and Rps26 incorporation (scaiola2018structureofa media 392eda28) |
+| Component of late 80S-like pre-ribosomal checkpoint particles | Pno1/Dim2 is present with Rio1 and Nob1 in late cytoplasmic 80S-like particles; Rio1 ATPase activity promotes release of Pno1/Dim2, Nob1, and other factors from these particles (cerezo2019maturationofpre‐40s pages 4-5) | Rio1; Nob1; 80S-like pre-ribosomes (cerezo2019maturationofpre‐40s pages 4-5) | Cytoplasm (late maturation stage) (cerezo2019maturationofpre‐40s pages 4-5) | Cerezo et al., 2019, WIREs RNA, https://doi.org/10.1002/wrna.1516 (cerezo2019maturationofpre‐40s pages 4-5) | Review synthesizes structural and biochemical evidence but notes uncertainty over whether D-site cleavage occurs before or after 80S-like particle dissociation (cerezo2019maturationofpre‐40s pages 4-5) |
+| Quality-control checkpoint preventing immature SSU entry into translation | Pno1 and Nob1 establish a Rio1-regulated QC checkpoint. Pno1 blocks mRNA recruitment and the Rps26 site until correct 18S 3′-end processing; Rio1 releases Nob1/Pno1 only from properly matured particles (parker2023qualitycontrolensures pages 10-12, parker2024thekinaserio1 pages 1-2) | Rio1; Nob1; Rps26; translating pool exclusion machinery (parker2023qualitycontrolensures pages 10-12, parker2024thekinaserio1 pages 1-2) | Cytoplasmic late pre-40S / translation-entry checkpoint (parker2023qualitycontrolensures pages 10-12, parker2024thekinaserio1 pages 1-2) | Parker & Karbstein, 2023, J Cell Biol, https://doi.org/10.1083/jcb.202209115; Parker et al., 2024, PLOS Biology, https://doi.org/10.1371/journal.pbio.3001767 (parker2023qualitycontrolensures pages 10-12, parker2024thekinaserio1 pages 1-2) | Review notes that checkpoint-bypassing Pno1 mutants release particles with uncleaved 20S or miscleaved 18S into translation, causing translation errors/collisions; RIOK1 amplification is noted in 29% of cancers in the broader conserved context (parker2023qualitycontrolensures pages 10-12) |
+| Surveillance of precise 18S 3′-end cleavage | Rio1 binds miscleaved 18S products less well; excess Pno1 increases accumulation of miscleaved rRNA, showing Pno1 dosage and release are part of the surveillance system for accurate cleavage (parker2024thekinaserio1 pages 15-17, parker2024thekinaserio1 pages 1-2) | Rio1; Nob1; miscleaved 18S-containing ribosomes (parker2024thekinaserio1 pages 15-17) | Cytoplasm / translating pool interface (parker2024thekinaserio1 pages 15-17) | Parker et al., 2024, PLOS Biology, https://doi.org/10.1371/journal.pbio.3001767 (parker2024thekinaserio1 pages 15-17, parker2024thekinaserio1 pages 1-2) | Miscleaved 18S increased from 1.9% in WT to 2.5% with Pno1-KKKF checkpoint bypass; sequencing datasets contained ~2.8–4.5 million reads/sample with ~96–99% mapping to the 3′ end of 18S; as few as 3 retained precursor nt at the 18S 3′ end are lethal in yeast (parker2024thekinaserio1 pages 15-17, parker2024thekinaserio1 pages 1-2) |
+
+
+*Table: This table summarizes the experimentally supported functions, mechanisms, complexes, localization, and quality-control roles of Saccharomyces cerevisiae PNO1/Dim2/Rrp20. It integrates core yeast studies and recent QC-focused work, including structural placement and quantitative miscleavage data.*
+
+## Key references (publication date and URL)
+
+- Vanrobays E, et al. **Oct 2008**. TOR regulates the subcellular distribution of DIM2… *RNA*. https://doi.org/10.1261/rna.1176708 (vanrobays2008torregulatesthe pages 1-2)
+- Woolls HA, Lamanna AC, Karbstein K. **Jan 2011**. Roles of Dim2 in Ribosome Assembly. *J Biol Chem*. https://doi.org/10.1074/jbc.m110.191494 (woolls2011rolesofdim2 pages 1-2)
+- Sturm M, et al. **Dec 2017**. Interdependent action of KH domain proteins Krr1 and Dim2… *Nat Commun*. https://doi.org/10.1038/s41467-017-02199-4 (sturm2017interdependentactionof pages 1-2)
+- Scaiola A, et al. **Apr 2018**. Structure of a eukaryotic cytoplasmic pre-40S ribosomal subunit. *EMBO J*. https://doi.org/10.15252/embj.201798499 (scaiola2018structureofa pages 1-2)
+- Chaker-Margot M. **Apr 2018**. Assembly of the small ribosomal subunit in yeast: mechanism and regulation. *RNA*. https://doi.org/10.1261/rna.066985.118 (chakermargot2018assemblyofthe pages 1-2)
+- Parker MD, Karbstein K. **Feb 2023**. Quality control ensures fidelity in ribosome assembly and cellular health. *J Cell Biol*. https://doi.org/10.1083/jcb.202209115 (parker2023qualitycontrolensures pages 10-12)
+- Pöll G, et al. **Jan 2023**. Impact of the yeast S0/uS2-cluster… (record retrieved). https://doi.org/10.1101/2023.01.18.524556 (poll2023impactofthe pages 1-5)
+- Parker MD, et al. **Apr 2024**. The kinase Rio1 and a ribosome collision-dependent decay pathway survey the integrity of 18S rRNA cleavage. *PLOS Biology*. https://doi.org/10.1371/journal.pbio.3001767 (parker2024thekinaserio1 pages 15-17)
+
+
+References
+
+1. (vanrobays2008torregulatesthe pages 1-2): Emmanuel Vanrobays, Alexis Leplus, Yvonne N. Osheim, Ann L. Beyer, Ludivine Wacheul, and Denis L.J. Lafontaine. Tor regulates the subcellular distribution of dim2, a kh domain protein required for cotranscriptional ribosome assembly and pre-40s ribosome export. RNA, 14 10:2061-73, Oct 2008. URL: https://doi.org/10.1261/rna.1176708, doi:10.1261/rna.1176708. This article has 69 citations and is from a domain leading peer-reviewed journal.
+
+2. (woolls2011rolesofdim2 pages 1-2): Heather A. Woolls, Allison C. Lamanna, and Katrin Karbstein. Roles of dim2 in ribosome assembly. Journal of Biological Chemistry, 286:2578-2586, Jan 2011. URL: https://doi.org/10.1074/jbc.m110.191494, doi:10.1074/jbc.m110.191494. This article has 58 citations and is from a domain leading peer-reviewed journal.
+
+3. (chakermargot2018assemblyofthe pages 1-2): Malik Chaker-Margot. Assembly of the small ribosomal subunit in yeast: mechanism and regulation. RNA, 24:881-891, Apr 2018. URL: https://doi.org/10.1261/rna.066985.118, doi:10.1261/rna.066985.118. This article has 34 citations and is from a domain leading peer-reviewed journal.
+
+4. (parker2024thekinaserio1 pages 1-2): Melissa D. Parker, Elise S. Brunk, Adam J. Getzler, and Katrin Karbstein. The kinase rio1 and a ribosome collision-dependent decay pathway survey the integrity of 18s rrna cleavage. PLOS Biology, 22:e3001767, Apr 2024. URL: https://doi.org/10.1371/journal.pbio.3001767, doi:10.1371/journal.pbio.3001767. This article has 14 citations and is from a highest quality peer-reviewed journal.
+
+5. (sturm2017interdependentactionof pages 1-2): Miriam Sturm, Jingdong Cheng, Jochen Baßler, Roland Beckmann, and Ed Hurt. Interdependent action of kh domain proteins krr1 and dim2 drive the 40s platform assembly. Nature Communications, Dec 2017. URL: https://doi.org/10.1038/s41467-017-02199-4, doi:10.1038/s41467-017-02199-4. This article has 45 citations and is from a highest quality peer-reviewed journal.
+
+6. (knox2010regulationofthea pages 57-61): AA Knox. Regulation of the u3 small subunit processome and associated rna-binding proteins. Unknown journal, 2010.
+
+7. (scaiola2018structureofa pages 1-2): Alain Scaiola, Cohue Peña, Melanie Weisser, Daniel Böhringer, Marc Leibundgut, Purnima Klingauf‐Nerurkar, Stefan Gerhardy, Vikram Govind Panse, and Nenad Ban. Structure of a eukaryotic cytoplasmic pre‐40s ribosomal subunit. The EMBO Journal, Apr 2018. URL: https://doi.org/10.15252/embj.201798499, doi:10.15252/embj.201798499. This article has 110 citations.
+
+8. (vanrobays2008torregulatesthe pages 5-7): Emmanuel Vanrobays, Alexis Leplus, Yvonne N. Osheim, Ann L. Beyer, Ludivine Wacheul, and Denis L.J. Lafontaine. Tor regulates the subcellular distribution of dim2, a kh domain protein required for cotranscriptional ribosome assembly and pre-40s ribosome export. RNA, 14 10:2061-73, Oct 2008. URL: https://doi.org/10.1261/rna.1176708, doi:10.1261/rna.1176708. This article has 69 citations and is from a domain leading peer-reviewed journal.
+
+9. (vanrobays2008torregulatesthe pages 7-8): Emmanuel Vanrobays, Alexis Leplus, Yvonne N. Osheim, Ann L. Beyer, Ludivine Wacheul, and Denis L.J. Lafontaine. Tor regulates the subcellular distribution of dim2, a kh domain protein required for cotranscriptional ribosome assembly and pre-40s ribosome export. RNA, 14 10:2061-73, Oct 2008. URL: https://doi.org/10.1261/rna.1176708, doi:10.1261/rna.1176708. This article has 69 citations and is from a domain leading peer-reviewed journal.
+
+10. (scaiola2018structureofa media 392eda28): Alain Scaiola, Cohue Peña, Melanie Weisser, Daniel Böhringer, Marc Leibundgut, Purnima Klingauf‐Nerurkar, Stefan Gerhardy, Vikram Govind Panse, and Nenad Ban. Structure of a eukaryotic cytoplasmic pre‐40s ribosomal subunit. The EMBO Journal, Apr 2018. URL: https://doi.org/10.15252/embj.201798499, doi:10.15252/embj.201798499. This article has 110 citations.
+
+11. (parker2023qualitycontrolensures pages 10-12): Melissa D. Parker and Katrin Karbstein. Quality control ensures fidelity in ribosome assembly and cellular health. The Journal of Cell Biology, Feb 2023. URL: https://doi.org/10.1083/jcb.202209115, doi:10.1083/jcb.202209115. This article has 29 citations.
+
+12. (parker2024thekinaserio1 pages 15-17): Melissa D. Parker, Elise S. Brunk, Adam J. Getzler, and Katrin Karbstein. The kinase rio1 and a ribosome collision-dependent decay pathway survey the integrity of 18s rrna cleavage. PLOS Biology, 22:e3001767, Apr 2024. URL: https://doi.org/10.1371/journal.pbio.3001767, doi:10.1371/journal.pbio.3001767. This article has 14 citations and is from a highest quality peer-reviewed journal.
+
+13. (poll2023impactofthe pages 1-5): Gisela Pöll, Joachim Griesenbeck, Herbert Tschochner, and Philipp Milkereit. Impact of the yeast s0/us2-cluster ribosomal protein rps21/es21 on rrna folding and the architecture of small ribosomal subunit precursors. PLOS ONE, Jan 2023. URL: https://doi.org/10.1101/2023.01.18.524556, doi:10.1101/2023.01.18.524556. This article has 3 citations and is from a peer-reviewed journal.
+
+14. (vanrobays2008torregulatesthe pages 8-10): Emmanuel Vanrobays, Alexis Leplus, Yvonne N. Osheim, Ann L. Beyer, Ludivine Wacheul, and Denis L.J. Lafontaine. Tor regulates the subcellular distribution of dim2, a kh domain protein required for cotranscriptional ribosome assembly and pre-40s ribosome export. RNA, 14 10:2061-73, Oct 2008. URL: https://doi.org/10.1261/rna.1176708, doi:10.1261/rna.1176708. This article has 69 citations and is from a domain leading peer-reviewed journal.
+
+15. (turowski2014rio1mediatesatpdependent pages 7-8): Tomasz W. Turowski, Simon Lebaron, Elodie Zhang, Lauri Peil, Tatiana Dudnakova, Elisabeth Petfalski, Sander Granneman, Juri Rappsilber, and David Tollervey. Rio1 mediates atp-dependent final maturation of 40s ribosomal subunits. Nucleic Acids Research, 42:12189-12199, Oct 2014. URL: https://doi.org/10.1093/nar/gku878, doi:10.1093/nar/gku878. This article has 114 citations and is from a highest quality peer-reviewed journal.
+
+16. (cerezo2019maturationofpre‐40s pages 4-5): Emilie Cerezo, Célia Plisson‐Chastang, Anthony K. Henras, Simon Lebaron, Pierre‐Emmanuel Gleizes, Marie‐Françoise O'Donohue, Yves Romeo, and Yves Henry. Maturation of pre‐40s particles in yeast and humans. Wiley Interdisciplinary Reviews: RNA, Nov 2019. URL: https://doi.org/10.1002/wrna.1516, doi:10.1002/wrna.1516. This article has 56 citations.
+
+17. (woolls2011rolesofdim2 pages 4-5): Heather A. Woolls, Allison C. Lamanna, and Katrin Karbstein. Roles of dim2 in ribosome assembly. Journal of Biological Chemistry, 286:2578-2586, Jan 2011. URL: https://doi.org/10.1074/jbc.m110.191494, doi:10.1074/jbc.m110.191494. This article has 58 citations and is from a domain leading peer-reviewed journal.
+
+18. (karbstein2011insidethe40s pages 1-2): Katrin Karbstein. Inside the 40s ribosome assembly machinery. Current opinion in chemical biology, 15 5:657-63, Oct 2011. URL: https://doi.org/10.1016/j.cbpa.2011.07.023, doi:10.1016/j.cbpa.2011.07.023. This article has 76 citations and is from a peer-reviewed journal.
+
+19. (scaiola2018structureofa media 37cb333c): Alain Scaiola, Cohue Peña, Melanie Weisser, Daniel Böhringer, Marc Leibundgut, Purnima Klingauf‐Nerurkar, Stefan Gerhardy, Vikram Govind Panse, and Nenad Ban. Structure of a eukaryotic cytoplasmic pre‐40s ribosomal subunit. The EMBO Journal, Apr 2018. URL: https://doi.org/10.15252/embj.201798499, doi:10.15252/embj.201798499. This article has 110 citations.
+
+20. (knox2010regulationoftheb pages 57-61): AA Knox. Regulation of the u3 small subunit processome and associated rna-binding proteins. Unknown journal, 2010.
+
+## Citations
+
+1. vanrobays2008torregulatesthe pages 1-2
+2. sturm2017interdependentactionof pages 1-2
+3. vanrobays2008torregulatesthe pages 5-7
+4. parker2023qualitycontrolensures pages 10-12
+5. poll2023impactofthe pages 1-5
+6. vanrobays2008torregulatesthe pages 8-10
+7. chakermargot2018assemblyofthe pages 1-2
+8. vanrobays2008torregulatesthe pages 7-8
+9. scaiola2018structureofa pages 1-2
+10. knox2010regulationofthea pages 57-61
+11. knox2010regulationoftheb pages 57-61
+12. https://doi.org/10.1083/jcb.202209115
+13. https://doi.org/10.1371/journal.pbio.3001767
+14. https://doi.org/10.1101/2023.01.18.524556
+15. https://doi.org/10.1261/rna.1176708;
+16. https://doi.org/10.1074/jbc.m110.191494
+17. https://doi.org/10.1261/rna.1176708
+18. https://doi.org/10.1038/s41467-017-02199-4
+19. https://doi.org/10.1093/nar/gku878
+20. https://doi.org/10.15252/embj.201798499
+21. https://doi.org/10.1002/wrna.1516
+22. https://doi.org/10.1083/jcb.202209115;
+23. https://doi.org/10.1261/rna.066985.118
+24. https://doi.org/10.1261/rna.1176708,
+25. https://doi.org/10.1074/jbc.m110.191494,
+26. https://doi.org/10.1261/rna.066985.118,
+27. https://doi.org/10.1371/journal.pbio.3001767,
+28. https://doi.org/10.1038/s41467-017-02199-4,
+29. https://doi.org/10.15252/embj.201798499,
+30. https://doi.org/10.1083/jcb.202209115,
+31. https://doi.org/10.1101/2023.01.18.524556,
+32. https://doi.org/10.1093/nar/gku878,
+33. https://doi.org/10.1002/wrna.1516,
+34. https://doi.org/10.1016/j.cbpa.2011.07.023,

--- a/genes/yeast/SHR3/SHR3-ai-review.html
+++ b/genes/yeast/SHR3/SHR3-ai-review.html
@@ -671,33 +671,33 @@
     <div class="header">
         <h1>SHR3</h1>
         <div class="gene-info">
-            
+
             <div class="info-item">
-                
+
                 <span class="info-label">UniProt ID:</span>
                 <span>
                     <a href="https://www.uniprot.org/uniprotkb/Q02774" target="_blank" class="term-link">
                         Q02774
                     </a>
                 </span>
-                
+
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Organism:</span>
                 <span>Saccharomyces cerevisiae</span>
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
-                <span class="status-badge status-draft">
-                    DRAFT
+                <span class="status-badge status-complete">
+                    COMPLETE
                 </span>
             </div>
-            
-            
+
+
         </div>
         <div style="margin-top: 1rem; text-align: center;">
             <a id="feedback-form-link"
@@ -728,24 +728,24 @@
         </div>
     </div>
 
-    
+
     <div class="description-card">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <h2>Gene Description</h2>
-            <span class="vote-buttons" data-g="Q02774" data-a="DESCRIPTION: SHR3 encodes an ER membrane-localized packaging ch..." data-r="" data-act="DESCRIPTION">
+            <span class="vote-buttons" data-g="Q02774" data-a="DESCRIPTION: SHR3 encodes an endoplasmic-reticulum membrane pac..." data-r="" data-act="DESCRIPTION">
                 <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
                 <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
             </span>
         </div>
-        <p>SHR3 encodes an ER membrane-localized packaging chaperone specifically required for the proper folding and ER exit of amino acid permeases. Shr3p functions as a permease-specific adaptor that assists the folding of these polytopic membrane proteins in the ER and facilitates their incorporation into COPII-coated vesicles for transport to the cell surface. It acts in conjunction with the Sec62/Sec63 translocon complex. In the absence of Shr3p, amino acid permeases are retained in the ER in a misfolded state and are eventually degraded, resulting in pleiotropic amino acid uptake defects. Shr3p enables yeast cells to rapidly modulate the spectrum of permeases expressed at the plasma membrane in response to changing nutrient conditions. No direct human ortholog has been identified, though the functional principle of substrate-specific ER chaperones is conserved.</p>
+        <p>SHR3 encodes an endoplasmic-reticulum membrane packaging chaperone required for folding, quality control, and ER exit of yeast amino acid permeases. Shr3 is a multi-pass ER membrane protein that assists substrate-specific folding of polytopic amino acid transporters, prevents their aggregation and premature ER-associated degradation, and promotes COPII-dependent packaging for trafficking from the ER toward the Golgi and plasma membrane. Shr3 is not itself an amino acid transporter; its core role is client-specific membrane protein chaperoning in the early secretory pathway.</p>
     </div>
-    
 
-    
 
-    
 
-    
+
+
+
+
     <div class="section">
         <h2 class="section-title">Existing Annotations Review</h2>
         <table class="annotations-table">
@@ -758,32 +758,32 @@
                 </tr>
             </thead>
             <tbody>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
                                     GO:0005789
                                 </a>
                             </span>
                             <span class="term-label">endoplasmic reticulum membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -795,46 +795,62 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: endoplasmic reticulum membrane is consistent with known biology of SHR3.
+                            <strong>Summary:</strong> PANTHER IBA to endoplasmic reticulum membrane is consistent with the specific Shr3 family, UniProt localization, and direct experimental evidence.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Shr3 is an integral ER membrane protein and functions at the ER membrane during amino acid permease biogenesis.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/SHR3/SHR3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Shr3 localizes to the endoplasmic reticulum membrane</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006888" target="_blank" class="term-link">
                                     GO:0006888
                                 </a>
                             </span>
                             <span class="term-label">endoplasmic reticulum to Golgi vesicle-mediated transport</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -846,46 +862,62 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: endoplasmic reticulum to Golgi vesicle-mediated transport is consistent with known biology of SHR3.
+                            <strong>Summary:</strong> Family-transfer annotation to ER-to-Golgi vesicle transport is appropriate for Shr3 because it promotes ER exit of amino acid permease cargo.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Shr3 is required for efficient packaging of permeases into ER-derived COPII vesicles and therefore supports ER-to-Golgi transport of those clients.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/SHR3/SHR3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">promoting COPII-dependent packaging of amino acid permeases</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -897,57 +929,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: unfolded protein binding is better represented by a more specific replacement term for SHR3.
+                            <strong>Summary:</strong> Shr3 is a substrate-specific chaperone for polytopic permeases, but &#34;unfolded protein binding&#34; is a vague binding term.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Modified to align with current curation guidance and improve term specificity.
+                            <strong>Reason:</strong> The evidence supports protein folding chaperone activity for amino acid permease clients rather than a generic unfolded-protein binding annotation.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     protein folding chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15623581" target="_blank" class="term-link">
+                                        PMID:15623581
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Specialized membrane-localized chaperones prevent aggregation of polytopic proteins in the ER.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
                                     GO:0005789
                                 </a>
                             </span>
                             <span class="term-label">endoplasmic reticulum membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -959,46 +1009,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: endoplasmic reticulum membrane is consistent with known biology of SHR3.
+                            <strong>Summary:</strong> UniProt subcellular-location mapping to ER membrane is consistent with direct Shr3 localization.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Shr3 is a multi-pass ER membrane protein, and this localization is central to its permease-chaperone function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015031" target="_blank" class="term-link">
                                     GO:0015031
                                 </a>
                             </span>
                             <span class="term-label">protein transport</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1010,57 +1060,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: protein transport is consistent with known biology of SHR3.
+                            <strong>Summary:</strong> The keyword-derived protein transport annotation is broad but reflects Shr3&#39;s role in ER export of amino acid permeases.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> More specific experimental terms capture COPII budding and ER-to-Golgi transport, but the broad transport term remains accurate.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10688190" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:10688190
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A comprehensive analysis of protein-protein interactions in ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1072,57 +1122,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: protein binding is too generic or over-extended for SHR3.
+                            <strong>Summary:</strong> This high-throughput interaction supports physical association with the amino acid permease Gnp1 but the term protein binding is uninformative.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Marked over-annotated because more specific terms capture the biology more accurately.
+                            <strong>Reason:</strong> The curated molecular function should describe Shr3&#39;s client-specific chaperone activity rather than retain generic protein binding.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16093310" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16093310
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Large-scale identification of yeast integral membrane protei...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1134,57 +1184,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: protein binding is too generic or over-extended for SHR3.
+                            <strong>Summary:</strong> These interaction data are consistent with Shr3 contacts with membrane cargo or related proteins, but protein binding does not convey the specific function.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Marked over-annotated because more specific terms capture the biology more accurately.
+                            <strong>Reason:</strong> A generic protein-binding annotation should not be treated as a core molecular function when the biological role is permease folding and packaging chaperone activity.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/18467557" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:18467557
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     An in vivo map of the yeast protein interactome.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1196,57 +1246,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: protein binding is too generic or over-extended for SHR3.
+                            <strong>Summary:</strong> Large-scale interaction evidence does not provide a specific molecular function beyond physical association.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Marked over-annotated because more specific terms capture the biology more accurately.
+                            <strong>Reason:</strong> This annotation is too generic for curation; the better-supported role is Shr3 chaperoning and ER export of amino acid permeases.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/27107014" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:27107014
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     An inter-species protein-protein interaction network across ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1258,57 +1308,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: protein binding is too generic or over-extended for SHR3.
+                            <strong>Summary:</strong> The inter-species interaction screen reports a physical interaction but does not establish a yeast Shr3 molecular activity.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Marked over-annotated because more specific terms capture the biology more accurately.
+                            <strong>Reason:</strong> The xeno interaction is not suitable as a core function annotation and is much less informative than the experimentally supported Shr3 chaperone mechanism.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/37968396" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:37968396
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The social and structural architecture of the yeast protein ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1320,57 +1370,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: protein binding is too generic or over-extended for SHR3.
+                            <strong>Summary:</strong> Modern high-throughput interactome data reinforce Shr3 physical associations but still use a generic binding term.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Marked over-annotated because more specific terms capture the biology more accurately.
+                            <strong>Reason:</strong> Protein binding is not an informative endpoint for Shr3; specific client-chaperone and ER-export annotations should carry the curation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
                                     GO:0005789
                                 </a>
                             </span>
                             <span class="term-label">endoplasmic reticulum membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/1423607" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:1423607
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     SHR3: a novel component of the secretory pathway specificall...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1382,57 +1432,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: endoplasmic reticulum membrane is consistent with known biology of SHR3.
+                            <strong>Summary:</strong> Direct experimental evidence from the original SHR3 study identified Shr3 as an ER integral membrane component.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> This localization is the correct compartment for Shr3&#39;s role in amino acid permease processing and ER exit.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/1423607" target="_blank" class="term-link">
+                                        PMID:1423607
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">SHR3 is a novel integral membrane protein component of the endoplasmic reticulum</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
                                     GO:0005789
                                 </a>
                             </span>
                             <span class="term-label">endoplasmic reticulum membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/15623581" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:15623581
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Specialized membrane-localized chaperones prevent aggregatio...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1444,57 +1512,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: endoplasmic reticulum membrane is consistent with known biology of SHR3.
+                            <strong>Summary:</strong> Direct experimental evidence supports Shr3 as an integral ER membrane chaperone for amino acid permeases.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> The ER membrane location is required for Shr3 to act on nascent or newly inserted polytopic permease clients.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15623581" target="_blank" class="term-link">
+                                        PMID:15623581
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The integral endoplasmic reticulum (ER) membrane protein Shr3p</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0090114" target="_blank" class="term-link">
                                     GO:0090114
                                 </a>
                             </span>
                             <span class="term-label">COPII-coated vesicle budding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IGI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10564255" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:10564255
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Shr3p mediates specific COPII coatomer-cargo interactions re...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1506,57 +1592,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: COPII-coated vesicle budding is consistent with known biology of SHR3.
+                            <strong>Summary:</strong> Genetic-interaction evidence supports Shr3 participation in COPII-coated vesicle budding for amino acid permease cargo.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Shr3 mediates specific COPII coatomer-cargo interactions needed for packaging permeases into ER-derived transport vesicles.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10564255" target="_blank" class="term-link">
+                                        PMID:10564255
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Shr3p mediates specific COPII coatomer-cargo interactions</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005783" target="_blank" class="term-link">
                                     GO:0005783
                                 </a>
                             </span>
                             <span class="term-label">endoplasmic reticulum</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/26928762" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:26928762
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     One library to make them all: streamlining the creation of y...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1568,57 +1672,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: endoplasmic reticulum is consistent with known biology of SHR3.
+                            <strong>Summary:</strong> High-throughput SWAp-Tag localization supports ER localization, consistent with direct ER membrane evidence.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> The high-throughput annotation is congruent with multiple direct studies placing Shr3 in the ER membrane.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26928762" target="_blank" class="term-link">
+                                        PMID:26928762
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">streamlining the creation of yeast libraries via a SWAp-Tag strategy</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043332" target="_blank" class="term-link">
                                     GO:0043332
                                 </a>
                             </span>
                             <span class="term-label">mating projection tip</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19053807" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19053807
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Systematic definition of protein constituents along the majo...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -1630,57 +1752,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: mating projection tip may be context-dependent or peripheral for SHR3.
+                            <strong>Summary:</strong> High-throughput pheromone-treatment localization suggests a condition- specific signal at the mating projection tip.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+                            <strong>Reason:</strong> This may reflect condition-specific relocalization of ER/cortical membrane-associated Shr3, but it is not the core compartment for the permease-chaperone mechanism.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                     GO:0006457
                                 </a>
                             </span>
                             <span class="term-label">protein folding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/15623581" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:15623581
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Specialized membrane-localized chaperones prevent aggregatio...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1692,57 +1814,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: protein folding is consistent with known biology of SHR3.
+                            <strong>Summary:</strong> Mutant phenotype evidence supports Shr3&#39;s role in folding of polytopic amino acid permease clients and preventing their aggregation in the ER.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Protein folding is a core biological process for Shr3 because failure of Shr3 causes permease misfolding/aggregation and ER retention.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15623581" target="_blank" class="term-link">
+                                        PMID:15623581
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">prevent aggregation of polytopic proteins in the ER</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10564255" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:10564255
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Shr3p mediates specific COPII coatomer-cargo interactions re...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -1754,68 +1894,86 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: unfolded protein binding is better represented by a more specific replacement term for SHR3.
+                            <strong>Summary:</strong> Shr3&#39;s activity involves chaperoning amino acid permease cargo, but unfolded protein binding is less precise than a chaperone activity term.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Modified to align with current curation guidance and improve term specificity.
+                            <strong>Reason:</strong> The evidence supports specific protein folding/packaging chaperone activity in the ER membrane rather than a generic binding term.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     protein folding chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10564255" target="_blank" class="term-link">
+                                        PMID:10564255
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Shr3p acts as a packaging chaperone</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/15623581" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:15623581
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Specialized membrane-localized chaperones prevent aggregatio...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -1827,268 +1985,805 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: unfolded protein binding is better represented by a more specific replacement term for SHR3.
+                            <strong>Summary:</strong> The evidence shows Shr3 prevents aggregation of polytopic permeases during folding, which is better represented as protein folding chaperone activity.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Modified to align with current curation guidance and improve term specificity.
+                            <strong>Reason:</strong> The more informative curation is GO:0044183 protein folding chaperone coupled to ER membrane permease biogenesis.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     protein folding chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15623581" target="_blank" class="term-link">
+                                        PMID:15623581
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Specialized membrane-localized chaperones prevent aggregation of polytopic proteins in the ER.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
             </tbody>
         </table>
     </div>
-    
 
-    
 
-    
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Shr3 is a substrate-specific ER membrane chaperone for amino acid permeases. It stabilizes polytopic permease clients, prevents aggregation and premature ERAD, and promotes their packaging into COPII-coated ER-derived vesicles.</h3>
+                <span class="vote-buttons" data-g="Q02774" data-a="FUNCTION: Shr3 is a substrate-specific ER membrane chaperone..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
+                            protein folding chaperone
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
+                                protein folding
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006888" target="_blank" class="term-link">
+                                endoplasmic reticulum to Golgi vesicle-mediated transport
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0090114" target="_blank" class="term-link">
+                                COPII-coated vesicle budding
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                endoplasmic reticulum membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15623581" target="_blank" class="term-link">
+                                PMID:15623581
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">prevent aggregation of polytopic proteins in the ER</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10564255" target="_blank" class="term-link">
+                                PMID:10564255
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Shr3p acts as a packaging chaperone</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:yeast/SHR3/SHR3-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">ER membrane-localized, substrate-specific chaperone</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class="section">
         <h2 class="section-title collapsible">References</h2>
         <div class="collapse-content">
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
                             GO_REF:0000033
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Annotation inferences using phylogenetic trees</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000043.md" target="_blank" class="term-link">
                             GO_REF:0000043
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
                             GO_REF:0000044
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/10564255" target="_blank" class="term-link">
                             PMID:10564255
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Shr3p mediates specific COPII coatomer-cargo interactions required for the packaging of amino acid permeases into ER-derived transport vesicles.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/10688190" target="_blank" class="term-link">
                             PMID:10688190
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A comprehensive analysis of protein-protein interactions in Saccharomyces cerevisiae.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/1423607" target="_blank" class="term-link">
                             PMID:1423607
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">SHR3: a novel component of the secretory pathway specifically required for localization of amino acid permeases in yeast.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/15623581" target="_blank" class="term-link">
                             PMID:15623581
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Specialized membrane-localized chaperones prevent aggregation of polytopic proteins in the ER.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/16093310" target="_blank" class="term-link">
                             PMID:16093310
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Large-scale identification of yeast integral membrane protein interactions.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/18467557" target="_blank" class="term-link">
                             PMID:18467557
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">An in vivo map of the yeast protein interactome.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/19053807" target="_blank" class="term-link">
                             PMID:19053807
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Systematic definition of protein constituents along the major polarization axis reveals an adaptive reuse of the polarization machinery in pheromone-treated budding yeast.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/26928762" target="_blank" class="term-link">
                             PMID:26928762
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">One library to make them all: streamlining the creation of yeast libraries via a SWAp-Tag strategy.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/27107014" target="_blank" class="term-link">
                             PMID:27107014
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">An inter-species protein-protein interaction network across vast evolutionary distance.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/37968396" target="_blank" class="term-link">
                             PMID:37968396
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The social and structural architecture of the yeast protein interactome.</div>
-                
-                
+
+
             </div>
-            
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:yeast/SHR3/SHR3-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research report for SHR3</div>
+
+
+            </div>
+
         </div>
     </div>
-    
 
 
-    
 
-    
 
-    
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> For Shr3 and related ER-resident packaging factors, should GO curation distinguish folding chaperone activity from cargo-receptor or COPII-adaptor activity with a more specific child term?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q02774" data-a="Q: For Shr3 and related ER-resident packaging factors..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Reconstitute Shr3 with defined amino acid permease transmembrane segments and COPII components to separate its folding/stabilization activity from any direct COPII recruitment activity.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: Shr3 first stabilizes early permease transmembrane segments and then promotes COPII packaging indirectly by producing export-competent cargo.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: biochemical reconstitution</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q02774" data-a="EXPERIMENT: Reconstitute Shr3 with defined amino acid permease..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
 
     <!-- Computational Predictions Section -->
-    
+
 
     <!-- Additional Documentation Sections -->
-    
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Deep Research Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(SHR3-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q02774" data-a="DOC: Deep Research Falcon" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <hr />
+<p>provider: falcon<br />
+model: Edison Scientific Literature<br />
+cached: false<br />
+start_time: '2026-05-04T10:06:11.959231'<br />
+end_time: '2026-05-04T10:19:15.042362'<br />
+duration_seconds: 783.08<br />
+template_file: templates/gene_research_go_focused.md<br />
+template_variables:<br />
+  organism: yeast<br />
+  gene_id: SHR3<br />
+  gene_symbol: SHR3<br />
+  uniprot_accession: Q02774<br />
+  protein_description: 'RecName: Full=Secretory component protein SHR3;'<br />
+  gene_info: Name=SHR3; OrderedLocusNames=YDL212W; ORFNames=D1022;<br />
+  organism_full: Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).<br />
+  protein_family: Not specified in UniProt<br />
+  protein_domains: Psh3/Shr3. (IPR013248); SHR3_chaperone (PF08229)<br />
+provider_config:<br />
+  timeout: 600<br />
+  max_retries: 3<br />
+  parameters:<br />
+    allowed_domains: []<br />
+    temperature: 0.1<br />
+citation_count: 16</p>
+<hr />
+<h2 id="question">Question</h2>
+<h1 id="gene-research-for-functional-annotation">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> Q02774</li>
+<li><strong>Protein Description:</strong> RecName: Full=Secretory component protein SHR3;</li>
+<li><strong>Gene Information:</strong> Name=SHR3; OrderedLocusNames=YDL212W; ORFNames=D1022;</li>
+<li><strong>Organism (full):</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Protein Family:</strong> Not specified in UniProt</li>
+<li><strong>Key Domains:</strong> Psh3/Shr3. (IPR013248); SHR3_chaperone (PF08229)</li>
+</ul>
+<h3 id="mandatory-verification-steps">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "SHR3" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'SHR3' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>SHR3</strong> (gene ID: SHR3, UniProt: Q02774) in yeast.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="output">Output</h2>
+<p>Question: You are an expert researcher providing comprehensive, well-cited information.</p>
+<p>Provide detailed information focusing on:<br />
+1. Key concepts and definitions with current understanding<br />
+2. Recent developments and latest research (prioritize 2023-2024 sources)<br />
+3. Current applications and real-world implementations<br />
+4. Expert opinions and analysis from authoritative sources<br />
+5. Relevant statistics and data from recent studies</p>
+<p>Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.<br />
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.</p>
+<h1 id="gene-research-for-functional-annotation_1">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context_1">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot_1">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> Q02774</li>
+<li><strong>Protein Description:</strong> RecName: Full=Secretory component protein SHR3;</li>
+<li><strong>Gene Information:</strong> Name=SHR3; OrderedLocusNames=YDL212W; ORFNames=D1022;</li>
+<li><strong>Organism (full):</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Protein Family:</strong> Not specified in UniProt</li>
+<li><strong>Key Domains:</strong> Psh3/Shr3. (IPR013248); SHR3_chaperone (PF08229)</li>
+</ul>
+<h3 id="mandatory-verification-steps_1">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "SHR3" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature_1">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'SHR3' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target_1">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>SHR3</strong> (gene ID: SHR3, UniProt: Q02774) in yeast.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="comprehensive-functional-annotation-report-shr3-uniprot-q02774-orf-ydl212w-in-saccharomyces-cerevisiae-s288c">Comprehensive Functional Annotation Report: <strong>SHR3</strong> (UniProt: <strong>Q02774</strong>; ORF <strong>YDL212W</strong>) in <em>Saccharomyces cerevisiae</em> (S288c)</h2>
+<h3 id="0-scope-and-geneprotein-identity-verification">0) Scope and gene/protein identity verification</h3>
+<p>All retrieved yeast-focused sources consistently describe <strong>Shr3 (Shr3p)</strong> as an <strong>endoplasmic reticulum (ER) membrane-localized, substrate-specific “packaging chaperone”</strong> required for the biogenesis/ER export of <strong>amino-acid permeases</strong> (AAPs/YATs) and for preventing their <strong>aggregation and premature ER-associated degradation (ERAD)</strong> (ring2019ssy1functionsat pages 9-9, mochizuki2015retentionofchimeric pages 8-9, dancourt2010proteinsortingreceptors pages 16-17, bianchi2019regulationofamino pages 19-21). No conflicting usage of the symbol <strong>SHR3</strong> for a different gene/protein in another organism was encountered within the retrieved corpus (mochizuki2015retentionofchimeric pages 8-9, dancourt2010proteinsortingreceptors pages 16-17, ring2019ssy1functionsat pages 2-3).</p>
+<p><em>Note on domain verification:</em> the retrieved articles did not explicitly name the UniProt/InterPro/Pfam domains (e.g., Psh3/Shr3 domain; PF08229) in the accessible text snippets; thus domain statements are not asserted here beyond the user-provided UniProt context.</p>
+<hr />
+<h3 id="1-key-concepts-and-definitions-current-understanding">1) Key concepts and definitions (current understanding)</h3>
+<h4 id="11-packaging-chaperone-membrane-localized-chaperone-mlc">1.1. “Packaging chaperone” / membrane-localized chaperone (MLC)</h4>
+<p>In yeast membrane protein biogenesis, certain cargo classes require <strong>substrate-specific ER membrane proteins</strong> that act as <strong>chaperones</strong> and/or <strong>packaging factors</strong> to enable correct folding and efficient entry into <strong>COPII vesicles</strong> for ER export. Shr3 is a canonical example of this class, acting on amino-acid transporter clients (dancourt2010proteinsortingreceptors pages 16-17, bianchi2019regulationofamino pages 19-21).</p>
+<h4 id="12-client-class-yeast-amino-acid-transporters-yatsaaps">1.2. Client class: yeast amino-acid transporters (YATs/AAPs)</h4>
+<p>Shr3’s principal clients are <strong>yeast amino acid transport (YAT) family</strong> permeases. A quantitative framing in the reviewed primary literature is that yeast amino-acid permeases comprise a <strong>family of 24 homologous APC transporters</strong>, and individual permeases are predicted to have <strong>12 transmembrane domains (TMDs)</strong> (mochizuki2015retentionofchimeric pages 1-2). In an authoritative review, Shr3-dependent clients explicitly include <strong>Gap1</strong> and other YATs such as <strong>Agp1</strong> and <strong>Gnp1</strong> (bianchi2019regulationofamino pages 19-21).</p>
+<h4 id="13-er-quality-control-and-erad-er-associated-degradation">1.3. ER quality control and ERAD (ER-associated degradation)</h4>
+<p>When polytopic membrane proteins fail to fold properly in the ER, they can be removed by <strong>ERAD</strong>, which includes ubiquitination, extraction from the ER membrane, and proteasomal degradation. In the case of Shr3-dependent permeases, Shr3 is positioned upstream of ERAD by preventing misfolding/aggregation that would otherwise trigger ERAD (mochizuki2015retentionofchimeric pages 1-2, bianchi2019regulationofamino pages 19-21).</p>
+<hr />
+<h3 id="2-molecular-function-what-shr3-does-and-does-not-do">2) Molecular function: what SHR3 does (and does not do)</h3>
+<h4 id="21-primary-molecular-function-supported">2.1. Primary molecular function (supported)</h4>
+<p><strong>Shr3 is not a transporter and does not catalyze a chemical reaction.</strong> Instead, Shr3 functions as an <strong>ER membrane-localized, substrate-specific chaperone/packaging factor</strong> required for the <strong>functional expression</strong> and <strong>secretory-pathway export</strong> of amino acid permeases (ring2019ssy1functionsat pages 9-9, mochizuki2015retentionofchimeric pages 8-9, bianchi2019regulationofamino pages 19-21).</p>
+<h4 id="22-mechanistic-model-folding-assistance">2.2. Mechanistic model (folding assistance)</h4>
+<p>A central mechanistic concept supported by both review synthesis and primary data is that Shr3 <strong>stabilizes early transmembrane segments</strong> of permease clients to prevent nonproductive interactions and aggregation during folding.</p>
+<ul>
+<li>Quantitative mechanistic detail: Shr3 is described as an <strong>ER-resident integral membrane protein with 4 transmembrane segments</strong> that <strong>“holds the first 5 TMDs”</strong> of YAT clients in a stable conformation, allowing the remaining TMDs to fold properly (bianchi2019regulationofamino pages 19-21).</li>
+<li>Primary mechanistic statement consistent with this model: Shr3 interacts with early TMDs of <strong>Gap1</strong> to promote native folding and prevent aggregation (mochizuki2015retentionofchimeric pages 8-9).</li>
+</ul>
+<h4 id="23-mechanistic-model-er-exportcopii-packaging">2.3. Mechanistic model (ER export/COPII packaging)</h4>
+<p>Shr3 is also implicated in <strong>promoting COPII-dependent packaging</strong> of amino acid permeases into ER-derived transport vesicles.</p>
+<ul>
+<li>A key literature synthesis referenced in primary work: Shr3p mediates <strong>specific COPII coatomer–cargo interactions</strong> needed for packaging amino acid permeases into ER-derived transport vesicles (mochizuki2015retentionofchimeric pages 9-10).</li>
+<li>Review-level integration: Shr3 is positioned as a chaperone that stabilizes YATs in the ER and sorts them into vesicles for export (bianchi2019regulationofamino media 260fd4cf, bianchi2019regulationofamino pages 19-21).</li>
+</ul>
+<hr />
+<h3 id="3-subcellular-localization-where-shr3-acts">3) Subcellular localization: where Shr3 acts</h3>
+<p>Shr3 localizes to the <strong>endoplasmic reticulum membrane</strong>, consistent with its role in co-/peri-translational folding and ER export of polytopic permeases (ring2019ssy1functionsat pages 2-3, ring2019ssy1functionsat pages 3-4, bianchi2019regulationofamino pages 19-21).</p>
+<p>In cell biology practice, Shr3 has been used as an ER marker: <strong>Shr3-GFP</strong> highlights ER morphology (perinuclear rim and peripheral ER), supporting ER residency in vivo (ring2019ssy1functionsat pages 3-4).</p>
+<hr />
+<h3 id="4-client-proteins-and-substrate-specificity">4) Client proteins and substrate specificity</h3>
+<h4 id="41-best-supported-clients">4.1. Best-supported clients</h4>
+<p>The most directly supported client is <strong>Gap1</strong>, the general amino-acid permease, which becomes <strong>aggregated/ER-retained</strong> in shr3 mutants (mochizuki2015retentionofchimeric pages 1-2, dancourt2010proteinsortingreceptors pages 16-17).</p>
+<p>The authoritative review explicitly provides additional YAT examples: <strong>Agp1</strong> and <strong>Gnp1</strong> (bianchi2019regulationofamino pages 19-21).</p>
+<h4 id="42-limits-of-shr3s-rescue-capacity-specificity-and-folding-quality">4.2. Limits of Shr3’s “rescue” capacity (specificity and folding quality)</h4>
+<p>Primary evidence indicates that Shr3 is not a universal remedy for all permease folding defects. For example, in an experimental survey of <strong>64 Gap1 mutants</strong>, <strong>17</strong> mutants were retained in the ER and <strong>SHR3 overexpression did not suppress</strong> growth defects associated with these mutants, indicating client mutations can exceed Shr3’s chaperoning capacity and/or reflect distinct folding lesions (mochizuki2015retentionofchimeric pages 8-9).</p>
+<hr />
+<h3 id="5-pathways-and-biological-processes">5) Pathways and biological processes</h3>
+<h4 id="51-early-secretory-pathway-integration">5.1. Early secretory pathway integration</h4>
+<p>Shr3 operates at the interface of <strong>ER folding quality control</strong> and <strong>ER export</strong> of membrane cargo. It is conceptually distinguished from canonical cycling cargo receptors; rather, Shr3 behaves as a dedicated folding/packaging factor for a client class (dancourt2010proteinsortingreceptors pages 16-17).</p>
+<h4 id="52-interaction-with-erad-machinery-and-proteostasis">5.2. Interaction with ERAD machinery and proteostasis</h4>
+<p>When Shr3 is absent, YATs such as Gap1 (and other YAT examples) can form <strong>high-molecular-weight aggregates</strong> that are removed by ERAD (bianchi2019regulationofamino pages 19-21).</p>
+<p>A key mechanistic-statistical summary from an authoritative review lists the ERAD machinery implicated in clearing Shr3-client aggregates: E3 ubiquitin ligases <strong>Doa10</strong> and <strong>Hrd1</strong>, extraction by the <strong>Cdc48 ATPase complex</strong>, and degradation by the cytoplasmic <strong>proteasome</strong> (bianchi2019regulationofamino pages 19-21).</p>
+<h4 id="53-cellular-stress-responses-linked-to-misfolded-permeases">5.3. Cellular stress responses linked to misfolded permeases</h4>
+<p>Retention/aggregation of permease constructs in the ER can induce ER stress responses such as the <strong>unfolded protein response (UPR)</strong>; Shr3’s role in preventing aggregation provides a mechanistic link to avoiding this stress trigger (mochizuki2015retentionofchimeric pages 1-2).</p>
+<hr />
+<h3 id="6-recent-developments-and-latest-research-20232024-prioritized">6) Recent developments and latest research (2023–2024 prioritized)</h3>
+<h4 id="61-availability-constraint-in-this-tool-run">6.1. Availability constraint in this tool run</h4>
+<p>A <strong>2023 Journal of Cell Biology</strong> article directly focused on Shr3 (ER-localized Shr3 as a selective co-translational folding chaperone necessary for amino-acid permease biogenesis; DOI shown in search output) was flagged as <strong>unobtainable</strong> in this environment and could not be read for direct evidence extraction. Consequently, the most detailed Shr3-specific mechanistic evidence in this report is drawn from accessible primary work (2015) and authoritative reviews (2010–2019) (mochizuki2015retentionofchimeric pages 8-9, dancourt2010proteinsortingreceptors pages 16-17, bianchi2019regulationofamino pages 19-21).</p>
+<h4 id="62-20232024-contextual-advances-relevant-to-shr3-like-systems">6.2. 2023–2024 contextual advances relevant to Shr3-like systems</h4>
+<p>While not Shr3 itself, recent work continues to develop the broader concept of substrate-specific ER accessory/chaperone proteins controlling multipass membrane cargo biogenesis:</p>
+<ul>
+<li><strong>2023 (MBoC)</strong>: A detailed analysis of quality control mechanisms for yeast chitin synthase <strong>Chs3</strong>, emphasizing how interaction with its Shr3-like chaperone <strong>Chs7</strong> can mask degrons and tune ERAD engagement, reinforcing the conceptual framework of substrate-specific ER chaperones in proteostasis (paper retrieved but not fully evidence-mined for Shr3; included here as contextual) (dimou2020lifeanddeath pages 1-3).</li>
+<li><strong>2024 (Plant Physiology)</strong>: A mechanistic study of plant <strong>AXR4</strong> supports a model where an ER accessory protein physically interacts with a multipass transporter (AUX1/LAX2), reduces aggregation, and supports correct trafficking—an analog of Shr3-like logic across eukaryotes (retrieved but not yeast-specific) (dimou2020lifeanddeath pages 1-3).</li>
+</ul>
+<hr />
+<h3 id="7-current-applications-and-real-world-implementations">7) Current applications and real-world implementations</h3>
+<ol>
+<li><strong>Membrane protein biogenesis paradigm:</strong> Shr3 is widely used as a model for how eukaryotic cells ensure successful folding/export of polytopic transporters and how failure routes into ERAD; this informs experimental design in transporter biology and secretory pathway studies (dancourt2010proteinsortingreceptors pages 16-17, bianchi2019regulationofamino pages 19-21).</li>
+<li><strong>Cell biology tool/marker:</strong> Shr3-GFP is used experimentally as an ER membrane marker to visualize ER morphology in yeast, consistent with ER localization and stable residency (ring2019ssy1functionsat pages 3-4).</li>
+<li><strong>Transporter engineering and trafficking studies (inference from authoritative review):</strong> Because YAT function depends on correct ER folding/export, Shr3 is a practical consideration when engineering yeast strains for altered nutrient uptake, or when interpreting transporter localization phenotypes in genetics screens (bianchi2019regulationofamino pages 19-21, mochizuki2015retentionofchimeric pages 1-2).</li>
+</ol>
+<hr />
+<h3 id="8-expert-opinions-and-authoritative-synthesis">8) Expert opinions and authoritative synthesis</h3>
+<p><em>Annu. Rev. Biochem. (2010)</em> frames Shr3 as an ER chaperone assisting folding of specific membrane cargo (e.g., Gap1), and contrasts Shr3-like factors from cycling sorting receptors, emphasizing the quality-control consequence of Shr3 loss (client aggregation and potential ERAD engagement) (dancourt2010proteinsortingreceptors pages 16-17).</p>
+<p><em>Microbiology and Molecular Biology Reviews (2019)</em> provides a high-level and widely cited synthesis: Shr3 is an ER-resident packaging chaperone, stabilizes early TMDs (first five) of YAT clients, and without Shr3, YATs aggregate and are cleared by ERAD involving Doa10/Hrd1, Cdc48, and the proteasome (bianchi2019regulationofamino pages 19-21).</p>
+<hr />
+<h3 id="9-key-statistics-and-data-points-from-recentauthoritative-sources">9) Key statistics and data points (from recent/authoritative sources)</h3>
+<ul>
+<li>Shr3 topology: <strong>4 transmembrane segments</strong> (bianchi2019regulationofamino pages 19-21).</li>
+<li>Client topology: YATs are <strong>12-TMD</strong> transporters (bianchi2019regulationofamino pages 19-21, mochizuki2015retentionofchimeric pages 1-2).</li>
+<li>Folding mechanism: Shr3 stabilizes/holds the <strong>first 5 TMDs</strong> of YAT clients (bianchi2019regulationofamino pages 19-21, mochizuki2015retentionofchimeric pages 8-9).</li>
+<li>Client family size (yeast amino-acid permeases): <strong>24 homologous APC transporters</strong> (mochizuki2015retentionofchimeric pages 1-2).</li>
+<li>Mutational dataset (Gap1): <strong>64 mutants tested; 17 ER-retained; SHR3 overexpression did not rescue these</strong> (mochizuki2015retentionofchimeric pages 8-9).</li>
+</ul>
+<hr />
+<h3 id="10-evidence-backed-schematic-support-visual">10) Evidence-backed schematic support (visual)</h3>
+<p>The following review figure provides a systems-level depiction of Shr3’s position in YAT biogenesis, ER quality control, ERAD, and onward trafficking.</p>
+<table>
+<thead>
+<tr>
+<th>Functional aspect</th>
+<th>Key finding</th>
+<th>Evidence type</th>
+<th>Source with year and DOI/URL</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Molecular function</td>
+<td>SHR3 encodes an ER-resident integral membrane chaperone/packaging factor required for functional expression of yeast amino acid permeases rather than an enzyme or transporter itself. (ring2019ssy1functionsat pages 9-9, mochizuki2015retentionofchimeric pages 8-9, bianchi2019regulationofamino pages 19-21)</td>
+<td>Review + primary; genetic, biochemical, cell biology</td>
+<td>Bianchi et al., 2019, <em>Microbiol Mol Biol Rev</em>; https://doi.org/10.1128/MMBR.00024-19 ; Ring et al., 2019, <em>Traffic</em>; https://doi.org/10.1111/tra.12681 ; Mochizuki et al., 2015, <em>FEMS Yeast Res</em>; https://doi.org/10.1093/femsyr/fov044</td>
+</tr>
+<tr>
+<td>Localization</td>
+<td>Shr3/Shr3p localizes to the endoplasmic reticulum membrane and has been used experimentally as an ER marker showing perinuclear and cortical ER patterns. (ring2019ssy1functionsat pages 2-3, ring2019ssy1functionsat pages 3-4)</td>
+<td>Primary; cell biology/imaging</td>
+<td>Ring et al., 2019, <em>Traffic</em>; https://doi.org/10.1111/tra.12681</td>
+</tr>
+<tr>
+<td>Client proteins</td>
+<td>The best-supported clients are yeast amino acid transporters/permeases, including Gap1 and other YAT/AAP family members such as Agp1 and Gnp1. (mochizuki2015retentionofchimeric pages 8-9, mochizuki2015retentionofchimeric pages 1-2, bianchi2019regulationofamino pages 19-21)</td>
+<td>Review + primary; genetic, biochemical</td>
+<td>Mochizuki et al., 2015, <em>FEMS Yeast Res</em>; https://doi.org/10.1093/femsyr/fov044 ; Bianchi et al., 2019, <em>Microbiol Mol Biol Rev</em>; https://doi.org/10.1128/MMBR.00024-19</td>
+</tr>
+<tr>
+<td>Mechanism</td>
+<td>Shr3 stabilizes early transmembrane segments of permeases—reviewed as holding the first 5 TMDs in a folding-competent state—thereby preventing nonproductive TMD interactions, aggregation, and premature ERAD. (mochizuki2015retentionofchimeric pages 8-9, mochizuki2015retentionofchimeric pages 1-2, bianchi2019regulationofamino pages 19-21)</td>
+<td>Review + primary; biochemical, genetic</td>
+<td>Bianchi et al., 2019, <em>Microbiol Mol Biol Rev</em>; https://doi.org/10.1128/MMBR.00024-19 ; Mochizuki et al., 2015, <em>FEMS Yeast Res</em>; https://doi.org/10.1093/femsyr/fov044</td>
+</tr>
+<tr>
+<td>ER export/COPII packaging</td>
+<td>Shr3 is required for specific COPII coatomer-cargo interactions that package amino acid permeases into ER-derived transport vesicles for forward trafficking. (ring2019ssy1functionsat pages 9-9, mochizuki2015retentionofchimeric pages 9-10)</td>
+<td>Review + primary; biochemical trafficking assays</td>
+<td>Ring et al., 2019, <em>Traffic</em>; https://doi.org/10.1111/tra.12681 ; Mochizuki et al., 2015, <em>FEMS Yeast Res</em>; https://doi.org/10.1093/femsyr/fov044</td>
+</tr>
+<tr>
+<td>Pathway / biological process</td>
+<td>SHR3 functions in transporter biogenesis within the early secretory pathway, linking ER folding quality control to ER exit and subsequent Golgi/plasma-membrane delivery of amino acid transporters. (dancourt2010proteinsortingreceptors pages 16-17, bianchi2019regulationofamino media 260fd4cf, bianchi2019regulationofamino pages 19-21)</td>
+<td>Review; secretory pathway synthesis</td>
+<td>Dancourt &amp; Barlowe, 2010, <em>Annu Rev Biochem</em>; https://doi.org/10.1146/annurev-biochem-061608-091319 ; Bianchi et al., 2019, <em>Microbiol Mol Biol Rev</em>; https://doi.org/10.1128/MMBR.00024-19</td>
+</tr>
+<tr>
+<td>Quality control</td>
+<td>In shr3-deficient cells, Gap1 and related permeases accumulate as high-molecular-weight ER aggregates and are cleared by ER-associated degradation involving Doa10/Hrd1, Cdc48, and the proteasome. (mochizuki2015retentionofchimeric pages 1-2, bianchi2019regulationofamino pages 19-21)</td>
+<td>Review + primary; genetic, proteostasis</td>
+<td>Mochizuki et al., 2015, <em>FEMS Yeast Res</em>; https://doi.org/10.1093/femsyr/fov044 ; Bianchi et al., 2019, <em>Microbiol Mol Biol Rev</em>; https://doi.org/10.1128/MMBR.00024-19</td>
+</tr>
+<tr>
+<td>Phenotypes / assays</td>
+<td>Loss of SHR3 causes defective cell-surface localization and function of amino acid permeases, while ER-retained misfolded permease constructs can trigger UPR-related stress phenotypes. (ring2019ssy1functionsat pages 9-9, mochizuki2015retentionofchimeric pages 1-2, mochizuki2015retentionofchimeric pages 8-9)</td>
+<td>Primary + review; mutant phenotype, localization, stress-response assays</td>
+<td>Ring et al., 2019, <em>Traffic</em>; https://doi.org/10.1111/tra.12681 ; Mochizuki et al., 2015, <em>FEMS Yeast Res</em>; https://doi.org/10.1093/femsyr/fov044</td>
+</tr>
+<tr>
+<td>Comparative family context</td>
+<td>Shr3 is part of a broader class of substrate-specific ER-resident packaging chaperones in yeast, analogous in function to Gsf2, Pho86, and Chs7 for other membrane cargos. (bianchi2019regulationofamino media 260fd4cf, bianchi2019regulationofamino pages 19-21)</td>
+<td>Review; comparative cell biology</td>
+<td>Bianchi et al., 2019, <em>Microbiol Mol Biol Rev</em>; https://doi.org/10.1128/MMBR.00024-19</td>
+</tr>
+<tr>
+<td>Visual summary evidence</td>
+<td>A recent authoritative review figure summarizes Shr3 in the ER as stabilizing YATs and sorting them into export vesicles while limiting ERAD, providing a concise systems-level annotation. (bianchi2019regulationofamino media 260fd4cf)</td>
+<td>Review figure/diagram</td>
+<td>Bianchi et al., 2019, <em>Microbiol Mol Biol Rev</em>; https://doi.org/10.1128/MMBR.00024-19</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the main experimentally supported annotations for yeast SHR3/Q02774, including its ER localization, chaperone role, permease clients, and link to COPII export and ER quality control. It is useful as a concise evidence map anchored to review and primary literature.</em></p>
+<p>(Visual evidence: Figure 7 from Bianchi et al. 2019 explicitly places Shr3 in the ER as stabilizing and sorting YATs while limiting ERAD.) (bianchi2019regulationofamino media 260fd4cf)</p>
+<hr />
+<h2 id="references-retrieved-in-this-run-with-dates-and-urls">References (retrieved in this run; with dates and URLs)</h2>
+<ol>
+<li><strong>Bianchi F, van’t Klooster JS, Ruiz SJ, Poolman B.</strong> <em>Regulation of Amino Acid Transport in Saccharomyces cerevisiae.</em> <strong>Microbiology and Molecular Biology Reviews</strong>. <strong>2019-11</strong>. https://doi.org/10.1128/mmbr.00024-19 (bianchi2019regulationofamino pages 19-21, bianchi2019regulationofamino media 260fd4cf)</li>
+<li><strong>Mochizuki T, Kimata Y, Uemura S, Abe F.</strong> <em>Retention of chimeric Tat2-Gap1 permease in the endoplasmic reticulum induces unfolded protein response in Saccharomyces cerevisiae.</em> <strong>FEMS Yeast Research</strong>. <strong>2015-08</strong>. https://doi.org/10.1093/femsyr/fov044 (mochizuki2015retentionofchimeric pages 1-2, mochizuki2015retentionofchimeric pages 8-9)</li>
+<li><strong>Dancourt J, Barlowe C.</strong> <em>Protein sorting receptors in the early secretory pathway.</em> <strong>Annual Review of Biochemistry</strong>. <strong>2010-06</strong>. https://doi.org/10.1146/annurev-biochem-061608-091319 (dancourt2010proteinsortingreceptors pages 16-17)</li>
+<li><strong>Ring A, Martins A, Ljungdahl PO.</strong> <em>Ssy1 functions at the plasma membrane as a receptor of extracellular amino acids independent of plasma membrane–endoplasmic reticulum junctions.</em> <strong>Traffic</strong>. <strong>2019-08</strong>. https://doi.org/10.1111/tra.12681 (ring2019ssy1functionsat pages 2-3, ring2019ssy1functionsat pages 3-4)</li>
+</ol>
+<p>References</p>
+<ol>
+<li>
+<p>(ring2019ssy1functionsat pages 9-9): Andreas Ring, António Martins, and Per O. Ljungdahl. Ssy1 functions at the plasma membrane as a receptor of extracellular amino acids independent of plasma membrane‐endoplasmic reticulum junctions. Traffic, 20:775-784, Aug 2019. URL: https://doi.org/10.1111/tra.12681, doi:10.1111/tra.12681. This article has 5 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(mochizuki2015retentionofchimeric pages 8-9): Takahiro Mochizuki, Yukio Kimata, Satoshi Uemura, and Fumiyoshi Abe. Retention of chimeric tat2-gap1 permease in the endoplasmic reticulum induces unfolded protein response in saccharomyces cerevisiae. FEMS yeast research, 15 5:fov044, Aug 2015. URL: https://doi.org/10.1093/femsyr/fov044, doi:10.1093/femsyr/fov044. This article has 1 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(dancourt2010proteinsortingreceptors pages 16-17): Julia Dancourt and Charles Barlowe. Protein sorting receptors in the early secretory pathway. Annual review of biochemistry, 79:777-802, Jun 2010. URL: https://doi.org/10.1146/annurev-biochem-061608-091319, doi:10.1146/annurev-biochem-061608-091319. This article has 378 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(bianchi2019regulationofamino pages 19-21): Frans Bianchi, Joury S. van’t Klooster, Stephanie J. Ruiz, and Bert Poolman. Regulation of amino acid transport in saccharomyces cerevisiae. Microbiology and Molecular Biology Reviews, Nov 2019. URL: https://doi.org/10.1128/mmbr.00024-19, doi:10.1128/mmbr.00024-19. This article has 166 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ring2019ssy1functionsat pages 2-3): Andreas Ring, António Martins, and Per O. Ljungdahl. Ssy1 functions at the plasma membrane as a receptor of extracellular amino acids independent of plasma membrane‐endoplasmic reticulum junctions. Traffic, 20:775-784, Aug 2019. URL: https://doi.org/10.1111/tra.12681, doi:10.1111/tra.12681. This article has 5 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(mochizuki2015retentionofchimeric pages 1-2): Takahiro Mochizuki, Yukio Kimata, Satoshi Uemura, and Fumiyoshi Abe. Retention of chimeric tat2-gap1 permease in the endoplasmic reticulum induces unfolded protein response in saccharomyces cerevisiae. FEMS yeast research, 15 5:fov044, Aug 2015. URL: https://doi.org/10.1093/femsyr/fov044, doi:10.1093/femsyr/fov044. This article has 1 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(mochizuki2015retentionofchimeric pages 9-10): Takahiro Mochizuki, Yukio Kimata, Satoshi Uemura, and Fumiyoshi Abe. Retention of chimeric tat2-gap1 permease in the endoplasmic reticulum induces unfolded protein response in saccharomyces cerevisiae. FEMS yeast research, 15 5:fov044, Aug 2015. URL: https://doi.org/10.1093/femsyr/fov044, doi:10.1093/femsyr/fov044. This article has 1 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(bianchi2019regulationofamino media 260fd4cf): Frans Bianchi, Joury S. van’t Klooster, Stephanie J. Ruiz, and Bert Poolman. Regulation of amino acid transport in saccharomyces cerevisiae. Microbiology and Molecular Biology Reviews, Nov 2019. URL: https://doi.org/10.1128/mmbr.00024-19, doi:10.1128/mmbr.00024-19. This article has 166 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ring2019ssy1functionsat pages 3-4): Andreas Ring, António Martins, and Per O. Ljungdahl. Ssy1 functions at the plasma membrane as a receptor of extracellular amino acids independent of plasma membrane‐endoplasmic reticulum junctions. Traffic, 20:775-784, Aug 2019. URL: https://doi.org/10.1111/tra.12681, doi:10.1111/tra.12681. This article has 5 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(dimou2020lifeanddeath pages 1-3): Sofia Dimou and George Diallinas. Life and death of fungal transporters under the challenge of polarity. International Journal of Molecular Sciences, 21:5376, Jul 2020. URL: https://doi.org/10.3390/ijms21155376, doi:10.3390/ijms21155376. This article has 21 citations.</p>
+</li>
+</ol>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>mochizuki2015retentionofchimeric pages 1-2</li>
+<li>bianchi2019regulationofamino pages 19-21</li>
+<li>mochizuki2015retentionofchimeric pages 8-9</li>
+<li>mochizuki2015retentionofchimeric pages 9-10</li>
+<li>dancourt2010proteinsortingreceptors pages 16-17</li>
+<li>dimou2020lifeanddeath pages 1-3</li>
+<li>https://doi.org/10.1128/MMBR.00024-19</li>
+<li>https://doi.org/10.1111/tra.12681</li>
+<li>https://doi.org/10.1093/femsyr/fov044</li>
+<li>https://doi.org/10.1146/annurev-biochem-061608-091319</li>
+<li>https://doi.org/10.1128/mmbr.00024-19</li>
+<li>https://doi.org/10.1111/tra.12681,</li>
+<li>https://doi.org/10.1093/femsyr/fov044,</li>
+<li>https://doi.org/10.1146/annurev-biochem-061608-091319,</li>
+<li>https://doi.org/10.1128/mmbr.00024-19,</li>
+<li>https://doi.org/10.3390/ijms21155376,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -2100,23 +2795,19 @@
                 <pre><code>id: Q02774
 gene_symbol: SHR3
 product_type: PROTEIN
-status: DRAFT
+status: COMPLETE
 taxon:
   id: NCBITaxon:559292
   label: Saccharomyces cerevisiae
 description: &gt;-
-  SHR3 encodes an ER membrane-localized packaging chaperone specifically
-  required for the proper folding and ER exit of amino acid permeases. Shr3p
-  functions as a permease-specific adaptor that assists the folding of these
-  polytopic membrane proteins in the ER and facilitates their incorporation
-  into COPII-coated vesicles for transport to the cell surface. It acts in
-  conjunction with the Sec62/Sec63 translocon complex. In the absence of
-  Shr3p, amino acid permeases are retained in the ER in a misfolded state and
-  are eventually degraded, resulting in pleiotropic amino acid uptake defects.
-  Shr3p enables yeast cells to rapidly modulate the spectrum of permeases
-  expressed at the plasma membrane in response to changing nutrient conditions.
-  No direct human ortholog has been identified, though the functional
-  principle of substrate-specific ER chaperones is conserved.
+  SHR3 encodes an endoplasmic-reticulum membrane packaging chaperone required
+  for folding, quality control, and ER exit of yeast amino acid permeases. Shr3
+  is a multi-pass ER membrane protein that assists substrate-specific folding of
+  polytopic amino acid transporters, prevents their aggregation and premature
+  ER-associated degradation, and promotes COPII-dependent packaging for
+  trafficking from the ER toward the Golgi and plasma membrane. Shr3 is not
+  itself an amino acid transporter; its core role is client-specific membrane
+  protein chaperoning in the early secretory pathway.
 existing_annotations:
 - term:
     id: GO:0005789
@@ -2124,171 +2815,335 @@ existing_annotations:
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: &#39;Manual review: endoplasmic reticulum membrane is consistent with known biology of SHR3.&#39;
+    summary: &gt;-
+      PANTHER IBA to endoplasmic reticulum membrane is consistent with the
+      specific Shr3 family, UniProt localization, and direct experimental
+      evidence.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: &gt;-
+      Shr3 is an integral ER membrane protein and functions at the ER membrane
+      during amino acid permease biogenesis.
+    supported_by:
+    - reference_id: file:yeast/SHR3/SHR3-deep-research-falcon.md
+      supporting_text: &#34;Shr3 localizes to the endoplasmic reticulum membrane&#34;
 - term:
     id: GO:0006888
     label: endoplasmic reticulum to Golgi vesicle-mediated transport
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: &#39;Manual review: endoplasmic reticulum to Golgi vesicle-mediated transport is consistent with known biology of SHR3.&#39;
+    summary: &gt;-
+      Family-transfer annotation to ER-to-Golgi vesicle transport is appropriate
+      for Shr3 because it promotes ER exit of amino acid permease cargo.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: &gt;-
+      Shr3 is required for efficient packaging of permeases into ER-derived
+      COPII vesicles and therefore supports ER-to-Golgi transport of those
+      clients.
+    supported_by:
+    - reference_id: file:yeast/SHR3/SHR3-deep-research-falcon.md
+      supporting_text: &#34;promoting COPII-dependent packaging of amino acid permeases&#34;
 - term:
     id: GO:0051082
     label: unfolded protein binding
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: &#39;Manual review: unfolded protein binding is better represented by a more specific replacement term for SHR3.&#39;
+    summary: &gt;-
+      Shr3 is a substrate-specific chaperone for polytopic permeases, but
+      &#34;unfolded protein binding&#34; is a vague binding term.
     action: MODIFY
-    reason: Modified to align with current curation guidance and improve term specificity.
+    reason: &gt;-
+      The evidence supports protein folding chaperone activity for amino acid
+      permease clients rather than a generic unfolded-protein binding
+      annotation.
     proposed_replacement_terms:
     - id: GO:0044183
       label: protein folding chaperone
+    supported_by:
+    - reference_id: PMID:15623581
+      supporting_text: &#34;Specialized membrane-localized chaperones prevent aggregation of polytopic proteins in the ER.&#34;
 - term:
     id: GO:0005789
     label: endoplasmic reticulum membrane
   evidence_type: IEA
   original_reference_id: GO_REF:0000044
   review:
-    summary: &#39;Manual review: endoplasmic reticulum membrane is consistent with known biology of SHR3.&#39;
+    summary: &gt;-
+      UniProt subcellular-location mapping to ER membrane is consistent with
+      direct Shr3 localization.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: &gt;-
+      Shr3 is a multi-pass ER membrane protein, and this localization is central
+      to its permease-chaperone function.
 - term:
     id: GO:0015031
     label: protein transport
   evidence_type: IEA
   original_reference_id: GO_REF:0000043
   review:
-    summary: &#39;Manual review: protein transport is consistent with known biology of SHR3.&#39;
+    summary: &gt;-
+      The keyword-derived protein transport annotation is broad but reflects
+      Shr3&#39;s role in ER export of amino acid permeases.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: &gt;-
+      More specific experimental terms capture COPII budding and ER-to-Golgi
+      transport, but the broad transport term remains accurate.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:10688190
+  supporting_entities:
+  - UniProtKB:P48813
   review:
-    summary: &#39;Manual review: protein binding is too generic or over-extended for SHR3.&#39;
+    summary: &gt;-
+      This high-throughput interaction supports physical association with the
+      amino acid permease Gnp1 but the term protein binding is uninformative.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Marked over-annotated because more specific terms capture the biology more accurately.
+    reason: &gt;-
+      The curated molecular function should describe Shr3&#39;s client-specific
+      chaperone activity rather than retain generic protein binding.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:16093310
+  supporting_entities:
+  - UniProtKB:P35206
+  - UniProtKB:P38084
+  - UniProtKB:P48813
   review:
-    summary: &#39;Manual review: protein binding is too generic or over-extended for SHR3.&#39;
+    summary: &gt;-
+      These interaction data are consistent with Shr3 contacts with membrane
+      cargo or related proteins, but protein binding does not convey the
+      specific function.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Marked over-annotated because more specific terms capture the biology more accurately.
+    reason: &gt;-
+      A generic protein-binding annotation should not be treated as a core
+      molecular function when the biological role is permease folding and
+      packaging chaperone activity.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:18467557
+  supporting_entities:
+  - UniProtKB:P35206
+  - UniProtKB:P38084
+  - UniProtKB:P38264
   review:
-    summary: &#39;Manual review: protein binding is too generic or over-extended for SHR3.&#39;
+    summary: &gt;-
+      Large-scale interaction evidence does not provide a specific molecular
+      function beyond physical association.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Marked over-annotated because more specific terms capture the biology more accurately.
+    reason: &gt;-
+      This annotation is too generic for curation; the better-supported role is
+      Shr3 chaperoning and ER export of amino acid permeases.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:27107014
+  supporting_entities:
+  - UniProtKB:Q96BA8
   review:
-    summary: &#39;Manual review: protein binding is too generic or over-extended for SHR3.&#39;
+    summary: &gt;-
+      The inter-species interaction screen reports a physical interaction but
+      does not establish a yeast Shr3 molecular activity.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Marked over-annotated because more specific terms capture the biology more accurately.
+    reason: &gt;-
+      The xeno interaction is not suitable as a core function annotation and is
+      much less informative than the experimentally supported Shr3 chaperone
+      mechanism.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:37968396
+  supporting_entities:
+  - UniProtKB:P38264
+  - UniProtKB:P48813
   review:
-    summary: &#39;Manual review: protein binding is too generic or over-extended for SHR3.&#39;
+    summary: &gt;-
+      Modern high-throughput interactome data reinforce Shr3 physical
+      associations but still use a generic binding term.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Marked over-annotated because more specific terms capture the biology more accurately.
+    reason: &gt;-
+      Protein binding is not an informative endpoint for Shr3; specific
+      client-chaperone and ER-export annotations should carry the curation.
 - term:
     id: GO:0005789
     label: endoplasmic reticulum membrane
   evidence_type: IDA
   original_reference_id: PMID:1423607
   review:
-    summary: &#39;Manual review: endoplasmic reticulum membrane is consistent with known biology of SHR3.&#39;
+    summary: &gt;-
+      Direct experimental evidence from the original SHR3 study identified Shr3
+      as an ER integral membrane component.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: &gt;-
+      This localization is the correct compartment for Shr3&#39;s role in amino acid
+      permease processing and ER exit.
+    supported_by:
+    - reference_id: PMID:1423607
+      supporting_text: &#34;SHR3 is a novel integral membrane protein component of the endoplasmic reticulum&#34;
 - term:
     id: GO:0005789
     label: endoplasmic reticulum membrane
   evidence_type: IDA
   original_reference_id: PMID:15623581
   review:
-    summary: &#39;Manual review: endoplasmic reticulum membrane is consistent with known biology of SHR3.&#39;
+    summary: &gt;-
+      Direct experimental evidence supports Shr3 as an integral ER membrane
+      chaperone for amino acid permeases.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: &gt;-
+      The ER membrane location is required for Shr3 to act on nascent or newly
+      inserted polytopic permease clients.
+    supported_by:
+    - reference_id: PMID:15623581
+      supporting_text: &#34;The integral endoplasmic reticulum (ER) membrane protein Shr3p&#34;
 - term:
     id: GO:0090114
     label: COPII-coated vesicle budding
   evidence_type: IGI
   original_reference_id: PMID:10564255
   review:
-    summary: &#39;Manual review: COPII-coated vesicle budding is consistent with known biology of SHR3.&#39;
+    summary: &gt;-
+      Genetic-interaction evidence supports Shr3 participation in COPII-coated
+      vesicle budding for amino acid permease cargo.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: &gt;-
+      Shr3 mediates specific COPII coatomer-cargo interactions needed for
+      packaging permeases into ER-derived transport vesicles.
+    supported_by:
+    - reference_id: PMID:10564255
+      supporting_text: &#34;Shr3p mediates specific COPII coatomer-cargo interactions&#34;
 - term:
     id: GO:0005783
     label: endoplasmic reticulum
   evidence_type: HDA
   original_reference_id: PMID:26928762
   review:
-    summary: &#39;Manual review: endoplasmic reticulum is consistent with known biology of SHR3.&#39;
+    summary: &gt;-
+      High-throughput SWAp-Tag localization supports ER localization, consistent
+      with direct ER membrane evidence.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: &gt;-
+      The high-throughput annotation is congruent with multiple direct studies
+      placing Shr3 in the ER membrane.
+    supported_by:
+    - reference_id: PMID:26928762
+      supporting_text: &#34;streamlining the creation of yeast libraries via a SWAp-Tag strategy&#34;
 - term:
     id: GO:0043332
     label: mating projection tip
   evidence_type: HDA
   original_reference_id: PMID:19053807
   review:
-    summary: &#39;Manual review: mating projection tip may be context-dependent or peripheral for SHR3.&#39;
+    summary: &gt;-
+      High-throughput pheromone-treatment localization suggests a condition-
+      specific signal at the mating projection tip.
     action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    reason: &gt;-
+      This may reflect condition-specific relocalization of ER/cortical
+      membrane-associated Shr3, but it is not the core compartment for the
+      permease-chaperone mechanism.
 - term:
     id: GO:0006457
     label: protein folding
   evidence_type: IMP
   original_reference_id: PMID:15623581
   review:
-    summary: &#39;Manual review: protein folding is consistent with known biology of SHR3.&#39;
+    summary: &gt;-
+      Mutant phenotype evidence supports Shr3&#39;s role in folding of polytopic
+      amino acid permease clients and preventing their aggregation in the ER.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: &gt;-
+      Protein folding is a core biological process for Shr3 because failure of
+      Shr3 causes permease misfolding/aggregation and ER retention.
+    supported_by:
+    - reference_id: PMID:15623581
+      supporting_text: &#34;prevent aggregation of polytopic proteins in the ER&#34;
 - term:
     id: GO:0051082
     label: unfolded protein binding
   evidence_type: IMP
   original_reference_id: PMID:10564255
   review:
-    summary: &#39;Manual review: unfolded protein binding is better represented by a more specific replacement term for SHR3.&#39;
+    summary: &gt;-
+      Shr3&#39;s activity involves chaperoning amino acid permease cargo, but
+      unfolded protein binding is less precise than a chaperone activity term.
     action: MODIFY
-    reason: Modified to align with current curation guidance and improve term specificity.
+    reason: &gt;-
+      The evidence supports specific protein folding/packaging chaperone
+      activity in the ER membrane rather than a generic binding term.
     proposed_replacement_terms:
     - id: GO:0044183
       label: protein folding chaperone
+    supported_by:
+    - reference_id: PMID:10564255
+      supporting_text: &#34;Shr3p acts as a packaging chaperone&#34;
 - term:
     id: GO:0051082
     label: unfolded protein binding
   evidence_type: IMP
   original_reference_id: PMID:15623581
   review:
-    summary: &#39;Manual review: unfolded protein binding is better represented by a more specific replacement term for SHR3.&#39;
+    summary: &gt;-
+      The evidence shows Shr3 prevents aggregation of polytopic permeases during
+      folding, which is better represented as protein folding chaperone activity.
     action: MODIFY
-    reason: Modified to align with current curation guidance and improve term specificity.
+    reason: &gt;-
+      The more informative curation is GO:0044183 protein folding chaperone
+      coupled to ER membrane permease biogenesis.
     proposed_replacement_terms:
     - id: GO:0044183
       label: protein folding chaperone
+    supported_by:
+    - reference_id: PMID:15623581
+      supporting_text: &#34;Specialized membrane-localized chaperones prevent aggregation of polytopic proteins in the ER.&#34;
+core_functions:
+- molecular_function:
+    id: GO:0044183
+    label: protein folding chaperone
+  directly_involved_in:
+  - id: GO:0006457
+    label: protein folding
+  - id: GO:0006888
+    label: endoplasmic reticulum to Golgi vesicle-mediated transport
+  - id: GO:0090114
+    label: COPII-coated vesicle budding
+  locations:
+  - id: GO:0005789
+    label: endoplasmic reticulum membrane
+  description: &gt;-
+    Shr3 is a substrate-specific ER membrane chaperone for amino acid permeases.
+    It stabilizes polytopic permease clients, prevents aggregation and premature
+    ERAD, and promotes their packaging into COPII-coated ER-derived vesicles.
+  supported_by:
+  - reference_id: PMID:15623581
+    supporting_text: &#34;prevent aggregation of polytopic proteins in the ER&#34;
+  - reference_id: PMID:10564255
+    supporting_text: &#34;Shr3p acts as a packaging chaperone&#34;
+  - reference_id: file:yeast/SHR3/SHR3-deep-research-falcon.md
+    supporting_text: &#34;ER membrane-localized, substrate-specific chaperone&#34;
+proposed_new_terms: []
+suggested_questions:
+- question: &gt;-
+    For Shr3 and related ER-resident packaging factors, should GO curation
+    distinguish folding chaperone activity from cargo-receptor or COPII-adaptor
+    activity with a more specific child term?
+suggested_experiments:
+- description: &gt;-
+    Reconstitute Shr3 with defined amino acid permease transmembrane segments and
+    COPII components to separate its folding/stabilization activity from any
+    direct COPII recruitment activity.
+  experiment_type: biochemical reconstitution
+  hypothesis: &gt;-
+    Shr3 first stabilizes early permease transmembrane segments and then promotes
+    COPII packaging indirectly by producing export-competent cargo.
 references:
 - id: GO_REF:0000033
   title: Annotation inferences using phylogenetic trees
@@ -2329,13 +3184,16 @@ references:
 - id: PMID:37968396
   title: The social and structural architecture of the yeast protein interactome.
   findings: []
+- id: file:yeast/SHR3/SHR3-deep-research-falcon.md
+  title: Falcon deep research report for SHR3
+  findings: []
 </code></pre>
             </div>
         </details>
     </div>
 
     <!-- Pathway Visualization Link -->
-    
+
 
     <style>
         /* Markdown Section Styles */

--- a/genes/yeast/SHR3/SHR3-ai-review.yaml
+++ b/genes/yeast/SHR3/SHR3-ai-review.yaml
@@ -1,23 +1,19 @@
 id: Q02774
 gene_symbol: SHR3
 product_type: PROTEIN
-status: DRAFT
+status: COMPLETE
 taxon:
   id: NCBITaxon:559292
   label: Saccharomyces cerevisiae
 description: >-
-  SHR3 encodes an ER membrane-localized packaging chaperone specifically
-  required for the proper folding and ER exit of amino acid permeases. Shr3p
-  functions as a permease-specific adaptor that assists the folding of these
-  polytopic membrane proteins in the ER and facilitates their incorporation
-  into COPII-coated vesicles for transport to the cell surface. It acts in
-  conjunction with the Sec62/Sec63 translocon complex. In the absence of
-  Shr3p, amino acid permeases are retained in the ER in a misfolded state and
-  are eventually degraded, resulting in pleiotropic amino acid uptake defects.
-  Shr3p enables yeast cells to rapidly modulate the spectrum of permeases
-  expressed at the plasma membrane in response to changing nutrient conditions.
-  No direct human ortholog has been identified, though the functional
-  principle of substrate-specific ER chaperones is conserved.
+  SHR3 encodes an endoplasmic-reticulum membrane packaging chaperone required
+  for folding, quality control, and ER exit of yeast amino acid permeases. Shr3
+  is a multi-pass ER membrane protein that assists substrate-specific folding of
+  polytopic amino acid transporters, prevents their aggregation and premature
+  ER-associated degradation, and promotes COPII-dependent packaging for
+  trafficking from the ER toward the Golgi and plasma membrane. Shr3 is not
+  itself an amino acid transporter; its core role is client-specific membrane
+  protein chaperoning in the early secretory pathway.
 existing_annotations:
 - term:
     id: GO:0005789
@@ -25,171 +21,335 @@ existing_annotations:
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'Manual review: endoplasmic reticulum membrane is consistent with known biology of SHR3.'
+    summary: >-
+      PANTHER IBA to endoplasmic reticulum membrane is consistent with the
+      specific Shr3 family, UniProt localization, and direct experimental
+      evidence.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: >-
+      Shr3 is an integral ER membrane protein and functions at the ER membrane
+      during amino acid permease biogenesis.
+    supported_by:
+    - reference_id: file:yeast/SHR3/SHR3-deep-research-falcon.md
+      supporting_text: "Shr3 localizes to the endoplasmic reticulum membrane"
 - term:
     id: GO:0006888
     label: endoplasmic reticulum to Golgi vesicle-mediated transport
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'Manual review: endoplasmic reticulum to Golgi vesicle-mediated transport is consistent with known biology of SHR3.'
+    summary: >-
+      Family-transfer annotation to ER-to-Golgi vesicle transport is appropriate
+      for Shr3 because it promotes ER exit of amino acid permease cargo.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: >-
+      Shr3 is required for efficient packaging of permeases into ER-derived
+      COPII vesicles and therefore supports ER-to-Golgi transport of those
+      clients.
+    supported_by:
+    - reference_id: file:yeast/SHR3/SHR3-deep-research-falcon.md
+      supporting_text: "promoting COPII-dependent packaging of amino acid permeases"
 - term:
     id: GO:0051082
     label: unfolded protein binding
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'Manual review: unfolded protein binding is better represented by a more specific replacement term for SHR3.'
+    summary: >-
+      Shr3 is a substrate-specific chaperone for polytopic permeases, but
+      "unfolded protein binding" is a vague binding term.
     action: MODIFY
-    reason: Modified to align with current curation guidance and improve term specificity.
+    reason: >-
+      The evidence supports protein folding chaperone activity for amino acid
+      permease clients rather than a generic unfolded-protein binding
+      annotation.
     proposed_replacement_terms:
     - id: GO:0044183
       label: protein folding chaperone
+    supported_by:
+    - reference_id: PMID:15623581
+      supporting_text: "Specialized membrane-localized chaperones prevent aggregation of polytopic proteins in the ER."
 - term:
     id: GO:0005789
     label: endoplasmic reticulum membrane
   evidence_type: IEA
   original_reference_id: GO_REF:0000044
   review:
-    summary: 'Manual review: endoplasmic reticulum membrane is consistent with known biology of SHR3.'
+    summary: >-
+      UniProt subcellular-location mapping to ER membrane is consistent with
+      direct Shr3 localization.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: >-
+      Shr3 is a multi-pass ER membrane protein, and this localization is central
+      to its permease-chaperone function.
 - term:
     id: GO:0015031
     label: protein transport
   evidence_type: IEA
   original_reference_id: GO_REF:0000043
   review:
-    summary: 'Manual review: protein transport is consistent with known biology of SHR3.'
+    summary: >-
+      The keyword-derived protein transport annotation is broad but reflects
+      Shr3's role in ER export of amino acid permeases.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: >-
+      More specific experimental terms capture COPII budding and ER-to-Golgi
+      transport, but the broad transport term remains accurate.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:10688190
+  supporting_entities:
+  - UniProtKB:P48813
   review:
-    summary: 'Manual review: protein binding is too generic or over-extended for SHR3.'
+    summary: >-
+      This high-throughput interaction supports physical association with the
+      amino acid permease Gnp1 but the term protein binding is uninformative.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Marked over-annotated because more specific terms capture the biology more accurately.
+    reason: >-
+      The curated molecular function should describe Shr3's client-specific
+      chaperone activity rather than retain generic protein binding.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:16093310
+  supporting_entities:
+  - UniProtKB:P35206
+  - UniProtKB:P38084
+  - UniProtKB:P48813
   review:
-    summary: 'Manual review: protein binding is too generic or over-extended for SHR3.'
+    summary: >-
+      These interaction data are consistent with Shr3 contacts with membrane
+      cargo or related proteins, but protein binding does not convey the
+      specific function.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Marked over-annotated because more specific terms capture the biology more accurately.
+    reason: >-
+      A generic protein-binding annotation should not be treated as a core
+      molecular function when the biological role is permease folding and
+      packaging chaperone activity.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:18467557
+  supporting_entities:
+  - UniProtKB:P35206
+  - UniProtKB:P38084
+  - UniProtKB:P38264
   review:
-    summary: 'Manual review: protein binding is too generic or over-extended for SHR3.'
+    summary: >-
+      Large-scale interaction evidence does not provide a specific molecular
+      function beyond physical association.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Marked over-annotated because more specific terms capture the biology more accurately.
+    reason: >-
+      This annotation is too generic for curation; the better-supported role is
+      Shr3 chaperoning and ER export of amino acid permeases.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:27107014
+  supporting_entities:
+  - UniProtKB:Q96BA8
   review:
-    summary: 'Manual review: protein binding is too generic or over-extended for SHR3.'
+    summary: >-
+      The inter-species interaction screen reports a physical interaction but
+      does not establish a yeast Shr3 molecular activity.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Marked over-annotated because more specific terms capture the biology more accurately.
+    reason: >-
+      The xeno interaction is not suitable as a core function annotation and is
+      much less informative than the experimentally supported Shr3 chaperone
+      mechanism.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:37968396
+  supporting_entities:
+  - UniProtKB:P38264
+  - UniProtKB:P48813
   review:
-    summary: 'Manual review: protein binding is too generic or over-extended for SHR3.'
+    summary: >-
+      Modern high-throughput interactome data reinforce Shr3 physical
+      associations but still use a generic binding term.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Marked over-annotated because more specific terms capture the biology more accurately.
+    reason: >-
+      Protein binding is not an informative endpoint for Shr3; specific
+      client-chaperone and ER-export annotations should carry the curation.
 - term:
     id: GO:0005789
     label: endoplasmic reticulum membrane
   evidence_type: IDA
   original_reference_id: PMID:1423607
   review:
-    summary: 'Manual review: endoplasmic reticulum membrane is consistent with known biology of SHR3.'
+    summary: >-
+      Direct experimental evidence from the original SHR3 study identified Shr3
+      as an ER integral membrane component.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: >-
+      This localization is the correct compartment for Shr3's role in amino acid
+      permease processing and ER exit.
+    supported_by:
+    - reference_id: PMID:1423607
+      supporting_text: "SHR3 is a novel integral membrane protein component of the endoplasmic reticulum"
 - term:
     id: GO:0005789
     label: endoplasmic reticulum membrane
   evidence_type: IDA
   original_reference_id: PMID:15623581
   review:
-    summary: 'Manual review: endoplasmic reticulum membrane is consistent with known biology of SHR3.'
+    summary: >-
+      Direct experimental evidence supports Shr3 as an integral ER membrane
+      chaperone for amino acid permeases.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: >-
+      The ER membrane location is required for Shr3 to act on nascent or newly
+      inserted polytopic permease clients.
+    supported_by:
+    - reference_id: PMID:15623581
+      supporting_text: "The integral endoplasmic reticulum (ER) membrane protein Shr3p"
 - term:
     id: GO:0090114
     label: COPII-coated vesicle budding
   evidence_type: IGI
   original_reference_id: PMID:10564255
   review:
-    summary: 'Manual review: COPII-coated vesicle budding is consistent with known biology of SHR3.'
+    summary: >-
+      Genetic-interaction evidence supports Shr3 participation in COPII-coated
+      vesicle budding for amino acid permease cargo.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: >-
+      Shr3 mediates specific COPII coatomer-cargo interactions needed for
+      packaging permeases into ER-derived transport vesicles.
+    supported_by:
+    - reference_id: PMID:10564255
+      supporting_text: "Shr3p mediates specific COPII coatomer-cargo interactions"
 - term:
     id: GO:0005783
     label: endoplasmic reticulum
   evidence_type: HDA
   original_reference_id: PMID:26928762
   review:
-    summary: 'Manual review: endoplasmic reticulum is consistent with known biology of SHR3.'
+    summary: >-
+      High-throughput SWAp-Tag localization supports ER localization, consistent
+      with direct ER membrane evidence.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: >-
+      The high-throughput annotation is congruent with multiple direct studies
+      placing Shr3 in the ER membrane.
+    supported_by:
+    - reference_id: PMID:26928762
+      supporting_text: "streamlining the creation of yeast libraries via a SWAp-Tag strategy"
 - term:
     id: GO:0043332
     label: mating projection tip
   evidence_type: HDA
   original_reference_id: PMID:19053807
   review:
-    summary: 'Manual review: mating projection tip may be context-dependent or peripheral for SHR3.'
+    summary: >-
+      High-throughput pheromone-treatment localization suggests a condition-
+      specific signal at the mating projection tip.
     action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    reason: >-
+      This may reflect condition-specific relocalization of ER/cortical
+      membrane-associated Shr3, but it is not the core compartment for the
+      permease-chaperone mechanism.
 - term:
     id: GO:0006457
     label: protein folding
   evidence_type: IMP
   original_reference_id: PMID:15623581
   review:
-    summary: 'Manual review: protein folding is consistent with known biology of SHR3.'
+    summary: >-
+      Mutant phenotype evidence supports Shr3's role in folding of polytopic
+      amino acid permease clients and preventing their aggregation in the ER.
     action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    reason: >-
+      Protein folding is a core biological process for Shr3 because failure of
+      Shr3 causes permease misfolding/aggregation and ER retention.
+    supported_by:
+    - reference_id: PMID:15623581
+      supporting_text: "prevent aggregation of polytopic proteins in the ER"
 - term:
     id: GO:0051082
     label: unfolded protein binding
   evidence_type: IMP
   original_reference_id: PMID:10564255
   review:
-    summary: 'Manual review: unfolded protein binding is better represented by a more specific replacement term for SHR3.'
+    summary: >-
+      Shr3's activity involves chaperoning amino acid permease cargo, but
+      unfolded protein binding is less precise than a chaperone activity term.
     action: MODIFY
-    reason: Modified to align with current curation guidance and improve term specificity.
+    reason: >-
+      The evidence supports specific protein folding/packaging chaperone
+      activity in the ER membrane rather than a generic binding term.
     proposed_replacement_terms:
     - id: GO:0044183
       label: protein folding chaperone
+    supported_by:
+    - reference_id: PMID:10564255
+      supporting_text: "Shr3p acts as a packaging chaperone"
 - term:
     id: GO:0051082
     label: unfolded protein binding
   evidence_type: IMP
   original_reference_id: PMID:15623581
   review:
-    summary: 'Manual review: unfolded protein binding is better represented by a more specific replacement term for SHR3.'
+    summary: >-
+      The evidence shows Shr3 prevents aggregation of polytopic permeases during
+      folding, which is better represented as protein folding chaperone activity.
     action: MODIFY
-    reason: Modified to align with current curation guidance and improve term specificity.
+    reason: >-
+      The more informative curation is GO:0044183 protein folding chaperone
+      coupled to ER membrane permease biogenesis.
     proposed_replacement_terms:
     - id: GO:0044183
       label: protein folding chaperone
+    supported_by:
+    - reference_id: PMID:15623581
+      supporting_text: "Specialized membrane-localized chaperones prevent aggregation of polytopic proteins in the ER."
+core_functions:
+- molecular_function:
+    id: GO:0044183
+    label: protein folding chaperone
+  directly_involved_in:
+  - id: GO:0006457
+    label: protein folding
+  - id: GO:0006888
+    label: endoplasmic reticulum to Golgi vesicle-mediated transport
+  - id: GO:0090114
+    label: COPII-coated vesicle budding
+  locations:
+  - id: GO:0005789
+    label: endoplasmic reticulum membrane
+  description: >-
+    Shr3 is a substrate-specific ER membrane chaperone for amino acid permeases.
+    It stabilizes polytopic permease clients, prevents aggregation and premature
+    ERAD, and promotes their packaging into COPII-coated ER-derived vesicles.
+  supported_by:
+  - reference_id: PMID:15623581
+    supporting_text: "prevent aggregation of polytopic proteins in the ER"
+  - reference_id: PMID:10564255
+    supporting_text: "Shr3p acts as a packaging chaperone"
+  - reference_id: file:yeast/SHR3/SHR3-deep-research-falcon.md
+    supporting_text: "ER membrane-localized, substrate-specific chaperone"
+proposed_new_terms: []
+suggested_questions:
+- question: >-
+    For Shr3 and related ER-resident packaging factors, should GO curation
+    distinguish folding chaperone activity from cargo-receptor or COPII-adaptor
+    activity with a more specific child term?
+suggested_experiments:
+- description: >-
+    Reconstitute Shr3 with defined amino acid permease transmembrane segments and
+    COPII components to separate its folding/stabilization activity from any
+    direct COPII recruitment activity.
+  experiment_type: biochemical reconstitution
+  hypothesis: >-
+    Shr3 first stabilizes early permease transmembrane segments and then promotes
+    COPII packaging indirectly by producing export-competent cargo.
 references:
 - id: GO_REF:0000033
   title: Annotation inferences using phylogenetic trees
@@ -229,4 +389,7 @@ references:
   findings: []
 - id: PMID:37968396
   title: The social and structural architecture of the yeast protein interactome.
+  findings: []
+- id: file:yeast/SHR3/SHR3-deep-research-falcon.md
+  title: Falcon deep research report for SHR3
   findings: []

--- a/genes/yeast/SHR3/SHR3-deep-research-falcon.md
+++ b/genes/yeast/SHR3/SHR3-deep-research-falcon.md
@@ -1,0 +1,321 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-04T10:06:11.959231'
+end_time: '2026-05-04T10:19:15.042362'
+duration_seconds: 783.08
+template_file: templates/gene_research_go_focused.md
+template_variables:
+  organism: yeast
+  gene_id: SHR3
+  gene_symbol: SHR3
+  uniprot_accession: Q02774
+  protein_description: 'RecName: Full=Secretory component protein SHR3;'
+  gene_info: Name=SHR3; OrderedLocusNames=YDL212W; ORFNames=D1022;
+  organism_full: Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+  protein_family: Not specified in UniProt
+  protein_domains: Psh3/Shr3. (IPR013248); SHR3_chaperone (PF08229)
+provider_config:
+  timeout: 600
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 16
+---
+
+## Question
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** Q02774
+- **Protein Description:** RecName: Full=Secretory component protein SHR3;
+- **Gene Information:** Name=SHR3; OrderedLocusNames=YDL212W; ORFNames=D1022;
+- **Organism (full):** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+- **Protein Family:** Not specified in UniProt
+- **Key Domains:** Psh3/Shr3. (IPR013248); SHR3_chaperone (PF08229)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "SHR3" matches the protein description above**
+2. **Verify the organism is correct:** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'SHR3' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **SHR3** (gene ID: SHR3, UniProt: Q02774) in yeast.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** Q02774
+- **Protein Description:** RecName: Full=Secretory component protein SHR3;
+- **Gene Information:** Name=SHR3; OrderedLocusNames=YDL212W; ORFNames=D1022;
+- **Organism (full):** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+- **Protein Family:** Not specified in UniProt
+- **Key Domains:** Psh3/Shr3. (IPR013248); SHR3_chaperone (PF08229)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "SHR3" matches the protein description above**
+2. **Verify the organism is correct:** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'SHR3' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **SHR3** (gene ID: SHR3, UniProt: Q02774) in yeast.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Comprehensive Functional Annotation Report: **SHR3** (UniProt: **Q02774**; ORF **YDL212W**) in *Saccharomyces cerevisiae* (S288c)
+
+### 0) Scope and gene/protein identity verification
+All retrieved yeast-focused sources consistently describe **Shr3 (Shr3p)** as an **endoplasmic reticulum (ER) membrane-localized, substrate-specific “packaging chaperone”** required for the biogenesis/ER export of **amino-acid permeases** (AAPs/YATs) and for preventing their **aggregation and premature ER-associated degradation (ERAD)** (ring2019ssy1functionsat pages 9-9, mochizuki2015retentionofchimeric pages 8-9, dancourt2010proteinsortingreceptors pages 16-17, bianchi2019regulationofamino pages 19-21). No conflicting usage of the symbol **SHR3** for a different gene/protein in another organism was encountered within the retrieved corpus (mochizuki2015retentionofchimeric pages 8-9, dancourt2010proteinsortingreceptors pages 16-17, ring2019ssy1functionsat pages 2-3).
+
+*Note on domain verification:* the retrieved articles did not explicitly name the UniProt/InterPro/Pfam domains (e.g., Psh3/Shr3 domain; PF08229) in the accessible text snippets; thus domain statements are not asserted here beyond the user-provided UniProt context.
+
+---
+
+### 1) Key concepts and definitions (current understanding)
+
+#### 1.1. “Packaging chaperone” / membrane-localized chaperone (MLC)
+In yeast membrane protein biogenesis, certain cargo classes require **substrate-specific ER membrane proteins** that act as **chaperones** and/or **packaging factors** to enable correct folding and efficient entry into **COPII vesicles** for ER export. Shr3 is a canonical example of this class, acting on amino-acid transporter clients (dancourt2010proteinsortingreceptors pages 16-17, bianchi2019regulationofamino pages 19-21).
+
+#### 1.2. Client class: yeast amino-acid transporters (YATs/AAPs)
+Shr3’s principal clients are **yeast amino acid transport (YAT) family** permeases. A quantitative framing in the reviewed primary literature is that yeast amino-acid permeases comprise a **family of 24 homologous APC transporters**, and individual permeases are predicted to have **12 transmembrane domains (TMDs)** (mochizuki2015retentionofchimeric pages 1-2). In an authoritative review, Shr3-dependent clients explicitly include **Gap1** and other YATs such as **Agp1** and **Gnp1** (bianchi2019regulationofamino pages 19-21).
+
+#### 1.3. ER quality control and ERAD (ER-associated degradation)
+When polytopic membrane proteins fail to fold properly in the ER, they can be removed by **ERAD**, which includes ubiquitination, extraction from the ER membrane, and proteasomal degradation. In the case of Shr3-dependent permeases, Shr3 is positioned upstream of ERAD by preventing misfolding/aggregation that would otherwise trigger ERAD (mochizuki2015retentionofchimeric pages 1-2, bianchi2019regulationofamino pages 19-21).
+
+---
+
+### 2) Molecular function: what SHR3 does (and does not do)
+
+#### 2.1. Primary molecular function (supported)
+**Shr3 is not a transporter and does not catalyze a chemical reaction.** Instead, Shr3 functions as an **ER membrane-localized, substrate-specific chaperone/packaging factor** required for the **functional expression** and **secretory-pathway export** of amino acid permeases (ring2019ssy1functionsat pages 9-9, mochizuki2015retentionofchimeric pages 8-9, bianchi2019regulationofamino pages 19-21).
+
+#### 2.2. Mechanistic model (folding assistance)
+A central mechanistic concept supported by both review synthesis and primary data is that Shr3 **stabilizes early transmembrane segments** of permease clients to prevent nonproductive interactions and aggregation during folding.
+
+* Quantitative mechanistic detail: Shr3 is described as an **ER-resident integral membrane protein with 4 transmembrane segments** that **“holds the first 5 TMDs”** of YAT clients in a stable conformation, allowing the remaining TMDs to fold properly (bianchi2019regulationofamino pages 19-21).
+* Primary mechanistic statement consistent with this model: Shr3 interacts with early TMDs of **Gap1** to promote native folding and prevent aggregation (mochizuki2015retentionofchimeric pages 8-9).
+
+#### 2.3. Mechanistic model (ER export/COPII packaging)
+Shr3 is also implicated in **promoting COPII-dependent packaging** of amino acid permeases into ER-derived transport vesicles.
+
+* A key literature synthesis referenced in primary work: Shr3p mediates **specific COPII coatomer–cargo interactions** needed for packaging amino acid permeases into ER-derived transport vesicles (mochizuki2015retentionofchimeric pages 9-10).
+* Review-level integration: Shr3 is positioned as a chaperone that stabilizes YATs in the ER and sorts them into vesicles for export (bianchi2019regulationofamino media 260fd4cf, bianchi2019regulationofamino pages 19-21).
+
+---
+
+### 3) Subcellular localization: where Shr3 acts
+Shr3 localizes to the **endoplasmic reticulum membrane**, consistent with its role in co-/peri-translational folding and ER export of polytopic permeases (ring2019ssy1functionsat pages 2-3, ring2019ssy1functionsat pages 3-4, bianchi2019regulationofamino pages 19-21).
+
+In cell biology practice, Shr3 has been used as an ER marker: **Shr3-GFP** highlights ER morphology (perinuclear rim and peripheral ER), supporting ER residency in vivo (ring2019ssy1functionsat pages 3-4).
+
+---
+
+### 4) Client proteins and substrate specificity
+
+#### 4.1. Best-supported clients
+The most directly supported client is **Gap1**, the general amino-acid permease, which becomes **aggregated/ER-retained** in shr3 mutants (mochizuki2015retentionofchimeric pages 1-2, dancourt2010proteinsortingreceptors pages 16-17).
+
+The authoritative review explicitly provides additional YAT examples: **Agp1** and **Gnp1** (bianchi2019regulationofamino pages 19-21).
+
+#### 4.2. Limits of Shr3’s “rescue” capacity (specificity and folding quality)
+Primary evidence indicates that Shr3 is not a universal remedy for all permease folding defects. For example, in an experimental survey of **64 Gap1 mutants**, **17** mutants were retained in the ER and **SHR3 overexpression did not suppress** growth defects associated with these mutants, indicating client mutations can exceed Shr3’s chaperoning capacity and/or reflect distinct folding lesions (mochizuki2015retentionofchimeric pages 8-9).
+
+---
+
+### 5) Pathways and biological processes
+
+#### 5.1. Early secretory pathway integration
+Shr3 operates at the interface of **ER folding quality control** and **ER export** of membrane cargo. It is conceptually distinguished from canonical cycling cargo receptors; rather, Shr3 behaves as a dedicated folding/packaging factor for a client class (dancourt2010proteinsortingreceptors pages 16-17).
+
+#### 5.2. Interaction with ERAD machinery and proteostasis
+When Shr3 is absent, YATs such as Gap1 (and other YAT examples) can form **high-molecular-weight aggregates** that are removed by ERAD (bianchi2019regulationofamino pages 19-21).
+
+A key mechanistic-statistical summary from an authoritative review lists the ERAD machinery implicated in clearing Shr3-client aggregates: E3 ubiquitin ligases **Doa10** and **Hrd1**, extraction by the **Cdc48 ATPase complex**, and degradation by the cytoplasmic **proteasome** (bianchi2019regulationofamino pages 19-21).
+
+#### 5.3. Cellular stress responses linked to misfolded permeases
+Retention/aggregation of permease constructs in the ER can induce ER stress responses such as the **unfolded protein response (UPR)**; Shr3’s role in preventing aggregation provides a mechanistic link to avoiding this stress trigger (mochizuki2015retentionofchimeric pages 1-2).
+
+---
+
+### 6) Recent developments and latest research (2023–2024 prioritized)
+
+#### 6.1. Availability constraint in this tool run
+A **2023 Journal of Cell Biology** article directly focused on Shr3 (ER-localized Shr3 as a selective co-translational folding chaperone necessary for amino-acid permease biogenesis; DOI shown in search output) was flagged as **unobtainable** in this environment and could not be read for direct evidence extraction. Consequently, the most detailed Shr3-specific mechanistic evidence in this report is drawn from accessible primary work (2015) and authoritative reviews (2010–2019) (mochizuki2015retentionofchimeric pages 8-9, dancourt2010proteinsortingreceptors pages 16-17, bianchi2019regulationofamino pages 19-21).
+
+#### 6.2. 2023–2024 contextual advances relevant to Shr3-like systems
+While not Shr3 itself, recent work continues to develop the broader concept of substrate-specific ER accessory/chaperone proteins controlling multipass membrane cargo biogenesis:
+
+* **2023 (MBoC)**: A detailed analysis of quality control mechanisms for yeast chitin synthase **Chs3**, emphasizing how interaction with its Shr3-like chaperone **Chs7** can mask degrons and tune ERAD engagement, reinforcing the conceptual framework of substrate-specific ER chaperones in proteostasis (paper retrieved but not fully evidence-mined for Shr3; included here as contextual) (dimou2020lifeanddeath pages 1-3).
+* **2024 (Plant Physiology)**: A mechanistic study of plant **AXR4** supports a model where an ER accessory protein physically interacts with a multipass transporter (AUX1/LAX2), reduces aggregation, and supports correct trafficking—an analog of Shr3-like logic across eukaryotes (retrieved but not yeast-specific) (dimou2020lifeanddeath pages 1-3).
+
+---
+
+### 7) Current applications and real-world implementations
+
+1. **Membrane protein biogenesis paradigm:** Shr3 is widely used as a model for how eukaryotic cells ensure successful folding/export of polytopic transporters and how failure routes into ERAD; this informs experimental design in transporter biology and secretory pathway studies (dancourt2010proteinsortingreceptors pages 16-17, bianchi2019regulationofamino pages 19-21).
+2. **Cell biology tool/marker:** Shr3-GFP is used experimentally as an ER membrane marker to visualize ER morphology in yeast, consistent with ER localization and stable residency (ring2019ssy1functionsat pages 3-4).
+3. **Transporter engineering and trafficking studies (inference from authoritative review):** Because YAT function depends on correct ER folding/export, Shr3 is a practical consideration when engineering yeast strains for altered nutrient uptake, or when interpreting transporter localization phenotypes in genetics screens (bianchi2019regulationofamino pages 19-21, mochizuki2015retentionofchimeric pages 1-2).
+
+---
+
+### 8) Expert opinions and authoritative synthesis
+
+*Annu. Rev. Biochem. (2010)* frames Shr3 as an ER chaperone assisting folding of specific membrane cargo (e.g., Gap1), and contrasts Shr3-like factors from cycling sorting receptors, emphasizing the quality-control consequence of Shr3 loss (client aggregation and potential ERAD engagement) (dancourt2010proteinsortingreceptors pages 16-17).
+
+*Microbiology and Molecular Biology Reviews (2019)* provides a high-level and widely cited synthesis: Shr3 is an ER-resident packaging chaperone, stabilizes early TMDs (first five) of YAT clients, and without Shr3, YATs aggregate and are cleared by ERAD involving Doa10/Hrd1, Cdc48, and the proteasome (bianchi2019regulationofamino pages 19-21).
+
+---
+
+### 9) Key statistics and data points (from recent/authoritative sources)
+
+* Shr3 topology: **4 transmembrane segments** (bianchi2019regulationofamino pages 19-21).
+* Client topology: YATs are **12-TMD** transporters (bianchi2019regulationofamino pages 19-21, mochizuki2015retentionofchimeric pages 1-2).
+* Folding mechanism: Shr3 stabilizes/holds the **first 5 TMDs** of YAT clients (bianchi2019regulationofamino pages 19-21, mochizuki2015retentionofchimeric pages 8-9).
+* Client family size (yeast amino-acid permeases): **24 homologous APC transporters** (mochizuki2015retentionofchimeric pages 1-2).
+* Mutational dataset (Gap1): **64 mutants tested; 17 ER-retained; SHR3 overexpression did not rescue these** (mochizuki2015retentionofchimeric pages 8-9).
+
+---
+
+### 10) Evidence-backed schematic support (visual)
+The following review figure provides a systems-level depiction of Shr3’s position in YAT biogenesis, ER quality control, ERAD, and onward trafficking.
+
+| Functional aspect | Key finding | Evidence type | Source with year and DOI/URL |
+|---|---|---|---|
+| Molecular function | SHR3 encodes an ER-resident integral membrane chaperone/packaging factor required for functional expression of yeast amino acid permeases rather than an enzyme or transporter itself. (ring2019ssy1functionsat pages 9-9, mochizuki2015retentionofchimeric pages 8-9, bianchi2019regulationofamino pages 19-21) | Review + primary; genetic, biochemical, cell biology | Bianchi et al., 2019, *Microbiol Mol Biol Rev*; https://doi.org/10.1128/MMBR.00024-19 ; Ring et al., 2019, *Traffic*; https://doi.org/10.1111/tra.12681 ; Mochizuki et al., 2015, *FEMS Yeast Res*; https://doi.org/10.1093/femsyr/fov044 |
+| Localization | Shr3/Shr3p localizes to the endoplasmic reticulum membrane and has been used experimentally as an ER marker showing perinuclear and cortical ER patterns. (ring2019ssy1functionsat pages 2-3, ring2019ssy1functionsat pages 3-4) | Primary; cell biology/imaging | Ring et al., 2019, *Traffic*; https://doi.org/10.1111/tra.12681 |
+| Client proteins | The best-supported clients are yeast amino acid transporters/permeases, including Gap1 and other YAT/AAP family members such as Agp1 and Gnp1. (mochizuki2015retentionofchimeric pages 8-9, mochizuki2015retentionofchimeric pages 1-2, bianchi2019regulationofamino pages 19-21) | Review + primary; genetic, biochemical | Mochizuki et al., 2015, *FEMS Yeast Res*; https://doi.org/10.1093/femsyr/fov044 ; Bianchi et al., 2019, *Microbiol Mol Biol Rev*; https://doi.org/10.1128/MMBR.00024-19 |
+| Mechanism | Shr3 stabilizes early transmembrane segments of permeases—reviewed as holding the first 5 TMDs in a folding-competent state—thereby preventing nonproductive TMD interactions, aggregation, and premature ERAD. (mochizuki2015retentionofchimeric pages 8-9, mochizuki2015retentionofchimeric pages 1-2, bianchi2019regulationofamino pages 19-21) | Review + primary; biochemical, genetic | Bianchi et al., 2019, *Microbiol Mol Biol Rev*; https://doi.org/10.1128/MMBR.00024-19 ; Mochizuki et al., 2015, *FEMS Yeast Res*; https://doi.org/10.1093/femsyr/fov044 |
+| ER export/COPII packaging | Shr3 is required for specific COPII coatomer-cargo interactions that package amino acid permeases into ER-derived transport vesicles for forward trafficking. (ring2019ssy1functionsat pages 9-9, mochizuki2015retentionofchimeric pages 9-10) | Review + primary; biochemical trafficking assays | Ring et al., 2019, *Traffic*; https://doi.org/10.1111/tra.12681 ; Mochizuki et al., 2015, *FEMS Yeast Res*; https://doi.org/10.1093/femsyr/fov044 |
+| Pathway / biological process | SHR3 functions in transporter biogenesis within the early secretory pathway, linking ER folding quality control to ER exit and subsequent Golgi/plasma-membrane delivery of amino acid transporters. (dancourt2010proteinsortingreceptors pages 16-17, bianchi2019regulationofamino media 260fd4cf, bianchi2019regulationofamino pages 19-21) | Review; secretory pathway synthesis | Dancourt & Barlowe, 2010, *Annu Rev Biochem*; https://doi.org/10.1146/annurev-biochem-061608-091319 ; Bianchi et al., 2019, *Microbiol Mol Biol Rev*; https://doi.org/10.1128/MMBR.00024-19 |
+| Quality control | In shr3-deficient cells, Gap1 and related permeases accumulate as high-molecular-weight ER aggregates and are cleared by ER-associated degradation involving Doa10/Hrd1, Cdc48, and the proteasome. (mochizuki2015retentionofchimeric pages 1-2, bianchi2019regulationofamino pages 19-21) | Review + primary; genetic, proteostasis | Mochizuki et al., 2015, *FEMS Yeast Res*; https://doi.org/10.1093/femsyr/fov044 ; Bianchi et al., 2019, *Microbiol Mol Biol Rev*; https://doi.org/10.1128/MMBR.00024-19 |
+| Phenotypes / assays | Loss of SHR3 causes defective cell-surface localization and function of amino acid permeases, while ER-retained misfolded permease constructs can trigger UPR-related stress phenotypes. (ring2019ssy1functionsat pages 9-9, mochizuki2015retentionofchimeric pages 1-2, mochizuki2015retentionofchimeric pages 8-9) | Primary + review; mutant phenotype, localization, stress-response assays | Ring et al., 2019, *Traffic*; https://doi.org/10.1111/tra.12681 ; Mochizuki et al., 2015, *FEMS Yeast Res*; https://doi.org/10.1093/femsyr/fov044 |
+| Comparative family context | Shr3 is part of a broader class of substrate-specific ER-resident packaging chaperones in yeast, analogous in function to Gsf2, Pho86, and Chs7 for other membrane cargos. (bianchi2019regulationofamino media 260fd4cf, bianchi2019regulationofamino pages 19-21) | Review; comparative cell biology | Bianchi et al., 2019, *Microbiol Mol Biol Rev*; https://doi.org/10.1128/MMBR.00024-19 |
+| Visual summary evidence | A recent authoritative review figure summarizes Shr3 in the ER as stabilizing YATs and sorting them into export vesicles while limiting ERAD, providing a concise systems-level annotation. (bianchi2019regulationofamino media 260fd4cf) | Review figure/diagram | Bianchi et al., 2019, *Microbiol Mol Biol Rev*; https://doi.org/10.1128/MMBR.00024-19 |
+
+
+*Table: This table summarizes the main experimentally supported annotations for yeast SHR3/Q02774, including its ER localization, chaperone role, permease clients, and link to COPII export and ER quality control. It is useful as a concise evidence map anchored to review and primary literature.*
+
+(Visual evidence: Figure 7 from Bianchi et al. 2019 explicitly places Shr3 in the ER as stabilizing and sorting YATs while limiting ERAD.) (bianchi2019regulationofamino media 260fd4cf)
+
+---
+
+## References (retrieved in this run; with dates and URLs)
+
+1. **Bianchi F, van’t Klooster JS, Ruiz SJ, Poolman B.** *Regulation of Amino Acid Transport in Saccharomyces cerevisiae.* **Microbiology and Molecular Biology Reviews**. **2019-11**. https://doi.org/10.1128/mmbr.00024-19 (bianchi2019regulationofamino pages 19-21, bianchi2019regulationofamino media 260fd4cf)
+2. **Mochizuki T, Kimata Y, Uemura S, Abe F.** *Retention of chimeric Tat2-Gap1 permease in the endoplasmic reticulum induces unfolded protein response in Saccharomyces cerevisiae.* **FEMS Yeast Research**. **2015-08**. https://doi.org/10.1093/femsyr/fov044 (mochizuki2015retentionofchimeric pages 1-2, mochizuki2015retentionofchimeric pages 8-9)
+3. **Dancourt J, Barlowe C.** *Protein sorting receptors in the early secretory pathway.* **Annual Review of Biochemistry**. **2010-06**. https://doi.org/10.1146/annurev-biochem-061608-091319 (dancourt2010proteinsortingreceptors pages 16-17)
+4. **Ring A, Martins A, Ljungdahl PO.** *Ssy1 functions at the plasma membrane as a receptor of extracellular amino acids independent of plasma membrane–endoplasmic reticulum junctions.* **Traffic**. **2019-08**. https://doi.org/10.1111/tra.12681 (ring2019ssy1functionsat pages 2-3, ring2019ssy1functionsat pages 3-4)
+
+
+
+References
+
+1. (ring2019ssy1functionsat pages 9-9): Andreas Ring, António Martins, and Per O. Ljungdahl. Ssy1 functions at the plasma membrane as a receptor of extracellular amino acids independent of plasma membrane‐endoplasmic reticulum junctions. Traffic, 20:775-784, Aug 2019. URL: https://doi.org/10.1111/tra.12681, doi:10.1111/tra.12681. This article has 5 citations and is from a peer-reviewed journal.
+
+2. (mochizuki2015retentionofchimeric pages 8-9): Takahiro Mochizuki, Yukio Kimata, Satoshi Uemura, and Fumiyoshi Abe. Retention of chimeric tat2-gap1 permease in the endoplasmic reticulum induces unfolded protein response in saccharomyces cerevisiae. FEMS yeast research, 15 5:fov044, Aug 2015. URL: https://doi.org/10.1093/femsyr/fov044, doi:10.1093/femsyr/fov044. This article has 1 citations and is from a peer-reviewed journal.
+
+3. (dancourt2010proteinsortingreceptors pages 16-17): Julia Dancourt and Charles Barlowe. Protein sorting receptors in the early secretory pathway. Annual review of biochemistry, 79:777-802, Jun 2010. URL: https://doi.org/10.1146/annurev-biochem-061608-091319, doi:10.1146/annurev-biochem-061608-091319. This article has 378 citations and is from a domain leading peer-reviewed journal.
+
+4. (bianchi2019regulationofamino pages 19-21): Frans Bianchi, Joury S. van’t Klooster, Stephanie J. Ruiz, and Bert Poolman. Regulation of amino acid transport in saccharomyces cerevisiae. Microbiology and Molecular Biology Reviews, Nov 2019. URL: https://doi.org/10.1128/mmbr.00024-19, doi:10.1128/mmbr.00024-19. This article has 166 citations and is from a domain leading peer-reviewed journal.
+
+5. (ring2019ssy1functionsat pages 2-3): Andreas Ring, António Martins, and Per O. Ljungdahl. Ssy1 functions at the plasma membrane as a receptor of extracellular amino acids independent of plasma membrane‐endoplasmic reticulum junctions. Traffic, 20:775-784, Aug 2019. URL: https://doi.org/10.1111/tra.12681, doi:10.1111/tra.12681. This article has 5 citations and is from a peer-reviewed journal.
+
+6. (mochizuki2015retentionofchimeric pages 1-2): Takahiro Mochizuki, Yukio Kimata, Satoshi Uemura, and Fumiyoshi Abe. Retention of chimeric tat2-gap1 permease in the endoplasmic reticulum induces unfolded protein response in saccharomyces cerevisiae. FEMS yeast research, 15 5:fov044, Aug 2015. URL: https://doi.org/10.1093/femsyr/fov044, doi:10.1093/femsyr/fov044. This article has 1 citations and is from a peer-reviewed journal.
+
+7. (mochizuki2015retentionofchimeric pages 9-10): Takahiro Mochizuki, Yukio Kimata, Satoshi Uemura, and Fumiyoshi Abe. Retention of chimeric tat2-gap1 permease in the endoplasmic reticulum induces unfolded protein response in saccharomyces cerevisiae. FEMS yeast research, 15 5:fov044, Aug 2015. URL: https://doi.org/10.1093/femsyr/fov044, doi:10.1093/femsyr/fov044. This article has 1 citations and is from a peer-reviewed journal.
+
+8. (bianchi2019regulationofamino media 260fd4cf): Frans Bianchi, Joury S. van’t Klooster, Stephanie J. Ruiz, and Bert Poolman. Regulation of amino acid transport in saccharomyces cerevisiae. Microbiology and Molecular Biology Reviews, Nov 2019. URL: https://doi.org/10.1128/mmbr.00024-19, doi:10.1128/mmbr.00024-19. This article has 166 citations and is from a domain leading peer-reviewed journal.
+
+9. (ring2019ssy1functionsat pages 3-4): Andreas Ring, António Martins, and Per O. Ljungdahl. Ssy1 functions at the plasma membrane as a receptor of extracellular amino acids independent of plasma membrane‐endoplasmic reticulum junctions. Traffic, 20:775-784, Aug 2019. URL: https://doi.org/10.1111/tra.12681, doi:10.1111/tra.12681. This article has 5 citations and is from a peer-reviewed journal.
+
+10. (dimou2020lifeanddeath pages 1-3): Sofia Dimou and George Diallinas. Life and death of fungal transporters under the challenge of polarity. International Journal of Molecular Sciences, 21:5376, Jul 2020. URL: https://doi.org/10.3390/ijms21155376, doi:10.3390/ijms21155376. This article has 21 citations.
+
+## Citations
+
+1. mochizuki2015retentionofchimeric pages 1-2
+2. bianchi2019regulationofamino pages 19-21
+3. mochizuki2015retentionofchimeric pages 8-9
+4. mochizuki2015retentionofchimeric pages 9-10
+5. dancourt2010proteinsortingreceptors pages 16-17
+6. dimou2020lifeanddeath pages 1-3
+7. https://doi.org/10.1128/MMBR.00024-19
+8. https://doi.org/10.1111/tra.12681
+9. https://doi.org/10.1093/femsyr/fov044
+10. https://doi.org/10.1146/annurev-biochem-061608-091319
+11. https://doi.org/10.1128/mmbr.00024-19
+12. https://doi.org/10.1111/tra.12681,
+13. https://doi.org/10.1093/femsyr/fov044,
+14. https://doi.org/10.1146/annurev-biochem-061608-091319,
+15. https://doi.org/10.1128/mmbr.00024-19,
+16. https://doi.org/10.3390/ijms21155376,

--- a/genes/yeast/ZNG1/ZNG1-ai-review.html
+++ b/genes/yeast/ZNG1/ZNG1-ai-review.html
@@ -671,33 +671,33 @@
     <div class="header">
         <h1>ZNG1</h1>
         <div class="gene-info">
-            
+
             <div class="info-item">
-                
+
                 <span class="info-label">UniProt ID:</span>
                 <span>
                     <a href="https://www.uniprot.org/uniprotkb/P53729" target="_blank" class="term-link">
                         P53729
                     </a>
                 </span>
-                
+
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Organism:</span>
-                <span>Saccharomyces cerevisiae S288C</span>
+                <span>Saccharomyces cerevisiae</span>
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
-                <span class="status-badge status-draft">
-                    DRAFT
+                <span class="status-badge status-complete">
+                    COMPLETE
                 </span>
             </div>
-            
-            
+
+
         </div>
         <div style="margin-top: 1rem; text-align: center;">
             <a id="feedback-form-link"
@@ -728,77 +728,24 @@
         </div>
     </div>
 
-    
+
     <div class="description-card">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <h2>Gene Description</h2>
-            <span class="vote-buttons" data-g="P53729" data-a="DESCRIPTION: ZNG1 encodes a zinc-regulated GTPase that function..." data-r="" data-act="DESCRIPTION">
+            <span class="vote-buttons" data-g="P53729" data-a="DESCRIPTION: ZNG1 encodes a COG0523/SIMIBI G3E P-loop GTPase me..." data-r="" data-act="DESCRIPTION">
                 <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
                 <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
             </span>
         </div>
-        <p>ZNG1 encodes a zinc-regulated GTPase that functions as a zinc chaperone, directly transferring zinc cofactor to target metalloproteins. Its primary substrate is methionine aminopeptidase MAP1, which removes initiator methionine from nascent polypeptides. ZNG1 binds MAP1 through an N-terminal psi-PxLVp motif, transfers zinc from its CXCC motif to MAP1 in a GTP hydrolysis-dependent manner, and releases active MAP1 after GTP/GDP exchange. This protein exemplifies the COG0523 family of G3E P-loop GTPases that couple nucleotide hydrolysis to metal ion transfer, representing a universally conserved mechanism for metalloprotein activation that is often misannotated across species.</p>
+        <p>ZNG1 encodes a COG0523/SIMIBI G3E P-loop GTPase metallochaperone that activates the zinc-dependent methionine aminopeptidase Map1 by GTP-dependent zinc transfer. Zng1 binds zinc through conserved cysteine-rich motifs, uses GTP hydrolysis to drive cofactor delivery, and supports Map1-dependent N-terminal methionine excision and protein maturation, especially under zinc limitation. Its core function is zinc chaperone/metalloprotein activator activity, not generic protein binding or bulk zinc transport.</p>
     </div>
-    
 
-    
 
-    
-    <div class="section">
-        <h2 class="section-title">Proposed New Ontology Terms</h2>
-        
-        <div class="proposed-term">
-            <div style="display: flex; justify-content: space-between; align-items: center;">
-                <h3>metallochaperone GTPase activity</h3>
-                <span class="vote-buttons" data-g="P53729" data-a="metallochaperone GTPase activity" data-r="" data-act="NEW">
-                    <button class="vote-btn" data-v="up" title="Agree this term should be created">👍</button>
-                    <button class="vote-btn" data-v="down" title="Disagree with creating this term">👎</button>
-                </span>
-            </div>
 
-            
-            <p><strong>Definition:</strong> Catalysis of GTP hydrolysis coupled to the transfer of metal ions to target metalloproteins</p>
-            
 
-            
-            <p><strong>Justification:</strong> ZNG1 and the COG0523 family represent a distinct class of GTPases that couple nucleotide hydrolysis to metal ion transfer. This term would capture the unique mechanism that distinguishes them from other chaperones and GTPases.</p>
-            
 
-            
 
-            
 
-            
-        </div>
-        
-        <div class="proposed-term">
-            <div style="display: flex; justify-content: space-between; align-items: center;">
-                <h3>zinc transferase activity</h3>
-                <span class="vote-buttons" data-g="P53729" data-a="zinc transferase activity" data-r="" data-act="NEW">
-                    <button class="vote-btn" data-v="up" title="Agree this term should be created">👍</button>
-                    <button class="vote-btn" data-v="down" title="Disagree with creating this term">👎</button>
-                </span>
-            </div>
-
-            
-            <p><strong>Definition:</strong> Catalysis of the transfer of zinc ions from a donor molecule to an acceptor metalloprotein</p>
-            
-
-            
-            <p><strong>Justification:</strong> More specific than zinc chaperone activity, emphasizing the direct transfer mechanism demonstrated for ZNG1 to MAP1.</p>
-            
-
-            
-
-            
-
-            
-        </div>
-        
-    </div>
-    
-
-    
     <div class="section">
         <h2 class="section-title">Existing Annotations Review</h2>
         <table class="annotations-table">
@@ -811,32 +758,32 @@
                 </tr>
             </thead>
             <tbody>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -848,58 +795,62 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Cytoplasmic localization for zinc delivery to MAP1
+                            <strong>Summary:</strong> PANTHER IBA to cytoplasm is consistent with Zng1&#39;s client Map1/MetAP1 acting during cytosolic nascent-polypeptide maturation.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Zng1&#39;s conserved Map1 activation role is expected in the cytosol, and the same compartment is supported by high-throughput yeast localization.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    file:yeast/ZNG1/ZNG1-falcon-research.md
-                                    
+
+                                    file:yeast/ZNG1/ZNG1-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">See deep research file for comprehensive analysis</div>
-                                
+
+                                <div class="support-text">the most defensible annotation for yeast Zng1p localization from this evidence is cytosolic</div>
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008270" target="_blank" class="term-link">
                                     GO:0008270
                                 </a>
                             </span>
                             <span class="term-label">zinc ion binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -911,60 +862,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Binds zinc via CXCC motif for transfer to target proteins
+                            <strong>Summary:</strong> Family-transfer zinc binding is appropriate for Zng1, which uses conserved cysteine-rich motifs to bind and transfer zinc to Map1.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Zinc binding is integral to Zng1&#39;s zinc chaperone activity.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/35584675" target="_blank" class="term-link">
                                         PMID:35584675
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">conserved family of putative metal transferases in human and fungi</div>
-                                
+
+                                <div class="support-text">transfer Zn2+ or Co2+ to apo-Map1p</div>
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051604" target="_blank" class="term-link">
                                     GO:0051604
                                 </a>
                             </span>
                             <span class="term-label">protein maturation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -976,60 +931,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Activates MAP1 for methionine excision, enabling protein maturation
+                            <strong>Summary:</strong> Zng1 supports Map1 metallation, enabling methionine aminopeptidase activity for initiator methionine removal from nascent proteins.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Protein maturation is a core downstream process of Zng1 zinc chaperone activity.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/35584675" target="_blank" class="term-link">
                                         PMID:35584675
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">interact with Zn-dependent methionine aminopeptidase type I</div>
-                                
+
+                                <div class="support-text">needed for activation of methionine aminopeptidase</div>
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140827" target="_blank" class="term-link">
                                     GO:0140827
                                 </a>
                             </span>
                             <span class="term-label">zinc chaperone activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1041,107 +1000,115 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Primary molecular function - transfers zinc to MAP1
+                            <strong>Summary:</strong> PANTHER IBA to zinc chaperone activity matches the experimentally supported function of yeast Zng1.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Zng1 directly transfers zinc to Map1 in a GTP-dependent process, making this the most specific and informative molecular function term.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/35584675" target="_blank" class="term-link">
                                         PMID:35584675
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">conserved family of putative metal transferases in human and fungi</div>
-                                
+
+                                <div class="support-text">Zng1 is a GTP-dependent zinc transferase</div>
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000166" target="_blank" class="term-link">
                                     GO:0000166
                                 </a>
                             </span>
                             <span class="term-label">nucleotide binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-remove">
-                            REMOVE
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="P53729" data-a="GO:0000166" data-r="GO_REF:0000043" data-act="REMOVE">
+                        <span class="vote-buttons" data-g="P53729" data-a="GO:0000166" data-r="GO_REF:0000043" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Too general - more specific as GTP binding
+                            <strong>Summary:</strong> Nucleotide binding is true for a P-loop GTPase but too generic for Zng1 because GTP binding and GTPase activity are annotated separately.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> The broad nucleotide-binding term should not be treated as a core annotation when the specific nucleotide and catalytic activity are known.
+                        </div>
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005525" target="_blank" class="term-link">
                                     GO:0005525
                                 </a>
                             </span>
                             <span class="term-label">GTP binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1153,299 +1120,321 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Binds GTP as part of G3E P-loop GTPase family
+                            <strong>Summary:</strong> GTP binding is supported by Zng1&#39;s P-loop GTPase domain and mechanistic requirement for GTP hydrolysis.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> GTP binding is a necessary part of the zinc-transfer cycle.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/ZNG1/ZNG1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">GTP hydrolysis by ZNG1 drives</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016787" target="_blank" class="term-link">
                                     GO:0016787
                                 </a>
                             </span>
                             <span class="term-label">hydrolase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-remove">
-                            REMOVE
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="P53729" data-a="GO:0016787" data-r="GO_REF:0000043" data-act="REMOVE">
+                        <span class="vote-buttons" data-g="P53729" data-a="GO:0016787" data-r="GO_REF:0000043" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Too general - more specific as GTPase activity
+                            <strong>Summary:</strong> Hydrolase activity is a broad parent term for Zng1&#39;s specific GTPase activity.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> GO:0003924 GTPase activity is the more precise activity supported by the literature and direct assay annotation.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003924" target="_blank" class="term-link">
+                                    GTPase activity
+                                </a>
+                            </span>
+
+                        </div>
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046872" target="_blank" class="term-link">
                                     GO:0046872
                                 </a>
                             </span>
                             <span class="term-label">metal ion binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-remove">
-                            REMOVE
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="P53729" data-a="GO:0046872" data-r="GO_REF:0000043" data-act="REMOVE">
+                        <span class="vote-buttons" data-g="P53729" data-a="GO:0046872" data-r="GO_REF:0000043" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Redundant with more specific zinc ion binding
+                            <strong>Summary:</strong> Metal ion binding is accurate but too generic for Zng1&#39;s specific zinc chaperone mechanism.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> GO:0008270 zinc ion binding is the appropriate specific binding term for the known cofactor-transfer mechanism.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008270" target="_blank" class="term-link">
+                                    zinc ion binding
+                                </a>
+                            </span>
+
+                        </div>
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16429126" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16429126
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Proteome survey reveals modularity of the yeast cell machine...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-remove">
-                            REMOVE
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="P53729" data-a="GO:0005515" data-r="PMID:16429126" data-act="REMOVE">
+                        <span class="vote-buttons" data-g="P53729" data-a="GO:0005515" data-r="PMID:16429126" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Non-specific - should specify MAP1 binding
+                            <strong>Summary:</strong> High-throughput interactome evidence reports protein associations, but the generic protein binding term is not informative for Zng1 function.
                         </div>
-                        
-                        
-                        
-                        
-                        <div class="supported-by">
-                            <div class="supported-by-title">Supporting Evidence:</div>
-                            
-                            <div class="support-item">
-                                <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16429126" target="_blank" class="term-link">
-                                        PMID:16429126
-                                    </a>
-                                    
-                                </span>
-                                
-                                <div class="support-text">Proteome survey reveals modularity of the yeast cell machinery.</div>
-                                
-                            </div>
-                            
+
+
+                        <div>
+                            <strong>Reason:</strong> Zng1&#39;s relevant interaction is the specific Map1/MetAP1 zinc-transfer client relationship, which is better captured by zinc chaperone and enzyme activator annotations.
                         </div>
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19536198" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19536198
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     An atlas of chaperone-protein interactions in Saccharomyces ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-remove">
-                            REMOVE
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="P53729" data-a="GO:0005515" data-r="PMID:19536198" data-act="REMOVE">
+                        <span class="vote-buttons" data-g="P53729" data-a="GO:0005515" data-r="PMID:19536198" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Non-specific protein binding
+                            <strong>Summary:</strong> Chaperone-interaction atlas evidence does not define a specific Zng1 molecular activity and should not be retained as a core function.
                         </div>
-                        
-                        
-                        
-                        
-                        <div class="supported-by">
-                            <div class="supported-by-title">Supporting Evidence:</div>
-                            
-                            <div class="support-item">
-                                <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19536198" target="_blank" class="term-link">
-                                        PMID:19536198
-                                    </a>
-                                    
-                                </span>
-                                
-                                <div class="support-text">An atlas of chaperone-protein interactions in Saccharomyces cerevisiae: implications to protein folding pathways in the cell.</div>
-                                
-                            </div>
-                            
+
+
+                        <div>
+                            <strong>Reason:</strong> The term protein binding is too vague; Zng1 should be curated to its specific GTP-dependent zinc chaperone activity.
                         </div>
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003924" target="_blank" class="term-link">
                                     GO:0003924
                                 </a>
                             </span>
                             <span class="term-label">GTPase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/35584675" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:35584675
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Zng1 is a GTP-dependent zinc transferase needed for activati...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1457,71 +1446,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> GTP hydrolysis drives zinc transfer to MAP1
+                            <strong>Summary:</strong> Direct assay evidence supports Zng1 GTPase activity coupled to metal transfer.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> GTP hydrolysis is mechanistically required for zinc transfer to Map1 and is part of Zng1&#39;s core molecular function.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/35584675" target="_blank" class="term-link">
                                         PMID:35584675
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">transfer is dependent on GTP hydrolysis</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140827" target="_blank" class="term-link">
                                     GO:0140827
                                 </a>
                             </span>
                             <span class="term-label">zinc chaperone activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/35584675" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:35584675
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Zng1 is a GTP-dependent zinc transferase needed for activati...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1533,71 +1526,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Direct experimental evidence for zinc chaperone function
+                            <strong>Summary:</strong> Direct experimental evidence demonstrates Zng1 zinc transfer to apo-Map1p.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> This is the central molecular function for ZNG1 and should be retained as core.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/35584675" target="_blank" class="term-link">
                                         PMID:35584675
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Zng1p can transfer Zn2+ or Co2+ to apo-Map1p</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008047" target="_blank" class="term-link">
                                     GO:0008047
                                 </a>
                             </span>
                             <span class="term-label">enzyme activator activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/35584675" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:35584675
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Zng1 is a GTP-dependent zinc transferase needed for activati...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1609,235 +1606,235 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Activates MAP1 methionine aminopeptidase by zinc transfer
+                            <strong>Summary:</strong> Zng1 activates Map1 methionine aminopeptidase by delivering the metal cofactor needed for activity.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> ZNG1 specifically activates MAP1 enzyme by delivering zinc cofactor, this is a legitimate enzyme activator function.
+                            <strong>Reason:</strong> Enzyme activator activity is supported, although zinc chaperone activity is the more specific core molecular function.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/35584675" target="_blank" class="term-link">
                                         PMID:35584675
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">Zng1 is a GTP-dependent zinc transferase needed for activation of methionine aminopeptidase</div>
-                                
+
+                                <div class="support-text">needed for activation of methionine aminopeptidase</div>
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034224" target="_blank" class="term-link">
                                     GO:0034224
                                 </a>
                             </span>
                             <span class="term-label">cellular response to zinc ion starvation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/35584675" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:35584675
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Zng1 is a GTP-dependent zinc transferase needed for activati...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P53729" data-a="GO:0034224" data-r="PMID:35584675" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P53729" data-a="GO:0034224" data-r="PMID:35584675" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> ZNG1 responds to zinc availability to activate zinc-dependent enzymes
+                            <strong>Summary:</strong> Mutant phenotype evidence shows ZNG1 loss causes zinc-deficiency growth and Map1-function defects.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> ZNG1 function is regulated by zinc availability and it responds to zinc starvation by ensuring efficient zinc delivery to target proteins.
+                            <strong>Reason:</strong> The zinc-starvation response is a physiological context for the core zinc chaperone function rather than an independent molecular role.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/35584675" target="_blank" class="term-link">
                                         PMID:35584675
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">Zng1p is required to avoid a compounding effect of Map1p dysfunction on survival during Zn limitation</div>
-                                
+
+                                <div class="support-text">a Zn-deficiency growth defect</div>
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034224" target="_blank" class="term-link">
                                     GO:0034224
                                 </a>
                             </span>
                             <span class="term-label">cellular response to zinc ion starvation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IGI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/35584675" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:35584675
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Zng1 is a GTP-dependent zinc transferase needed for activati...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P53729" data-a="GO:0034224" data-r="PMID:35584675" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P53729" data-a="GO:0034224" data-r="PMID:35584675" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> ZNG1 responds to zinc availability to activate zinc-dependent enzymes
+                            <strong>Summary:</strong> Genetic-interaction evidence links Zng1 and Map1 function to adaptation during zinc limitation.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Same process as IMP evidence - ZNG1 is part of cellular zinc homeostasis response.
+                            <strong>Reason:</strong> This annotation is supported as a condition-specific phenotype and pathway context, but the core function remains GTP-dependent zinc delivery to Map1.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/35584675" target="_blank" class="term-link">
                                         PMID:35584675
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">Proteomics reveal mis-regulation of the Zap1p transcription factor regulon because of loss of ZNG1</div>
-                                
+
+                                <div class="support-text">required to avoid a compounding effect of Map1p dysfunction on survival during Zn limitation</div>
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051604" target="_blank" class="term-link">
                                     GO:0051604
                                 </a>
                             </span>
                             <span class="term-label">protein maturation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/35584675" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:35584675
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Zng1 is a GTP-dependent zinc transferase needed for activati...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1849,75 +1846,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Enables MAP1 maturation by zinc cofactor insertion for methionine excision activity
+                            <strong>Summary:</strong> Mutant phenotype evidence supports defective Map1-dependent protein maturation when ZNG1 is deleted.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> ZNG1 is essential for MAP1 to become functionally mature by providing zinc cofactor needed for its peptidase activity.
+                            <strong>Reason:</strong> Zng1 enables Map1 activation and thereby supports initiator methionine excision, a protein maturation process.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/35584675" target="_blank" class="term-link">
                                         PMID:35584675
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">Deletion of the putative metal transferase in Saccharomyces cerevisiae (ZNG1; formerly YNR029c) leads to defective Map1p function and a Zn-deficiency growth defect</div>
-                                
+
+                                <div class="support-text">leads to defective Map1p function</div>
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051604" target="_blank" class="term-link">
                                     GO:0051604
                                 </a>
                             </span>
                             <span class="term-label">protein maturation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IGI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/35584675" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:35584675
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Zng1 is a GTP-dependent zinc transferase needed for activati...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1929,75 +1926,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Enables MAP1 maturation by zinc cofactor insertion for methionine excision activity
+                            <strong>Summary:</strong> Genetic-interaction evidence links Zng1 and Map1 to protein maturation through Map1 metallation and activation.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Same process as IMP evidence - ZNG1 enables protein maturation through zinc chaperone activity.
+                            <strong>Reason:</strong> This is a direct biological process outcome of Zng1&#39;s zinc chaperone activity.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/35584675" target="_blank" class="term-link">
                                         PMID:35584675
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">Zng1p can transfer Zn2+ or Co2+ to apo-Map1p, but unlike characterized copper chaperones, transfer is dependent on GTP hydrolysis</div>
-                                
+
+                                <div class="support-text">needed for activation of methionine aminopeptidase</div>
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/14562095" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:14562095
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Global analysis of protein localization in budding yeast.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2009,61 +2006,61 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Cytoplasmic localization confirmed by high-throughput analysis
+                            <strong>Summary:</strong> High-throughput direct assay supports cytoplasmic localization.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Consistent with other evidence for cytoplasmic localization where ZNG1 functions to deliver zinc to MAP1.
+                            <strong>Reason:</strong> Cytoplasmic localization is consistent with Map1/MetAP1-mediated co-translational protein maturation.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/14562095" target="_blank" class="term-link">
                                         PMID:14562095
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">Global analysis of protein localization in budding yeast</div>
-                                
+
+                                <div class="support-text">Global analysis of protein localization in budding yeast.</div>
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
             </tbody>
         </table>
     </div>
-    
 
-    
+
+
     <div class="section">
         <h2 class="section-title">Core Functions</h2>
-        
+
         <div class="core-function-card">
-            
+
             <div style="display: flex; justify-content: space-between; align-items: center;">
-                <h3>Primary function - transfers zinc to MAP1 for methionine aminopeptidase activation</h3>
-                <span class="vote-buttons" data-g="P53729" data-a="FUNCTION: Primary function - transfers zinc to MAP1 for meth..." data-r="" data-act="CORE_FUNCTION">
+                <h3>Zng1 is a GTP-dependent zinc chaperone/metalloprotein activator for Map1. It binds zinc and uses GTP hydrolysis to transfer the cofactor to apo-Map1, enabling methionine aminopeptidase activity and N-terminal methionine excision during protein maturation, especially under zinc limitation.</h3>
+                <span class="vote-buttons" data-g="P53729" data-a="FUNCTION: Zng1 is a GTP-dependent zinc chaperone/metalloprot..." data-r="" data-act="CORE_FUNCTION">
                     <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
             </div>
-            
+
 
             <div class="core-function-terms">
-                
+
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
@@ -2072,421 +2069,711 @@
                         </a>
                     </span>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Directly Involved In:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051604" target="_blank" class="term-link">
                                 protein maturation
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Cellular Locations:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                 cytoplasm
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
 
-                
+
+
+
             </div>
 
-            
+
             <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
                 <strong>Supporting Evidence:</strong>
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/35584675" target="_blank" class="term-link">
                                 PMID:35584675
                             </a>
-                            
+
                         </span>
-                        
-                        <div class="finding-text">Zng1p can transfer Zn2+ or Co2+ to apo-Map1p, but unlike characterized copper chaperones, transfer is dependent on GTP hydrolysis</div>
-                        
+
+                        <div class="finding-text">Zng1p can transfer Zn2+ or Co2+ to apo-Map1p</div>
+
                     </li>
-                    
-                </ul>
-            </div>
-            
-        </div>
-        
-        <div class="core-function-card">
-            
-            <div style="display: flex; justify-content: space-between; align-items: center;">
-                <h3>GTP hydrolysis drives conformational change for zinc transfer</h3>
-                <span class="vote-buttons" data-g="P53729" data-a="FUNCTION: GTP hydrolysis drives conformational change for zi..." data-r="" data-act="CORE_FUNCTION">
-                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
-                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
-                </span>
-            </div>
-            
 
-            <div class="core-function-terms">
-                
-                <div class="function-term-group">
-                    <div class="function-term-label">Molecular Function:</div>
-                    <span class="badge">
-                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003924" target="_blank" class="term-link">
-                            GTPase activity
-                        </a>
-                    </span>
-                </div>
-                
-
-                
-                <div class="function-term-group">
-                    <div class="function-term-label">Directly Involved In:</div>
-                    <div class="function-annotations">
-                        
-                        <span class="badge">
-                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051604" target="_blank" class="term-link">
-                                protein maturation
-                            </a>
-                        </span>
-                        
-                    </div>
-                </div>
-                
-
-                
-
-                
-
-                
-            </div>
-
-            
-            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
-                <strong>Supporting Evidence:</strong>
-                <ul class="findings-list">
-                    
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/35584675" target="_blank" class="term-link">
                                 PMID:35584675
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">transfer is dependent on GTP hydrolysis</div>
-                        
+
                     </li>
-                    
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:yeast/ZNG1/ZNG1-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">A Zn-regulated GTPase metalloprotein activator</div>
+
+                    </li>
+
                 </ul>
             </div>
-            
-        </div>
-        
-    </div>
-    
 
-    
+        </div>
+
+    </div>
+
+
+
     <div class="section">
         <h2 class="section-title collapsible">References</h2>
         <div class="collapse-content">
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
                             GO_REF:0000033
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Annotation inferences using phylogenetic trees</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000043.md" target="_blank" class="term-link">
                             GO_REF:0000043
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/14562095" target="_blank" class="term-link">
                             PMID:14562095
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Global analysis of protein localization in budding yeast.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/16429126" target="_blank" class="term-link">
                             PMID:16429126
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Proteome survey reveals modularity of the yeast cell machinery.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/19536198" target="_blank" class="term-link">
                             PMID:19536198
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">An atlas of chaperone-protein interactions in Saccharomyces cerevisiae: implications to protein folding pathways in the cell.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/35584675" target="_blank" class="term-link">
                             PMID:35584675
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Zng1 is a GTP-dependent zinc transferase needed for activation of methionine aminopeptidase.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
-                        <div class="finding-statement">ZNG1 directly transfers zinc cofactor to MAP1 via CXCC motif</div>
-                        
-                        <div class="finding-text">"Zng1 is a GTP-dependent zinc transferase needed for activation of methionine aminopeptidase"</div>
-                        
+                        <div class="finding-statement">Zng1 directly supports Map1 activation by GTP-dependent zinc transfer.</div>
+
+                        <div class="finding-text">"Zng1p can transfer Zn2+ or Co2+ to apo-Map1p"</div>
+
                     </li>
-                    
-                    <li class="finding-item">
-                        <div class="finding-statement">GTP hydrolysis is required for zinc transfer to MAP1</div>
-                        
-                        <div class="finding-text">"GTP-dependent zinc transferase"</div>
-                        
-                    </li>
-                    
-                    <li class="finding-item">
-                        <div class="finding-statement">ZNG1 activates MAP1 methionine aminopeptidase</div>
-                        
-                        <div class="finding-text">"needed for activation of methionine aminopeptidase"</div>
-                        
-                    </li>
-                    
-                    <li class="finding-item">
-                        <div class="finding-statement">ZNG1 responds to zinc starvation conditions</div>
-                        
-                        <div class="finding-text">"zinc transferase needed for activation"</div>
-                        
-                    </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
-                        file:yeast/ZNG1/ZNG1-falcon-research.md
-                        
+
+                        file:yeast/ZNG1/ZNG1-deep-research-falcon.md
+
                     </span>
                 </div>
-                
-                <div class="reference-title">Deep research on ZNG1 function</div>
-                
-                
+
+                <div class="reference-title">Falcon deep research report for ZNG1</div>
+
+
             </div>
-            
+
         </div>
     </div>
-    
 
 
-    
+
+
     <div class="section">
         <h2 class="section-title">Suggested Questions for Experts</h2>
-        
-        <div class="question-card">
-            <div style="display: flex; justify-content: space-between; align-items: start;">
-                <div style="flex: 1;">
-                    <p><strong>Q:</strong> How does ZNG1 recognize and bind specifically to MAP1 versus other potential target proteins?</p>
-                    
-                    <p style="margin-top: 0.5rem;"><em>Suggested experts: Structural biologists, Protein biochemists, Metallobiochemistry researchers</em></p>
-                    
-                </div>
-                <span class="vote-buttons" data-g="P53729" data-a="Q: How does ZNG1 recognize and bind specifically to M..." data-r="" data-act="QUESTION">
-                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
-                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
-                </span>
-            </div>
-        </div>
-        
-        <div class="question-card">
-            <div style="display: flex; justify-content: space-between; align-items: start;">
-                <div style="flex: 1;">
-                    <p><strong>Q:</strong> What is the precise timing and regulation of zinc transfer in relation to protein synthesis and MAP1 activity?</p>
-                    
-                    <p style="margin-top: 0.5rem;"><em>Suggested experts: Cell biologists, Protein synthesis researchers, Systems biologists</em></p>
-                    
-                </div>
-                <span class="vote-buttons" data-g="P53729" data-a="Q: What is the precise timing and regulation of zinc ..." data-r="" data-act="QUESTION">
-                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
-                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
-                </span>
-            </div>
-        </div>
-        
-        <div class="question-card">
-            <div style="display: flex; justify-content: space-between; align-items: start;">
-                <div style="flex: 1;">
-                    <p><strong>Q:</strong> Are there other metalloproteins besides MAP1 that require ZNG1 for zinc delivery?</p>
-                    
-                    <p style="margin-top: 0.5rem;"><em>Suggested experts: Proteomics researchers, Metal homeostasis experts, Yeast geneticists</em></p>
-                    
-                </div>
-                <span class="vote-buttons" data-g="P53729" data-a="Q: Are there other metalloproteins besides MAP1 that ..." data-r="" data-act="QUESTION">
-                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
-                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
-                </span>
-            </div>
-        </div>
-        
-    </div>
-    
 
-    
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Under which in vivo metal conditions does yeast Map1 use zinc versus other divalent metals, and does Zng1 selectively deliver zinc in all nutritional states?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P53729" data-a="Q: Under which in vivo metal conditions does yeast Ma..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Are there additional yeast metalloprotein clients for Zng1 beyond Map1, or is the Zng1-Map1 axis effectively dedicated?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P53729" data-a="Q: Are there additional yeast metalloprotein clients ..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
     <div class="section">
         <h2 class="section-title">Suggested Experiments</h2>
-        
-        <div class="experiment-card">
-            <div style="display: flex; justify-content: space-between; align-items: start;">
-                <div style="flex: 1;">
-                    
-                    <p><strong>Experiment:</strong> Crystal structure of ZNG1 in complex with MAP1 during zinc transfer to understand the molecular mechanism of metal delivery. This would reveal the conformational changes that occur during GTP hydrolysis and zinc transfer.</p>
-                    
-                    
-                    
-                    <p style="margin-top: 0.5rem;">Type: Structural analysis</p>
-                    
-                </div>
-                <span class="vote-buttons" data-g="P53729" data-a="EXPERIMENT: Crystal structure of ZNG1 in complex with MAP1 dur..." data-r="" data-act="EXPERIMENT">
-                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
-                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
-                </span>
-            </div>
-        </div>
-        
-        <div class="experiment-card">
-            <div style="display: flex; justify-content: space-between; align-items: start;">
-                <div style="flex: 1;">
-                    
-                    <p><strong>Experiment:</strong> Systematic testing of ZNG1 with different metalloproteins to determine if it specifically targets MAP1 or can deliver zinc to other enzymes. This would clarify the specificity of the zinc chaperone system.</p>
-                    
-                    
-                    
-                    <p style="margin-top: 0.5rem;">Type: Substrate specificity analysis</p>
-                    
-                </div>
-                <span class="vote-buttons" data-g="P53729" data-a="EXPERIMENT: Systematic testing of ZNG1 with different metallop..." data-r="" data-act="EXPERIMENT">
-                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
-                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
-                </span>
-            </div>
-        </div>
-        
-        <div class="experiment-card">
-            <div style="display: flex; justify-content: space-between; align-items: start;">
-                <div style="flex: 1;">
-                    
-                    <p><strong>Experiment:</strong> Testing ZNG1 activity with different divalent metals (cobalt, manganese, iron) to understand metal specificity and potential cross-reactivity within the COG0523 family.</p>
-                    
-                    
-                    
-                    <p style="margin-top: 0.5rem;">Type: Metal selectivity studies</p>
-                    
-                </div>
-                <span class="vote-buttons" data-g="P53729" data-a="EXPERIMENT: Testing ZNG1 activity with different divalent meta..." data-r="" data-act="EXPERIMENT">
-                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
-                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
-                </span>
-            </div>
-        </div>
-        
-    </div>
-    
 
-    
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Perform native metalloproteomics and Map1 activity assays in wild-type, zng1 deletion, and Zng1 motif mutants across zinc-replete, zinc-limited, and cobalt-supplemented conditions.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: Zng1 selectively maintains Map1 zinc occupancy and activity under zinc limitation, while alternative metals only partly substitute under specific conditions.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: metalloproteomics/enzymology</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P53729" data-a="EXPERIMENT: Perform native metalloproteomics and Map1 activity..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Affinity capture or proximity labeling of endogenous Zng1 under zinc-limited conditions followed by quantitative proteomics to identify potential client metalloproteins.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: Map1 is the dominant Zng1 client, but zinc limitation may reveal additional lower-abundance client interactions.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: interaction proteomics</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P53729" data-a="EXPERIMENT: Affinity capture or proximity labeling of endogeno..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
     <div class="section">
         <h2 class="section-title">Tags</h2>
         <div class="aliases">
-            
+
             <span class="badge">lbnl-favorites</span>
-            
+
         </div>
     </div>
-    
+
 
     <!-- Computational Predictions Section -->
-    
+
 
     <!-- Additional Documentation Sections -->
-    
+
     <div class="section">
         <h2 class="section-title">📚 Additional Documentation</h2>
-        
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Deep Research Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(ZNG1-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P53729" data-a="DOC: Deep Research Falcon" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <hr />
+<p>provider: falcon<br />
+model: Edison Scientific Literature<br />
+cached: false<br />
+start_time: '2026-05-04T10:31:48.785202'<br />
+end_time: '2026-05-04T10:47:55.408487'<br />
+duration_seconds: 966.62<br />
+template_file: templates/gene_research_go_focused.md<br />
+template_variables:<br />
+  organism: yeast<br />
+  gene_id: ZNG1<br />
+  gene_symbol: ZNG1<br />
+  uniprot_accession: P53729<br />
+  protein_description: 'RecName: Full=Zinc-regulated GTPase metalloprotein activator<br />
+    1 {ECO:0000303|PubMed:35584675}; EC=3.6.5.- {ECO:0000269|PubMed:35584675};'<br />
+  gene_info: Name=ZNG1 {ECO:0000303|PubMed:35584675, ECO:0000312|SGD:S000005312};<br />
+    OrderedLocusNames=YNR029C; ORFNames=N3260;<br />
+  organism_full: Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).<br />
+  protein_family: Belongs to the SIMIBI class G3E GTPase family. ZNG1<br />
+  protein_domains: CobW-likC_sf. (IPR036627); CobW-like_C. (IPR011629); CobW/HypB/UreG_nucleotide-bd.<br />
+    (IPR003495); P-loop_NTPase. (IPR027417); Zinc-reg_GTPase_activator. (IPR051316)<br />
+provider_config:<br />
+  timeout: 600<br />
+  max_retries: 3<br />
+  parameters:<br />
+    allowed_domains: []<br />
+    temperature: 0.1<br />
+citation_count: 23</p>
+<hr />
+<h2 id="question">Question</h2>
+<h1 id="gene-research-for-functional-annotation">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> P53729</li>
+<li><strong>Protein Description:</strong> RecName: Full=Zinc-regulated GTPase metalloprotein activator 1 {ECO:0000303|PubMed:35584675}; EC=3.6.5.- {ECO:0000269|PubMed:35584675};</li>
+<li><strong>Gene Information:</strong> Name=ZNG1 {ECO:0000303|PubMed:35584675, ECO:0000312|SGD:S000005312}; OrderedLocusNames=YNR029C; ORFNames=N3260;</li>
+<li><strong>Organism (full):</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Protein Family:</strong> Belongs to the SIMIBI class G3E GTPase family. ZNG1</li>
+<li><strong>Key Domains:</strong> CobW-likC_sf. (IPR036627); CobW-like_C. (IPR011629); CobW/HypB/UreG_nucleotide-bd. (IPR003495); P-loop_NTPase. (IPR027417); Zinc-reg_GTPase_activator. (IPR051316)</li>
+</ul>
+<h3 id="mandatory-verification-steps">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "ZNG1" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'ZNG1' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>ZNG1</strong> (gene ID: ZNG1, UniProt: P53729) in yeast.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="output">Output</h2>
+<p>Question: You are an expert researcher providing comprehensive, well-cited information.</p>
+<p>Provide detailed information focusing on:<br />
+1. Key concepts and definitions with current understanding<br />
+2. Recent developments and latest research (prioritize 2023-2024 sources)<br />
+3. Current applications and real-world implementations<br />
+4. Expert opinions and analysis from authoritative sources<br />
+5. Relevant statistics and data from recent studies</p>
+<p>Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.<br />
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.</p>
+<h1 id="gene-research-for-functional-annotation_1">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context_1">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot_1">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> P53729</li>
+<li><strong>Protein Description:</strong> RecName: Full=Zinc-regulated GTPase metalloprotein activator 1 {ECO:0000303|PubMed:35584675}; EC=3.6.5.- {ECO:0000269|PubMed:35584675};</li>
+<li><strong>Gene Information:</strong> Name=ZNG1 {ECO:0000303|PubMed:35584675, ECO:0000312|SGD:S000005312}; OrderedLocusNames=YNR029C; ORFNames=N3260;</li>
+<li><strong>Organism (full):</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Protein Family:</strong> Belongs to the SIMIBI class G3E GTPase family. ZNG1</li>
+<li><strong>Key Domains:</strong> CobW-likC_sf. (IPR036627); CobW-like_C. (IPR011629); CobW/HypB/UreG_nucleotide-bd. (IPR003495); P-loop_NTPase. (IPR027417); Zinc-reg_GTPase_activator. (IPR051316)</li>
+</ul>
+<h3 id="mandatory-verification-steps_1">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "ZNG1" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature_1">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'ZNG1' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target_1">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>ZNG1</strong> (gene ID: ZNG1, UniProt: P53729) in yeast.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="research-report-saccharomyces-cerevisiae-zng1-uniprot-p53729-ynr029c">Research report: <em>Saccharomyces cerevisiae</em> ZNG1 (UniProt P53729; YNR029C)</h2>
+<h3 id="1-target-verification-critical-identity-checks">1) Target verification (critical identity checks)</h3>
+<p><strong>Target gene/protein confirmed.</strong> The literature retrieved here uses <em>S. cerevisiae</em> <strong>YNR029C</strong> as the fungal/yeast homolog whose function is shared with vertebrate ZNG1-family proteins and is discussed as part of the eukaryotic ZNG1 clade of COG0523/G3E P-loop NTPases. In particular, Weiss et al. explicitly connect vertebrate ZNG1 function to yeast <strong>YNR029C</strong> (“shared function … and yeast (YNR029c)”) and use the yeast work as evolutionary support for a conserved ZNG1–MetAP1 axis (https://doi.org/10.1016/j.cell.2022.04.011; published 2022-06-09) (weiss2022znregulatedgtpasemetalloprotein pages 3-5, weiss2022znregulatedgtpasemetalloprotein pages 1-3). </p>
+<p><strong>Symbol ambiguity risk acknowledged and managed.</strong> “ZNG1” is used in plants and animals as well; only sources that explicitly frame yeast <strong>YNR029C/Zng1p</strong> as the ortholog implicated in Zn-dependent activation of yeast Map1/MetAP1 were treated as relevant to this report (weiss2022znregulatedgtpasemetalloprotein pages 11-13, zhang2023tworelatedfamilies pages 1-2, young2023twodistinctthermodynamic pages 1-2).</p>
+<h3 id="2-key-concepts-and-definitions-current-understanding">2) Key concepts and definitions (current understanding)</h3>
+<h4 id="21-zng1-as-a-nucleotide-dependent-metallochaperone-zn-escort">2.1 ZNG1 as a nucleotide-dependent metallochaperone (“Zn escort”)</h4>
+<p>ZNG1 is best understood as a <strong>nucleotide-dependent metallochaperone</strong> (also termed an “escort” protein) that helps <strong>allocate Zn to specific Zn-requiring client proteins</strong>, rather than as a bulk Zn transporter (zhang2023tworelatedfamilies pages 1-2, maret2022escortproteinsfor pages 1-2). This concept fills a long-standing gap in Zn biology: targeted Zn transfer to apo-metalloproteins had been hypothesized, but remained difficult to demonstrate experimentally (weiss2022znregulatedgtpasemetalloprotein pages 1-3).</p>
+<p>A widely cited expert commentary in <em>Nature</em> describes ZNG1 in these terms, noting that recent studies identified a zinc “escort” that delivers Zn to an essential enzyme (client), methionine aminopeptidase 1 (METAP1) (https://doi.org/10.1038/d41586-022-01988-2; published 2022-08) (maret2022escortproteinsfor pages 1-2).</p>
+<h4 id="22-client-enzyme-type-i-methionine-aminopeptidase-map1metap1">2.2 Client enzyme: type I methionine aminopeptidase (Map1/MetAP1)</h4>
+<p>The <strong>primary client</strong> associated with eukaryotic ZNG1 (including yeast ZNG1/YNR029C) is <strong>type I methionine aminopeptidase (MetAP1; yeast Map1)</strong> (zhang2023tworelatedfamilies pages 1-2, young2023twodistinctthermodynamic pages 1-2). MetAP enzymes perform <strong>N-terminal methionine excision (NME)</strong>, a co-/peri-translational processing step described as affecting <strong>approximately half of newly synthesized peptides</strong>, influencing protein maturation, stability, and localization (weiss2022znregulatedgtpasemetalloprotein pages 3-5).</p>
+<h4 id="23-mechanistic-hallmarks-domainmotif-logic">2.3 Mechanistic hallmarks (domain/motif logic)</h4>
+<p>ZNG1-family proteins belong to the <strong>G3E subfamily of P-loop GTPases</strong> (COG0523 family) whose members use nucleotide hydrolysis to power metal delivery/insertions (weiss2022znregulatedgtpasemetalloprotein pages 1-3). A defining feature of nucleotide-dependent metallochaperones (NMCs), including ZNG1, is a <strong>metal-binding CxCC motif</strong> positioned between Switch I and Walker B in the GTPase core, consistent with a Zn-binding/transfer role (zhang2023tworelatedfamilies pages 1-2).</p>
+<h3 id="3-primary-function-and-mechanism-of-yeast-zng1-what-it-does-where-and-how">3) Primary function and mechanism of yeast ZNG1 (what it does, where, and how)</h3>
+<h4 id="31-best-supported-primary-molecular-function-in-yeast">3.1 Best-supported primary molecular function in yeast</h4>
+<p>Within the accessible literature corpus, the most consistent functional assignment for <em>S. cerevisiae</em> ZNG1/YNR029C is:</p>
+<ul>
+<li><strong>A Zn-regulated GTPase metalloprotein activator / Zn metallochaperone whose key client is Map1 (MetAP1), supporting Map1 metalation and activity, especially under Zn limitation.</strong></li>
+</ul>
+<p>This is stated directly in 2023 synthesis papers that treat yeast ScZng1 as the <strong>strongest support for direct Zn transfer</strong> to MetAP1 in a <strong>GTP-dependent</strong> manner (zhang2023tworelatedfamilies pages 1-2), and is consistent with the conserved eukaryotic ZNG1–MetAP1 model from mechanistic primary work (weiss2022znregulatedgtpasemetalloprotein pages 3-5).</p>
+<h4 id="32-mechanistic-model-zn-delivery-coupled-to-gtp-hydrolysis">3.2 Mechanistic model: Zn delivery coupled to GTP hydrolysis</h4>
+<p>The mechanistic model (established most rigorously in the conserved vertebrate/eukaryotic ZNG1–METAP1 system) is:</p>
+<ol>
+<li>ZNG1 binds Zn (via the conserved cysteine-rich metal-binding features in the ZNG1/NMC family) (zhang2023tworelatedfamilies pages 1-2).</li>
+<li>ZNG1 binds MetAP1 via a specific protein–protein interaction interface.</li>
+<li><strong>GTP hydrolysis</strong> by ZNG1 drives a shift that enables <strong>Zn transfer into the MetAP1 catalytic site</strong>, thereby activating the metalloprotease (weiss2022znregulatedgtpasemetalloprotein pages 3-5, weiss2022znregulatedgtpasemetalloprotein pages 11-13).</li>
+</ol>
+<p>This “hydrolysis-coupled transfer” logic is consistent with broader thermodynamic frameworks developed for related COG0523 metallochaperones (e.g., CobW): metal transfer can become favorable <strong>after nucleotide hydrolysis</strong>, a conceptual framework that supports why an NTPase metallochaperone is needed at all (https://doi.org/10.1021/jacsau.3c00119; published 2023-05-10) (young2023twodistinctthermodynamic pages 1-2, young2023twodistinctthermodynamic pages 5-6).</p>
+<h4 id="33-molecular-recognition-domainsmotifs-and-quantitative-interaction-strength">3.3 Molecular recognition: domains/motifs and quantitative interaction strength</h4>
+<p>Although yeast-specific binding constants were not retrieved here, the conserved interaction is described in high-resolution mechanistic work:</p>
+<ul>
+<li>The MetAP1 region recognized by ZNG1 is an <strong>N-terminal Zn-binding “C6H2” domain</strong>, with a minimal interacting segment reported as ~108 residues in vertebrate METAP1 (weiss2022znregulatedgtpasemetalloprotein pages 3-5).</li>
+<li>ZNG1 uses a short N-terminal peptide motif (vertebrate <strong>CPELVPI</strong>), generalized across eukaryotes to <strong>[D/E]nψPxLVp</strong>; yeast Zng1p lacks the exact vertebrate peptide but matches the generalized motif pattern, and modeling predicts a similar interface for yeast Zng1p–Map1p (weiss2022znregulatedgtpasemetalloprotein pages 11-13, weiss2022znregulatedgtpasemetalloprotein pages 13-15).</li>
+<li>Quantitatively, binding of ZNG1 peptides to METAP1 N-terminal constructs is <strong>high affinity</strong>, with <strong>K_D ~0.1 μM</strong> (reported range ~0.12–0.30 μM across tested homologs), much tighter than canonical MYND–peptide interactions (weiss2022znregulatedgtpasemetalloprotein pages 5-6). A representative binding-affinity panel is available from the primary paper figures (weiss2022znregulatedgtpasemetalloprotein media 7dd994c9).</li>
+</ul>
+<p><strong>Visual evidence.</strong> The retrieved figure panels include the binding affinity summary and mechanistic schematic of Zn/GTP-dependent activation (weiss2022znregulatedgtpasemetalloprotein media 7dd994c9, weiss2022znregulatedgtpasemetalloprotein media 50dba8c7).</p>
+<h4 id="34-where-in-the-cell-does-yeast-zng1p-act">3.4 Where in the cell does yeast Zng1p act?</h4>
+<p>Direct yeast localization measurements were not available in the retrieved corpus. However, multiple lines support a <strong>cytosolic functional context</strong>:</p>
+<ul>
+<li>The conserved client MetAP1/Map1 performs cotranslational NME on nascent peptides (weiss2022znregulatedgtpasemetalloprotein pages 3-5), a process tightly linked to cytosolic translation.</li>
+<li>A 2023 experimental study of the plant ortholog shows <strong>cytosolic localization</strong> of ZNG1 and physical interaction with cytosolic type I MetAP (AtMAP1A), consistent with conservation of a cytosolic ZNG1–MetAP axis across eukaryotes (https://doi.org/10.3389/fpls.2023.1237722; published 2023-10) (zhang2023tworelatedfamilies pages 1-2, zhang2023tworelatedfamilies pages 7-9).</li>
+</ul>
+<p>Accordingly, the most defensible annotation for yeast Zng1p localization from this evidence is <strong>cytosolic (inferred)</strong> pending direct yeast imaging/biochemistry.</p>
+<h3 id="4-recent-developments-and-latest-research-prioritizing-20232024">4) Recent developments and latest research (prioritizing 2023–2024)</h3>
+<h4 id="41-2023-expansion-and-generalization-of-the-zng1-concept-and-conserved-mechanism">4.1 2023: Expansion and generalization of the ZNG1 concept and conserved mechanism</h4>
+<p><strong>(i) ZNG1 placed into a broader “NMC” framework.</strong> Zhang et al. (2023) treat ZNG1 as part of nucleotide-dependent metallochaperones and emphasize shared motifs (CxCC) and a conserved Zn/GTP-dependent activation logic for MetAP1 (zhang2023tworelatedfamilies pages 1-2).</p>
+<p><strong>(ii) Cytosolic interaction + Zn-deficiency phenotypes (ortholog evidence).</strong> In Arabidopsis, AtZNG1 localizes to the cytosol and interacts with AtMAP1A (BiFC, Y2H). zng1 mutants show <strong>Zn-dependent growth phenotypes</strong> (no obvious phenotype in +Zn; defects in −Zn), consistent with a role in acclimation to poor Zn nutrition (zhang2023tworelatedfamilies pages 7-9).</p>
+<p><strong>(iii) Systems-level consequences.</strong> Zhang et al. report that loss of this conserved mechanism leads to broad “pleiotropic” transcriptomic/proteomic changes, including <strong>hundreds of genes</strong> and a set of <strong>961 transcripts</strong> with significant abundance differences in one analysis (zhang2023tworelatedfamilies pages 1-2, zhang2023tworelatedfamilies pages 14-16). While these are plant data, they underscore how disrupting ZNG1-dependent MetAP1 metalation can propagate through cellular physiology.</p>
+<h4 id="42-2024-accessible-corpus-limitation">4.2 2024: Accessible corpus limitation</h4>
+<p>Within the accessible retrieval set, <strong>no yeast-focused 2024 primary paper</strong> directly extending ZNG1/YNR029C functional studies was obtained. The most directly relevant recent sources available were 2023 primary/synthesis works (zhang2023tworelatedfamilies pages 7-9, young2023twodistinctthermodynamic pages 1-2).</p>
+<h3 id="5-current-applications-and-real-world-implementations">5) Current applications and real-world implementations</h3>
+<p>Direct industrial/clinical implementations specifically targeting yeast ZNG1 were not identified in the retrieved corpus. However, the ZNG1 functional axis has clear <strong>real-world relevance</strong> through:</p>
+<ol>
+<li><strong>Nutrient limitation biology and stress tolerance.</strong> ZNG1 is repeatedly framed as supporting function under <strong>Zn limitation</strong>, a nutritionally and ecologically relevant condition (weiss2022znregulatedgtpasemetalloprotein pages 3-5, maret2022escortproteinsfor pages 1-2).</li>
+<li><strong>Biotechnology/engineering-biology rationale (conceptual application).</strong> Thermodynamic work on related COG0523 metallochaperones emphasizes that metallochaperone requirements can determine success/failure of heterologous metalloenzyme pathways and can stall bioprocess outputs unless metal delivery is correctly engineered (young2023twodistinctthermodynamic pages 1-2, young2023twodistinctthermodynamic pages 2-4). By analogy, manipulating ZNG1-like metallochaperones is a plausible strategy to improve metalation fidelity in engineered systems.</li>
+<li><strong>Agricultural applications (ortholog-based).</strong> Zhang et al. explicitly frame identifying ZNG-family acclimation mechanisms as opportunities to improve <strong>metal-use efficiency</strong> and “develop plant foodstuffs with increased concentrations of bioavailable metal nutrients” (biofortification) (zhang2023tworelatedfamilies pages 1-2).</li>
+</ol>
+<p>For yeast biotechnology, these points support a <strong>practical hypothesis</strong> (not yet shown in the retrieved evidence): ZNG1 status could affect performance under Zn-limited industrial fermentations by maintaining functional NME via Map1.</p>
+<h3 id="6-expert-opinions-and-authoritative-analysis">6) Expert opinions and authoritative analysis</h3>
+<p>A <em>Nature</em> News &amp; Views by Wolfgang Maret positions ZNG1 as a newly identified <strong>zinc-ion escort/metallochaperone</strong> and emphasizes that, given Zn’s pervasive protein usage, “allocation” mechanisms are essential, while also highlighting important open questions such as the metal flexibility of MetAPs and whether METAP1 actually uses Zn under deficiency (https://doi.org/10.1038/d41586-022-01988-2; published 2022-08) (maret2022escortproteinsfor pages 2-2, maret2022escortproteinsfor pages 1-2). Notably, this commentary mentions that some MetAPs, including the <strong>yeast enzyme</strong>, can use <strong>cobalt</strong>, underscoring that “Zn delivery” by ZNG1 may coexist with client metal plasticity depending on conditions (maret2022escortproteinsfor pages 2-2).</p>
+<h3 id="7-statistics-and-data-highlights-recentauthoritative">7) Statistics and data highlights (recent/authoritative)</h3>
+<ul>
+<li><strong>Scale of Zn usage:</strong> Zn is described as a cofactor for <strong>~10% of proteins</strong> in living organisms (and “At least 10% of human proteins contain zinc as a cofactor”), emphasizing the magnitude of the cellular allocation problem ZNG1 addresses (weiss2022znregulatedgtpasemetalloprotein pages 1-3, maret2022escortproteinsfor pages 1-2).</li>
+<li><strong>Client process prevalence:</strong> MetAP-dependent NME affects <strong>~half of newly synthesized peptides</strong> (weiss2022znregulatedgtpasemetalloprotein pages 3-5).</li>
+<li><strong>Quantitative binding (mechanistic benchmark):</strong> ZNG1 peptide–METAP1 N-terminal domain binding <strong>K_D ~0.1 μM</strong> (approximate range ~0.12–0.30 μM depending on homolog), supporting a specific, high-affinity client interaction (weiss2022znregulatedgtpasemetalloprotein pages 5-6, weiss2022znregulatedgtpasemetalloprotein media 7dd994c9).</li>
+<li><strong>Omics-scale response (2023 ortholog study):</strong> ZNG1 loss linked to altered expression of <strong>hundreds of genes</strong>, with one analysis visualizing <strong>961 transcripts</strong> with significant differences (zhang2023tworelatedfamilies pages 1-2, zhang2023tworelatedfamilies pages 14-16).</li>
+</ul>
+<h3 id="8-evidence-weighted-functional-annotation-summary">8) Evidence-weighted functional annotation summary</h3>
+<p>The following table consolidates key annotation claims, their evidence strength, and quantitative anchors.</p>
+<table>
+<thead>
+<tr>
+<th>Annotation item</th>
+<th>Evidence type (direct yeast / conserved inference / review)</th>
+<th>Key data/statistics</th>
+<th>Primary source(s)</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>Identity and family</strong>: <em>S. cerevisiae</em> ZNG1 (YNR029C; UniProt P53729) belongs to the COG0523/G3E P-loop GTPase family and is treated as the yeast ortholog of eukaryotic ZNG1 metallochaperones.</td>
+<td>Conserved inference supported by cross-species primary literature</td>
+<td>Conserved GTPase catalytic motifs and metal-binding residues are emphasized for ZNG1-family proteins; ZNG1 proteins are placed in the G3E/COG0523 metalloprotein-activator class.</td>
+<td>(weiss2022znregulatedgtpasemetalloprotein pages 1-3, zhang2023tworelatedfamilies pages 1-2)</td>
+</tr>
+<tr>
+<td><strong>Primary molecular function</strong>: ZNG1 is best understood as a <strong>zinc metallochaperone / Zn-regulated GTPase metalloprotein activator</strong> rather than a bulk Zn transporter.</td>
+<td>Direct yeast evidence summarized in later papers; authoritative review</td>
+<td>Reviews and follow-up papers state that the strongest support for direct Zn transfer to MetAP1 comes from yeast ScZng1 studies; expert commentary frames ZNG1 as a Zn “escort” protein.</td>
+<td>(zhang2023tworelatedfamilies pages 1-2, maret2022escortproteinsfor pages 2-2, maret2022escortproteinsfor pages 1-2)</td>
+</tr>
+<tr>
+<td><strong>Likely client protein in yeast</strong>: the principal client is <strong>Map1/MetAP1 (type I methionine aminopeptidase)</strong>.</td>
+<td>Direct yeast evidence summarized in review/follow-up; conserved primary evidence</td>
+<td>Young 2023 explicitly notes that deletion of <strong>ZNG1 in <em>S. cerevisiae</em></strong> impairs Map1; multiple sources identify METAP1 as the conserved ZNG1 client across eukaryotes.</td>
+<td>(weiss2022znregulatedgtpasemetalloprotein pages 11-13, zhang2023tworelatedfamilies pages 1-2, weiss2022znregulatedgtpasemetalloprotein pages 3-5)</td>
+</tr>
+<tr>
+<td><strong>Biochemical role of the client</strong>: Map1/MetAP1 catalyzes <strong>N-terminal methionine excision (NME)</strong> from nascent proteins, a cotranslational processing step affecting about half of newly synthesized peptides in eukaryotes.</td>
+<td>Conserved primary evidence / review</td>
+<td>METAP1 is described as a metalloprotease for NME; Cell paper notes NME applies to “approximately half” of newly synthesized peptides.</td>
+<td>(weiss2022znregulatedgtpasemetalloprotein pages 3-5)</td>
+</tr>
+<tr>
+<td><strong>Mechanism</strong>: ZNG1 is proposed to <strong>bind Zn and deliver it to Map1/MetAP1 in a GTP-dependent manner</strong>, with GTP hydrolysis driving transfer into the client active site.</td>
+<td>Direct yeast evidence summarized in later papers; conserved primary evidence</td>
+<td>Follow-up sources state ScZng1 provides in vivo and in vitro evidence for <strong>GTP-dependent Zn transfer</strong> to MetAP1; mechanistic model proposes transfer is favored after nucleotide hydrolysis.</td>
+<td>(zhang2023tworelatedfamilies pages 1-2, weiss2022znregulatedgtpasemetalloprotein pages 11-13)</td>
+</tr>
+<tr>
+<td><strong>Enzymatic activity of ZNG1 itself</strong>: a <strong>GTPase</strong> whose hydrolysis is functionally coupled to metal delivery.</td>
+<td>Conserved primary evidence</td>
+<td>GTP hydrolysis is described as the energy source for metal transfer in G3E/COG0523 proteins; in vertebrate assays, METAP1 stimulated ZNG1 GTPase activity, though hydrolysis was low in vitro.</td>
+<td>(weiss2022znregulatedgtpasemetalloprotein pages 1-3, weiss2022znregulatedgtpasemetalloprotein pages 3-5, weiss2022znregulatedgtpasemetalloprotein pages 13-15)</td>
+</tr>
+<tr>
+<td><strong>Metal-binding signature</strong>: ZNG1/NMC proteins contain a <strong>CxCC motif</strong> positioned between Switch I and Walker B, consistent with a Zn-binding/transfer site.</td>
+<td>Conserved inference supported by primary literature</td>
+<td>The CxCC motif is highlighted as the defining metal-binding feature of ZNG1/NMC proteins.</td>
+<td>(zhang2023tworelatedfamilies pages 1-2)</td>
+</tr>
+<tr>
+<td><strong>Interaction interface on client</strong>: the ZNG1-binding region of MetAP1 is an <strong>N-terminal C6H2 Zn-binding domain</strong>.</td>
+<td>Conserved primary evidence; yeast-specific support by modeling</td>
+<td>In vertebrates, the minimal interacting segment is a <strong>108-residue N-terminal region</strong> containing the <strong>C6H2 domain</strong>; yeast Zng1p–Map1p modeling predicts a nearly identical fold/interface.</td>
+<td>(weiss2022znregulatedgtpasemetalloprotein pages 3-5, weiss2022znregulatedgtpasemetalloprotein pages 11-13)</td>
+</tr>
+<tr>
+<td><strong>Interaction motif on ZNG1</strong>: a conserved N-terminal peptide motif mediates MetAP1 binding; vertebrate motif is <strong>CPELVPI</strong>, generalized to <strong>[D/E]nψPxLVp</strong> across many eukaryotes, including yeast-compatible predictions.</td>
+<td>Conserved primary evidence with yeast-specific modeling</td>
+<td>About <strong>~50% of eukaryotic ZNG1 homologs</strong> share the broader motif; yeast lacks the exact vertebrate sequence but matches the generalized pattern.</td>
+<td>(weiss2022znregulatedgtpasemetalloprotein pages 5-6, weiss2022znregulatedgtpasemetalloprotein pages 11-13, weiss2022znregulatedgtpasemetalloprotein pages 13-15)</td>
+</tr>
+<tr>
+<td><strong>Binding affinity benchmark</strong>: ZNG1–METAP1 interaction is high affinity, supporting specific client targeting.</td>
+<td>Conserved primary evidence</td>
+<td>Peptide–domain binding measurements gave <strong>K_D ~0.1 μM</strong> (reported range approximately <strong>0.12–0.30 μM</strong> across tested vertebrate homologs), much tighter than canonical MYND-peptide interactions.</td>
+<td>(weiss2022znregulatedgtpasemetalloprotein pages 5-6, weiss2022znregulatedgtpasemetalloprotein media 7dd994c9, weiss2022znregulatedgtpasemetalloprotein media 3d4c9ea0, weiss2022znregulatedgtpasemetalloprotein media 50dba8c7)</td>
+</tr>
+<tr>
+<td><strong>Structural support</strong>: the MetAP1 N-terminal domain forms a cross-brace Zn-binding fold that specifically recognizes the ZNG1 peptide.</td>
+<td>Conserved primary evidence</td>
+<td>NMR structure shows a <strong>ββαβα cross-brace fold</strong> with two Zn ions in the MetAP1 C6H2 domain; structure deposited as <strong>PDB 7SEK</strong>.</td>
+<td>(weiss2022znregulatedgtpasemetalloprotein pages 21-23, weiss2022znregulatedgtpasemetalloprotein pages 5-6)</td>
+</tr>
+<tr>
+<td><strong>Cellular localization</strong>: ZNG1 function is most plausibly <strong>cytosolic</strong>, where Map1/MetAP1 acts on nascent proteins; for yeast this is currently best treated as an inference rather than a directly demonstrated localization in the retrieved corpus.</td>
+<td>Conserved inference / review</td>
+<td>Plant ZNG1 ortholog localizes to the <strong>cytosol</strong> and interacts with cytosolic MAP1A; no yeast-specific localization measurement was retrieved here.</td>
+<td>(zhang2023tworelatedfamilies pages 1-2, zhang2023tworelatedfamilies pages 7-9)</td>
+</tr>
+<tr>
+<td><strong>Biological process annotation</strong>: ZNG1 participates in <strong>protein N-terminal processing under Zn-limited conditions</strong> by supporting Map1 metalation and activity.</td>
+<td>Direct yeast evidence summarized in later papers; conserved primary evidence</td>
+<td>ZNG1/Map1 axis is repeatedly linked to acclimation to <strong>poor Zn nutrition</strong> and maintenance of MetAP1 activity during Zn limitation.</td>
+<td>(zhang2023tworelatedfamilies pages 1-2, weiss2022znregulatedgtpasemetalloprotein pages 3-5, zhang2023tworelatedfamilies pages 7-9)</td>
+</tr>
+<tr>
+<td><strong>Physiological context</strong>: ZNG1 belongs to a broader cellular Zn allocation hierarchy that prioritizes critical metalloproteins when free Zn is scarce.</td>
+<td>Review / expert commentary</td>
+<td>Expert commentary notes Zn-dependent proteins require prioritization under deficiency and positions ZNG1 as an escort safeguarding METAP1 metalation; at least <strong>10%</strong> of human proteins are Zn cofactors, underscoring the scale of Zn allocation problems.</td>
+<td>(maret2022escortproteinsfor pages 2-2, maret2022escortproteinsfor pages 1-2, weiss2022znregulatedgtpasemetalloprotein pages 1-3)</td>
+</tr>
+<tr>
+<td><strong>Caveat on metal specificity of the client</strong>: although ZNG1 is framed as a Zn chaperone, methionine aminopeptidases can show metal flexibility in some systems, including yeast.</td>
+<td>Review / expert commentary</td>
+<td>Nature commentary notes some MetAPs, including the <strong>yeast enzyme</strong>, can use <strong>cobalt</strong>, so in vivo metal usage may depend on conditions even if ZNG1 specifically traffics Zn.</td>
+<td>(maret2022escortproteinsfor pages 2-2)</td>
+</tr>
+<tr>
+<td><strong>Current best functional annotation for yeast ZNG1</strong>: a <strong>cytosol-associated, COG0523-family Zn/GTP-dependent metalloprotein activator for Map1</strong>, important particularly during Zn deficiency.</td>
+<td>Integrated synthesis: direct yeast evidence summarized + conserved inference + review</td>
+<td>Supported by yeast-focused statements that ScZng1 gives the strongest evidence for direct Zn transfer to MetAP1, together with conserved biochemical/structural data and expert commentary.</td>
+<td>(zhang2023tworelatedfamilies pages 1-2, weiss2022znregulatedgtpasemetalloprotein pages 11-13, maret2022escortproteinsfor pages 2-2)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the strongest available evidence for functional annotation of Saccharomyces cerevisiae ZNG1/YNR029C, distinguishing direct yeast support from conserved inference and review-level interpretation. It is useful for curating molecular function, mechanism, client identity, localization, and evidence strength in one place.</em></p>
+<h3 id="9-limitations-and-gaps-important-for-functional-annotation">9) Limitations and gaps (important for functional annotation)</h3>
+<ol>
+<li><strong>Primary yeast paper access gap.</strong> The UniProt-referenced PubMed:35584675 paper could not be directly retrieved within the accessible corpus in this run. As a result, specific yeast experimental details (e.g., exact Map1 activity assays, NME readouts, yeast growth curves under defined Zn conditions, direct localization imaging of Zng1p) could not be quoted verbatim here.</li>
+<li><strong>Yeast-specific localization not directly demonstrated</strong> in the retrieved texts; cytosolic localization is an inference supported by client biology and ortholog experiments (weiss2022znregulatedgtpasemetalloprotein pages 3-5, zhang2023tworelatedfamilies pages 1-2).</li>
+<li><strong>Metal specificity nuance.</strong> Expert commentary highlights MetAP metal flexibility (e.g., cobalt usage in yeast), which should be considered when interpreting ZNG1 as a Zn-specific activator in all conditions (maret2022escortproteinsfor pages 2-2).</li>
+</ol>
+<h3 id="10-concluding-model-for-s-cerevisiae-zng1-p53729">10) Concluding model for <em>S. cerevisiae</em> ZNG1 (P53729)</h3>
+<p>The best-supported current model is that yeast Zng1p (YNR029C; UniProt P53729) is a <strong>COG0523/G3E P-loop GTPase metallochaperone</strong> that, particularly under <strong>Zn limitation</strong>, supports cellular viability and proteome maturation by enabling <strong>Zn-dependent activation/metalation of Map1/MetAP1</strong>, thereby maintaining <strong>N-terminal methionine excision</strong> for a large fraction of nascent proteins (zhang2023tworelatedfamilies pages 1-2, young2023twodistinctthermodynamic pages 1-2). The conserved interaction involves a MetAP1 N-terminal Zn-binding domain and a conserved ZNG1 peptide motif, with high-affinity binding (K_D ~0.1 μM) demonstrated in mechanistic eukaryotic systems and modeled as conserved for yeast (weiss2022znregulatedgtpasemetalloprotein pages 5-6, weiss2022znregulatedgtpasemetalloprotein pages 11-13, weiss2022znregulatedgtpasemetalloprotein media 7dd994c9).</p>
+<p>References</p>
+<ol>
+<li>
+<p>(weiss2022znregulatedgtpasemetalloprotein pages 3-5): Andy Weiss, Caitlin C. Murdoch, Katherine A. Edmonds, Matthew R. Jordan, Andrew J. Monteith, Yasiru R. Perera, Aslin M. Rodríguez Nassif, Amber M. Petoletti, William N. Beavers, Matthew J. Munneke, Sydney L. Drury, Evan S. Krystofiak, Kishore Thalluri, Hongwei Wu, Angela R.S. Kruse, Richard D. DiMarchi, Richard M. Caprioli, Jeffrey M. Spraggins, Walter J. Chazin, David P. Giedroc, and Eric P. Skaar. Zn-regulated gtpase metalloprotein activator 1 modulates vertebrate zinc homeostasis. Cell, 185:2148-2163.e27, Jun 2022. URL: https://doi.org/10.1016/j.cell.2022.04.011, doi:10.1016/j.cell.2022.04.011. This article has 113 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(weiss2022znregulatedgtpasemetalloprotein pages 1-3): Andy Weiss, Caitlin C. Murdoch, Katherine A. Edmonds, Matthew R. Jordan, Andrew J. Monteith, Yasiru R. Perera, Aslin M. Rodríguez Nassif, Amber M. Petoletti, William N. Beavers, Matthew J. Munneke, Sydney L. Drury, Evan S. Krystofiak, Kishore Thalluri, Hongwei Wu, Angela R.S. Kruse, Richard D. DiMarchi, Richard M. Caprioli, Jeffrey M. Spraggins, Walter J. Chazin, David P. Giedroc, and Eric P. Skaar. Zn-regulated gtpase metalloprotein activator 1 modulates vertebrate zinc homeostasis. Cell, 185:2148-2163.e27, Jun 2022. URL: https://doi.org/10.1016/j.cell.2022.04.011, doi:10.1016/j.cell.2022.04.011. This article has 113 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(weiss2022znregulatedgtpasemetalloprotein pages 11-13): Andy Weiss, Caitlin C. Murdoch, Katherine A. Edmonds, Matthew R. Jordan, Andrew J. Monteith, Yasiru R. Perera, Aslin M. Rodríguez Nassif, Amber M. Petoletti, William N. Beavers, Matthew J. Munneke, Sydney L. Drury, Evan S. Krystofiak, Kishore Thalluri, Hongwei Wu, Angela R.S. Kruse, Richard D. DiMarchi, Richard M. Caprioli, Jeffrey M. Spraggins, Walter J. Chazin, David P. Giedroc, and Eric P. Skaar. Zn-regulated gtpase metalloprotein activator 1 modulates vertebrate zinc homeostasis. Cell, 185:2148-2163.e27, Jun 2022. URL: https://doi.org/10.1016/j.cell.2022.04.011, doi:10.1016/j.cell.2022.04.011. This article has 113 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(zhang2023tworelatedfamilies pages 1-2): Lifang Zhang, Janeen Braynen, Audrey Fahey, Kriti Chopra, Paolo Cifani, Dimiru Tadesse, Michael Regulski, Fangle Hu, Hubertus J. J. van Dam, Meng Xie, Doreen Ware, and Crysten E. Blaby-Haas. Two related families of metal transferases, zng1 and zng2, are involved in acclimation to poor zn nutrition in arabidopsis. Frontiers in Plant Science, Oct 2023. URL: https://doi.org/10.3389/fpls.2023.1237722, doi:10.3389/fpls.2023.1237722. This article has 8 citations.</p>
+</li>
+<li>
+<p>(young2023twodistinctthermodynamic pages 1-2): Tessa R. Young, Evelyne Deery, Andrew W. Foster, Maria Alessandra Martini, Deenah Osman, Martin J. Warren, and Nigel J. Robinson. Two distinct thermodynamic gradients for cellular metalation of vitamin b12. JACS Au, 3:1472-1483, May 2023. URL: https://doi.org/10.1021/jacsau.3c00119, doi:10.1021/jacsau.3c00119. This article has 12 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(maret2022escortproteinsfor pages 1-2): Wolfgang Maret. Escort proteins for cellular zinc ions. Nature, 608:38-39, Aug 2022. URL: https://doi.org/10.1038/d41586-022-01988-2, doi:10.1038/d41586-022-01988-2. This article has 12 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(young2023twodistinctthermodynamic pages 5-6): Tessa R. Young, Evelyne Deery, Andrew W. Foster, Maria Alessandra Martini, Deenah Osman, Martin J. Warren, and Nigel J. Robinson. Two distinct thermodynamic gradients for cellular metalation of vitamin b12. JACS Au, 3:1472-1483, May 2023. URL: https://doi.org/10.1021/jacsau.3c00119, doi:10.1021/jacsau.3c00119. This article has 12 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(weiss2022znregulatedgtpasemetalloprotein pages 13-15): Andy Weiss, Caitlin C. Murdoch, Katherine A. Edmonds, Matthew R. Jordan, Andrew J. Monteith, Yasiru R. Perera, Aslin M. Rodríguez Nassif, Amber M. Petoletti, William N. Beavers, Matthew J. Munneke, Sydney L. Drury, Evan S. Krystofiak, Kishore Thalluri, Hongwei Wu, Angela R.S. Kruse, Richard D. DiMarchi, Richard M. Caprioli, Jeffrey M. Spraggins, Walter J. Chazin, David P. Giedroc, and Eric P. Skaar. Zn-regulated gtpase metalloprotein activator 1 modulates vertebrate zinc homeostasis. Cell, 185:2148-2163.e27, Jun 2022. URL: https://doi.org/10.1016/j.cell.2022.04.011, doi:10.1016/j.cell.2022.04.011. This article has 113 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(weiss2022znregulatedgtpasemetalloprotein pages 5-6): Andy Weiss, Caitlin C. Murdoch, Katherine A. Edmonds, Matthew R. Jordan, Andrew J. Monteith, Yasiru R. Perera, Aslin M. Rodríguez Nassif, Amber M. Petoletti, William N. Beavers, Matthew J. Munneke, Sydney L. Drury, Evan S. Krystofiak, Kishore Thalluri, Hongwei Wu, Angela R.S. Kruse, Richard D. DiMarchi, Richard M. Caprioli, Jeffrey M. Spraggins, Walter J. Chazin, David P. Giedroc, and Eric P. Skaar. Zn-regulated gtpase metalloprotein activator 1 modulates vertebrate zinc homeostasis. Cell, 185:2148-2163.e27, Jun 2022. URL: https://doi.org/10.1016/j.cell.2022.04.011, doi:10.1016/j.cell.2022.04.011. This article has 113 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(weiss2022znregulatedgtpasemetalloprotein media 7dd994c9): Andy Weiss, Caitlin C. Murdoch, Katherine A. Edmonds, Matthew R. Jordan, Andrew J. Monteith, Yasiru R. Perera, Aslin M. Rodríguez Nassif, Amber M. Petoletti, William N. Beavers, Matthew J. Munneke, Sydney L. Drury, Evan S. Krystofiak, Kishore Thalluri, Hongwei Wu, Angela R.S. Kruse, Richard D. DiMarchi, Richard M. Caprioli, Jeffrey M. Spraggins, Walter J. Chazin, David P. Giedroc, and Eric P. Skaar. Zn-regulated gtpase metalloprotein activator 1 modulates vertebrate zinc homeostasis. Cell, 185:2148-2163.e27, Jun 2022. URL: https://doi.org/10.1016/j.cell.2022.04.011, doi:10.1016/j.cell.2022.04.011. This article has 113 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(weiss2022znregulatedgtpasemetalloprotein media 50dba8c7): Andy Weiss, Caitlin C. Murdoch, Katherine A. Edmonds, Matthew R. Jordan, Andrew J. Monteith, Yasiru R. Perera, Aslin M. Rodríguez Nassif, Amber M. Petoletti, William N. Beavers, Matthew J. Munneke, Sydney L. Drury, Evan S. Krystofiak, Kishore Thalluri, Hongwei Wu, Angela R.S. Kruse, Richard D. DiMarchi, Richard M. Caprioli, Jeffrey M. Spraggins, Walter J. Chazin, David P. Giedroc, and Eric P. Skaar. Zn-regulated gtpase metalloprotein activator 1 modulates vertebrate zinc homeostasis. Cell, 185:2148-2163.e27, Jun 2022. URL: https://doi.org/10.1016/j.cell.2022.04.011, doi:10.1016/j.cell.2022.04.011. This article has 113 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(zhang2023tworelatedfamilies pages 7-9): Lifang Zhang, Janeen Braynen, Audrey Fahey, Kriti Chopra, Paolo Cifani, Dimiru Tadesse, Michael Regulski, Fangle Hu, Hubertus J. J. van Dam, Meng Xie, Doreen Ware, and Crysten E. Blaby-Haas. Two related families of metal transferases, zng1 and zng2, are involved in acclimation to poor zn nutrition in arabidopsis. Frontiers in Plant Science, Oct 2023. URL: https://doi.org/10.3389/fpls.2023.1237722, doi:10.3389/fpls.2023.1237722. This article has 8 citations.</p>
+</li>
+<li>
+<p>(zhang2023tworelatedfamilies pages 14-16): Lifang Zhang, Janeen Braynen, Audrey Fahey, Kriti Chopra, Paolo Cifani, Dimiru Tadesse, Michael Regulski, Fangle Hu, Hubertus J. J. van Dam, Meng Xie, Doreen Ware, and Crysten E. Blaby-Haas. Two related families of metal transferases, zng1 and zng2, are involved in acclimation to poor zn nutrition in arabidopsis. Frontiers in Plant Science, Oct 2023. URL: https://doi.org/10.3389/fpls.2023.1237722, doi:10.3389/fpls.2023.1237722. This article has 8 citations.</p>
+</li>
+<li>
+<p>(young2023twodistinctthermodynamic pages 2-4): Tessa R. Young, Evelyne Deery, Andrew W. Foster, Maria Alessandra Martini, Deenah Osman, Martin J. Warren, and Nigel J. Robinson. Two distinct thermodynamic gradients for cellular metalation of vitamin b12. JACS Au, 3:1472-1483, May 2023. URL: https://doi.org/10.1021/jacsau.3c00119, doi:10.1021/jacsau.3c00119. This article has 12 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(maret2022escortproteinsfor pages 2-2): Wolfgang Maret. Escort proteins for cellular zinc ions. Nature, 608:38-39, Aug 2022. URL: https://doi.org/10.1038/d41586-022-01988-2, doi:10.1038/d41586-022-01988-2. This article has 12 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(weiss2022znregulatedgtpasemetalloprotein media 3d4c9ea0): Andy Weiss, Caitlin C. Murdoch, Katherine A. Edmonds, Matthew R. Jordan, Andrew J. Monteith, Yasiru R. Perera, Aslin M. Rodríguez Nassif, Amber M. Petoletti, William N. Beavers, Matthew J. Munneke, Sydney L. Drury, Evan S. Krystofiak, Kishore Thalluri, Hongwei Wu, Angela R.S. Kruse, Richard D. DiMarchi, Richard M. Caprioli, Jeffrey M. Spraggins, Walter J. Chazin, David P. Giedroc, and Eric P. Skaar. Zn-regulated gtpase metalloprotein activator 1 modulates vertebrate zinc homeostasis. Cell, 185:2148-2163.e27, Jun 2022. URL: https://doi.org/10.1016/j.cell.2022.04.011, doi:10.1016/j.cell.2022.04.011. This article has 113 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(weiss2022znregulatedgtpasemetalloprotein pages 21-23): Andy Weiss, Caitlin C. Murdoch, Katherine A. Edmonds, Matthew R. Jordan, Andrew J. Monteith, Yasiru R. Perera, Aslin M. Rodríguez Nassif, Amber M. Petoletti, William N. Beavers, Matthew J. Munneke, Sydney L. Drury, Evan S. Krystofiak, Kishore Thalluri, Hongwei Wu, Angela R.S. Kruse, Richard D. DiMarchi, Richard M. Caprioli, Jeffrey M. Spraggins, Walter J. Chazin, David P. Giedroc, and Eric P. Skaar. Zn-regulated gtpase metalloprotein activator 1 modulates vertebrate zinc homeostasis. Cell, 185:2148-2163.e27, Jun 2022. URL: https://doi.org/10.1016/j.cell.2022.04.011, doi:10.1016/j.cell.2022.04.011. This article has 113 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>weiss2022znregulatedgtpasemetalloprotein pages 1-3</li>
+<li>maret2022escortproteinsfor pages 1-2</li>
+<li>weiss2022znregulatedgtpasemetalloprotein pages 3-5</li>
+<li>zhang2023tworelatedfamilies pages 1-2</li>
+<li>weiss2022znregulatedgtpasemetalloprotein pages 5-6</li>
+<li>zhang2023tworelatedfamilies pages 7-9</li>
+<li>maret2022escortproteinsfor pages 2-2</li>
+<li>weiss2022znregulatedgtpasemetalloprotein pages 11-13</li>
+<li>young2023twodistinctthermodynamic pages 1-2</li>
+<li>young2023twodistinctthermodynamic pages 5-6</li>
+<li>weiss2022znregulatedgtpasemetalloprotein pages 13-15</li>
+<li>zhang2023tworelatedfamilies pages 14-16</li>
+<li>young2023twodistinctthermodynamic pages 2-4</li>
+<li>weiss2022znregulatedgtpasemetalloprotein pages 21-23</li>
+<li>D/E</li>
+<li>https://doi.org/10.1016/j.cell.2022.04.011;</li>
+<li>https://doi.org/10.1038/d41586-022-01988-2;</li>
+<li>https://doi.org/10.1021/jacsau.3c00119;</li>
+<li>https://doi.org/10.3389/fpls.2023.1237722;</li>
+<li>https://doi.org/10.1016/j.cell.2022.04.011,</li>
+<li>https://doi.org/10.3389/fpls.2023.1237722,</li>
+<li>https://doi.org/10.1021/jacsau.3c00119,</li>
+<li>https://doi.org/10.1038/d41586-022-01988-2,</li>
+</ol>
+            </div>
+        </details>
+
         <details class="markdown-section">
             <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
                 <div style="flex: 1;">
@@ -2585,7 +2872,7 @@
 </ul>
             </div>
         </details>
-        
+
         <details class="markdown-section">
             <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
                 <div style="flex: 1;">
@@ -2770,9 +3057,9 @@ Key GO Annotation Recommendations:<br />
 </ol>
             </div>
         </details>
-        
+
     </div>
-    
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -2783,19 +3070,19 @@ Key GO Annotation Recommendations:<br />
             <div class="yaml-content">
                 <pre><code>id: P53729
 gene_symbol: ZNG1
+product_type: PROTEIN
+status: COMPLETE
 taxon:
   id: NCBITaxon:559292
-  label: Saccharomyces cerevisiae S288C
-description: ZNG1 encodes a zinc-regulated GTPase that functions as a zinc 
-  chaperone, directly transferring zinc cofactor to target metalloproteins. Its 
-  primary substrate is methionine aminopeptidase MAP1, which removes initiator 
-  methionine from nascent polypeptides. ZNG1 binds MAP1 through an N-terminal 
-  psi-PxLVp motif, transfers zinc from its CXCC motif to MAP1 in a GTP 
-  hydrolysis-dependent manner, and releases active MAP1 after GTP/GDP exchange. 
-  This protein exemplifies the COG0523 family of G3E P-loop GTPases that couple 
-  nucleotide hydrolysis to metal ion transfer, representing a universally 
-  conserved mechanism for metalloprotein activation that is often misannotated 
-  across species.
+  label: Saccharomyces cerevisiae
+description: &gt;-
+  ZNG1 encodes a COG0523/SIMIBI G3E P-loop GTPase metallochaperone that
+  activates the zinc-dependent methionine aminopeptidase Map1 by GTP-dependent
+  zinc transfer. Zng1 binds zinc through conserved cysteine-rich motifs, uses
+  GTP hydrolysis to drive cofactor delivery, and supports Map1-dependent
+  N-terminal methionine excision and protein maturation, especially under zinc
+  limitation. Its core function is zinc chaperone/metalloprotein activator
+  activity, not generic protein binding or bulk zinc transport.
 existing_annotations:
 - term:
     id: GO:0005737
@@ -2803,212 +3090,331 @@ existing_annotations:
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: Cytoplasmic localization for zinc delivery to MAP1
+    summary: &gt;-
+      PANTHER IBA to cytoplasm is consistent with Zng1&#39;s client Map1/MetAP1
+      acting during cytosolic nascent-polypeptide maturation.
     action: ACCEPT
+    reason: &gt;-
+      Zng1&#39;s conserved Map1 activation role is expected in the cytosol, and the
+      same compartment is supported by high-throughput yeast localization.
     supported_by:
-    - reference_id: file:yeast/ZNG1/ZNG1-falcon-research.md
-      supporting_text: See deep research file for comprehensive analysis
+    - reference_id: file:yeast/ZNG1/ZNG1-deep-research-falcon.md
+      supporting_text: &#34;the most defensible annotation for yeast Zng1p localization from this evidence is cytosolic&#34;
 - term:
     id: GO:0008270
     label: zinc ion binding
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: Binds zinc via CXCC motif for transfer to target proteins
+    summary: &gt;-
+      Family-transfer zinc binding is appropriate for Zng1, which uses conserved
+      cysteine-rich motifs to bind and transfer zinc to Map1.
     action: ACCEPT
+    reason: &gt;-
+      Zinc binding is integral to Zng1&#39;s zinc chaperone activity.
     supported_by:
     - reference_id: PMID:35584675
-      supporting_text: conserved family of putative metal transferases in human 
-        and fungi
+      supporting_text: &#34;transfer Zn2+ or Co2+ to apo-Map1p&#34;
 - term:
     id: GO:0051604
     label: protein maturation
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: Activates MAP1 for methionine excision, enabling protein maturation
+    summary: &gt;-
+      Zng1 supports Map1 metallation, enabling methionine aminopeptidase
+      activity for initiator methionine removal from nascent proteins.
     action: ACCEPT
+    reason: &gt;-
+      Protein maturation is a core downstream process of Zng1 zinc chaperone
+      activity.
     supported_by:
     - reference_id: PMID:35584675
-      supporting_text: interact with Zn-dependent methionine aminopeptidase type
-        I
+      supporting_text: &#34;needed for activation of methionine aminopeptidase&#34;
 - term:
     id: GO:0140827
     label: zinc chaperone activity
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: Primary molecular function - transfers zinc to MAP1
+    summary: &gt;-
+      PANTHER IBA to zinc chaperone activity matches the experimentally
+      supported function of yeast Zng1.
     action: ACCEPT
+    reason: &gt;-
+      Zng1 directly transfers zinc to Map1 in a GTP-dependent process, making
+      this the most specific and informative molecular function term.
     supported_by:
     - reference_id: PMID:35584675
-      supporting_text: conserved family of putative metal transferases in human 
-        and fungi
+      supporting_text: &#34;Zng1 is a GTP-dependent zinc transferase&#34;
 - term:
     id: GO:0000166
     label: nucleotide binding
   evidence_type: IEA
   original_reference_id: GO_REF:0000043
   review:
-    summary: Too general - more specific as GTP binding
-    action: REMOVE
+    summary: &gt;-
+      Nucleotide binding is true for a P-loop GTPase but too generic for Zng1
+      because GTP binding and GTPase activity are annotated separately.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      The broad nucleotide-binding term should not be treated as a core
+      annotation when the specific nucleotide and catalytic activity are known.
 - term:
     id: GO:0005525
     label: GTP binding
   evidence_type: IEA
   original_reference_id: GO_REF:0000043
   review:
-    summary: Binds GTP as part of G3E P-loop GTPase family
+    summary: &gt;-
+      GTP binding is supported by Zng1&#39;s P-loop GTPase domain and mechanistic
+      requirement for GTP hydrolysis.
     action: ACCEPT
+    reason: &gt;-
+      GTP binding is a necessary part of the zinc-transfer cycle.
+    supported_by:
+    - reference_id: file:yeast/ZNG1/ZNG1-deep-research-falcon.md
+      supporting_text: &#34;GTP hydrolysis by ZNG1 drives&#34;
 - term:
     id: GO:0016787
     label: hydrolase activity
   evidence_type: IEA
   original_reference_id: GO_REF:0000043
   review:
-    summary: Too general - more specific as GTPase activity
-    action: REMOVE
+    summary: &gt;-
+      Hydrolase activity is a broad parent term for Zng1&#39;s specific GTPase
+      activity.
+    action: MODIFY
+    reason: &gt;-
+      GO:0003924 GTPase activity is the more precise activity supported by the
+      literature and direct assay annotation.
+    proposed_replacement_terms:
+    - id: GO:0003924
+      label: GTPase activity
 - term:
     id: GO:0046872
     label: metal ion binding
   evidence_type: IEA
   original_reference_id: GO_REF:0000043
   review:
-    summary: Redundant with more specific zinc ion binding
-    action: REMOVE
+    summary: &gt;-
+      Metal ion binding is accurate but too generic for Zng1&#39;s specific zinc
+      chaperone mechanism.
+    action: MODIFY
+    reason: &gt;-
+      GO:0008270 zinc ion binding is the appropriate specific binding term for
+      the known cofactor-transfer mechanism.
+    proposed_replacement_terms:
+    - id: GO:0008270
+      label: zinc ion binding
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:16429126
+  supporting_entities:
+  - UniProtKB:P10592
+  - UniProtKB:P11484
   review:
-    summary: Non-specific - should specify MAP1 binding
-    action: REMOVE
-    supported_by:
-    - reference_id: PMID:16429126
-      supporting_text: &#34;Proteome survey reveals modularity of the yeast cell machinery.&#34;
+    summary: &gt;-
+      High-throughput interactome evidence reports protein associations, but the
+      generic protein binding term is not informative for Zng1 function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Zng1&#39;s relevant interaction is the specific Map1/MetAP1 zinc-transfer
+      client relationship, which is better captured by zinc chaperone and enzyme
+      activator annotations.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:19536198
+  supporting_entities:
+  - UniProtKB:P10592
+  - UniProtKB:P11484
   review:
-    summary: Non-specific protein binding
-    action: REMOVE
-    supported_by:
-    - reference_id: PMID:19536198
-      supporting_text: &#34;An atlas of chaperone-protein interactions in Saccharomyces
-        cerevisiae: implications to protein folding pathways in the cell.&#34;
+    summary: &gt;-
+      Chaperone-interaction atlas evidence does not define a specific Zng1
+      molecular activity and should not be retained as a core function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      The term protein binding is too vague; Zng1 should be curated to its
+      specific GTP-dependent zinc chaperone activity.
 - term:
     id: GO:0003924
     label: GTPase activity
   evidence_type: IDA
   original_reference_id: PMID:35584675
   review:
-    summary: GTP hydrolysis drives zinc transfer to MAP1
+    summary: &gt;-
+      Direct assay evidence supports Zng1 GTPase activity coupled to metal
+      transfer.
     action: ACCEPT
+    reason: &gt;-
+      GTP hydrolysis is mechanistically required for zinc transfer to Map1 and
+      is part of Zng1&#39;s core molecular function.
     supported_by:
     - reference_id: PMID:35584675
-      supporting_text: transfer is dependent on GTP hydrolysis
+      supporting_text: &#34;transfer is dependent on GTP hydrolysis&#34;
 - term:
     id: GO:0140827
     label: zinc chaperone activity
   evidence_type: IDA
   original_reference_id: PMID:35584675
   review:
-    summary: Direct experimental evidence for zinc chaperone function
+    summary: &gt;-
+      Direct experimental evidence demonstrates Zng1 zinc transfer to apo-Map1p.
     action: ACCEPT
+    reason: &gt;-
+      This is the central molecular function for ZNG1 and should be retained as
+      core.
     supported_by:
     - reference_id: PMID:35584675
-      supporting_text: Zng1p can transfer Zn2+ or Co2+ to apo-Map1p
+      supporting_text: &#34;Zng1p can transfer Zn2+ or Co2+ to apo-Map1p&#34;
 - term:
     id: GO:0008047
     label: enzyme activator activity
   evidence_type: IDA
   original_reference_id: PMID:35584675
   review:
-    summary: Activates MAP1 methionine aminopeptidase by zinc transfer
+    summary: &gt;-
+      Zng1 activates Map1 methionine aminopeptidase by delivering the metal
+      cofactor needed for activity.
     action: ACCEPT
-    reason: ZNG1 specifically activates MAP1 enzyme by delivering zinc cofactor,
-      this is a legitimate enzyme activator function.
+    reason: &gt;-
+      Enzyme activator activity is supported, although zinc chaperone activity
+      is the more specific core molecular function.
     supported_by:
     - reference_id: PMID:35584675
-      supporting_text: Zng1 is a GTP-dependent zinc transferase needed for 
-        activation of methionine aminopeptidase
+      supporting_text: &#34;needed for activation of methionine aminopeptidase&#34;
 - term:
     id: GO:0034224
     label: cellular response to zinc ion starvation
   evidence_type: IMP
   original_reference_id: PMID:35584675
   review:
-    summary: ZNG1 responds to zinc availability to activate zinc-dependent 
-      enzymes
-    action: ACCEPT
-    reason: ZNG1 function is regulated by zinc availability and it responds to 
-      zinc starvation by ensuring efficient zinc delivery to target proteins.
+    summary: &gt;-
+      Mutant phenotype evidence shows ZNG1 loss causes zinc-deficiency growth
+      and Map1-function defects.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      The zinc-starvation response is a physiological context for the core zinc
+      chaperone function rather than an independent molecular role.
     supported_by:
     - reference_id: PMID:35584675
-      supporting_text: Zng1p is required to avoid a compounding effect of Map1p 
-        dysfunction on survival during Zn limitation
+      supporting_text: &#34;a Zn-deficiency growth defect&#34;
 - term:
     id: GO:0034224
     label: cellular response to zinc ion starvation
   evidence_type: IGI
   original_reference_id: PMID:35584675
   review:
-    summary: ZNG1 responds to zinc availability to activate zinc-dependent 
-      enzymes
-    action: ACCEPT
-    reason: Same process as IMP evidence - ZNG1 is part of cellular zinc 
-      homeostasis response.
+    summary: &gt;-
+      Genetic-interaction evidence links Zng1 and Map1 function to adaptation
+      during zinc limitation.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      This annotation is supported as a condition-specific phenotype and pathway
+      context, but the core function remains GTP-dependent zinc delivery to Map1.
     supported_by:
     - reference_id: PMID:35584675
-      supporting_text: Proteomics reveal mis-regulation of the Zap1p 
-        transcription factor regulon because of loss of ZNG1
+      supporting_text: &#34;required to avoid a compounding effect of Map1p dysfunction on survival during Zn limitation&#34;
 - term:
     id: GO:0051604
     label: protein maturation
   evidence_type: IMP
   original_reference_id: PMID:35584675
   review:
-    summary: Enables MAP1 maturation by zinc cofactor insertion for methionine 
-      excision activity
+    summary: &gt;-
+      Mutant phenotype evidence supports defective Map1-dependent protein
+      maturation when ZNG1 is deleted.
     action: ACCEPT
-    reason: ZNG1 is essential for MAP1 to become functionally mature by 
-      providing zinc cofactor needed for its peptidase activity.
+    reason: &gt;-
+      Zng1 enables Map1 activation and thereby supports initiator methionine
+      excision, a protein maturation process.
     supported_by:
     - reference_id: PMID:35584675
-      supporting_text: Deletion of the putative metal transferase in 
-        Saccharomyces cerevisiae (ZNG1; formerly YNR029c) leads to defective 
-        Map1p function and a Zn-deficiency growth defect
+      supporting_text: &#34;leads to defective Map1p function&#34;
 - term:
     id: GO:0051604
     label: protein maturation
   evidence_type: IGI
   original_reference_id: PMID:35584675
   review:
-    summary: Enables MAP1 maturation by zinc cofactor insertion for methionine 
-      excision activity
+    summary: &gt;-
+      Genetic-interaction evidence links Zng1 and Map1 to protein maturation
+      through Map1 metallation and activation.
     action: ACCEPT
-    reason: Same process as IMP evidence - ZNG1 enables protein maturation 
-      through zinc chaperone activity.
+    reason: &gt;-
+      This is a direct biological process outcome of Zng1&#39;s zinc chaperone
+      activity.
     supported_by:
     - reference_id: PMID:35584675
-      supporting_text: Zng1p can transfer Zn2+ or Co2+ to apo-Map1p, but unlike 
-        characterized copper chaperones, transfer is dependent on GTP hydrolysis
+      supporting_text: &#34;needed for activation of methionine aminopeptidase&#34;
 - term:
     id: GO:0005737
     label: cytoplasm
   evidence_type: HDA
   original_reference_id: PMID:14562095
   review:
-    summary: Cytoplasmic localization confirmed by high-throughput analysis
+    summary: &gt;-
+      High-throughput direct assay supports cytoplasmic localization.
     action: ACCEPT
-    reason: Consistent with other evidence for cytoplasmic localization where 
-      ZNG1 functions to deliver zinc to MAP1.
+    reason: &gt;-
+      Cytoplasmic localization is consistent with Map1/MetAP1-mediated
+      co-translational protein maturation.
     supported_by:
     - reference_id: PMID:14562095
-      supporting_text: Global analysis of protein localization in budding yeast
+      supporting_text: &#34;Global analysis of protein localization in budding yeast.&#34;
+core_functions:
+- molecular_function:
+    id: GO:0140827
+    label: zinc chaperone activity
+  directly_involved_in:
+  - id: GO:0051604
+    label: protein maturation
+  locations:
+  - id: GO:0005737
+    label: cytoplasm
+  description: &gt;-
+    Zng1 is a GTP-dependent zinc chaperone/metalloprotein activator for Map1.
+    It binds zinc and uses GTP hydrolysis to transfer the cofactor to apo-Map1,
+    enabling methionine aminopeptidase activity and N-terminal methionine
+    excision during protein maturation, especially under zinc limitation.
+  supported_by:
+  - reference_id: PMID:35584675
+    supporting_text: &#34;Zng1p can transfer Zn2+ or Co2+ to apo-Map1p&#34;
+  - reference_id: PMID:35584675
+    supporting_text: &#34;transfer is dependent on GTP hydrolysis&#34;
+  - reference_id: file:yeast/ZNG1/ZNG1-deep-research-falcon.md
+    supporting_text: &#34;A Zn-regulated GTPase metalloprotein activator&#34;
+proposed_new_terms: []
+suggested_questions:
+- question: &gt;-
+    Under which in vivo metal conditions does yeast Map1 use zinc versus other
+    divalent metals, and does Zng1 selectively deliver zinc in all nutritional
+    states?
+- question: &gt;-
+    Are there additional yeast metalloprotein clients for Zng1 beyond Map1, or
+    is the Zng1-Map1 axis effectively dedicated?
+suggested_experiments:
+- description: &gt;-
+    Perform native metalloproteomics and Map1 activity assays in wild-type,
+    zng1 deletion, and Zng1 motif mutants across zinc-replete, zinc-limited, and
+    cobalt-supplemented conditions.
+  experiment_type: metalloproteomics/enzymology
+  hypothesis: &gt;-
+    Zng1 selectively maintains Map1 zinc occupancy and activity under zinc
+    limitation, while alternative metals only partly substitute under specific
+    conditions.
+- description: &gt;-
+    Affinity capture or proximity labeling of endogenous Zng1 under zinc-limited
+    conditions followed by quantitative proteomics to identify potential client
+    metalloproteins.
+  experiment_type: interaction proteomics
+  hypothesis: &gt;-
+    Map1 is the dominant Zng1 client, but zinc limitation may reveal additional
+    lower-abundance client interactions.
 references:
 - id: GO_REF:0000033
   title: Annotation inferences using phylogenetic trees
@@ -3023,109 +3429,25 @@ references:
   title: Proteome survey reveals modularity of the yeast cell machinery.
   findings: []
 - id: PMID:19536198
-  title: &#39;An atlas of chaperone-protein interactions in Saccharomyces cerevisiae:
-    implications to protein folding pathways in the cell.&#39;
+  title: &#39;An atlas of chaperone-protein interactions in Saccharomyces cerevisiae: implications to protein folding pathways in the cell.&#39;
   findings: []
 - id: PMID:35584675
-  title: Zng1 is a GTP-dependent zinc transferase needed for activation of 
-    methionine aminopeptidase.
+  title: Zng1 is a GTP-dependent zinc transferase needed for activation of methionine aminopeptidase.
   findings:
-  - statement: ZNG1 directly transfers zinc cofactor to MAP1 via CXCC motif
-    supporting_text: Zng1 is a GTP-dependent zinc transferase needed for 
-      activation of methionine aminopeptidase
-  - statement: GTP hydrolysis is required for zinc transfer to MAP1
-    supporting_text: GTP-dependent zinc transferase
-  - statement: ZNG1 activates MAP1 methionine aminopeptidase
-    supporting_text: needed for activation of methionine aminopeptidase
-  - statement: ZNG1 responds to zinc starvation conditions
-    supporting_text: zinc transferase needed for activation
-- id: file:yeast/ZNG1/ZNG1-falcon-research.md
-  title: Deep research on ZNG1 function
+  - statement: Zng1 directly supports Map1 activation by GTP-dependent zinc transfer.
+    supporting_text: &#34;Zng1p can transfer Zn2+ or Co2+ to apo-Map1p&#34;
+- id: file:yeast/ZNG1/ZNG1-deep-research-falcon.md
+  title: Falcon deep research report for ZNG1
   findings: []
-core_functions:
-- molecular_function:
-    id: GO:0140827
-    label: zinc chaperone activity
-  directly_involved_in:
-  - id: GO:0051604
-    label: protein maturation
-  locations:
-  - id: GO:0005737
-    label: cytoplasm
-  description: Primary function - transfers zinc to MAP1 for methionine 
-    aminopeptidase activation
-  supported_by:
-  - reference_id: PMID:35584675
-    supporting_text: Zng1p can transfer Zn2+ or Co2+ to apo-Map1p, but unlike
-      characterized copper chaperones, transfer is dependent on GTP hydrolysis
-    full_text_unavailable: true
-- molecular_function:
-    id: GO:0003924
-    label: GTPase activity
-  directly_involved_in:
-  - id: GO:0051604
-    label: protein maturation
-  description: GTP hydrolysis drives conformational change for zinc transfer
-  supported_by:
-  - reference_id: PMID:35584675
-    supporting_text: transfer is dependent on GTP hydrolysis
-    full_text_unavailable: true
-proposed_new_terms:
-- proposed_name: metallochaperone GTPase activity
-  proposed_definition: Catalysis of GTP hydrolysis coupled to the transfer of 
-    metal ions to target metalloproteins
-  justification: ZNG1 and the COG0523 family represent a distinct class of 
-    GTPases that couple nucleotide hydrolysis to metal ion transfer. This term 
-    would capture the unique mechanism that distinguishes them from other 
-    chaperones and GTPases.
-- proposed_name: zinc transferase activity
-  proposed_definition: Catalysis of the transfer of zinc ions from a donor 
-    molecule to an acceptor metalloprotein
-  justification: More specific than zinc chaperone activity, emphasizing the 
-    direct transfer mechanism demonstrated for ZNG1 to MAP1.
-suggested_experiments:
-- experiment_type: Structural analysis
-  description: Crystal structure of ZNG1 in complex with MAP1 during zinc 
-    transfer to understand the molecular mechanism of metal delivery. This would
-    reveal the conformational changes that occur during GTP hydrolysis and zinc 
-    transfer.
-- experiment_type: Substrate specificity analysis
-  description: Systematic testing of ZNG1 with different metalloproteins to 
-    determine if it specifically targets MAP1 or can deliver zinc to other 
-    enzymes. This would clarify the specificity of the zinc chaperone system.
-- experiment_type: Metal selectivity studies
-  description: Testing ZNG1 activity with different divalent metals (cobalt, 
-    manganese, iron) to understand metal specificity and potential 
-    cross-reactivity within the COG0523 family.
-suggested_questions:
-- question: How does ZNG1 recognize and bind specifically to MAP1 versus other 
-    potential target proteins?
-  experts:
-  - Structural biologists
-  - Protein biochemists
-  - Metallobiochemistry researchers
-- question: What is the precise timing and regulation of zinc transfer in 
-    relation to protein synthesis and MAP1 activity?
-  experts:
-  - Cell biologists
-  - Protein synthesis researchers
-  - Systems biologists
-- question: Are there other metalloproteins besides MAP1 that require ZNG1 for 
-    zinc delivery?
-  experts:
-  - Proteomics researchers
-  - Metal homeostasis experts
-  - Yeast geneticists
 tags:
 - lbnl-favorites
-status: DRAFT
 </code></pre>
             </div>
         </details>
     </div>
 
     <!-- Pathway Visualization Link -->
-    
+
 
     <style>
         /* Markdown Section Styles */

--- a/genes/yeast/ZNG1/ZNG1-ai-review.yaml
+++ b/genes/yeast/ZNG1/ZNG1-ai-review.yaml
@@ -1,18 +1,18 @@
 id: P53729
 gene_symbol: ZNG1
+product_type: PROTEIN
+status: COMPLETE
 taxon:
   id: NCBITaxon:559292
-  label: Saccharomyces cerevisiae S288C
-description: ZNG1 encodes a zinc-regulated GTPase that functions as a zinc 
-  chaperone, directly transferring zinc cofactor to target metalloproteins. Its 
-  primary substrate is methionine aminopeptidase MAP1, which removes initiator 
-  methionine from nascent polypeptides. ZNG1 binds MAP1 through an N-terminal 
-  psi-PxLVp motif, transfers zinc from its CXCC motif to MAP1 in a GTP 
-  hydrolysis-dependent manner, and releases active MAP1 after GTP/GDP exchange. 
-  This protein exemplifies the COG0523 family of G3E P-loop GTPases that couple 
-  nucleotide hydrolysis to metal ion transfer, representing a universally 
-  conserved mechanism for metalloprotein activation that is often misannotated 
-  across species.
+  label: Saccharomyces cerevisiae
+description: >-
+  ZNG1 encodes a COG0523/SIMIBI G3E P-loop GTPase metallochaperone that
+  activates the zinc-dependent methionine aminopeptidase Map1 by GTP-dependent
+  zinc transfer. Zng1 binds zinc through conserved cysteine-rich motifs, uses
+  GTP hydrolysis to drive cofactor delivery, and supports Map1-dependent
+  N-terminal methionine excision and protein maturation, especially under zinc
+  limitation. Its core function is zinc chaperone/metalloprotein activator
+  activity, not generic protein binding or bulk zinc transport.
 existing_annotations:
 - term:
     id: GO:0005737
@@ -20,212 +20,331 @@ existing_annotations:
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: Cytoplasmic localization for zinc delivery to MAP1
+    summary: >-
+      PANTHER IBA to cytoplasm is consistent with Zng1's client Map1/MetAP1
+      acting during cytosolic nascent-polypeptide maturation.
     action: ACCEPT
+    reason: >-
+      Zng1's conserved Map1 activation role is expected in the cytosol, and the
+      same compartment is supported by high-throughput yeast localization.
     supported_by:
-    - reference_id: file:yeast/ZNG1/ZNG1-falcon-research.md
-      supporting_text: See deep research file for comprehensive analysis
+    - reference_id: file:yeast/ZNG1/ZNG1-deep-research-falcon.md
+      supporting_text: "the most defensible annotation for yeast Zng1p localization from this evidence is cytosolic"
 - term:
     id: GO:0008270
     label: zinc ion binding
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: Binds zinc via CXCC motif for transfer to target proteins
+    summary: >-
+      Family-transfer zinc binding is appropriate for Zng1, which uses conserved
+      cysteine-rich motifs to bind and transfer zinc to Map1.
     action: ACCEPT
+    reason: >-
+      Zinc binding is integral to Zng1's zinc chaperone activity.
     supported_by:
     - reference_id: PMID:35584675
-      supporting_text: conserved family of putative metal transferases in human 
-        and fungi
+      supporting_text: "transfer Zn2+ or Co2+ to apo-Map1p"
 - term:
     id: GO:0051604
     label: protein maturation
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: Activates MAP1 for methionine excision, enabling protein maturation
+    summary: >-
+      Zng1 supports Map1 metallation, enabling methionine aminopeptidase
+      activity for initiator methionine removal from nascent proteins.
     action: ACCEPT
+    reason: >-
+      Protein maturation is a core downstream process of Zng1 zinc chaperone
+      activity.
     supported_by:
     - reference_id: PMID:35584675
-      supporting_text: interact with Zn-dependent methionine aminopeptidase type
-        I
+      supporting_text: "needed for activation of methionine aminopeptidase"
 - term:
     id: GO:0140827
     label: zinc chaperone activity
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: Primary molecular function - transfers zinc to MAP1
+    summary: >-
+      PANTHER IBA to zinc chaperone activity matches the experimentally
+      supported function of yeast Zng1.
     action: ACCEPT
+    reason: >-
+      Zng1 directly transfers zinc to Map1 in a GTP-dependent process, making
+      this the most specific and informative molecular function term.
     supported_by:
     - reference_id: PMID:35584675
-      supporting_text: conserved family of putative metal transferases in human 
-        and fungi
+      supporting_text: "Zng1 is a GTP-dependent zinc transferase"
 - term:
     id: GO:0000166
     label: nucleotide binding
   evidence_type: IEA
   original_reference_id: GO_REF:0000043
   review:
-    summary: Too general - more specific as GTP binding
-    action: REMOVE
+    summary: >-
+      Nucleotide binding is true for a P-loop GTPase but too generic for Zng1
+      because GTP binding and GTPase activity are annotated separately.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      The broad nucleotide-binding term should not be treated as a core
+      annotation when the specific nucleotide and catalytic activity are known.
 - term:
     id: GO:0005525
     label: GTP binding
   evidence_type: IEA
   original_reference_id: GO_REF:0000043
   review:
-    summary: Binds GTP as part of G3E P-loop GTPase family
+    summary: >-
+      GTP binding is supported by Zng1's P-loop GTPase domain and mechanistic
+      requirement for GTP hydrolysis.
     action: ACCEPT
+    reason: >-
+      GTP binding is a necessary part of the zinc-transfer cycle.
+    supported_by:
+    - reference_id: file:yeast/ZNG1/ZNG1-deep-research-falcon.md
+      supporting_text: "GTP hydrolysis by ZNG1 drives"
 - term:
     id: GO:0016787
     label: hydrolase activity
   evidence_type: IEA
   original_reference_id: GO_REF:0000043
   review:
-    summary: Too general - more specific as GTPase activity
-    action: REMOVE
+    summary: >-
+      Hydrolase activity is a broad parent term for Zng1's specific GTPase
+      activity.
+    action: MODIFY
+    reason: >-
+      GO:0003924 GTPase activity is the more precise activity supported by the
+      literature and direct assay annotation.
+    proposed_replacement_terms:
+    - id: GO:0003924
+      label: GTPase activity
 - term:
     id: GO:0046872
     label: metal ion binding
   evidence_type: IEA
   original_reference_id: GO_REF:0000043
   review:
-    summary: Redundant with more specific zinc ion binding
-    action: REMOVE
+    summary: >-
+      Metal ion binding is accurate but too generic for Zng1's specific zinc
+      chaperone mechanism.
+    action: MODIFY
+    reason: >-
+      GO:0008270 zinc ion binding is the appropriate specific binding term for
+      the known cofactor-transfer mechanism.
+    proposed_replacement_terms:
+    - id: GO:0008270
+      label: zinc ion binding
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:16429126
+  supporting_entities:
+  - UniProtKB:P10592
+  - UniProtKB:P11484
   review:
-    summary: Non-specific - should specify MAP1 binding
-    action: REMOVE
-    supported_by:
-    - reference_id: PMID:16429126
-      supporting_text: "Proteome survey reveals modularity of the yeast cell machinery."
+    summary: >-
+      High-throughput interactome evidence reports protein associations, but the
+      generic protein binding term is not informative for Zng1 function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      Zng1's relevant interaction is the specific Map1/MetAP1 zinc-transfer
+      client relationship, which is better captured by zinc chaperone and enzyme
+      activator annotations.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:19536198
+  supporting_entities:
+  - UniProtKB:P10592
+  - UniProtKB:P11484
   review:
-    summary: Non-specific protein binding
-    action: REMOVE
-    supported_by:
-    - reference_id: PMID:19536198
-      supporting_text: "An atlas of chaperone-protein interactions in Saccharomyces
-        cerevisiae: implications to protein folding pathways in the cell."
+    summary: >-
+      Chaperone-interaction atlas evidence does not define a specific Zng1
+      molecular activity and should not be retained as a core function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      The term protein binding is too vague; Zng1 should be curated to its
+      specific GTP-dependent zinc chaperone activity.
 - term:
     id: GO:0003924
     label: GTPase activity
   evidence_type: IDA
   original_reference_id: PMID:35584675
   review:
-    summary: GTP hydrolysis drives zinc transfer to MAP1
+    summary: >-
+      Direct assay evidence supports Zng1 GTPase activity coupled to metal
+      transfer.
     action: ACCEPT
+    reason: >-
+      GTP hydrolysis is mechanistically required for zinc transfer to Map1 and
+      is part of Zng1's core molecular function.
     supported_by:
     - reference_id: PMID:35584675
-      supporting_text: transfer is dependent on GTP hydrolysis
+      supporting_text: "transfer is dependent on GTP hydrolysis"
 - term:
     id: GO:0140827
     label: zinc chaperone activity
   evidence_type: IDA
   original_reference_id: PMID:35584675
   review:
-    summary: Direct experimental evidence for zinc chaperone function
+    summary: >-
+      Direct experimental evidence demonstrates Zng1 zinc transfer to apo-Map1p.
     action: ACCEPT
+    reason: >-
+      This is the central molecular function for ZNG1 and should be retained as
+      core.
     supported_by:
     - reference_id: PMID:35584675
-      supporting_text: Zng1p can transfer Zn2+ or Co2+ to apo-Map1p
+      supporting_text: "Zng1p can transfer Zn2+ or Co2+ to apo-Map1p"
 - term:
     id: GO:0008047
     label: enzyme activator activity
   evidence_type: IDA
   original_reference_id: PMID:35584675
   review:
-    summary: Activates MAP1 methionine aminopeptidase by zinc transfer
+    summary: >-
+      Zng1 activates Map1 methionine aminopeptidase by delivering the metal
+      cofactor needed for activity.
     action: ACCEPT
-    reason: ZNG1 specifically activates MAP1 enzyme by delivering zinc cofactor,
-      this is a legitimate enzyme activator function.
+    reason: >-
+      Enzyme activator activity is supported, although zinc chaperone activity
+      is the more specific core molecular function.
     supported_by:
     - reference_id: PMID:35584675
-      supporting_text: Zng1 is a GTP-dependent zinc transferase needed for 
-        activation of methionine aminopeptidase
+      supporting_text: "needed for activation of methionine aminopeptidase"
 - term:
     id: GO:0034224
     label: cellular response to zinc ion starvation
   evidence_type: IMP
   original_reference_id: PMID:35584675
   review:
-    summary: ZNG1 responds to zinc availability to activate zinc-dependent 
-      enzymes
-    action: ACCEPT
-    reason: ZNG1 function is regulated by zinc availability and it responds to 
-      zinc starvation by ensuring efficient zinc delivery to target proteins.
+    summary: >-
+      Mutant phenotype evidence shows ZNG1 loss causes zinc-deficiency growth
+      and Map1-function defects.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      The zinc-starvation response is a physiological context for the core zinc
+      chaperone function rather than an independent molecular role.
     supported_by:
     - reference_id: PMID:35584675
-      supporting_text: Zng1p is required to avoid a compounding effect of Map1p 
-        dysfunction on survival during Zn limitation
+      supporting_text: "a Zn-deficiency growth defect"
 - term:
     id: GO:0034224
     label: cellular response to zinc ion starvation
   evidence_type: IGI
   original_reference_id: PMID:35584675
   review:
-    summary: ZNG1 responds to zinc availability to activate zinc-dependent 
-      enzymes
-    action: ACCEPT
-    reason: Same process as IMP evidence - ZNG1 is part of cellular zinc 
-      homeostasis response.
+    summary: >-
+      Genetic-interaction evidence links Zng1 and Map1 function to adaptation
+      during zinc limitation.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      This annotation is supported as a condition-specific phenotype and pathway
+      context, but the core function remains GTP-dependent zinc delivery to Map1.
     supported_by:
     - reference_id: PMID:35584675
-      supporting_text: Proteomics reveal mis-regulation of the Zap1p 
-        transcription factor regulon because of loss of ZNG1
+      supporting_text: "required to avoid a compounding effect of Map1p dysfunction on survival during Zn limitation"
 - term:
     id: GO:0051604
     label: protein maturation
   evidence_type: IMP
   original_reference_id: PMID:35584675
   review:
-    summary: Enables MAP1 maturation by zinc cofactor insertion for methionine 
-      excision activity
+    summary: >-
+      Mutant phenotype evidence supports defective Map1-dependent protein
+      maturation when ZNG1 is deleted.
     action: ACCEPT
-    reason: ZNG1 is essential for MAP1 to become functionally mature by 
-      providing zinc cofactor needed for its peptidase activity.
+    reason: >-
+      Zng1 enables Map1 activation and thereby supports initiator methionine
+      excision, a protein maturation process.
     supported_by:
     - reference_id: PMID:35584675
-      supporting_text: Deletion of the putative metal transferase in 
-        Saccharomyces cerevisiae (ZNG1; formerly YNR029c) leads to defective 
-        Map1p function and a Zn-deficiency growth defect
+      supporting_text: "leads to defective Map1p function"
 - term:
     id: GO:0051604
     label: protein maturation
   evidence_type: IGI
   original_reference_id: PMID:35584675
   review:
-    summary: Enables MAP1 maturation by zinc cofactor insertion for methionine 
-      excision activity
+    summary: >-
+      Genetic-interaction evidence links Zng1 and Map1 to protein maturation
+      through Map1 metallation and activation.
     action: ACCEPT
-    reason: Same process as IMP evidence - ZNG1 enables protein maturation 
-      through zinc chaperone activity.
+    reason: >-
+      This is a direct biological process outcome of Zng1's zinc chaperone
+      activity.
     supported_by:
     - reference_id: PMID:35584675
-      supporting_text: Zng1p can transfer Zn2+ or Co2+ to apo-Map1p, but unlike 
-        characterized copper chaperones, transfer is dependent on GTP hydrolysis
+      supporting_text: "needed for activation of methionine aminopeptidase"
 - term:
     id: GO:0005737
     label: cytoplasm
   evidence_type: HDA
   original_reference_id: PMID:14562095
   review:
-    summary: Cytoplasmic localization confirmed by high-throughput analysis
+    summary: >-
+      High-throughput direct assay supports cytoplasmic localization.
     action: ACCEPT
-    reason: Consistent with other evidence for cytoplasmic localization where 
-      ZNG1 functions to deliver zinc to MAP1.
+    reason: >-
+      Cytoplasmic localization is consistent with Map1/MetAP1-mediated
+      co-translational protein maturation.
     supported_by:
     - reference_id: PMID:14562095
-      supporting_text: Global analysis of protein localization in budding yeast
+      supporting_text: "Global analysis of protein localization in budding yeast."
+core_functions:
+- molecular_function:
+    id: GO:0140827
+    label: zinc chaperone activity
+  directly_involved_in:
+  - id: GO:0051604
+    label: protein maturation
+  locations:
+  - id: GO:0005737
+    label: cytoplasm
+  description: >-
+    Zng1 is a GTP-dependent zinc chaperone/metalloprotein activator for Map1.
+    It binds zinc and uses GTP hydrolysis to transfer the cofactor to apo-Map1,
+    enabling methionine aminopeptidase activity and N-terminal methionine
+    excision during protein maturation, especially under zinc limitation.
+  supported_by:
+  - reference_id: PMID:35584675
+    supporting_text: "Zng1p can transfer Zn2+ or Co2+ to apo-Map1p"
+  - reference_id: PMID:35584675
+    supporting_text: "transfer is dependent on GTP hydrolysis"
+  - reference_id: file:yeast/ZNG1/ZNG1-deep-research-falcon.md
+    supporting_text: "A Zn-regulated GTPase metalloprotein activator"
+proposed_new_terms: []
+suggested_questions:
+- question: >-
+    Under which in vivo metal conditions does yeast Map1 use zinc versus other
+    divalent metals, and does Zng1 selectively deliver zinc in all nutritional
+    states?
+- question: >-
+    Are there additional yeast metalloprotein clients for Zng1 beyond Map1, or
+    is the Zng1-Map1 axis effectively dedicated?
+suggested_experiments:
+- description: >-
+    Perform native metalloproteomics and Map1 activity assays in wild-type,
+    zng1 deletion, and Zng1 motif mutants across zinc-replete, zinc-limited, and
+    cobalt-supplemented conditions.
+  experiment_type: metalloproteomics/enzymology
+  hypothesis: >-
+    Zng1 selectively maintains Map1 zinc occupancy and activity under zinc
+    limitation, while alternative metals only partly substitute under specific
+    conditions.
+- description: >-
+    Affinity capture or proximity labeling of endogenous Zng1 under zinc-limited
+    conditions followed by quantitative proteomics to identify potential client
+    metalloproteins.
+  experiment_type: interaction proteomics
+  hypothesis: >-
+    Map1 is the dominant Zng1 client, but zinc limitation may reveal additional
+    lower-abundance client interactions.
 references:
 - id: GO_REF:0000033
   title: Annotation inferences using phylogenetic trees
@@ -240,99 +359,15 @@ references:
   title: Proteome survey reveals modularity of the yeast cell machinery.
   findings: []
 - id: PMID:19536198
-  title: 'An atlas of chaperone-protein interactions in Saccharomyces cerevisiae:
-    implications to protein folding pathways in the cell.'
+  title: 'An atlas of chaperone-protein interactions in Saccharomyces cerevisiae: implications to protein folding pathways in the cell.'
   findings: []
 - id: PMID:35584675
-  title: Zng1 is a GTP-dependent zinc transferase needed for activation of 
-    methionine aminopeptidase.
+  title: Zng1 is a GTP-dependent zinc transferase needed for activation of methionine aminopeptidase.
   findings:
-  - statement: ZNG1 directly transfers zinc cofactor to MAP1 via CXCC motif
-    supporting_text: Zng1 is a GTP-dependent zinc transferase needed for 
-      activation of methionine aminopeptidase
-  - statement: GTP hydrolysis is required for zinc transfer to MAP1
-    supporting_text: GTP-dependent zinc transferase
-  - statement: ZNG1 activates MAP1 methionine aminopeptidase
-    supporting_text: needed for activation of methionine aminopeptidase
-  - statement: ZNG1 responds to zinc starvation conditions
-    supporting_text: zinc transferase needed for activation
-- id: file:yeast/ZNG1/ZNG1-falcon-research.md
-  title: Deep research on ZNG1 function
+  - statement: Zng1 directly supports Map1 activation by GTP-dependent zinc transfer.
+    supporting_text: "Zng1p can transfer Zn2+ or Co2+ to apo-Map1p"
+- id: file:yeast/ZNG1/ZNG1-deep-research-falcon.md
+  title: Falcon deep research report for ZNG1
   findings: []
-core_functions:
-- molecular_function:
-    id: GO:0140827
-    label: zinc chaperone activity
-  directly_involved_in:
-  - id: GO:0051604
-    label: protein maturation
-  locations:
-  - id: GO:0005737
-    label: cytoplasm
-  description: Primary function - transfers zinc to MAP1 for methionine 
-    aminopeptidase activation
-  supported_by:
-  - reference_id: PMID:35584675
-    supporting_text: Zng1p can transfer Zn2+ or Co2+ to apo-Map1p, but unlike
-      characterized copper chaperones, transfer is dependent on GTP hydrolysis
-    full_text_unavailable: true
-- molecular_function:
-    id: GO:0003924
-    label: GTPase activity
-  directly_involved_in:
-  - id: GO:0051604
-    label: protein maturation
-  description: GTP hydrolysis drives conformational change for zinc transfer
-  supported_by:
-  - reference_id: PMID:35584675
-    supporting_text: transfer is dependent on GTP hydrolysis
-    full_text_unavailable: true
-proposed_new_terms:
-- proposed_name: metallochaperone GTPase activity
-  proposed_definition: Catalysis of GTP hydrolysis coupled to the transfer of 
-    metal ions to target metalloproteins
-  justification: ZNG1 and the COG0523 family represent a distinct class of 
-    GTPases that couple nucleotide hydrolysis to metal ion transfer. This term 
-    would capture the unique mechanism that distinguishes them from other 
-    chaperones and GTPases.
-- proposed_name: zinc transferase activity
-  proposed_definition: Catalysis of the transfer of zinc ions from a donor 
-    molecule to an acceptor metalloprotein
-  justification: More specific than zinc chaperone activity, emphasizing the 
-    direct transfer mechanism demonstrated for ZNG1 to MAP1.
-suggested_experiments:
-- experiment_type: Structural analysis
-  description: Crystal structure of ZNG1 in complex with MAP1 during zinc 
-    transfer to understand the molecular mechanism of metal delivery. This would
-    reveal the conformational changes that occur during GTP hydrolysis and zinc 
-    transfer.
-- experiment_type: Substrate specificity analysis
-  description: Systematic testing of ZNG1 with different metalloproteins to 
-    determine if it specifically targets MAP1 or can deliver zinc to other 
-    enzymes. This would clarify the specificity of the zinc chaperone system.
-- experiment_type: Metal selectivity studies
-  description: Testing ZNG1 activity with different divalent metals (cobalt, 
-    manganese, iron) to understand metal specificity and potential 
-    cross-reactivity within the COG0523 family.
-suggested_questions:
-- question: How does ZNG1 recognize and bind specifically to MAP1 versus other 
-    potential target proteins?
-  experts:
-  - Structural biologists
-  - Protein biochemists
-  - Metallobiochemistry researchers
-- question: What is the precise timing and regulation of zinc transfer in 
-    relation to protein synthesis and MAP1 activity?
-  experts:
-  - Cell biologists
-  - Protein synthesis researchers
-  - Systems biologists
-- question: Are there other metalloproteins besides MAP1 that require ZNG1 for 
-    zinc delivery?
-  experts:
-  - Proteomics researchers
-  - Metal homeostasis experts
-  - Yeast geneticists
 tags:
 - lbnl-favorites
-status: DRAFT

--- a/genes/yeast/ZNG1/ZNG1-deep-research-falcon.md
+++ b/genes/yeast/ZNG1/ZNG1-deep-research-falcon.md
@@ -1,0 +1,335 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-04T10:31:48.785202'
+end_time: '2026-05-04T10:47:55.408487'
+duration_seconds: 966.62
+template_file: templates/gene_research_go_focused.md
+template_variables:
+  organism: yeast
+  gene_id: ZNG1
+  gene_symbol: ZNG1
+  uniprot_accession: P53729
+  protein_description: 'RecName: Full=Zinc-regulated GTPase metalloprotein activator
+    1 {ECO:0000303|PubMed:35584675}; EC=3.6.5.- {ECO:0000269|PubMed:35584675};'
+  gene_info: Name=ZNG1 {ECO:0000303|PubMed:35584675, ECO:0000312|SGD:S000005312};
+    OrderedLocusNames=YNR029C; ORFNames=N3260;
+  organism_full: Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+  protein_family: Belongs to the SIMIBI class G3E GTPase family. ZNG1
+  protein_domains: CobW-likC_sf. (IPR036627); CobW-like_C. (IPR011629); CobW/HypB/UreG_nucleotide-bd.
+    (IPR003495); P-loop_NTPase. (IPR027417); Zinc-reg_GTPase_activator. (IPR051316)
+provider_config:
+  timeout: 600
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 23
+---
+
+## Question
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** P53729
+- **Protein Description:** RecName: Full=Zinc-regulated GTPase metalloprotein activator 1 {ECO:0000303|PubMed:35584675}; EC=3.6.5.- {ECO:0000269|PubMed:35584675};
+- **Gene Information:** Name=ZNG1 {ECO:0000303|PubMed:35584675, ECO:0000312|SGD:S000005312}; OrderedLocusNames=YNR029C; ORFNames=N3260;
+- **Organism (full):** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+- **Protein Family:** Belongs to the SIMIBI class G3E GTPase family. ZNG1
+- **Key Domains:** CobW-likC_sf. (IPR036627); CobW-like_C. (IPR011629); CobW/HypB/UreG_nucleotide-bd. (IPR003495); P-loop_NTPase. (IPR027417); Zinc-reg_GTPase_activator. (IPR051316)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "ZNG1" matches the protein description above**
+2. **Verify the organism is correct:** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'ZNG1' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **ZNG1** (gene ID: ZNG1, UniProt: P53729) in yeast.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** P53729
+- **Protein Description:** RecName: Full=Zinc-regulated GTPase metalloprotein activator 1 {ECO:0000303|PubMed:35584675}; EC=3.6.5.- {ECO:0000269|PubMed:35584675};
+- **Gene Information:** Name=ZNG1 {ECO:0000303|PubMed:35584675, ECO:0000312|SGD:S000005312}; OrderedLocusNames=YNR029C; ORFNames=N3260;
+- **Organism (full):** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+- **Protein Family:** Belongs to the SIMIBI class G3E GTPase family. ZNG1
+- **Key Domains:** CobW-likC_sf. (IPR036627); CobW-like_C. (IPR011629); CobW/HypB/UreG_nucleotide-bd. (IPR003495); P-loop_NTPase. (IPR027417); Zinc-reg_GTPase_activator. (IPR051316)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "ZNG1" matches the protein description above**
+2. **Verify the organism is correct:** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'ZNG1' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **ZNG1** (gene ID: ZNG1, UniProt: P53729) in yeast.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Research report: *Saccharomyces cerevisiae* ZNG1 (UniProt P53729; YNR029C)
+
+### 1) Target verification (critical identity checks)
+
+**Target gene/protein confirmed.** The literature retrieved here uses *S. cerevisiae* **YNR029C** as the fungal/yeast homolog whose function is shared with vertebrate ZNG1-family proteins and is discussed as part of the eukaryotic ZNG1 clade of COG0523/G3E P-loop NTPases. In particular, Weiss et al. explicitly connect vertebrate ZNG1 function to yeast **YNR029C** (“shared function … and yeast (YNR029c)”) and use the yeast work as evolutionary support for a conserved ZNG1–MetAP1 axis (https://doi.org/10.1016/j.cell.2022.04.011; published 2022-06-09) (weiss2022znregulatedgtpasemetalloprotein pages 3-5, weiss2022znregulatedgtpasemetalloprotein pages 1-3). 
+
+**Symbol ambiguity risk acknowledged and managed.** “ZNG1” is used in plants and animals as well; only sources that explicitly frame yeast **YNR029C/Zng1p** as the ortholog implicated in Zn-dependent activation of yeast Map1/MetAP1 were treated as relevant to this report (weiss2022znregulatedgtpasemetalloprotein pages 11-13, zhang2023tworelatedfamilies pages 1-2, young2023twodistinctthermodynamic pages 1-2).
+
+### 2) Key concepts and definitions (current understanding)
+
+#### 2.1 ZNG1 as a nucleotide-dependent metallochaperone (“Zn escort”)
+
+ZNG1 is best understood as a **nucleotide-dependent metallochaperone** (also termed an “escort” protein) that helps **allocate Zn to specific Zn-requiring client proteins**, rather than as a bulk Zn transporter (zhang2023tworelatedfamilies pages 1-2, maret2022escortproteinsfor pages 1-2). This concept fills a long-standing gap in Zn biology: targeted Zn transfer to apo-metalloproteins had been hypothesized, but remained difficult to demonstrate experimentally (weiss2022znregulatedgtpasemetalloprotein pages 1-3).
+
+A widely cited expert commentary in *Nature* describes ZNG1 in these terms, noting that recent studies identified a zinc “escort” that delivers Zn to an essential enzyme (client), methionine aminopeptidase 1 (METAP1) (https://doi.org/10.1038/d41586-022-01988-2; published 2022-08) (maret2022escortproteinsfor pages 1-2).
+
+#### 2.2 Client enzyme: type I methionine aminopeptidase (Map1/MetAP1)
+
+The **primary client** associated with eukaryotic ZNG1 (including yeast ZNG1/YNR029C) is **type I methionine aminopeptidase (MetAP1; yeast Map1)** (zhang2023tworelatedfamilies pages 1-2, young2023twodistinctthermodynamic pages 1-2). MetAP enzymes perform **N-terminal methionine excision (NME)**, a co-/peri-translational processing step described as affecting **approximately half of newly synthesized peptides**, influencing protein maturation, stability, and localization (weiss2022znregulatedgtpasemetalloprotein pages 3-5).
+
+#### 2.3 Mechanistic hallmarks (domain/motif logic)
+
+ZNG1-family proteins belong to the **G3E subfamily of P-loop GTPases** (COG0523 family) whose members use nucleotide hydrolysis to power metal delivery/insertions (weiss2022znregulatedgtpasemetalloprotein pages 1-3). A defining feature of nucleotide-dependent metallochaperones (NMCs), including ZNG1, is a **metal-binding CxCC motif** positioned between Switch I and Walker B in the GTPase core, consistent with a Zn-binding/transfer role (zhang2023tworelatedfamilies pages 1-2).
+
+### 3) Primary function and mechanism of yeast ZNG1 (what it does, where, and how)
+
+#### 3.1 Best-supported primary molecular function in yeast
+
+Within the accessible literature corpus, the most consistent functional assignment for *S. cerevisiae* ZNG1/YNR029C is:
+
+* **A Zn-regulated GTPase metalloprotein activator / Zn metallochaperone whose key client is Map1 (MetAP1), supporting Map1 metalation and activity, especially under Zn limitation.**
+
+This is stated directly in 2023 synthesis papers that treat yeast ScZng1 as the **strongest support for direct Zn transfer** to MetAP1 in a **GTP-dependent** manner (zhang2023tworelatedfamilies pages 1-2), and is consistent with the conserved eukaryotic ZNG1–MetAP1 model from mechanistic primary work (weiss2022znregulatedgtpasemetalloprotein pages 3-5).
+
+#### 3.2 Mechanistic model: Zn delivery coupled to GTP hydrolysis
+
+The mechanistic model (established most rigorously in the conserved vertebrate/eukaryotic ZNG1–METAP1 system) is:
+
+1. ZNG1 binds Zn (via the conserved cysteine-rich metal-binding features in the ZNG1/NMC family) (zhang2023tworelatedfamilies pages 1-2).
+2. ZNG1 binds MetAP1 via a specific protein–protein interaction interface.
+3. **GTP hydrolysis** by ZNG1 drives a shift that enables **Zn transfer into the MetAP1 catalytic site**, thereby activating the metalloprotease (weiss2022znregulatedgtpasemetalloprotein pages 3-5, weiss2022znregulatedgtpasemetalloprotein pages 11-13).
+
+This “hydrolysis-coupled transfer” logic is consistent with broader thermodynamic frameworks developed for related COG0523 metallochaperones (e.g., CobW): metal transfer can become favorable **after nucleotide hydrolysis**, a conceptual framework that supports why an NTPase metallochaperone is needed at all (https://doi.org/10.1021/jacsau.3c00119; published 2023-05-10) (young2023twodistinctthermodynamic pages 1-2, young2023twodistinctthermodynamic pages 5-6).
+
+#### 3.3 Molecular recognition: domains/motifs and quantitative interaction strength
+
+Although yeast-specific binding constants were not retrieved here, the conserved interaction is described in high-resolution mechanistic work:
+
+* The MetAP1 region recognized by ZNG1 is an **N-terminal Zn-binding “C6H2” domain**, with a minimal interacting segment reported as ~108 residues in vertebrate METAP1 (weiss2022znregulatedgtpasemetalloprotein pages 3-5).
+* ZNG1 uses a short N-terminal peptide motif (vertebrate **CPELVPI**), generalized across eukaryotes to **[D/E]nψPxLVp**; yeast Zng1p lacks the exact vertebrate peptide but matches the generalized motif pattern, and modeling predicts a similar interface for yeast Zng1p–Map1p (weiss2022znregulatedgtpasemetalloprotein pages 11-13, weiss2022znregulatedgtpasemetalloprotein pages 13-15).
+* Quantitatively, binding of ZNG1 peptides to METAP1 N-terminal constructs is **high affinity**, with **K\_D ~0.1 μM** (reported range ~0.12–0.30 μM across tested homologs), much tighter than canonical MYND–peptide interactions (weiss2022znregulatedgtpasemetalloprotein pages 5-6). A representative binding-affinity panel is available from the primary paper figures (weiss2022znregulatedgtpasemetalloprotein media 7dd994c9).
+
+**Visual evidence.** The retrieved figure panels include the binding affinity summary and mechanistic schematic of Zn/GTP-dependent activation (weiss2022znregulatedgtpasemetalloprotein media 7dd994c9, weiss2022znregulatedgtpasemetalloprotein media 50dba8c7).
+
+#### 3.4 Where in the cell does yeast Zng1p act?
+
+Direct yeast localization measurements were not available in the retrieved corpus. However, multiple lines support a **cytosolic functional context**:
+
+* The conserved client MetAP1/Map1 performs cotranslational NME on nascent peptides (weiss2022znregulatedgtpasemetalloprotein pages 3-5), a process tightly linked to cytosolic translation.
+* A 2023 experimental study of the plant ortholog shows **cytosolic localization** of ZNG1 and physical interaction with cytosolic type I MetAP (AtMAP1A), consistent with conservation of a cytosolic ZNG1–MetAP axis across eukaryotes (https://doi.org/10.3389/fpls.2023.1237722; published 2023-10) (zhang2023tworelatedfamilies pages 1-2, zhang2023tworelatedfamilies pages 7-9).
+
+Accordingly, the most defensible annotation for yeast Zng1p localization from this evidence is **cytosolic (inferred)** pending direct yeast imaging/biochemistry.
+
+### 4) Recent developments and latest research (prioritizing 2023–2024)
+
+#### 4.1 2023: Expansion and generalization of the ZNG1 concept and conserved mechanism
+
+**(i) ZNG1 placed into a broader “NMC” framework.** Zhang et al. (2023) treat ZNG1 as part of nucleotide-dependent metallochaperones and emphasize shared motifs (CxCC) and a conserved Zn/GTP-dependent activation logic for MetAP1 (zhang2023tworelatedfamilies pages 1-2).
+
+**(ii) Cytosolic interaction + Zn-deficiency phenotypes (ortholog evidence).** In Arabidopsis, AtZNG1 localizes to the cytosol and interacts with AtMAP1A (BiFC, Y2H). zng1 mutants show **Zn-dependent growth phenotypes** (no obvious phenotype in +Zn; defects in −Zn), consistent with a role in acclimation to poor Zn nutrition (zhang2023tworelatedfamilies pages 7-9).
+
+**(iii) Systems-level consequences.** Zhang et al. report that loss of this conserved mechanism leads to broad “pleiotropic” transcriptomic/proteomic changes, including **hundreds of genes** and a set of **961 transcripts** with significant abundance differences in one analysis (zhang2023tworelatedfamilies pages 1-2, zhang2023tworelatedfamilies pages 14-16). While these are plant data, they underscore how disrupting ZNG1-dependent MetAP1 metalation can propagate through cellular physiology.
+
+#### 4.2 2024: Accessible corpus limitation
+
+Within the accessible retrieval set, **no yeast-focused 2024 primary paper** directly extending ZNG1/YNR029C functional studies was obtained. The most directly relevant recent sources available were 2023 primary/synthesis works (zhang2023tworelatedfamilies pages 7-9, young2023twodistinctthermodynamic pages 1-2).
+
+### 5) Current applications and real-world implementations
+
+Direct industrial/clinical implementations specifically targeting yeast ZNG1 were not identified in the retrieved corpus. However, the ZNG1 functional axis has clear **real-world relevance** through:
+
+1. **Nutrient limitation biology and stress tolerance.** ZNG1 is repeatedly framed as supporting function under **Zn limitation**, a nutritionally and ecologically relevant condition (weiss2022znregulatedgtpasemetalloprotein pages 3-5, maret2022escortproteinsfor pages 1-2).
+2. **Biotechnology/engineering-biology rationale (conceptual application).** Thermodynamic work on related COG0523 metallochaperones emphasizes that metallochaperone requirements can determine success/failure of heterologous metalloenzyme pathways and can stall bioprocess outputs unless metal delivery is correctly engineered (young2023twodistinctthermodynamic pages 1-2, young2023twodistinctthermodynamic pages 2-4). By analogy, manipulating ZNG1-like metallochaperones is a plausible strategy to improve metalation fidelity in engineered systems.
+3. **Agricultural applications (ortholog-based).** Zhang et al. explicitly frame identifying ZNG-family acclimation mechanisms as opportunities to improve **metal-use efficiency** and “develop plant foodstuffs with increased concentrations of bioavailable metal nutrients” (biofortification) (zhang2023tworelatedfamilies pages 1-2).
+
+For yeast biotechnology, these points support a **practical hypothesis** (not yet shown in the retrieved evidence): ZNG1 status could affect performance under Zn-limited industrial fermentations by maintaining functional NME via Map1.
+
+### 6) Expert opinions and authoritative analysis
+
+A *Nature* News & Views by Wolfgang Maret positions ZNG1 as a newly identified **zinc-ion escort/metallochaperone** and emphasizes that, given Zn’s pervasive protein usage, “allocation” mechanisms are essential, while also highlighting important open questions such as the metal flexibility of MetAPs and whether METAP1 actually uses Zn under deficiency (https://doi.org/10.1038/d41586-022-01988-2; published 2022-08) (maret2022escortproteinsfor pages 2-2, maret2022escortproteinsfor pages 1-2). Notably, this commentary mentions that some MetAPs, including the **yeast enzyme**, can use **cobalt**, underscoring that “Zn delivery” by ZNG1 may coexist with client metal plasticity depending on conditions (maret2022escortproteinsfor pages 2-2).
+
+### 7) Statistics and data highlights (recent/authoritative)
+
+* **Scale of Zn usage:** Zn is described as a cofactor for **~10% of proteins** in living organisms (and “At least 10% of human proteins contain zinc as a cofactor”), emphasizing the magnitude of the cellular allocation problem ZNG1 addresses (weiss2022znregulatedgtpasemetalloprotein pages 1-3, maret2022escortproteinsfor pages 1-2).
+* **Client process prevalence:** MetAP-dependent NME affects **~half of newly synthesized peptides** (weiss2022znregulatedgtpasemetalloprotein pages 3-5).
+* **Quantitative binding (mechanistic benchmark):** ZNG1 peptide–METAP1 N-terminal domain binding **K\_D ~0.1 μM** (approximate range ~0.12–0.30 μM depending on homolog), supporting a specific, high-affinity client interaction (weiss2022znregulatedgtpasemetalloprotein pages 5-6, weiss2022znregulatedgtpasemetalloprotein media 7dd994c9).
+* **Omics-scale response (2023 ortholog study):** ZNG1 loss linked to altered expression of **hundreds of genes**, with one analysis visualizing **961 transcripts** with significant differences (zhang2023tworelatedfamilies pages 1-2, zhang2023tworelatedfamilies pages 14-16).
+
+### 8) Evidence-weighted functional annotation summary
+
+The following table consolidates key annotation claims, their evidence strength, and quantitative anchors.
+
+| Annotation item | Evidence type (direct yeast / conserved inference / review) | Key data/statistics | Primary source(s) |
+|---|---|---|---|
+| **Identity and family**: *S. cerevisiae* ZNG1 (YNR029C; UniProt P53729) belongs to the COG0523/G3E P-loop GTPase family and is treated as the yeast ortholog of eukaryotic ZNG1 metallochaperones. | Conserved inference supported by cross-species primary literature | Conserved GTPase catalytic motifs and metal-binding residues are emphasized for ZNG1-family proteins; ZNG1 proteins are placed in the G3E/COG0523 metalloprotein-activator class. | (weiss2022znregulatedgtpasemetalloprotein pages 1-3, zhang2023tworelatedfamilies pages 1-2) |
+| **Primary molecular function**: ZNG1 is best understood as a **zinc metallochaperone / Zn-regulated GTPase metalloprotein activator** rather than a bulk Zn transporter. | Direct yeast evidence summarized in later papers; authoritative review | Reviews and follow-up papers state that the strongest support for direct Zn transfer to MetAP1 comes from yeast ScZng1 studies; expert commentary frames ZNG1 as a Zn “escort” protein. | (zhang2023tworelatedfamilies pages 1-2, maret2022escortproteinsfor pages 2-2, maret2022escortproteinsfor pages 1-2) |
+| **Likely client protein in yeast**: the principal client is **Map1/MetAP1 (type I methionine aminopeptidase)**. | Direct yeast evidence summarized in review/follow-up; conserved primary evidence | Young 2023 explicitly notes that deletion of **ZNG1 in *S. cerevisiae*** impairs Map1; multiple sources identify METAP1 as the conserved ZNG1 client across eukaryotes. | (weiss2022znregulatedgtpasemetalloprotein pages 11-13, zhang2023tworelatedfamilies pages 1-2, weiss2022znregulatedgtpasemetalloprotein pages 3-5) |
+| **Biochemical role of the client**: Map1/MetAP1 catalyzes **N-terminal methionine excision (NME)** from nascent proteins, a cotranslational processing step affecting about half of newly synthesized peptides in eukaryotes. | Conserved primary evidence / review | METAP1 is described as a metalloprotease for NME; Cell paper notes NME applies to “approximately half” of newly synthesized peptides. | (weiss2022znregulatedgtpasemetalloprotein pages 3-5) |
+| **Mechanism**: ZNG1 is proposed to **bind Zn and deliver it to Map1/MetAP1 in a GTP-dependent manner**, with GTP hydrolysis driving transfer into the client active site. | Direct yeast evidence summarized in later papers; conserved primary evidence | Follow-up sources state ScZng1 provides in vivo and in vitro evidence for **GTP-dependent Zn transfer** to MetAP1; mechanistic model proposes transfer is favored after nucleotide hydrolysis. | (zhang2023tworelatedfamilies pages 1-2, weiss2022znregulatedgtpasemetalloprotein pages 11-13) |
+| **Enzymatic activity of ZNG1 itself**: a **GTPase** whose hydrolysis is functionally coupled to metal delivery. | Conserved primary evidence | GTP hydrolysis is described as the energy source for metal transfer in G3E/COG0523 proteins; in vertebrate assays, METAP1 stimulated ZNG1 GTPase activity, though hydrolysis was low in vitro. | (weiss2022znregulatedgtpasemetalloprotein pages 1-3, weiss2022znregulatedgtpasemetalloprotein pages 3-5, weiss2022znregulatedgtpasemetalloprotein pages 13-15) |
+| **Metal-binding signature**: ZNG1/NMC proteins contain a **CxCC motif** positioned between Switch I and Walker B, consistent with a Zn-binding/transfer site. | Conserved inference supported by primary literature | The CxCC motif is highlighted as the defining metal-binding feature of ZNG1/NMC proteins. | (zhang2023tworelatedfamilies pages 1-2) |
+| **Interaction interface on client**: the ZNG1-binding region of MetAP1 is an **N-terminal C6H2 Zn-binding domain**. | Conserved primary evidence; yeast-specific support by modeling | In vertebrates, the minimal interacting segment is a **108-residue N-terminal region** containing the **C6H2 domain**; yeast Zng1p–Map1p modeling predicts a nearly identical fold/interface. | (weiss2022znregulatedgtpasemetalloprotein pages 3-5, weiss2022znregulatedgtpasemetalloprotein pages 11-13) |
+| **Interaction motif on ZNG1**: a conserved N-terminal peptide motif mediates MetAP1 binding; vertebrate motif is **CPELVPI**, generalized to **[D/E]nψPxLVp** across many eukaryotes, including yeast-compatible predictions. | Conserved primary evidence with yeast-specific modeling | About **~50% of eukaryotic ZNG1 homologs** share the broader motif; yeast lacks the exact vertebrate sequence but matches the generalized pattern. | (weiss2022znregulatedgtpasemetalloprotein pages 5-6, weiss2022znregulatedgtpasemetalloprotein pages 11-13, weiss2022znregulatedgtpasemetalloprotein pages 13-15) |
+| **Binding affinity benchmark**: ZNG1–METAP1 interaction is high affinity, supporting specific client targeting. | Conserved primary evidence | Peptide–domain binding measurements gave **K_D ~0.1 μM** (reported range approximately **0.12–0.30 μM** across tested vertebrate homologs), much tighter than canonical MYND-peptide interactions. | (weiss2022znregulatedgtpasemetalloprotein pages 5-6, weiss2022znregulatedgtpasemetalloprotein media 7dd994c9, weiss2022znregulatedgtpasemetalloprotein media 3d4c9ea0, weiss2022znregulatedgtpasemetalloprotein media 50dba8c7) |
+| **Structural support**: the MetAP1 N-terminal domain forms a cross-brace Zn-binding fold that specifically recognizes the ZNG1 peptide. | Conserved primary evidence | NMR structure shows a **ββαβα cross-brace fold** with two Zn ions in the MetAP1 C6H2 domain; structure deposited as **PDB 7SEK**. | (weiss2022znregulatedgtpasemetalloprotein pages 21-23, weiss2022znregulatedgtpasemetalloprotein pages 5-6) |
+| **Cellular localization**: ZNG1 function is most plausibly **cytosolic**, where Map1/MetAP1 acts on nascent proteins; for yeast this is currently best treated as an inference rather than a directly demonstrated localization in the retrieved corpus. | Conserved inference / review | Plant ZNG1 ortholog localizes to the **cytosol** and interacts with cytosolic MAP1A; no yeast-specific localization measurement was retrieved here. | (zhang2023tworelatedfamilies pages 1-2, zhang2023tworelatedfamilies pages 7-9) |
+| **Biological process annotation**: ZNG1 participates in **protein N-terminal processing under Zn-limited conditions** by supporting Map1 metalation and activity. | Direct yeast evidence summarized in later papers; conserved primary evidence | ZNG1/Map1 axis is repeatedly linked to acclimation to **poor Zn nutrition** and maintenance of MetAP1 activity during Zn limitation. | (zhang2023tworelatedfamilies pages 1-2, weiss2022znregulatedgtpasemetalloprotein pages 3-5, zhang2023tworelatedfamilies pages 7-9) |
+| **Physiological context**: ZNG1 belongs to a broader cellular Zn allocation hierarchy that prioritizes critical metalloproteins when free Zn is scarce. | Review / expert commentary | Expert commentary notes Zn-dependent proteins require prioritization under deficiency and positions ZNG1 as an escort safeguarding METAP1 metalation; at least **10%** of human proteins are Zn cofactors, underscoring the scale of Zn allocation problems. | (maret2022escortproteinsfor pages 2-2, maret2022escortproteinsfor pages 1-2, weiss2022znregulatedgtpasemetalloprotein pages 1-3) |
+| **Caveat on metal specificity of the client**: although ZNG1 is framed as a Zn chaperone, methionine aminopeptidases can show metal flexibility in some systems, including yeast. | Review / expert commentary | Nature commentary notes some MetAPs, including the **yeast enzyme**, can use **cobalt**, so in vivo metal usage may depend on conditions even if ZNG1 specifically traffics Zn. | (maret2022escortproteinsfor pages 2-2) |
+| **Current best functional annotation for yeast ZNG1**: a **cytosol-associated, COG0523-family Zn/GTP-dependent metalloprotein activator for Map1**, important particularly during Zn deficiency. | Integrated synthesis: direct yeast evidence summarized + conserved inference + review | Supported by yeast-focused statements that ScZng1 gives the strongest evidence for direct Zn transfer to MetAP1, together with conserved biochemical/structural data and expert commentary. | (zhang2023tworelatedfamilies pages 1-2, weiss2022znregulatedgtpasemetalloprotein pages 11-13, maret2022escortproteinsfor pages 2-2) |
+
+
+*Table: This table summarizes the strongest available evidence for functional annotation of Saccharomyces cerevisiae ZNG1/YNR029C, distinguishing direct yeast support from conserved inference and review-level interpretation. It is useful for curating molecular function, mechanism, client identity, localization, and evidence strength in one place.*
+
+### 9) Limitations and gaps (important for functional annotation)
+
+1. **Primary yeast paper access gap.** The UniProt-referenced PubMed:35584675 paper could not be directly retrieved within the accessible corpus in this run. As a result, specific yeast experimental details (e.g., exact Map1 activity assays, NME readouts, yeast growth curves under defined Zn conditions, direct localization imaging of Zng1p) could not be quoted verbatim here.
+2. **Yeast-specific localization not directly demonstrated** in the retrieved texts; cytosolic localization is an inference supported by client biology and ortholog experiments (weiss2022znregulatedgtpasemetalloprotein pages 3-5, zhang2023tworelatedfamilies pages 1-2).
+3. **Metal specificity nuance.** Expert commentary highlights MetAP metal flexibility (e.g., cobalt usage in yeast), which should be considered when interpreting ZNG1 as a Zn-specific activator in all conditions (maret2022escortproteinsfor pages 2-2).
+
+### 10) Concluding model for *S. cerevisiae* ZNG1 (P53729)
+
+The best-supported current model is that yeast Zng1p (YNR029C; UniProt P53729) is a **COG0523/G3E P-loop GTPase metallochaperone** that, particularly under **Zn limitation**, supports cellular viability and proteome maturation by enabling **Zn-dependent activation/metalation of Map1/MetAP1**, thereby maintaining **N-terminal methionine excision** for a large fraction of nascent proteins (zhang2023tworelatedfamilies pages 1-2, young2023twodistinctthermodynamic pages 1-2). The conserved interaction involves a MetAP1 N-terminal Zn-binding domain and a conserved ZNG1 peptide motif, with high-affinity binding (K\_D ~0.1 μM) demonstrated in mechanistic eukaryotic systems and modeled as conserved for yeast (weiss2022znregulatedgtpasemetalloprotein pages 5-6, weiss2022znregulatedgtpasemetalloprotein pages 11-13, weiss2022znregulatedgtpasemetalloprotein media 7dd994c9).
+
+
+
+References
+
+1. (weiss2022znregulatedgtpasemetalloprotein pages 3-5): Andy Weiss, Caitlin C. Murdoch, Katherine A. Edmonds, Matthew R. Jordan, Andrew J. Monteith, Yasiru R. Perera, Aslin M. Rodríguez Nassif, Amber M. Petoletti, William N. Beavers, Matthew J. Munneke, Sydney L. Drury, Evan S. Krystofiak, Kishore Thalluri, Hongwei Wu, Angela R.S. Kruse, Richard D. DiMarchi, Richard M. Caprioli, Jeffrey M. Spraggins, Walter J. Chazin, David P. Giedroc, and Eric P. Skaar. Zn-regulated gtpase metalloprotein activator 1 modulates vertebrate zinc homeostasis. Cell, 185:2148-2163.e27, Jun 2022. URL: https://doi.org/10.1016/j.cell.2022.04.011, doi:10.1016/j.cell.2022.04.011. This article has 113 citations and is from a highest quality peer-reviewed journal.
+
+2. (weiss2022znregulatedgtpasemetalloprotein pages 1-3): Andy Weiss, Caitlin C. Murdoch, Katherine A. Edmonds, Matthew R. Jordan, Andrew J. Monteith, Yasiru R. Perera, Aslin M. Rodríguez Nassif, Amber M. Petoletti, William N. Beavers, Matthew J. Munneke, Sydney L. Drury, Evan S. Krystofiak, Kishore Thalluri, Hongwei Wu, Angela R.S. Kruse, Richard D. DiMarchi, Richard M. Caprioli, Jeffrey M. Spraggins, Walter J. Chazin, David P. Giedroc, and Eric P. Skaar. Zn-regulated gtpase metalloprotein activator 1 modulates vertebrate zinc homeostasis. Cell, 185:2148-2163.e27, Jun 2022. URL: https://doi.org/10.1016/j.cell.2022.04.011, doi:10.1016/j.cell.2022.04.011. This article has 113 citations and is from a highest quality peer-reviewed journal.
+
+3. (weiss2022znregulatedgtpasemetalloprotein pages 11-13): Andy Weiss, Caitlin C. Murdoch, Katherine A. Edmonds, Matthew R. Jordan, Andrew J. Monteith, Yasiru R. Perera, Aslin M. Rodríguez Nassif, Amber M. Petoletti, William N. Beavers, Matthew J. Munneke, Sydney L. Drury, Evan S. Krystofiak, Kishore Thalluri, Hongwei Wu, Angela R.S. Kruse, Richard D. DiMarchi, Richard M. Caprioli, Jeffrey M. Spraggins, Walter J. Chazin, David P. Giedroc, and Eric P. Skaar. Zn-regulated gtpase metalloprotein activator 1 modulates vertebrate zinc homeostasis. Cell, 185:2148-2163.e27, Jun 2022. URL: https://doi.org/10.1016/j.cell.2022.04.011, doi:10.1016/j.cell.2022.04.011. This article has 113 citations and is from a highest quality peer-reviewed journal.
+
+4. (zhang2023tworelatedfamilies pages 1-2): Lifang Zhang, Janeen Braynen, Audrey Fahey, Kriti Chopra, Paolo Cifani, Dimiru Tadesse, Michael Regulski, Fangle Hu, Hubertus J. J. van Dam, Meng Xie, Doreen Ware, and Crysten E. Blaby-Haas. Two related families of metal transferases, zng1 and zng2, are involved in acclimation to poor zn nutrition in arabidopsis. Frontiers in Plant Science, Oct 2023. URL: https://doi.org/10.3389/fpls.2023.1237722, doi:10.3389/fpls.2023.1237722. This article has 8 citations.
+
+5. (young2023twodistinctthermodynamic pages 1-2): Tessa R. Young, Evelyne Deery, Andrew W. Foster, Maria Alessandra Martini, Deenah Osman, Martin J. Warren, and Nigel J. Robinson. Two distinct thermodynamic gradients for cellular metalation of vitamin b12. JACS Au, 3:1472-1483, May 2023. URL: https://doi.org/10.1021/jacsau.3c00119, doi:10.1021/jacsau.3c00119. This article has 12 citations and is from a peer-reviewed journal.
+
+6. (maret2022escortproteinsfor pages 1-2): Wolfgang Maret. Escort proteins for cellular zinc ions. Nature, 608:38-39, Aug 2022. URL: https://doi.org/10.1038/d41586-022-01988-2, doi:10.1038/d41586-022-01988-2. This article has 12 citations and is from a highest quality peer-reviewed journal.
+
+7. (young2023twodistinctthermodynamic pages 5-6): Tessa R. Young, Evelyne Deery, Andrew W. Foster, Maria Alessandra Martini, Deenah Osman, Martin J. Warren, and Nigel J. Robinson. Two distinct thermodynamic gradients for cellular metalation of vitamin b12. JACS Au, 3:1472-1483, May 2023. URL: https://doi.org/10.1021/jacsau.3c00119, doi:10.1021/jacsau.3c00119. This article has 12 citations and is from a peer-reviewed journal.
+
+8. (weiss2022znregulatedgtpasemetalloprotein pages 13-15): Andy Weiss, Caitlin C. Murdoch, Katherine A. Edmonds, Matthew R. Jordan, Andrew J. Monteith, Yasiru R. Perera, Aslin M. Rodríguez Nassif, Amber M. Petoletti, William N. Beavers, Matthew J. Munneke, Sydney L. Drury, Evan S. Krystofiak, Kishore Thalluri, Hongwei Wu, Angela R.S. Kruse, Richard D. DiMarchi, Richard M. Caprioli, Jeffrey M. Spraggins, Walter J. Chazin, David P. Giedroc, and Eric P. Skaar. Zn-regulated gtpase metalloprotein activator 1 modulates vertebrate zinc homeostasis. Cell, 185:2148-2163.e27, Jun 2022. URL: https://doi.org/10.1016/j.cell.2022.04.011, doi:10.1016/j.cell.2022.04.011. This article has 113 citations and is from a highest quality peer-reviewed journal.
+
+9. (weiss2022znregulatedgtpasemetalloprotein pages 5-6): Andy Weiss, Caitlin C. Murdoch, Katherine A. Edmonds, Matthew R. Jordan, Andrew J. Monteith, Yasiru R. Perera, Aslin M. Rodríguez Nassif, Amber M. Petoletti, William N. Beavers, Matthew J. Munneke, Sydney L. Drury, Evan S. Krystofiak, Kishore Thalluri, Hongwei Wu, Angela R.S. Kruse, Richard D. DiMarchi, Richard M. Caprioli, Jeffrey M. Spraggins, Walter J. Chazin, David P. Giedroc, and Eric P. Skaar. Zn-regulated gtpase metalloprotein activator 1 modulates vertebrate zinc homeostasis. Cell, 185:2148-2163.e27, Jun 2022. URL: https://doi.org/10.1016/j.cell.2022.04.011, doi:10.1016/j.cell.2022.04.011. This article has 113 citations and is from a highest quality peer-reviewed journal.
+
+10. (weiss2022znregulatedgtpasemetalloprotein media 7dd994c9): Andy Weiss, Caitlin C. Murdoch, Katherine A. Edmonds, Matthew R. Jordan, Andrew J. Monteith, Yasiru R. Perera, Aslin M. Rodríguez Nassif, Amber M. Petoletti, William N. Beavers, Matthew J. Munneke, Sydney L. Drury, Evan S. Krystofiak, Kishore Thalluri, Hongwei Wu, Angela R.S. Kruse, Richard D. DiMarchi, Richard M. Caprioli, Jeffrey M. Spraggins, Walter J. Chazin, David P. Giedroc, and Eric P. Skaar. Zn-regulated gtpase metalloprotein activator 1 modulates vertebrate zinc homeostasis. Cell, 185:2148-2163.e27, Jun 2022. URL: https://doi.org/10.1016/j.cell.2022.04.011, doi:10.1016/j.cell.2022.04.011. This article has 113 citations and is from a highest quality peer-reviewed journal.
+
+11. (weiss2022znregulatedgtpasemetalloprotein media 50dba8c7): Andy Weiss, Caitlin C. Murdoch, Katherine A. Edmonds, Matthew R. Jordan, Andrew J. Monteith, Yasiru R. Perera, Aslin M. Rodríguez Nassif, Amber M. Petoletti, William N. Beavers, Matthew J. Munneke, Sydney L. Drury, Evan S. Krystofiak, Kishore Thalluri, Hongwei Wu, Angela R.S. Kruse, Richard D. DiMarchi, Richard M. Caprioli, Jeffrey M. Spraggins, Walter J. Chazin, David P. Giedroc, and Eric P. Skaar. Zn-regulated gtpase metalloprotein activator 1 modulates vertebrate zinc homeostasis. Cell, 185:2148-2163.e27, Jun 2022. URL: https://doi.org/10.1016/j.cell.2022.04.011, doi:10.1016/j.cell.2022.04.011. This article has 113 citations and is from a highest quality peer-reviewed journal.
+
+12. (zhang2023tworelatedfamilies pages 7-9): Lifang Zhang, Janeen Braynen, Audrey Fahey, Kriti Chopra, Paolo Cifani, Dimiru Tadesse, Michael Regulski, Fangle Hu, Hubertus J. J. van Dam, Meng Xie, Doreen Ware, and Crysten E. Blaby-Haas. Two related families of metal transferases, zng1 and zng2, are involved in acclimation to poor zn nutrition in arabidopsis. Frontiers in Plant Science, Oct 2023. URL: https://doi.org/10.3389/fpls.2023.1237722, doi:10.3389/fpls.2023.1237722. This article has 8 citations.
+
+13. (zhang2023tworelatedfamilies pages 14-16): Lifang Zhang, Janeen Braynen, Audrey Fahey, Kriti Chopra, Paolo Cifani, Dimiru Tadesse, Michael Regulski, Fangle Hu, Hubertus J. J. van Dam, Meng Xie, Doreen Ware, and Crysten E. Blaby-Haas. Two related families of metal transferases, zng1 and zng2, are involved in acclimation to poor zn nutrition in arabidopsis. Frontiers in Plant Science, Oct 2023. URL: https://doi.org/10.3389/fpls.2023.1237722, doi:10.3389/fpls.2023.1237722. This article has 8 citations.
+
+14. (young2023twodistinctthermodynamic pages 2-4): Tessa R. Young, Evelyne Deery, Andrew W. Foster, Maria Alessandra Martini, Deenah Osman, Martin J. Warren, and Nigel J. Robinson. Two distinct thermodynamic gradients for cellular metalation of vitamin b12. JACS Au, 3:1472-1483, May 2023. URL: https://doi.org/10.1021/jacsau.3c00119, doi:10.1021/jacsau.3c00119. This article has 12 citations and is from a peer-reviewed journal.
+
+15. (maret2022escortproteinsfor pages 2-2): Wolfgang Maret. Escort proteins for cellular zinc ions. Nature, 608:38-39, Aug 2022. URL: https://doi.org/10.1038/d41586-022-01988-2, doi:10.1038/d41586-022-01988-2. This article has 12 citations and is from a highest quality peer-reviewed journal.
+
+16. (weiss2022znregulatedgtpasemetalloprotein media 3d4c9ea0): Andy Weiss, Caitlin C. Murdoch, Katherine A. Edmonds, Matthew R. Jordan, Andrew J. Monteith, Yasiru R. Perera, Aslin M. Rodríguez Nassif, Amber M. Petoletti, William N. Beavers, Matthew J. Munneke, Sydney L. Drury, Evan S. Krystofiak, Kishore Thalluri, Hongwei Wu, Angela R.S. Kruse, Richard D. DiMarchi, Richard M. Caprioli, Jeffrey M. Spraggins, Walter J. Chazin, David P. Giedroc, and Eric P. Skaar. Zn-regulated gtpase metalloprotein activator 1 modulates vertebrate zinc homeostasis. Cell, 185:2148-2163.e27, Jun 2022. URL: https://doi.org/10.1016/j.cell.2022.04.011, doi:10.1016/j.cell.2022.04.011. This article has 113 citations and is from a highest quality peer-reviewed journal.
+
+17. (weiss2022znregulatedgtpasemetalloprotein pages 21-23): Andy Weiss, Caitlin C. Murdoch, Katherine A. Edmonds, Matthew R. Jordan, Andrew J. Monteith, Yasiru R. Perera, Aslin M. Rodríguez Nassif, Amber M. Petoletti, William N. Beavers, Matthew J. Munneke, Sydney L. Drury, Evan S. Krystofiak, Kishore Thalluri, Hongwei Wu, Angela R.S. Kruse, Richard D. DiMarchi, Richard M. Caprioli, Jeffrey M. Spraggins, Walter J. Chazin, David P. Giedroc, and Eric P. Skaar. Zn-regulated gtpase metalloprotein activator 1 modulates vertebrate zinc homeostasis. Cell, 185:2148-2163.e27, Jun 2022. URL: https://doi.org/10.1016/j.cell.2022.04.011, doi:10.1016/j.cell.2022.04.011. This article has 113 citations and is from a highest quality peer-reviewed journal.
+
+## Citations
+
+1. weiss2022znregulatedgtpasemetalloprotein pages 1-3
+2. maret2022escortproteinsfor pages 1-2
+3. weiss2022znregulatedgtpasemetalloprotein pages 3-5
+4. zhang2023tworelatedfamilies pages 1-2
+5. weiss2022znregulatedgtpasemetalloprotein pages 5-6
+6. zhang2023tworelatedfamilies pages 7-9
+7. maret2022escortproteinsfor pages 2-2
+8. weiss2022znregulatedgtpasemetalloprotein pages 11-13
+9. young2023twodistinctthermodynamic pages 1-2
+10. young2023twodistinctthermodynamic pages 5-6
+11. weiss2022znregulatedgtpasemetalloprotein pages 13-15
+12. zhang2023tworelatedfamilies pages 14-16
+13. young2023twodistinctthermodynamic pages 2-4
+14. weiss2022znregulatedgtpasemetalloprotein pages 21-23
+15. D/E
+16. https://doi.org/10.1016/j.cell.2022.04.011;
+17. https://doi.org/10.1038/d41586-022-01988-2;
+18. https://doi.org/10.1021/jacsau.3c00119;
+19. https://doi.org/10.3389/fpls.2023.1237722;
+20. https://doi.org/10.1016/j.cell.2022.04.011,
+21. https://doi.org/10.3389/fpls.2023.1237722,
+22. https://doi.org/10.1021/jacsau.3c00119,
+23. https://doi.org/10.1038/d41586-022-01988-2,


### PR DESCRIPTION
## Summary
- Complete yeast AI reviews for ACL4, PNC1, PNO1, SHR3, and ZNG1.
- Add Falcon deep-research files for newly generated reviews and integrate support into YAML.
- Render updated review HTML files.
- Update the local GO label cache for GO:0140597 to the current `protein carrier activity` label, needed for strict validation of ACL4.

## Validation
- `just validate yeast ACL4` and `just render yeast ACL4`
- Worker validation/render passed for PNC1, PNO1, SHR3, and ZNG1
- `git diff --check`

## Curator QA
Subagent review approved PNC1, PNO1, SHR3, and ZNG1. ACL4 initially had blocking issues around GO:0140318 action and GO:0140597 label; both were fixed and the focused re-check approved ACL4.