### PR TITLE
Track GO:1990456 mito-ER tether obsoletion (geneontology/go-annotation#6397)

### DIFF
--- a/pages/projects/MITO_ER_TETHERING_OBSOLETION.html
+++ b/pages/projects/MITO_ER_TETHERING_OBSOLETION.html
@@ -1,0 +1,534 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Mitochondrion–ER Membrane Tethering — Obsoletion &amp; Replacement (GO:1990456) - AI Gene Review Projects</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-primary: #3498db;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1200px;
+            margin: 0 auto;
+        }
+
+        .breadcrumb {
+            margin-bottom: 1.5rem;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .breadcrumb a {
+            color: var(--color-primary);
+            text-decoration: none;
+        }
+
+        .breadcrumb a:hover {
+            text-decoration: underline;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        h2 {
+            font-size: 1.75rem;
+            font-weight: 600;
+            margin-top: 2rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        h3 {
+            font-size: 1.25rem;
+            font-weight: 600;
+            margin-top: 1.5rem;
+            margin-bottom: 0.75rem;
+            color: #374151;
+        }
+
+        h4 {
+            font-size: 1rem;
+            font-weight: 600;
+            margin-top: 1.25rem;
+            margin-bottom: 0.5rem;
+            color: #4b5563;
+        }
+
+        p {
+            margin-bottom: 1rem;
+        }
+
+        a {
+            color: var(--color-primary);
+            text-decoration: none;
+        }
+
+        a:hover {
+            text-decoration: underline;
+        }
+
+        /* Gene symbol links */
+        .content a[href*="/genes/"] {
+            background-color: #dbeafe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-weight: 500;
+        }
+
+        .content a[href*="/genes/"]:hover {
+            background-color: #bfdbfe;
+        }
+
+        ul, ol {
+            margin-bottom: 1rem;
+            padding-left: 2rem;
+        }
+
+        li {
+            margin-bottom: 0.25rem;
+        }
+
+        code {
+            background: #f4f4f4;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+            font-size: 0.875em;
+        }
+
+        pre {
+            background: #1f2937;
+            color: #f9fafb;
+            padding: 1rem;
+            border-radius: 0.5rem;
+            overflow-x: auto;
+            margin-bottom: 1rem;
+        }
+
+        pre code {
+            background: none;
+            padding: 0;
+            color: inherit;
+        }
+
+        blockquote {
+            border-left: 4px solid var(--color-primary);
+            margin-left: 0;
+            padding-left: 1.5rem;
+            color: #4b5563;
+            font-style: italic;
+            margin-bottom: 1rem;
+        }
+
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            margin: 1.5rem 0;
+        }
+
+        th, td {
+            border: 1px solid var(--border-color);
+            padding: 0.75rem;
+            text-align: left;
+        }
+
+        th {
+            background-color: var(--bg-light);
+            font-weight: 600;
+            color: var(--text-muted);
+            text-transform: uppercase;
+            font-size: 0.75rem;
+            letter-spacing: 0.05em;
+        }
+
+        tr:nth-child(even) {
+            background-color: #f9fafb;
+        }
+
+        tr:hover {
+            background-color: #f3f4f6;
+        }
+
+        /* Mermaid diagrams */
+        .mermaid {
+            text-align: center;
+            margin: 2rem 0;
+            background: white;
+            padding: 1.5rem;
+            border-radius: 0.5rem;
+            border: 1px solid var(--border-color);
+        }
+
+        .mermaid svg {
+            max-width: 100%;
+            height: auto;
+        }
+
+        /* Warnings section */
+        .warnings {
+            background-color: #fef3c7;
+            border: 1px solid #fde68a;
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 2rem;
+        }
+
+        .warnings h3 {
+            color: #92400e;
+            margin-top: 0;
+            margin-bottom: 0.5rem;
+            font-size: 1rem;
+        }
+
+        .warnings ul {
+            margin-bottom: 0;
+            color: #78350f;
+        }
+
+        /* Task lists (checkboxes) */
+        li input[type="checkbox"] {
+            margin-right: 0.5rem;
+        }
+
+        /* Status badges */
+        .badge {
+            display: inline-block;
+            padding: 0.25rem 0.625rem;
+            border-radius: 9999px;
+            font-size: 0.75rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .badge-success {
+            background-color: #d1fae5;
+            color: #065f46;
+        }
+
+        .badge-warning {
+            background-color: #fef3c7;
+            color: #92400e;
+        }
+
+        .badge-info {
+            background-color: #dbeafe;
+            color: #1e40af;
+        }
+
+        /* Content wrapper */
+        .content {
+            margin-bottom: 2rem;
+        }
+
+        /* Footer */
+        footer {
+            margin-top: 3rem;
+            padding-top: 1.5rem;
+            border-top: 1px solid var(--border-color);
+            color: var(--text-muted);
+            font-size: 0.875rem;
+            text-align: center;
+        }
+
+        footer small {
+            display: block;
+        }
+    </style>
+    <!-- Mermaid.js for diagram rendering -->
+    <script src="https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js"></script>
+    <script>
+        mermaid.initialize({
+            startOnLoad: true,
+            theme: 'default',
+            themeVariables: {
+                primaryColor: '#3498db',
+                primaryTextColor: '#fff',
+                primaryBorderColor: '#2c3e50',
+                lineColor: '#333',
+                secondaryColor: '#ecf0f1',
+                tertiaryColor: '#f39c12'
+            },
+            flowchart: {
+                htmlLabels: true,
+                curve: 'basis'
+            }
+        });
+    </script>
+</head>
+<body>
+    <nav class="breadcrumb">
+        <a href="../index.html">Home</a> &raquo;
+        <a href="index.html">Projects</a> &raquo;
+        Mitochondrion–ER Membrane Tethering — Obsoletion &amp; Replacement (GO:1990456)
+    </nav>
+
+    <header class="header">
+        <h1>Mitochondrion–ER Membrane Tethering — Obsoletion &amp; Replacement (GO:1990456)</h1>
+        
+    </header>
+
+    
+
+    <div class="content">
+        <h1 id="mitochondrioner-membrane-tethering-obsoletion-replacement-go1990456">Mitochondrion–ER Membrane Tethering — Obsoletion &amp; Replacement (<a href="http://amigo.geneontology.org/amigo/term/GO:1990456">GO:1990456</a>)</h1>
+<h2 id="overview">Overview</h2>
+<p>A GO obsoletion proposal will retire <strong><a href="http://amigo.geneontology.org/amigo/term/GO:1990456">GO:1990456</a> mitochondrion-endoplasmic<br />
+reticulum membrane tethering</strong> (a BP term). The rationale matches the parallel<br />
+ER–PM and peroxisome–chloroplast tether obsoletions: the activity is more<br />
+appropriately captured at the molecular function level by the existing<br />
+<strong><a href="http://amigo.geneontology.org/amigo/term/GO:0140474">GO:0140474</a> mitochondrion-endoplasmic reticulum membrane tether activity</strong>.</p>
+<p>This project tracks the impact on AI Gene Review and queues the canonical<br />
+mitochondrion–ER tether proteins for review.</p>
+<h2 id="upstream-tickets">Upstream tickets</h2>
+<ul>
+<li>Annotation tracker: <a href="https://github.com/geneontology/go-annotation/issues/6397">geneontology/go-annotation#6397</a></li>
+<li>Ontology ticket: <a href="https://github.com/geneontology/go-ontology/issues/31875">geneontology/go-ontology#31875</a></li>
+</ul>
+<h2 id="obsoletion-plan-per-upstream">Obsoletion plan (per upstream)</h2>
+<table>
+<thead>
+<tr>
+<th>Obsoleted term</th>
+<th>ID</th>
+<th>Replacement</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>mitochondrion-endoplasmic reticulum membrane tethering</td>
+<td><a href="http://amigo.geneontology.org/amigo/term/GO:1990456">GO:1990456</a></td>
+<td>MF: <a href="http://amigo.geneontology.org/amigo/term/GO:0140474">GO:0140474</a> mitochondrion-endoplasmic reticulum membrane tether activity</td>
+</tr>
+</tbody>
+</table>
+<h3 id="affected-upstream-groups-from-issue-body">Affected upstream groups (from issue body)</h3>
+<table>
+<thead>
+<tr>
+<th>Group</th>
+<th style="text-align: right;">Annotations</th>
+<th>Status</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>CACAO</td>
+<td style="text-align: right;">1</td>
+<td>pending</td>
+</tr>
+<tr>
+<td>ComplexPortal</td>
+<td style="text-align: right;">9</td>
+<td>pending</td>
+</tr>
+<tr>
+<td>FlyBase</td>
+<td style="text-align: right;">1</td>
+<td>DONE</td>
+</tr>
+<tr>
+<td>MGI</td>
+<td style="text-align: right;">1</td>
+<td>pending</td>
+</tr>
+<tr>
+<td>SGD</td>
+<td style="text-align: right;">6</td>
+<td>DONE</td>
+</tr>
+<tr>
+<td>UniProt</td>
+<td style="text-align: right;">7</td>
+<td>DONE</td>
+</tr>
+<tr>
+<td>dictyBase</td>
+<td style="text-align: right;">5</td>
+<td>pending</td>
+</tr>
+</tbody>
+</table>
+<h3 id="mappings-to-be-reviewed">Mappings to be reviewed</h3>
+<table>
+<thead>
+<tr>
+<th>Source</th>
+<th>Mapping</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>InterPro2GO</td>
+<td>InterPro:IPR039275 (PDZ domain-containing protein 8) → <a href="http://amigo.geneontology.org/amigo/term/GO:1990456">GO:1990456</a></td>
+</tr>
+<tr>
+<td>HAMAP2GO</td>
+<td>HAMAP:MF_03102 (MDM10 family — ERMES component) → <a href="http://amigo.geneontology.org/amigo/term/GO:1990456">GO:1990456</a></td>
+</tr>
+<tr>
+<td>UniRule2GO</td>
+<td>UniRule:UR000106107 → <a href="http://amigo.geneontology.org/amigo/term/GO:1990456">GO:1990456</a></td>
+</tr>
+</tbody>
+</table>
+<h2 id="impact-on-this-repo">Impact on this repo</h2>
+<p>The obsoletion intersects existing reviews in the following way:</p>
+<table>
+<thead>
+<tr>
+<th>Gene</th>
+<th>Organism</th>
+<th>Existing action on <a href="http://amigo.geneontology.org/amigo/term/GO:1990456">GO:1990456</a></th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a href="../../genes/human/VMP1/VMP1-ai-review.html">VMP1</a></td>
+<td>human</td>
+<td>annotated with <a href="http://amigo.geneontology.org/amigo/term/GO:1990456">GO:1990456</a> in <code>genes/human/[VMP1](../../genes/human/VMP1/VMP1-ai-review.html)/VMP1-ai-review.yaml</code></td>
+</tr>
+<tr>
+<td><a href="../../genes/human/CALM1/CALM1-ai-review.html">CALM1</a></td>
+<td>human</td>
+<td><a href="http://amigo.geneontology.org/amigo/term/GO:1990456">GO:1990456</a> row currently <code>ACCEPT</code></td>
+</tr>
+<tr>
+<td><a href="../../genes/mouse/Calm1/Calm1-ai-review.html">Calm1</a></td>
+<td>mouse</td>
+<td><a href="http://amigo.geneontology.org/amigo/term/GO:1990456">GO:1990456</a> row present</td>
+</tr>
+<tr>
+<td><a href="../../genes/mouse/Calm2/Calm2-ai-review.html">Calm2</a></td>
+<td>mouse</td>
+<td><a href="http://amigo.geneontology.org/amigo/term/GO:1990456">GO:1990456</a> row present</td>
+</tr>
+<tr>
+<td><a href="../../genes/mouse/Calm3/Calm3-ai-review.html">Calm3</a></td>
+<td>mouse</td>
+<td><a href="http://amigo.geneontology.org/amigo/term/GO:1990456">GO:1990456</a> row present</td>
+</tr>
+</tbody>
+</table>
+<p>These reviews will need a refresh once the obsoletion lands — for <a href="../../genes/human/VMP1/VMP1-ai-review.html">VMP1</a> and the<br />
+calmodulin family the <a href="http://amigo.geneontology.org/amigo/term/GO:1990456">GO:1990456</a> annotation should be reassessed against<br />
+<a href="http://amigo.geneontology.org/amigo/term/GO:0140474">GO:0140474</a> (or, for calmodulins, likely <strong>REMOVED</strong> because the evidence does<br />
+not show that calmodulin itself is a mitochondrion–ER tether). Human <a href="../../genes/human/VMP1/VMP1-ai-review.html">VMP1</a> and<br />
+<a href="../../genes/human/CALM1/CALM1-ai-review.html">CALM1</a> carry UniProt IDA annotations from PMID:28890335. Mouse <a href="../../genes/mouse/Calm1/Calm1-ai-review.html">Calm1</a>/2/3 carry<br />
+computational or similarity-propagated annotations (IEA/ISO/ISS), not Reactome<br />
+TAS annotations.</p>
+<p>Human CALM2 is not currently present in this repository, and human <a href="../../genes/human/CALM3/CALM3-ai-review.html">CALM3</a> does<br />
+not currently have a <a href="http://amigo.geneontology.org/amigo/term/GO:1990456">GO:1990456</a> row in either GOA or the review YAML.</p>
+<p>No canonical mito–ER tether genes (ERMES components, PDZD8, MFN2,<br />
+VAPB/PTPIP51) are currently reviewed in this repository.</p>
+<h2 id="scope">Scope</h2>
+<ul>
+<li><strong>Organisms</strong>: human (PDZD8, MFN2, VAPB, PTPIP51), S. cerevisiae (ERMES<br />
+  components: MMM1, MDM10, MDM12, MDM34), Dictyostelium (5 dictyBase<br />
+  annotations still pending), mouse (1 MGI annotation pending).</li>
+<li><strong>GO branches</strong>: BP (the obsoleted term itself) and MF <a href="http://amigo.geneontology.org/amigo/term/GO:0140474">GO:0140474</a>. Both<br />
+  belong to the membrane contact site (MCS) branch.</li>
+<li><strong>Type of fix</strong>: terminological in GO; biology is well established. Reviews<br />
+  should evaluate whether the MF replacement (<code>tether activity</code>) is the better<br />
+  core-function term and add it where the underlying assay supports it.</li>
+</ul>
+<h2 id="candidate-genes-for-initial-review">Candidate genes for initial review</h2>
+<p>Verify each with <code>just fetch-gene &lt;organism&gt; &lt;gene&gt;</code> before starting; do not<br />
+add files without confirming the UniProt accession from the UniProt API.</p>
+<h3 id="mammalian-mitoer-tethers">Mammalian mito–ER tethers</h3>
+<ol>
+<li><strong>PDZD8</strong> (human) — PDZ domain-containing protein 8. Direct target of the<br />
+   InterPro2GO mapping (IPR039275). Vertebrate functional analog of yeast<br />
+   Mmm1; established mito–ER tether (Hirabayashi et al. 2017, Science).</li>
+<li><strong>MFN2</strong> (human) — Mitofusin-2. Long-debated mito–ER tether at MAMs<br />
+   (de Brito &amp; Scorrano 2008, Nature), with substantial counter-evidence that<br />
+   MFN2 can instead act as a negative regulator of ER–mitochondria proximity<br />
+   (Filadi et al. 2015, PNAS).</li>
+<li><strong>VAPB</strong> (human) — VAMP-associated protein B/C. Forms a tether with<br />
+   PTPIP51 at MAMs (Stoica et al. 2014, Nat Commun).</li>
+<li><strong>PTPIP51</strong> / <strong>RMDN3</strong> (human) — partner of VAPB at MAMs.</li>
+</ol>
+<h3 id="yeast-ermes-complex-s-cerevisiae">Yeast ERMES complex (S. cerevisiae)</h3>
+<ol>
+<li><strong>MMM1</strong> — ER-anchored ERMES SMP-domain subunit. MMM1 is a sister ERMES<br />
+   subunit and should not be treated as the direct HAMAP MF_03102 target.</li>
+<li><strong>MDM10</strong> — outer mitochondrial membrane β-barrel; ERMES + TOM-assembly<br />
+   bridge. Direct target of HAMAP MF_03102.</li>
+<li><strong>MDM12</strong> — cytosolic SMP-domain subunit bridging Mmm1 and Mdm34.</li>
+<li><strong>MDM34</strong> — outer mitochondrial membrane SMP-domain subunit.</li>
+</ol>
+<p>Yeast SGD has already migrated its annotations upstream; review here would<br />
+serve to capture the canonical tether MF for these reference proteins rather<br />
+than to fix outstanding GOA rows.</p>
+<h3 id="other-organisms">Other organisms</h3>
+<ol>
+<li>The 5 dictyBase pending annotations are likely to be the <em>Dictyostelium</em><br />
+   ERMES homologs — review opportunistically once the gene set is confirmed.</li>
+</ol>
+<h2 id="proposed-approach-and-priority">Proposed approach and priority</h2>
+<ol>
+<li><strong>Refresh existing affected reviews</strong> (human <a href="../../genes/human/VMP1/VMP1-ai-review.html">VMP1</a> and <a href="../../genes/human/CALM1/CALM1-ai-review.html">CALM1</a>; mouse<br />
+<a href="../../genes/mouse/Calm1/Calm1-ai-review.html">Calm1</a>/2/3) to revisit <a href="http://amigo.geneontology.org/amigo/term/GO:1990456">GO:1990456</a> rows once the obsoletion lands. The<br />
+   calmodulin rows likely should be <strong>REMOVED</strong> rather than rerouted, but the<br />
+   rationale should distinguish the human UniProt IDA annotation from the mouse<br />
+   computational/similarity-propagated annotations.</li>
+<li><strong>Anchor new reviews</strong> on <strong>PDZD8</strong> + <strong>MFN2</strong> as the highest-impact<br />
+   mammalian tethers, and on <strong>MMM1</strong> + <strong>MDM12</strong> for the yeast ERMES anchor<br />
+   pair.</li>
+<li>Once <a href="http://amigo.geneontology.org/amigo/term/GO:0140474">GO:0140474</a> is the canonical MF term, audit other genes in this<br />
+   repository whose <code>core_functions</code> could legitimately gain it (e.g. through<br />
+   the <code>proposed_replacement_terms</code> mechanism).</li>
+</ol>
+<h2 id="status">Status</h2>
+<ul>
+<li>Upstream FlyBase, SGD, and UniProt updates are done; CACAO (1),<br />
+  ComplexPortal (9), MGI (1), and dictyBase (5) experimental annotations are<br />
+  still pending.</li>
+<li>Mappings (InterPro2GO IPR039275, HAMAP MF_03102, UniRule UR000106107) all<br />
+  need to be re-pointed to <a href="http://amigo.geneontology.org/amigo/term/GO:0140474">GO:0140474</a>.</li>
+<li>No reviews in this repo are blocked by the obsoletion; the impact is a<br />
+  refresh queue (human <a href="../../genes/human/VMP1/VMP1-ai-review.html">VMP1</a>/<a href="../../genes/human/CALM1/CALM1-ai-review.html">CALM1</a> plus mouse <a href="../../genes/mouse/Calm1/Calm1-ai-review.html">Calm1</a>/2/3) and a forward-looking<br />
+  review queue (PDZD8, MFN2, VAPB, PTPIP51, ERMES components).</li>
+<li>Recommend starting with <strong>PDZD8</strong> as the anchor review, since it is both<br />
+  the InterPro2GO mapping target and the most recently mechanistically<br />
+  characterized mammalian mito–ER tether.</li>
+</ul>
+    </div>
+
+    <footer>
+        <small>Generated from MITO_ER_TETHERING_OBSOLETION.md</small>
+        <small>AI Gene Review Project</small>
+    </footer>
+</body>
+</html>

--- a/pages/projects/index.html
+++ b/pages/projects/index.html
@@ -238,6 +238,9 @@
         <div class="project-card">
             <a href="ER_PM_TETHERING_OBSOLETION.html">ER-PM Tethering (GO:0061817 obsoletion)</a>
         </div>
+        <div class="project-card">
+            <a href="MITO_ER_TETHERING_OBSOLETION.html">Mitochondrion-ER Tethering (GO:1990456 obsoletion)</a>
+        </div>
     </div>
 
     <h2>Bacterial Projects</h2>

--- a/projects/MITO_ER_TETHERING_OBSOLETION.md
+++ b/projects/MITO_ER_TETHERING_OBSOLETION.md
@@ -50,16 +50,20 @@ The obsoletion intersects existing reviews in the following way:
 |---|---|---|
 | VMP1 | human | annotated with GO:1990456 in `genes/human/VMP1/VMP1-ai-review.yaml` |
 | CALM1 | human | GO:1990456 row currently `ACCEPT` |
-| CALM2 | human | GO:1990456 row present |
-| CALM3 | human | GO:1990456 row present |
 | Calm1 | mouse | GO:1990456 row present |
 | Calm2 | mouse | GO:1990456 row present |
 | Calm3 | mouse | GO:1990456 row present |
 
 These reviews will need a refresh once the obsoletion lands — for VMP1 and the
 calmodulin family the GO:1990456 annotation should be reassessed against
-GO:0140474 (or, for calmodulins, likely **REMOVED** as a downstream Reactome
-pathway over-annotation that was not based on a tether-activity assay).
+GO:0140474 (or, for calmodulins, likely **REMOVED** because the evidence does
+not show that calmodulin itself is a mitochondrion–ER tether). Human VMP1 and
+CALM1 carry UniProt IDA annotations from PMID:28890335. Mouse Calm1/2/3 carry
+computational or similarity-propagated annotations (IEA/ISO/ISS), not Reactome
+TAS annotations.
+
+Human CALM2 is not currently present in this repository, and human CALM3 does
+not currently have a GO:1990456 row in either GOA or the review YAML.
 
 No canonical mito–ER tether genes (ERMES components, PDZD8, MFN2,
 VAPB/PTPIP51) are currently reviewed in this repository.
@@ -86,15 +90,17 @@ add files without confirming the UniProt accession from the UniProt API.
    InterPro2GO mapping (IPR039275). Vertebrate functional analog of yeast
    Mmm1; established mito–ER tether (Hirabayashi et al. 2017, Science).
 2. **MFN2** (human) — Mitofusin-2. Long-debated mito–ER tether at MAMs
-   (de Brito & Scorrano 2008, Nature).
+   (de Brito & Scorrano 2008, Nature), with substantial counter-evidence that
+   MFN2 can instead act as a negative regulator of ER–mitochondria proximity
+   (Filadi et al. 2015, PNAS).
 3. **VAPB** (human) — VAMP-associated protein B/C. Forms a tether with
    PTPIP51 at MAMs (Stoica et al. 2014, Nat Commun).
 4. **PTPIP51** / **RMDN3** (human) — partner of VAPB at MAMs.
 
 ### Yeast ERMES complex (S. cerevisiae)
 
-5. **MMM1** — ER-anchored ERMES SMP-domain subunit (HAMAP MF_03102 family
-   member is *MDM10*; MMM1 is a sister subunit).
+5. **MMM1** — ER-anchored ERMES SMP-domain subunit. MMM1 is a sister ERMES
+   subunit and should not be treated as the direct HAMAP MF_03102 target.
 6. **MDM10** — outer mitochondrial membrane β-barrel; ERMES + TOM-assembly
    bridge. Direct target of HAMAP MF_03102.
 7. **MDM12** — cytosolic SMP-domain subunit bridging Mmm1 and Mdm34.
@@ -111,10 +117,11 @@ than to fix outstanding GOA rows.
 
 ## Proposed approach and priority
 
-1. **Refresh existing affected reviews** (VMP1, CALM1/2/3 in human + mouse)
-   to revisit GO:1990456 rows once the obsoletion lands. Most of these are
-   likely Reactome-pathway over-annotations that should be **REMOVED** rather
-   than rerouted.
+1. **Refresh existing affected reviews** (human VMP1 and CALM1; mouse
+   Calm1/2/3) to revisit GO:1990456 rows once the obsoletion lands. The
+   calmodulin rows likely should be **REMOVED** rather than rerouted, but the
+   rationale should distinguish the human UniProt IDA annotation from the mouse
+   computational/similarity-propagated annotations.
 2. **Anchor new reviews** on **PDZD8** + **MFN2** as the highest-impact
    mammalian tethers, and on **MMM1** + **MDM12** for the yeast ERMES anchor
    pair.
@@ -130,8 +137,8 @@ than to fix outstanding GOA rows.
 - Mappings (InterPro2GO IPR039275, HAMAP MF_03102, UniRule UR000106107) all
   need to be re-pointed to GO:0140474.
 - No reviews in this repo are blocked by the obsoletion; the impact is a
-  refresh queue (VMP1 + CALM1/2/3) and a forward-looking review queue (PDZD8,
-  MFN2, VAPB, PTPIP51, ERMES components).
+  refresh queue (human VMP1/CALM1 plus mouse Calm1/2/3) and a forward-looking
+  review queue (PDZD8, MFN2, VAPB, PTPIP51, ERMES components).
 - Recommend starting with **PDZD8** as the anchor review, since it is both
   the InterPro2GO mapping target and the most recently mechanistically
   characterized mammalian mito–ER tether.

--- a/projects/MITO_ER_TETHERING_OBSOLETION.md
+++ b/projects/MITO_ER_TETHERING_OBSOLETION.md
@@ -1,0 +1,137 @@
+# Mitochondrion–ER Membrane Tethering — Obsoletion & Replacement (GO:1990456)
+
+## Overview
+
+A GO obsoletion proposal will retire **GO:1990456 mitochondrion-endoplasmic
+reticulum membrane tethering** (a BP term). The rationale matches the parallel
+ER–PM and peroxisome–chloroplast tether obsoletions: the activity is more
+appropriately captured at the molecular function level by the existing
+**GO:0140474 mitochondrion-endoplasmic reticulum membrane tether activity**.
+
+This project tracks the impact on AI Gene Review and queues the canonical
+mitochondrion–ER tether proteins for review.
+
+## Upstream tickets
+
+- Annotation tracker: [geneontology/go-annotation#6397](https://github.com/geneontology/go-annotation/issues/6397)
+- Ontology ticket: [geneontology/go-ontology#31875](https://github.com/geneontology/go-ontology/issues/31875)
+
+## Obsoletion plan (per upstream)
+
+| Obsoleted term | ID | Replacement |
+|---|---|---|
+| mitochondrion-endoplasmic reticulum membrane tethering | GO:1990456 | MF: GO:0140474 mitochondrion-endoplasmic reticulum membrane tether activity |
+
+### Affected upstream groups (from issue body)
+
+| Group | Annotations | Status |
+|---|---:|---|
+| CACAO | 1 | pending |
+| ComplexPortal | 9 | pending |
+| FlyBase | 1 | DONE |
+| MGI | 1 | pending |
+| SGD | 6 | DONE |
+| UniProt | 7 | DONE |
+| dictyBase | 5 | pending |
+
+### Mappings to be reviewed
+
+| Source | Mapping |
+|---|---|
+| InterPro2GO | InterPro:IPR039275 (PDZ domain-containing protein 8) → GO:1990456 |
+| HAMAP2GO | HAMAP:MF_03102 (MDM10 family — ERMES component) → GO:1990456 |
+| UniRule2GO | UniRule:UR000106107 → GO:1990456 |
+
+## Impact on this repo
+
+The obsoletion intersects existing reviews in the following way:
+
+| Gene | Organism | Existing action on GO:1990456 |
+|---|---|---|
+| VMP1 | human | annotated with GO:1990456 in `genes/human/VMP1/VMP1-ai-review.yaml` |
+| CALM1 | human | GO:1990456 row currently `ACCEPT` |
+| CALM2 | human | GO:1990456 row present |
+| CALM3 | human | GO:1990456 row present |
+| Calm1 | mouse | GO:1990456 row present |
+| Calm2 | mouse | GO:1990456 row present |
+| Calm3 | mouse | GO:1990456 row present |
+
+These reviews will need a refresh once the obsoletion lands — for VMP1 and the
+calmodulin family the GO:1990456 annotation should be reassessed against
+GO:0140474 (or, for calmodulins, likely **REMOVED** as a downstream Reactome
+pathway over-annotation that was not based on a tether-activity assay).
+
+No canonical mito–ER tether genes (ERMES components, PDZD8, MFN2,
+VAPB/PTPIP51) are currently reviewed in this repository.
+
+## Scope
+
+- **Organisms**: human (PDZD8, MFN2, VAPB, PTPIP51), S. cerevisiae (ERMES
+  components: MMM1, MDM10, MDM12, MDM34), Dictyostelium (5 dictyBase
+  annotations still pending), mouse (1 MGI annotation pending).
+- **GO branches**: BP (the obsoleted term itself) and MF GO:0140474. Both
+  belong to the membrane contact site (MCS) branch.
+- **Type of fix**: terminological in GO; biology is well established. Reviews
+  should evaluate whether the MF replacement (`tether activity`) is the better
+  core-function term and add it where the underlying assay supports it.
+
+## Candidate genes for initial review
+
+Verify each with `just fetch-gene <organism> <gene>` before starting; do not
+add files without confirming the UniProt accession from the UniProt API.
+
+### Mammalian mito–ER tethers
+
+1. **PDZD8** (human) — PDZ domain-containing protein 8. Direct target of the
+   InterPro2GO mapping (IPR039275). Vertebrate functional analog of yeast
+   Mmm1; established mito–ER tether (Hirabayashi et al. 2017, Science).
+2. **MFN2** (human) — Mitofusin-2. Long-debated mito–ER tether at MAMs
+   (de Brito & Scorrano 2008, Nature).
+3. **VAPB** (human) — VAMP-associated protein B/C. Forms a tether with
+   PTPIP51 at MAMs (Stoica et al. 2014, Nat Commun).
+4. **PTPIP51** / **RMDN3** (human) — partner of VAPB at MAMs.
+
+### Yeast ERMES complex (S. cerevisiae)
+
+5. **MMM1** — ER-anchored ERMES SMP-domain subunit (HAMAP MF_03102 family
+   member is *MDM10*; MMM1 is a sister subunit).
+6. **MDM10** — outer mitochondrial membrane β-barrel; ERMES + TOM-assembly
+   bridge. Direct target of HAMAP MF_03102.
+7. **MDM12** — cytosolic SMP-domain subunit bridging Mmm1 and Mdm34.
+8. **MDM34** — outer mitochondrial membrane SMP-domain subunit.
+
+Yeast SGD has already migrated its annotations upstream; review here would
+serve to capture the canonical tether MF for these reference proteins rather
+than to fix outstanding GOA rows.
+
+### Other organisms
+
+9. The 5 dictyBase pending annotations are likely to be the *Dictyostelium*
+   ERMES homologs — review opportunistically once the gene set is confirmed.
+
+## Proposed approach and priority
+
+1. **Refresh existing affected reviews** (VMP1, CALM1/2/3 in human + mouse)
+   to revisit GO:1990456 rows once the obsoletion lands. Most of these are
+   likely Reactome-pathway over-annotations that should be **REMOVED** rather
+   than rerouted.
+2. **Anchor new reviews** on **PDZD8** + **MFN2** as the highest-impact
+   mammalian tethers, and on **MMM1** + **MDM12** for the yeast ERMES anchor
+   pair.
+3. Once GO:0140474 is the canonical MF term, audit other genes in this
+   repository whose `core_functions` could legitimately gain it (e.g. through
+   the `proposed_replacement_terms` mechanism).
+
+## Status
+
+- Upstream FlyBase, SGD, and UniProt updates are done; CACAO (1),
+  ComplexPortal (9), MGI (1), and dictyBase (5) experimental annotations are
+  still pending.
+- Mappings (InterPro2GO IPR039275, HAMAP MF_03102, UniRule UR000106107) all
+  need to be re-pointed to GO:0140474.
+- No reviews in this repo are blocked by the obsoletion; the impact is a
+  refresh queue (VMP1 + CALM1/2/3) and a forward-looking review queue (PDZD8,
+  MFN2, VAPB, PTPIP51, ERMES components).
+- Recommend starting with **PDZD8** as the anchor review, since it is both
+  the InterPro2GO mapping target and the most recently mechanistically
+  characterized mammalian mito–ER tether.


### PR DESCRIPTION
## Summary

- Add `projects/MITO_ER_TETHERING_OBSOLETION.md` scoping the upstream proposal to obsolete **GO:1990456 mitochondrion-endoplasmic reticulum membrane tethering** in favor of the existing MF term **GO:0140474 mitochondrion-endoplasmic reticulum membrane tether activity**.
- Identifies the existing reviews that will need refresh (VMP1, CALM1/2/3 in human and mouse — all currently carry a GO:1990456 row, mostly from Reactome pathway annotation).
- Queues the canonical mito–ER tether proteins (PDZD8, MFN2, VAPB, PTPIP51, ERMES components) as anchor reviews; **PDZD8** recommended first since it is the InterPro2GO mapping target (IPR039275).

Addresses geneontology/go-annotation#6397 (upstream ontology ticket: geneontology/go-ontology#31875).

## Test plan

- [ ] Review the project file scope and candidate gene list for accuracy.
- [ ] Confirm `projects/MITO_ER_TETHERING_OBSOLETION.md` renders cleanly via `just render-projects`.
- [ ] When advancing this project, run `just fetch-gene human PDZD8` followed by `/review` as the first concrete review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)