### PR TITLE
Address stalled review comments

### DIFF
--- a/genes/ANOGA/DNAAF1/DNAAF1-ai-review.html
+++ b/genes/ANOGA/DNAAF1/DNAAF1-ai-review.html
@@ -777,12 +777,19 @@
                         
                         
                         
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000024
+                            
+                        </span>
+                        
                     </td>
                     <td>
                         <span class="action-badge action-accept">
                             ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q7PK92" data-a="GO:0070840" data-r="" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="Q7PK92" data-a="GO:0070840" data-r="GO_REF:0000024" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1045,12 +1052,19 @@
                         
                         
                         
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000024
+                            
+                        </span>
+                        
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
                             KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q7PK92" data-a="GO:0060271" data-r="" data-act="KEEP_AS_NON_CORE">
+                        <span class="vote-buttons" data-g="Q7PK92" data-a="GO:0060271" data-r="GO_REF:0000024" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1176,12 +1190,19 @@
                         
                         
                         
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000024
+                            
+                        </span>
+                        
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
                             KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q7PK92" data-a="GO:0005930" data-r="" data-act="KEEP_AS_NON_CORE">
+                        <span class="vote-buttons" data-g="Q7PK92" data-a="GO:0005930" data-r="GO_REF:0000024" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1238,12 +1259,19 @@
                         
                         
                         
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000044
+                            
+                        </span>
+                        
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
                             KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q7PK92" data-a="GO:0005929" data-r="" data-act="KEEP_AS_NON_CORE">
+                        <span class="vote-buttons" data-g="Q7PK92" data-a="GO:0005929" data-r="GO_REF:0000044" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1300,12 +1328,30 @@
                         
                         
                         
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18385425" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:18385425
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    LRRC50, a Conserved Ciliary Protein Implicated in Polycystic...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
                     </td>
                     <td>
                         <span class="action-badge action-new">
                             NEW
                         </span>
-                        <span class="vote-buttons" data-g="Q7PK92" data-a="GO:0005737" data-r="" data-act="NEW">
+                        <span class="vote-buttons" data-g="Q7PK92" data-a="GO:0005737" data-r="PMID:18385425" data-act="NEW">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1480,6 +1526,38 @@
                 </div>
                 
                 <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000024.md" target="_blank" class="term-link">
+                            GO_REF:0000024
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment of sequence similarity</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
                 
                 
             </div>
@@ -2027,6 +2105,12 @@ references:
   - id: GO_REF:0000033
     title: Annotation inferences using phylogenetic trees
     findings: []
+  - id: GO_REF:0000024
+    title: Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment of sequence similarity
+    findings: []
+  - id: GO_REF:0000044
+    title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt
+    findings: []
   - id: PMID:19944405
     title: Loss-of-function mutations in the human ortholog of Chlamydomonas reinhardtii
       ODA7 disrupt dynein arm assembly and cause primary ciliary dyskinesia
@@ -2083,6 +2167,7 @@ existing_annotations:
       id: GO:0070840
       label: dynein complex binding
     evidence_type: ISS
+    original_reference_id: GO_REF:0000024
     review:
       summary: &gt;-
         Correct annotation. DNAAF1/LRRC50/ODA7 binds dynein complexes as its core
@@ -2158,6 +2243,7 @@ existing_annotations:
       id: GO:0060271
       label: cilium assembly
     evidence_type: ISS
+    original_reference_id: GO_REF:0000024
     review:
       summary: &gt;-
         Appropriate annotation. DNAAF1 contributes to cilium assembly by enabling
@@ -2203,6 +2289,7 @@ existing_annotations:
       label: axoneme
     qualifier: located_in
     evidence_type: ISS
+    original_reference_id: GO_REF:0000024
     review:
       summary: &gt;-
         Consistent with the IBA annotation above. DNAAF1/ODA7 has been found
@@ -2220,6 +2307,7 @@ existing_annotations:
       label: cilium
     qualifier: located_in
     evidence_type: IEA
+    original_reference_id: GO_REF:0000044
     review:
       summary: &gt;-
         Consistent with the axoneme localization. The cilium is the parent structure
@@ -2239,6 +2327,7 @@ existing_annotations:
       label: cytoplasm
     qualifier: located_in
     evidence_type: ISS
+    original_reference_id: PMID:18385425
     review:
       summary: &gt;-
         DNAAF1 primarily functions in the cytoplasm where it assembles dynein arm

--- a/genes/ANOGA/DNAAF1/DNAAF1-ai-review.yaml
+++ b/genes/ANOGA/DNAAF1/DNAAF1-ai-review.yaml
@@ -245,6 +245,7 @@ existing_annotations:
       label: cytoplasm
     qualifier: located_in
     evidence_type: ISS
+    original_reference_id: PMID:18385425
     review:
       summary: >-
         DNAAF1 primarily functions in the cytoplasm where it assembles dynein arm

--- a/genes/OCTVU/OCTS1/OCTS1-ai-review.html
+++ b/genes/OCTVU/OCTS1/OCTS1-ai-review.html
@@ -950,7 +950,7 @@
                         </div>
                     </td>
                     <td>
-                        <span class="evidence-code">NAS</span>
+                        <span class="evidence-code">TAS</span>
                         
                         
                         
@@ -1056,7 +1056,7 @@
                         </div>
                     </td>
                     <td>
-                        <span class="evidence-code">NAS</span>
+                        <span class="evidence-code">IDA</span>
                         
                         
                         
@@ -2665,7 +2665,7 @@ existing_annotations:
 - term:
     id: GO:0005212
     label: structural constituent of eye lens
-  evidence_type: NAS
+  evidence_type: TAS
   original_reference_id: PMID:7639695
   review:
     summary: &gt;-
@@ -2701,7 +2701,7 @@ existing_annotations:
 - term:
     id: GO:0043295
     label: glutathione binding
-  evidence_type: NAS
+  evidence_type: IDA
   original_reference_id: PMID:27499004
   review:
     summary: &gt;-

--- a/genes/OCTVU/OCTS1/OCTS1-ai-review.yaml
+++ b/genes/OCTVU/OCTS1/OCTS1-ai-review.yaml
@@ -114,7 +114,7 @@ existing_annotations:
 - term:
     id: GO:0005212
     label: structural constituent of eye lens
-  evidence_type: NAS
+  evidence_type: TAS
   original_reference_id: PMID:7639695
   review:
     summary: >-
@@ -150,7 +150,7 @@ existing_annotations:
 - term:
     id: GO:0043295
     label: glutathione binding
-  evidence_type: NAS
+  evidence_type: IDA
   original_reference_id: PMID:27499004
   review:
     summary: >-

--- a/genes/human/MIR155/MIR155-ai-review.html
+++ b/genes/human/MIR155/MIR155-ai-review.html
@@ -766,8 +766,8 @@
 
             
             <p><strong>Parent term:</strong>
-                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003723" target="_blank" class="term-link">
-                    RNA binding
+                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003730" target="_blank" class="term-link">
+                    mRNA 3&#39;-UTR binding
                 </a>
             </p>
             
@@ -824,34 +824,23 @@
                         </div>
                     </td>
                     <td>
-                        <span class="evidence-code">IMP</span>
+                        <span class="evidence-code">IEA</span>
                         
                         
                         
                         <br>
                         <span style="font-size: 0.75rem;">
                             
-                            <a href="https://pubmed.ncbi.nlm.nih.gov/23416982" target="_blank" class="term-link" style="font-size: 0.75rem;">
-                                PMID:23416982
-                            </a>
-                            
-                                
-                                
-                                <br>
-                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
-                                    MiR-155 at the heart of oncogenic pathways
-                                </span>
-                                
-                            
+                            GO_REF:0000115
                             
                         </span>
                         
                     </td>
                     <td>
-                        <span class="action-badge action-new">
-                            NEW
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="URS000062749E_9606" data-a="GO:0035195" data-r="PMID:23416982" data-act="NEW">
+                        <span class="vote-buttons" data-g="URS000062749E_9606" data-a="GO:0035195" data-r="GO_REF:0000115" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -859,9 +848,13 @@
                     <td>
                         
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> This is the primary biological process that MIR155 participates in
+                            <strong>Summary:</strong> RNAcentral/Rfam annotation for the primary biological process that MIR155 participates in.
                         </div>
                         
+                        
+                        <div>
+                            <strong>Reason:</strong> MIR155 is a microRNA precursor and its mature product participates in miRNA-mediated post-transcriptional gene silencing.
+                        </div>
                         
                         
                         
@@ -891,25 +884,32 @@
                         <div class="term-info">
                             
                             <span class="term-id">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003723" target="_blank" class="term-link">
-                                    GO:0003723
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016442" target="_blank" class="term-link">
+                                    GO:0016442
                                 </a>
                             </span>
-                            <span class="term-label">RNA binding</span>
+                            <span class="term-label">RISC complex</span>
                             
                         </div>
                     </td>
                     <td>
-                        <span class="evidence-code">NAS</span>
+                        <span class="evidence-code">IEA</span>
                         
                         
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000115
+                            
+                        </span>
                         
                     </td>
                     <td>
-                        <span class="action-badge action-new">
-                            NEW
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="URS000062749E_9606" data-a="GO:0003723" data-r="" data-act="NEW">
+                        <span class="vote-buttons" data-g="URS000062749E_9606" data-a="GO:0016442" data-r="GO_REF:0000115" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -917,33 +917,15 @@
                     <td>
                         
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Added to align core_functions with existing annotations.
+                            <strong>Summary:</strong> RNAcentral/Rfam annotation placing MIR155 in the RNA-induced silencing complex context.
                         </div>
                         
                         
                         <div>
-                            <strong>Reason:</strong> Core function term not present in existing_annotations.
+                            <strong>Reason:</strong> Mature miRNAs guide RISC-mediated target repression, so this RNAcentral annotation is consistent with MIR155 biology.
                         </div>
                         
                         
-                        
-                        <div class="supported-by">
-                            <div class="supported-by-title">Supporting Evidence:</div>
-                            
-                            <div class="support-item">
-                                <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/23601686" target="_blank" class="term-link">
-                                        PMID:23601686
-                                    </a>
-                                    
-                                </span>
-                                
-                                <div class="support-text">Here we report that miRNA-155 is required for CD8(+) T cell responses to both virus and cancer.</div>
-                                
-                            </div>
-                            
-                        </div>
                         
                     </td>
                 </tr>
@@ -973,8 +955,8 @@
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
-                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003723" target="_blank" class="term-link">
-                            RNA binding
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003730" target="_blank" class="term-link">
+                            mRNA 3&#39;-UTR binding
                         </a>
                     </span>
                 </div>
@@ -1028,8 +1010,8 @@
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
-                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003723" target="_blank" class="term-link">
-                            RNA binding
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003730" target="_blank" class="term-link">
+                            mRNA 3&#39;-UTR binding
                         </a>
                     </span>
                 </div>
@@ -1083,8 +1065,8 @@
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
-                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003723" target="_blank" class="term-link">
-                            RNA binding
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003730" target="_blank" class="term-link">
+                            mRNA 3&#39;-UTR binding
                         </a>
                     </span>
                 </div>
@@ -1125,8 +1107,8 @@
         <div class="core-function-card">
             
             <div style="display: flex; justify-content: space-between; align-items: center;">
-                <h3>oncogene regulation</h3>
-                <span class="vote-buttons" data-g="URS000062749E_9606" data-a="FUNCTION: oncogene regulation..." data-r="" data-act="CORE_FUNCTION">
+                <h3>oncomiR activity suppressing tumor suppressor targets to promote oncogenesis</h3>
+                <span class="vote-buttons" data-g="URS000062749E_9606" data-a="FUNCTION: oncomiR activity suppressing tumor suppressor targ..." data-r="" data-act="CORE_FUNCTION">
                     <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
@@ -1138,8 +1120,8 @@
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
-                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003723" target="_blank" class="term-link">
-                            RNA binding
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003730" target="_blank" class="term-link">
+                            mRNA 3&#39;-UTR binding
                         </a>
                     </span>
                 </div>
@@ -1162,13 +1144,13 @@
                     <li class="finding-item">
                         <span class="reference-id">
                             
-                            <a href="https://pubmed.ncbi.nlm.nih.gov/23601686" target="_blank" class="term-link">
-                                PMID:23601686
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/23416982" target="_blank" class="term-link">
+                                PMID:23416982
                             </a>
                             
                         </span>
                         
-                        <div class="finding-text">miRNA-155 is required for CD8+ T cell responses to both virus and cancer</div>
+                        <div class="finding-text">miR-155 is an established oncomiR in breast cancer</div>
                         
                     </li>
                     
@@ -1221,14 +1203,14 @@
                 <div class="reference-header">
                     <span class="reference-id">
                         
-                        <a href="https://pubmed.ncbi.nlm.nih.gov/23601686" target="_blank" class="term-link">
-                            PMID:23601686
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000115.md" target="_blank" class="term-link">
+                            GO_REF:0000115
                         </a>
                         
                     </span>
                 </div>
                 
-                <div class="reference-title">MicroRNA-155 is required for effector CD8+ T cell responses to virus infection and cancer</div>
+                <div class="reference-title">Gene Ontology annotation based on Rfam2GO mapping</div>
                 
                 
             </div>
@@ -1350,39 +1332,37 @@ references:
   title: MiR-155 at the heart of oncogenic pathways
 - id: PMID:34626873
   title: MicroRNA-155 and antiviral immune responses
-- id: PMID:23601686
-  title: MicroRNA-155 is required for effector CD8+ T cell responses to virus 
-    infection and cancer
+- id: GO_REF:0000115
+  title: Gene Ontology annotation based on Rfam2GO mapping
+  findings: []
 existing_annotations:
 - term:
     id: GO:0035195
     label: miRNA-mediated post-transcriptional gene silencing
-  evidence_type: IMP
-  original_reference_id: PMID:23416982
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000115
   review:
-    summary: This is the primary biological process that MIR155 participates in
-    action: NEW
+    summary: RNAcentral/Rfam annotation for the primary biological process that MIR155 participates in.
+    action: ACCEPT
+    reason: MIR155 is a microRNA precursor and its mature product participates in miRNA-mediated post-transcriptional gene silencing.
     supported_by:
     - reference_id: PMID:23416982
       supporting_text: &#34;MicroRNA-155 (miR-155) is an established oncomiR in breast
         cancer and regulates several pro-oncogenic pathways.&#34;
 - term:
-    id: GO:0003723
-    label: RNA binding
-  evidence_type: NAS
+    id: GO:0016442
+    label: RISC complex
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000115
   review:
-    summary: Added to align core_functions with existing annotations.
-    action: NEW
-    reason: Core function term not present in existing_annotations.
-    supported_by:
-    - reference_id: PMID:23601686
-      supporting_text: Here we report that miRNA-155 is required for CD8(+) T 
-        cell responses to both virus and cancer.
+    summary: RNAcentral/Rfam annotation placing MIR155 in the RNA-induced silencing complex context.
+    action: ACCEPT
+    reason: Mature miRNAs guide RISC-mediated target repression, so this RNAcentral annotation is consistent with MIR155 biology.
 core_functions:
 - description: microRNA-mediated gene silencing
   molecular_function:
-    id: GO:0003723
-    label: RNA binding
+    id: GO:0003730
+    label: mRNA 3&#39;-UTR binding
   supported_by:
   - reference_id: PMID:23416982
     supporting_text: miR-155 is an established oncomiR that regulates several 
@@ -1390,28 +1370,27 @@ core_functions:
     full_text_unavailable: true
 - description: regulation of immune cell differentiation
   molecular_function:
-    id: GO:0003723
-    label: RNA binding
+    id: GO:0003730
+    label: mRNA 3&#39;-UTR binding
   supported_by:
   - reference_id: PMID:34626873
     supporting_text: miR-155 regulates both adaptive and innate immune responses
 - description: inflammatory response regulation
   molecular_function:
-    id: GO:0003723
-    label: RNA binding
+    id: GO:0003730
+    label: mRNA 3&#39;-UTR binding
   supported_by:
   - reference_id: PMID:34626873
     supporting_text: miR-155 affects both innate immunity and adaptive immunity 
       in viral infections
     full_text_unavailable: true
-- description: oncogene regulation
+- description: oncomiR activity suppressing tumor suppressor targets to promote oncogenesis
   molecular_function:
-    id: GO:0003723
-    label: RNA binding
+    id: GO:0003730
+    label: mRNA 3&#39;-UTR binding
   supported_by:
-  - reference_id: PMID:23601686
-    supporting_text: miRNA-155 is required for CD8+ T cell responses to both 
-      virus and cancer
+  - reference_id: PMID:23416982
+    supporting_text: miR-155 is an established oncomiR in breast cancer
 proposed_new_terms:
 - proposed_name: oncomiR activity
   proposed_definition: The molecular function of a microRNA that promotes 
@@ -1419,8 +1398,8 @@ proposed_new_terms:
   justification: MIR155 is a well-established oncomiR, but there is no specific 
     GO term for oncomiR activity
   proposed_parent:
-    id: GO:0003723
-    label: RNA binding
+    id: GO:0003730
+    label: mRNA 3&#39;-UTR binding
   supported_by:
   - reference_id: PMID:23416982
     supporting_text: miR-155 is an established oncomiR in breast cancer

--- a/genes/human/MIR155/MIR155-ai-review.yaml
+++ b/genes/human/MIR155/MIR155-ai-review.yaml
@@ -11,9 +11,6 @@ references:
   title: MiR-155 at the heart of oncogenic pathways
 - id: PMID:34626873
   title: MicroRNA-155 and antiviral immune responses
-- id: PMID:23601686
-  title: MicroRNA-155 is required for effector CD8+ T cell responses to virus 
-    infection and cancer
 - id: GO_REF:0000115
   title: Gene Ontology annotation based on Rfam2GO mapping
   findings: []
@@ -40,23 +37,11 @@ existing_annotations:
     summary: RNAcentral/Rfam annotation placing MIR155 in the RNA-induced silencing complex context.
     action: ACCEPT
     reason: Mature miRNAs guide RISC-mediated target repression, so this RNAcentral annotation is consistent with MIR155 biology.
-- term:
-    id: GO:0003723
-    label: RNA binding
-  evidence_type: NAS
-  review:
-    summary: Added to align core_functions with existing annotations.
-    action: NEW
-    reason: Core function term not present in existing_annotations.
-    supported_by:
-    - reference_id: PMID:23601686
-      supporting_text: Here we report that miRNA-155 is required for CD8(+) T 
-        cell responses to both virus and cancer.
 core_functions:
 - description: microRNA-mediated gene silencing
   molecular_function:
-    id: GO:0003723
-    label: RNA binding
+    id: GO:0003730
+    label: mRNA 3'-UTR binding
   supported_by:
   - reference_id: PMID:23416982
     supporting_text: miR-155 is an established oncomiR that regulates several 
@@ -64,28 +49,27 @@ core_functions:
     full_text_unavailable: true
 - description: regulation of immune cell differentiation
   molecular_function:
-    id: GO:0003723
-    label: RNA binding
+    id: GO:0003730
+    label: mRNA 3'-UTR binding
   supported_by:
   - reference_id: PMID:34626873
     supporting_text: miR-155 regulates both adaptive and innate immune responses
 - description: inflammatory response regulation
   molecular_function:
-    id: GO:0003723
-    label: RNA binding
+    id: GO:0003730
+    label: mRNA 3'-UTR binding
   supported_by:
   - reference_id: PMID:34626873
     supporting_text: miR-155 affects both innate immunity and adaptive immunity 
       in viral infections
     full_text_unavailable: true
-- description: oncogene regulation
+- description: oncomiR activity suppressing tumor suppressor targets to promote oncogenesis
   molecular_function:
-    id: GO:0003723
-    label: RNA binding
+    id: GO:0003730
+    label: mRNA 3'-UTR binding
   supported_by:
-  - reference_id: PMID:23601686
-    supporting_text: miRNA-155 is required for CD8+ T cell responses to both 
-      virus and cancer
+  - reference_id: PMID:23416982
+    supporting_text: miR-155 is an established oncomiR in breast cancer
 proposed_new_terms:
 - proposed_name: oncomiR activity
   proposed_definition: The molecular function of a microRNA that promotes 
@@ -93,8 +77,8 @@ proposed_new_terms:
   justification: MIR155 is a well-established oncomiR, but there is no specific 
     GO term for oncomiR activity
   proposed_parent:
-    id: GO:0003723
-    label: RNA binding
+    id: GO:0003730
+    label: mRNA 3'-UTR binding
   supported_by:
   - reference_id: PMID:23416982
     supporting_text: miR-155 is an established oncomiR in breast cancer


### PR DESCRIPTION
## Summary

Addresses the repeated source-YAML review comments from the stale generated-pages PR #353:

- MIR155: remove unsupported NEW GO:0003723 RNA binding annotation citing PMID:23601686; use GO:0003730 in core_functions; correct the oncomiR core function support to PMID:23416982.
- OCTS1: change GO:0005212 evidence_type NAS -> TAS and GO:0043295 NAS -> IDA.
- DNAAF1: add original_reference_id: PMID:18385425 to the GO:0005737 ISS cytoplasm annotation.
- Regenerate the three affected HTML pages.

## Validation

- just validate human MIR155 -> passed with 4 expected nonblocking GO:0003730 core-function warnings
- just validate OCTVU OCTS1 -> passed with 1 pre-existing deep-research warning
- just validate ANOGA DNAAF1 -> passed
- just render human MIR155
- just render OCTVU OCTS1
- just render ANOGA DNAAF1