### PR TITLE
BRAF: demote 45 protein binding IPI rows (batch 1 of #344)

### DIFF
--- a/genes/human/BRAF/BRAF-ai-review.yaml
+++ b/genes/human/BRAF/BRAF-ai-review.yaml
@@ -141,328 +141,369 @@ existing_annotations:
   evidence_type: IPI
   original_reference_id: PMID:12620389
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:15161933
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:15778465
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:16810323
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:16888650
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:17380122
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:17563371
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:17979178
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:20130576
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:20141835
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:21441910
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:21478863
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:21625473
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:22169110
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:22510884
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:22939624
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:23153539
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:23680146
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:23934108
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:24255178
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:24441586
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:24746704
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:25155755
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:25241761
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:25437913
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:25600339
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:26165597
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:26466569
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:26496610
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:28514442
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:30194290
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:31980649
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:32707033
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:33961781
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:34591642
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:35512704
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:35839996
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:36241744
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:36931259
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:37045861
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:40205054
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
 - term:
     id: GO:0042802
     label: identical protein binding
@@ -1061,8 +1102,9 @@ existing_annotations:
   evidence_type: IPI
   original_reference_id: PMID:18567582
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
 - term:
     id: GO:0007173
     label: epidermal growth factor receptor signaling pathway
@@ -1085,16 +1127,18 @@ existing_annotations:
   evidence_type: IPI
   original_reference_id: PMID:31024343
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:29433126
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
 - term:
     id: GO:0005829
     label: cytosol
@@ -1253,8 +1297,9 @@ existing_annotations:
   evidence_type: IPI
   original_reference_id: PMID:27353360
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
 - term:
     id: GO:0071277
     label: cellular response to calcium ion


### PR DESCRIPTION
## Summary

First annotation-review batch on BRAF (refs #344). Demotes the 45 PENDING
`GO:0005515 protein binding` IPI rows to `MARK_AS_OVER_ANNOTATED` with a
uniform template, matching the BAG3 #313 / KRAS #349 / RB1 #430 precedent.

- PENDING count: 172 → 127 (-45)
- All 45 rows changed identically: same `summary`, same `reason`, only
  `original_reference_id` differs (one PMID per row)
- No new publications fetched, no `references:` block changes, no
  `core_functions` changes — strictly an `existing_annotations` update

## Why MARK_AS_OVER_ANNOTATED rather than REMOVE

Per CLAUDE.md (`Avoid the term protein binding, this doesn't tell us
anything about the actual function`), `GO:0005515` is uninformative for a
RAF-family kinase whose biology is dominated by specific, well-characterized
partner interactions: RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD;
CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain;
MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and
Hsp90/CDC37 chaperones. The annotations aren't *wrong* — BRAF does bind
proteins — they just don't carry information about its function, which is
exactly what `MARK_AS_OVER_ANNOTATED` is for. Same call as BAG3, KRAS, RB1.

The corresponding *specific* MF terms (e.g. `GO:0019904` protein domain
specific binding, `GO:0019901` protein kinase binding, `GO:0042802`
identical protein binding for homodimerization) are already separate rows
in the seed and will be reviewed on their own merits in a subsequent batch.

## Validation

`just validate human BRAF` → ✓ Valid (3 warnings, all expected seed-state)
- Schema, term, reference checks all pass
- 127 remaining PENDING (down from 172)
- TODO description and no-core_functions warnings will clear as later
  batches review the canonical kinase / RAS-effector / dimerization rows

## Selection rationale (single-target scanner run)

Of the 8 open `curation`-labeled issues, six (#270, #305, #307, #308,
#309, #343) are in fully-cleared closure-ready state — all their pathway
PRs are merged on `main`; #270 has an explicit "stop posting" hand-off.
#347 RB1 just had its analogous protein-binding batch (#430) merged this
morning. That left **#344 BRAF** as the only candidate with substantive
unblocked scanner-actionable work.

The 45 protein binding IPI rows are the obvious starting batch — uniform
action, mechanical template, low risk, and the precedent across three
prior gene reviews (BAG3/KRAS/RB1) is consistent.

## Scope/risk

**Low.** Mechanical bulk update of `action: PENDING` → `action:
MARK_AS_OVER_ANNOTATED` for one term/evidence_type combination. The diff
is 135 insertions / 90 deletions, of which all but ~10 lines are the
identical template repeated 45 times.

## What's next (not in this PR)

- 127 remaining PENDING annotations across TAS (61 cytosol + 17 plasma
  membrane Reactome flood — next batch candidate), IDA (15), IEA (15),
  IBA (6), IPI on terms other than 0005515 (15 incl. 7 homodimerization),
  and EXP/IMP (6)
- Reactome cytosol/plasma-membrane TAS consolidation should be the next
  batch — same uniform-template pattern, ~78 rows
- Canonical kinase activity / RBD–RAS / dimerization rows next, once the
  bulk over-annotations are cleared
- A `BRAF-pathway.md` summary (matching ABCE1 / BAG3 / BCAP31 / ATF3 /
  KRAS) is the natural step *after* the full annotation review completes
- Deep research file (`BRAF-deep-research-falcon.md`) is still missing —
  that needs a maintainer with API keys; not a blocker for this batch

🤖 Generated with [Claude Code](https://claude.com/claude-code)