### PR TITLE
Use ai4c-agent for review workflow parity

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -55,7 +55,6 @@ jobs:
 
       - name: Generate ai4c-agent token
         id: ai4c-token
-        continue-on-error: true
         uses: actions/create-github-app-token@v1
         with:
           app-id: ${{ secrets.AI4C_AGENT_APP_ID }}
@@ -66,7 +65,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          github_token: ${{ steps.ai4c-token.outputs.token || github.token }}
+          github_token: ${{ steps.ai4c-token.outputs.token }}
           track_progress: ${{ github.event_name == 'pull_request' }}
           allowed_bots: 'claude,github-actions'
           claude_args: |

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -13,7 +13,7 @@ on:
         type: number
 
 concurrency:
-  group: claude-review-${{ github.event.pull_request.number || github.event.issue.number || github.event.inputs.pr_number }}
+  group: claude-review-${{ github.event_name }}-${{ github.event.pull_request.number || github.event.issue.number || github.event.inputs.pr_number }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary
- require the Claude Code Review workflow to use an ai4c-agent GitHub App token, with no fallback to `github.token`
- add the same event-aware concurrency key used by ../dismech for Claude Code Review runs
- keep the ai-gene-review-specific review prompt unchanged

## Operational note
- `AI4C_AGENT_APP_ID` and `AI4C_AGENT_PRIVATE_KEY` are configured for this repository
- `ai4c-agent` is installed for the `ai4curation` org with all-repository access
- rerunning the Claude Code Review job confirmed comments and approval are authored by `ai4c-agent[bot]`

## Testing
- Build and test: passed
- Claude Code Review rerun: passed as `ai4c-agent[bot]`
- inspected workflow diff and confirmed app installation