### PR TITLE
[codex] Add falcon deep research batch 2

### DIFF
--- a/genes/human/CALM3/CALM3-ai-review.html
+++ b/genes/human/CALM3/CALM3-ai-review.html
@@ -858,6 +858,22 @@
                         
                         
                         
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/CALM3/CALM3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">CaM has two homologous globular domains (N- and C-lobes) connected by a flexible central helix; each lobe contains two canonical EF-hand helix-loop-helix motifs, yielding four Ca2+ binding sites per CaM molecule.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
                 
@@ -1011,6 +1027,22 @@
                         
                         
                         
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/CALM3/CALM3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Calmodulin is a ubiquitously expressed Ca2+ sensor that transduces intracellular Ca2+ changes into functional regulation of diverse target proteins.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
                 
@@ -1317,6 +1349,22 @@
                         
                         
                         
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/CALM3/CALM3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">CaM is pre-associated with CaV1.2, and C-lobe EF-hand mutations that reduce Ca2+ binding can blunt calcium-dependent inactivation, increasing Ca2+ entry and prolonging action potentials.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
                 
@@ -7090,6 +7138,17 @@
                         
                     </li>
                     
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/CALM3/CALM3-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">CaM has two homologous globular domains (N- and C-lobes) connected by a flexible central helix; each lobe contains two canonical EF-hand helix-loop-helix motifs, yielding four Ca2+ binding sites per CaM molecule.</div>
+
+                    </li>
+
                 </ul>
             </div>
             
@@ -7197,6 +7256,17 @@
                         
                     </li>
                     
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/CALM3/CALM3-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">Ca2+/CaM activates CaMKII and calcineurin, linking CaM to phosphorylation/dephosphorylation cascades.</div>
+
+                    </li>
+
                 </ul>
             </div>
             
@@ -7304,6 +7374,17 @@
                         
                     </li>
                     
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/CALM3/CALM3-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">CaM regulates intracellular Ca2+ release channels. Notably, RyR2 is inhibited by both apoCaM and Ca2+/CaM.</div>
+
+                    </li>
+
                 </ul>
             </div>
             
@@ -7924,6 +8005,31 @@
                 
             </div>
             
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/CALM3/CALM3-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research report for CALM3</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Falcon research supports CALM3 as one of three human genes encoding identical calmodulin, a four-EF-hand calcium sensor that regulates target proteins including CaMKII, calcineurin, voltage-gated calcium channels, and ryanodine receptors.</div>
+
+                        <div class="finding-text">"three distinct human genes (CALM1, CALM2, CALM3) encode identical 149-aa calmodulin (CaM) protein sequences"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
         </div>
     </div>
     
@@ -7943,6 +8049,368 @@
     <div class="section">
         <h2 class="section-title">📚 Additional Documentation</h2>
         
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Deep Research Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(CALM3-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P0DP25" data-a="DOC: Deep Research Falcon" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <hr />
+<p>provider: falcon<br />
+model: Edison Scientific Literature<br />
+cached: false<br />
+start_time: '2026-05-10T19:59:57.145758'<br />
+end_time: '2026-05-10T20:11:51.248458'<br />
+duration_seconds: 714.1<br />
+template_file: templates/gene_research_go_focused.md<br />
+template_variables:<br />
+  organism: human<br />
+  gene_id: CALM3<br />
+  gene_symbol: CALM3<br />
+  uniprot_accession: P0DP25<br />
+  protein_description: 'RecName: Full=Calmodulin-3 {ECO:0000312|HGNC:HGNC:1449};'<br />
+  gene_info: Name=CALM3 {ECO:0000312|HGNC:HGNC:1449}; Synonyms=CALML2, CAM3, CAMC,<br />
+    CAMIII;<br />
+  organism_full: Homo sapiens (Human).<br />
+  protein_family: Belongs to the calmodulin family. .<br />
+  protein_domains: CALM/Myosin/TropC-like. (IPR050230); EF-hand-dom_pair. (IPR011992);<br />
+    EF_Hand_1_Ca_BS. (IPR018247); EF_hand_dom. (IPR002048); EF-hand_7 (PF13499)<br />
+provider_config:<br />
+  timeout: 600<br />
+  max_retries: 3<br />
+  parameters:<br />
+    allowed_domains: []<br />
+    temperature: 0.1<br />
+citation_count: 36</p>
+<hr />
+<h2 id="question">Question</h2>
+<h1 id="gene-research-for-functional-annotation">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> P0DP25</li>
+<li><strong>Protein Description:</strong> RecName: Full=Calmodulin-3 {ECO:0000312|HGNC:HGNC:1449};</li>
+<li><strong>Gene Information:</strong> Name=CALM3 {ECO:0000312|HGNC:HGNC:1449}; Synonyms=CALML2, CAM3, CAMC, CAMIII;</li>
+<li><strong>Organism (full):</strong> Homo sapiens (Human).</li>
+<li><strong>Protein Family:</strong> Belongs to the calmodulin family. .</li>
+<li><strong>Key Domains:</strong> CALM/Myosin/TropC-like. (IPR050230); EF-hand-dom_pair. (IPR011992); EF_Hand_1_Ca_BS. (IPR018247); EF_hand_dom. (IPR002048); EF-hand_7 (PF13499)</li>
+</ul>
+<h3 id="mandatory-verification-steps">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "CALM3" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Homo sapiens (Human).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'CALM3' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>CALM3</strong> (gene ID: CALM3, UniProt: P0DP25) in human.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="output">Output</h2>
+<p>Question: You are an expert researcher providing comprehensive, well-cited information.</p>
+<p>Provide detailed information focusing on:<br />
+1. Key concepts and definitions with current understanding<br />
+2. Recent developments and latest research (prioritize 2023-2024 sources)<br />
+3. Current applications and real-world implementations<br />
+4. Expert opinions and analysis from authoritative sources<br />
+5. Relevant statistics and data from recent studies</p>
+<p>Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.<br />
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.</p>
+<h1 id="gene-research-for-functional-annotation_1">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context_1">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot_1">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> P0DP25</li>
+<li><strong>Protein Description:</strong> RecName: Full=Calmodulin-3 {ECO:0000312|HGNC:HGNC:1449};</li>
+<li><strong>Gene Information:</strong> Name=CALM3 {ECO:0000312|HGNC:HGNC:1449}; Synonyms=CALML2, CAM3, CAMC, CAMIII;</li>
+<li><strong>Organism (full):</strong> Homo sapiens (Human).</li>
+<li><strong>Protein Family:</strong> Belongs to the calmodulin family. .</li>
+<li><strong>Key Domains:</strong> CALM/Myosin/TropC-like. (IPR050230); EF-hand-dom_pair. (IPR011992); EF_Hand_1_Ca_BS. (IPR018247); EF_hand_dom. (IPR002048); EF-hand_7 (PF13499)</li>
+</ul>
+<h3 id="mandatory-verification-steps_1">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "CALM3" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Homo sapiens (Human).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature_1">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'CALM3' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target_1">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>CALM3</strong> (gene ID: CALM3, UniProt: P0DP25) in human.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="research-report-human-calm3-uniprot-p0dp25-functional-annotation-pathways-and-clinical-relevance">Research report: Human <strong>CALM3</strong> (UniProt <strong>P0DP25</strong>) — functional annotation, pathways, and clinical relevance</h2>
+<h3 id="0-verification-of-correct-geneprotein-identity-critical">0) Verification of correct gene/protein identity (critical)</h3>
+<p>CALM3 (UniProt accession P0DP25) corresponds to <strong>human calmodulin-3</strong>, a canonical member of the <strong>calmodulin family</strong> (EF-hand Ca2+-binding protein). Multiple authoritative sources explicitly state that <strong>three distinct human genes (CALM1, CALM2, CALM3) encode identical 149-aa calmodulin (CaM) protein sequences</strong>, despite being located on different chromosomes. This resolves gene-symbol ambiguity and confirms that literature discussing human “calmodulin/CaM” protein function generally applies directly to CALM3’s protein product. (hussey2023calmodulinmutationsin pages 1-2, jensen2024calmodulinvariantsin pages 10-12)</p>
+<h3 id="1-key-concepts-and-definitions-current-understanding">1) Key concepts and definitions (current understanding)</h3>
+<h4 id="11-what-calm3-encodes-a-ca2-sensor-not-an-enzyme">1.1 What CALM3 encodes: a Ca2+ sensor (not an enzyme)</h4>
+<p>Calmodulin (CaM) is a <strong>ubiquitously expressed Ca2+ sensor</strong> that transduces intracellular Ca2+ changes into functional regulation of diverse target proteins; it does <strong>not catalyze</strong> a chemical reaction. It is a small (~17 kDa), <strong>149-amino-acid</strong> protein present in essentially all eukaryotic cells. (hussey2023calmodulinmutationsin pages 1-2)</p>
+<h4 id="12-core-structural-definition-ef-hands-and-two-lobes">1.2 Core structural definition: EF-hands and two lobes</h4>
+<p>CaM has <strong>two homologous globular domains (N- and C-lobes)</strong> connected by a flexible central helix; each lobe contains <strong>two canonical EF-hand helix–loop–helix motifs</strong>, yielding <strong>four Ca2+ binding sites per CaM molecule</strong>. (hussey2023calmodulinmutationsin pages 1-2, sobue2024calmodulinahighly pages 1-2)</p>
+<p>A structural analysis of many CaM–target complexes emphasizes conserved target-recognition principles (hydrophobic anchor residues in targets and methionine-rich interaction surfaces in CaM), supporting how CaM can bind many different partners using common physical interaction modes. (denesyuk2023canonicalstructuralbindingmodes pages 24-27)</p>
+<h4 id="13-calcium-binding-mechanism-and-ca2-triggered-switching">1.3 Calcium-binding mechanism and Ca2+-triggered switching</h4>
+<p>In resting cells, cytosolic free Ca2+ is ~10^-7 M, whereas extracellular Ca2+ is ~10^-3 M (a ~10,000-fold gradient). Upon stimulation, cytosolic Ca2+ can rise to ~10^-6–10^-5 M. These Ca2+ rises are the physiological signals that CaM detects via its EF-hands. (sobue2024calmodulinahighly pages 1-2)</p>
+<p>Ca2+ saturation of CaM is associated with conformational changes that expose hydrophobic surfaces and enable productive binding to target proteins, providing a mechanistic link between Ca2+ signals and downstream regulation. (sobue2024calmodulinahighly pages 1-2)</p>
+<h4 id="14-quantitative-ca2-binding-properties-biophysical-definition-of-lobe-asymmetry">1.4 Quantitative Ca2+ binding properties (biophysical “definition” of lobe asymmetry)</h4>
+<p>A mechanistically important feature is that the N- and C-lobes differ in Ca2+ affinity. One recent review reports approximate dissociation constants (KD) of ~16 µM (N-lobe) and ~2.4 µM (C-lobe), enabling partially separable “lobe-specific” regulation of targets. (hussey2023calmodulinmutationsin pages 1-2)</p>
+<p>Another recent review summarizes CaM Ca2+ affinity in the ~5×10^-7 to 5×10^-6 M range and estimates intracellular CaM concentrations in mammalian cells at ~2–10 µM, placing CaM in the concentration regime where it can act as a high-capacity Ca2+ signal decoder. (sobue2024calmodulinahighly pages 1-2)</p>
+<h3 id="2-primary-biological-function-pathways-and-mechanisms-of-action">2) Primary biological function, pathways, and mechanisms of action</h3>
+<h4 id="21-primary-function-regulate-targets-by-apocam-pre-association-and-ca2-dependent-switching">2.1 Primary function: regulate targets by apoCaM pre-association and Ca2+-dependent switching</h4>
+<p>A central modern concept is that many targets are <strong>pre-associated with Ca2+-free calmodulin (apoCaM)</strong>, so CaM acts as a “resident” Ca2+ sensor at the target. Upon Ca2+ binding, CaM changes binding mode and/or conformation, producing functional modulation such as feedback inhibition or facilitation. (hussey2023calmodulinmutationsin pages 2-4)</p>
+<p>Disease-associated EF-hand mutations can <strong>alter Ca2+ binding without disrupting the Ca2+-free structure</strong>, preserving apo-association but impairing Ca2+-dependent regulation—an important mechanistic explanation for dominant-negative effects in heterozygous patients. (hussey2023calmodulinmutationsin pages 2-4)</p>
+<h4 id="22-canonical-and-high-confidence-pathwaystargets-relevant-to-functional-annotation">2.2 Canonical and high-confidence pathways/targets relevant to functional annotation</h4>
+<p><strong>Voltage-gated Ca2+ channels (CaV1.x / CaV2.x)</strong>: CaM frequently binds an IQ motif in the channel C-terminus. Ca2+ binding to CaM then drives <strong>calcium-dependent inactivation (CDI)</strong> and/or <strong>calcium-dependent facilitation (CDF)</strong>, with strong lobe-specificity in several channels (e.g., CaV2.2/2.3 CDI driven by N-lobe; L-type channels can involve either lobe depending on context). (hussey2023calmodulinmutationsin pages 2-4)</p>
+<p><strong>CaV1.2 (cardiac L-type Ca2+ channel)</strong> is emphasized as a key pathogenic substrate in calmodulinopathy: CaM is pre-associated with CaV1.2, and C-lobe EF-hand mutations that reduce Ca2+ binding can blunt CDI, increasing Ca2+ entry and prolonging action potentials (a mechanistic route to LQTS). (hussey2023calmodulinmutationsin pages 9-11)</p>
+<p><strong>Ryanodine receptors (RyR1/RyR2)</strong>: CaM regulates intracellular Ca2+ release channels. Notably, RyR2 (cardiac) is inhibited by both apoCaM and Ca2+/CaM; the C-lobe of Ca2+/CaM can increase the termination threshold of spontaneous Ca2+ release, indicating state- and lobe-specific control of Ca2+ sparks/waves. (hussey2023calmodulinmutationsin pages 4-6)</p>
+<p><strong>SK (small-conductance Ca2+-activated K+) channels</strong>: CaM is constitutively associated and required for gating; one review notes <strong>four CaM molecules per channel</strong> and indicates that CaM’s N-lobe drives Ca2+ dependence for SK2. (hussey2023calmodulinmutationsin pages 2-4, hussey2023calmodulinmutationsin pages 4-6)</p>
+<p><strong>CaMKII and calcineurin/NFAT signaling</strong>: Ca2+/CaM activates CaMKII and calcineurin, linking CaM to phosphorylation/dephosphorylation cascades. CaMKII phosphorylates proteins central to excitation–contraction coupling (e.g., RyR2, L-type channels, phospholamban/SERCA regulation), and calcineurin can drive NFAT dephosphorylation and transcriptional signaling. (hussey2023calmodulinmutationsin pages 2-4, hussey2023calmodulinmutationsin pages 1-2)</p>
+<p><strong>IP3 receptors (IP3R)</strong>: CaM can decrease IP3 sensitivity in type I IP3R, with both apoCaM and Ca2+/CaM reported to reduce receptor sensitivity. (hussey2023calmodulinmutationsin pages 4-6)</p>
+<p><strong>Broader interaction landscape</strong>: A structural survey of CaM–target complexes (spanning apo and Ca2+-bound states) includes many relevant targets (e.g., CaMKII, calcineurin/PP2B, NaV1.5, RyR2, SK channels, MLCK), reinforcing the concept that CaM uses a conserved physical binding toolkit to regulate diverse pathways. (denesyuk2023canonicalstructuralbindingmodes pages 24-27)</p>
+<h3 id="3-subcellular-localization-where-calm3s-protein-product-acts">3) Subcellular localization: where CALM3’s protein product acts</h3>
+<p>CaM is an <strong>intracellular protein</strong> and functions at the <strong>cytosolic faces of target proteins</strong> (e.g., cytosolic C-tails of ion channels) and at intracellular membranes where channels like RyR/IP3R reside. It is broadly distributed across tissues (and by implication across many cellular compartments where its targets are located), with estimated intracellular concentration ~2–10 µM. (sobue2024calmodulinahighly pages 1-2, hussey2023calmodulinmutationsin pages 4-6, hussey2023calmodulinmutationsin pages 2-4)</p>
+<h3 id="4-disease-relevance-of-calm3-calmodulinopathy-and-variant-mechanisms">4) Disease relevance of CALM3: calmodulinopathy and variant mechanisms</h3>
+<h4 id="41-disease-entity-and-phenotypes">4.1 Disease entity and phenotypes</h4>
+<p>Dominant pathogenic variants in any of CALM1/2/3 (including <strong>CALM3</strong>) cause <strong>calmodulinopathy</strong>, classically presenting as <strong>CALM-LQTS</strong> and/or <strong>CALM-CPVT</strong>, with additional presentations including idiopathic ventricular fibrillation and syndromic features. (hussey2023calmodulinmutationsin pages 4-6, crotti2023clinicalpresentationof pages 8-9)</p>
+<p>A large 2023 update from the <strong>International Calmodulinopathy Registry (ICalmR)</strong> (European Heart Journal; published Aug 2023) provides the most authoritative recent clinical synthesis:<br />
+- <strong>N = 140 subjects</strong> total (97 index cases, 43 family members); median age <strong>10.8</strong> years (IQR 5–19). (crotti2023clinicalpresentationof pages 2-3)<br />
+- Phenotype proportions: <strong>CALM-LQTS 74 (53%)</strong>, <strong>CALM-CPVT 36 (26%)</strong>, <strong>LQTS/CPVT overlap 10 (7%)</strong>, <strong>IVF 7 (5%)</strong>, <strong>uncertain diagnosis 11 (8%)</strong>, atypical 2 (1%). (crotti2023clinicalpresentationof pages 3-4)<br />
+- <strong>Symptomatic/arrhythmic events</strong>: 103 symptomatic patients (<strong>74%</strong>). (crotti2023clinicalpresentationof pages 2-3)<br />
+- Compared with an earlier 2019 cohort, <strong>all cardiac events decreased 85% → 61% (P=0.001)</strong> and <strong>sudden death decreased 27% → 9% (P=0.008)</strong>, suggesting improving outcomes with broader recognition and management, while emphasizing that disease remains high-risk. (crotti2023clinicalpresentationof pages 2-3)</p>
+<h4 id="42-variant-clustering-and-molecular-interpretation">4.2 Variant clustering and molecular interpretation</h4>
+<p>In ICalmR, <strong>58/62 variants</strong> were classified pathogenic/likely pathogenic by ACMG curation, and <strong>49/58 (84%)</strong> clustered in <strong>exons 5–6</strong>, consistent with enrichment in C-lobe EF-hand regions central to Ca2+ chelation and target regulation. (crotti2023clinicalpresentationof pages 8-9)</p>
+<p>Mechanistically, the registry notes that many LQTS-associated CALM variants map to EF-hands III/IV and reduce C-domain Ca2+ binding, impairing CaM-mediated CaV1.2 CDI (prolonging repolarization). (crotti2023clinicalpresentationof pages 12-13)</p>
+<h4 id="43-extra-cardiac-manifestations-interpretation-and-caution">4.3 Extra-cardiac manifestations (interpretation and caution)</h4>
+<p>ICalmR also documents neurological involvement: among 111 evaluable patients, 35 had neurological disorders, including 20 primary neurological manifestations (not attributable to post-anoxic injury). (crotti2023clinicalpresentationof pages 3-4, crotti2023clinicalpresentationof pages 2-3)</p>
+<p>Separately, a 2024 preprint reported enrichment of ultra-rare CALM missense variants in schizophrenia cases vs controls, with all case variants in the C-lobe and an estimated odds ratio ~5.6 for carrying a C-lobe variant; the authors also identify functional classes (reduced vs increased Ca2+ affinity). This is not yet as clinically established as the cardiac calmodulinopathy literature and should be interpreted as emerging evidence. (jensen2024calmodulinvariantsin pages 10-12, jensen2024calmodulinvariantsin pages 3-5)</p>
+<h3 id="5-current-applications-and-real-world-implementations">5) Current applications and real-world implementations</h3>
+<h4 id="51-diagnostic-implementation-genetic-testing-and-registry-guided-practice">5.1 Diagnostic implementation: genetic testing and registry-guided practice</h4>
+<p>A major real-world development is the formalization and expansion of the <strong>International Calmodulinopathy Registry</strong>, which has nearly doubled enrolled cases since its initial report and is used to clarify genotype–phenotype variability and outcomes. (crotti2023clinicalpresentationof pages 4-4, crotti2023clinicalpresentationof pages 2-3)</p>
+<p>The ICalmR authors state that <strong>CALM1–3 are definitively associated with LQTS and CPVT and “should be screened in all LQTS and CPVT patients,”</strong> supporting routine inclusion of CALM genes on clinical genetic testing panels. (crotti2023clinicalpresentationof pages 4-4)</p>
+<h4 id="52-management-approaches-documented-in-contemporary-cohorts">5.2 Management approaches documented in contemporary cohorts</h4>
+<p>ICalmR reports that contemporary management commonly includes <strong>pharmacological and surgical antiadrenergic interventions</strong>, frequent use of <strong>sodium channel blockers</strong>, and <strong>implantable cardioverter–defibrillators (ICDs)</strong>; however, the authors emphasize that therapy data remain insufficient for definitive recommendations. (crotti2023clinicalpresentationof pages 2-3)</p>
+<h3 id="6-recent-developments-and-latest-research-prioritizing-20232024">6) Recent developments and latest research (prioritizing 2023–2024)</h3>
+<h4 id="61-2024-therapeutic-innovation-antisense-oligonucleotide-aso-depletion-strategy-proof-of-concept">6.1 2024 therapeutic innovation: antisense oligonucleotide (ASO) depletion strategy (proof-of-concept)</h4>
+<p>A 2024 Circulation study demonstrates a precision strategy that leverages the unusual redundancy that <strong>CALM1/2/3 encode identical protein</strong>: selectively depleting one affected gene can ameliorate phenotype while preserving total CaM protein. (bortolin2024antisenseoligonucleotidetherapy pages 1-3)</p>
+<p>Key results:<br />
+- In <strong>human CALM1F142L/+ iPSC-derived cardiomyocytes</strong>, CALM1 knockout or <strong>CALM1-depleting ASOs normalized repolarization duration</strong> without altering overall CaM protein level. (bortolin2024antisenseoligonucleotidetherapy pages 1-3)<br />
+- In mice, an ASO targeting murine Calm1 reduced Calm1 transcript without reducing CaM protein, and <strong>alleviated drug-induced bidirectional ventricular tachycardia</strong> in Calm1N98S/+ animals without adverse cardiac electrical/contractile effects. (bortolin2024antisenseoligonucleotidetherapy pages 1-3)</p>
+<p>While this work targeted CALM1 experimentally, the underlying principle is directly relevant to CALM3 because it depends on the <strong>three-gene/identical-protein architecture</strong> of human calmodulin. (bortolin2024antisenseoligonucleotidetherapy pages 1-3)</p>
+<h4 id="62-20232024-mechanistic-consolidation">6.2 2023–2024 mechanistic consolidation</h4>
+<p>Recent 2023 reviews synthesize evidence that calmodulinopathic variants disproportionately disrupt Ca2+ binding in EF-hands and thereby perturb key pre-associated targets such as CaV1.2 (via CDI failure) and RyR2 (via altered inhibition), providing a molecular explanation for how heterozygous variants cause severe arrhythmias. (hussey2023calmodulinmutationsin pages 4-6, hussey2023calmodulinmutationsin pages 9-11)</p>
+<h3 id="7-expert-opinion-and-authoritative-analysis-what-experts-emphasize">7) Expert opinion and authoritative analysis (what experts emphasize)</h3>
+<p>Across the highest-authority clinical source (ICalmR) and mechanistic reviews, the convergent expert view is:<br />
+1) <strong>CALM variants cause severe, early-onset arrhythmia syndromes</strong> with high event rates, but phenotypic variability is broad and includes milder familial forms. (crotti2023clinicalpresentationof pages 2-3)<br />
+2) The <strong>C-lobe EF-hands (EF3/EF4) are a mechanistic hotspot</strong>, because impaired Ca2+ binding there undermines regulation of pre-associated targets (especially CaV1.2 CDI), producing dominant effects even when wild-type CaM is abundant. (hussey2023calmodulinmutationsin pages 9-11, crotti2023clinicalpresentationof pages 12-13)<br />
+3) <strong>Registries and systematic genetic screening</strong> are essential because of rarity, heterogeneity, and management uncertainty; improved outcomes over time likely reflect increased recognition and multi-modality care, but evidence remains insufficient for definitive, variant-specific treatment rules. (crotti2023clinicalpresentationof pages 2-3, crotti2023clinicalpresentationof pages 4-4)</p>
+<h3 id="8-summary-evidence-map-table">8) Summary evidence map (table)</h3>
+<table>
+<thead>
+<tr>
+<th>Topic</th>
+<th>Key points</th>
+<th>Quantitative data (if any)</th>
+<th>Key sources (author year journal) and URLs</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Identity</td>
+<td><strong>Verified target:</strong> human <strong>CALM3</strong> encodes <strong>calmodulin-3</strong>, one of three human genes (<strong>CALM1/2/3</strong>) that encode the <strong>identical 149-aa calmodulin protein</strong>. CALM3 is a canonical calmodulin-family member, matching UniProt P0DP25 and the EF-hand calcium-sensor annotation. In heart, CALM3 transcript abundance is reported as relatively high among CALM genes, although newer expression analyses suggest gene contributions are tissue-dependent. (hussey2023calmodulinmutationsin pages 1-2, jensen2024calmodulinvariantsin pages 10-12)</td>
+<td>149 aa protein; CALM genes on distinct chromosomes; CALM3 reported as highest relative abundance in human heart in one review. (hussey2023calmodulinmutationsin pages 1-2)</td>
+<td>Hussey et al. 2023, <em>Channels</em> — https://doi.org/10.1080/19336950.2023.2165278; Jensen et al. 2024, <em>medRxiv</em> — https://doi.org/10.1101/2024.05.22.24307674</td>
+</tr>
+<tr>
+<td>Structure</td>
+<td>Calmodulin is a small, highly conserved Ca2+ sensor with <strong>two globular lobes (N and C)</strong> linked by a flexible central helix; <strong>each lobe contains two EF-hand motifs</strong> for a total of <strong>four Ca2+-binding sites</strong>. Ca2+ binding exposes hydrophobic surfaces that enable target engagement; methionine-rich surfaces contribute importantly to target recognition. (hussey2023calmodulinmutationsin pages 1-2, sobue2024calmodulinahighly pages 1-2, denesyuk2023canonicalstructuralbindingmodes pages 24-27)</td>
+<td>N-lobe Kd ~<strong>16 µM</strong> and C-lobe Kd ~<strong>2.4 µM</strong> in one review; overall Ca2+ affinity reported in the ~<strong>5×10^-7 to 5×10^-6 M</strong> range; intracellular CaM concentration ~<strong>2–10 µM</strong>. (hussey2023calmodulinmutationsin pages 1-2, sobue2024calmodulinahighly pages 1-2)</td>
+<td>Hussey et al. 2023, <em>Channels</em> — https://doi.org/10.1080/19336950.2023.2165278; Sobue 2024, <em>Proc Jpn Acad Ser B</em> — https://doi.org/10.2183/pjab.100.025; Denesyuk et al. 2023, <em>J Biomol Struct Dyn</em> — https://doi.org/10.1080/07391102.2022.2123391</td>
+</tr>
+<tr>
+<td>Mechanism</td>
+<td>CALM3/calmodulin is a <strong>signal transducer, not an enzyme</strong>: it <strong>binds Ca2+</strong> and converts Ca2+ transients into conformational changes that regulate partner proteins. Many targets are <strong>pre-associated with apoCaM</strong>, and Ca2+ loading of one or both lobes triggers altered binding and target control. Disease mutations often preserve apo-binding but disrupt Ca2+-dependent switching. (hussey2023calmodulinmutationsin pages 2-4, hussey2023calmodulinmutationsin pages 11-13, hussey2023calmodulinmutationsin pages 9-11)</td>
+<td>Resting cytosolic Ca2+ ~<strong>10^-7 M</strong>; stimulated intracellular Ca2+ rises to <strong>10^-6–10^-5 M</strong>; extracellular Ca2+ ~<strong>10^-3 M</strong>. (sobue2024calmodulinahighly pages 1-2)</td>
+<td>Hussey et al. 2023, <em>Channels</em> — https://doi.org/10.1080/19336950.2023.2165278; Sobue 2024, <em>Proc Jpn Acad Ser B</em> — https://doi.org/10.2183/pjab.100.025</td>
+</tr>
+<tr>
+<td>Pathways</td>
+<td>Key pathways/targets include <strong>L-type Ca2+ channels (CaV1.2/CaV1.3)</strong>, <strong>RyR2</strong>, <strong>SK channels</strong>, <strong>NaV1.5</strong>, <strong>CaMKII</strong>, and <strong>calcineurin/NFAT</strong>. Mechanistically, CaM mediates <strong>calcium-dependent inactivation/facilitation (CDI/CDF)</strong> of CaV channels, suppresses/reshapes <strong>RyR2</strong> opening, enables <strong>SK</strong> gating, and activates <strong>CaMKII</strong> and <strong>calcineurin</strong>, linking it to excitation–contraction coupling, membrane excitability, transcriptional responses, and neuronal plasticity. (hussey2023calmodulinmutationsin pages 2-4, hussey2023calmodulinmutationsin pages 9-11, hussey2023calmodulinmutationsin pages 13-15, hussey2023calmodulinmutationsin pages 4-6, sobue2024calmodulinahighly pages 6-19)</td>
+<td>SK channels can bind <strong>4 CaM molecules/channel</strong>; lobe-specific regulation documented for several channels. (hussey2023calmodulinmutationsin pages 2-4, hussey2023calmodulinmutationsin pages 4-6)</td>
+<td>Hussey et al. 2023, <em>Channels</em> — https://doi.org/10.1080/19336950.2023.2165278; Sobue 2024, <em>Proc Jpn Acad Ser B</em> — https://doi.org/10.2183/pjab.100.025</td>
+</tr>
+<tr>
+<td>Localization</td>
+<td>Calmodulin is <strong>ubiquitous and intracellular</strong>, functioning in the <strong>cytosol</strong> and on <strong>cytosolic faces of membrane proteins</strong> rather than as a secreted factor. It localizes functionally near plasma-membrane ion channels, intracellular Ca2+ release channels (e.g., <strong>RyR2</strong>, <strong>IP3R</strong>), and signaling complexes in heart, brain, immune cells, and muscle. CALM1-3 transcripts are also robustly expressed in brain cell types. (hussey2023calmodulinmutationsin pages 4-6, jensen2024calmodulinvariantsin pages 3-5, hussey2023calmodulinmutationsin pages 2-4, sobue2024calmodulinahighly pages 1-2)</td>
+<td>Broad tissue distribution; mammalian intracellular CaM estimated at <strong>2–10 µM</strong>. (sobue2024calmodulinahighly pages 1-2)</td>
+<td>Sobue 2024, <em>Proc Jpn Acad Ser B</em> — https://doi.org/10.2183/pjab.100.025; Hussey et al. 2023, <em>Channels</em> — https://doi.org/10.1080/19336950.2023.2165278; Jensen et al. 2024, <em>medRxiv</em> — https://doi.org/10.1101/2024.05.22.24307674</td>
+</tr>
+<tr>
+<td>Disease</td>
+<td>Pathogenic variants in <strong>CALM1/2/3</strong>, including <strong>CALM3</strong>, cause <strong>calmodulinopathy</strong>, especially <strong>long QT syndrome (CALM-LQTS)</strong> and <strong>catecholaminergic polymorphic ventricular tachycardia (CALM-CPVT)</strong>; variants cluster strongly in <strong>EF-hand/C-lobe</strong> regions that impair Ca2+ binding and downstream regulation of <strong>CaV1.2</strong> and/or <strong>RyR2</strong>. Structural heart disease and neurological manifestations can also occur. (hussey2023calmodulinmutationsin pages 4-6, crotti2023clinicalpresentationof pages 10-11, crotti2023clinicalpresentationof pages 8-9, crotti2023clinicalpresentationof pages 12-13)</td>
+<td>Registry: <strong>140</strong> subjects total; phenotypes <strong>LQTS 74 (53%)</strong>, <strong>CPVT 36 (26%)</strong>, <strong>LQTS/CPVT overlap 10 (7%)</strong>, <strong>IVF 7 (5%)</strong>, <strong>uncertain 11 (8%)</strong>; structural cardiac abnormalities in <strong>30%</strong>; symptomatic/arrhythmic event burden <strong>74%</strong>; sudden death reduced from <strong>27%</strong> in earlier cohort to <strong>9%</strong> in updated cohort. Most P/LP variants (<strong>49/58, 84%</strong>) cluster in <strong>exons 5–6</strong>. (crotti2023clinicalpresentationof pages 3-4, crotti2023clinicalpresentationof pages 8-9, crotti2023clinicalpresentationof pages 2-3)</td>
+<td>Crotti et al. 2023, <em>European Heart Journal</em> — https://doi.org/10.1093/eurheartj/ehad418; Hussey et al. 2023, <em>Channels</em> — https://doi.org/10.1080/19336950.2023.2165278</td>
+</tr>
+<tr>
+<td>Applications</td>
+<td><strong>Current real-world implementation:</strong> CALM genes are now recognized as definitive arrhythmia genes and should be included in <strong>genetic testing/panel screening</strong> for LQTS/CPVT and in some genotype-negative arrest survivors. The <strong>International Calmodulinopathy Registry</strong> is a major clinical infrastructure for diagnosis, genotype–phenotype correlation, and management refinement. Standard care remains antiadrenergic therapy, sodium-channel blockers in some cases, and ICD/other interventions when needed. (crotti2023clinicalpresentationof pages 4-4, crotti2023clinicalpresentationof pages 2-3, hussey2023calmodulinmutationsin pages 17-18)</td>
+<td>Registry nearly doubled from earlier reports to <strong>140</strong> enrolled subjects; <strong>103 (74%)</strong> had cardiac events. (crotti2023clinicalpresentationof pages 4-4, crotti2023clinicalpresentationof pages 2-3)</td>
+<td>Crotti et al. 2023, <em>European Heart Journal</em> — https://doi.org/10.1093/eurheartj/ehad418; Hussey et al. 2023, <em>Channels</em> — https://doi.org/10.1080/19336950.2023.2165278</td>
+</tr>
+<tr>
+<td>Recent developments (2023–2024)</td>
+<td>Major recent advances include: (1) expanded <strong>International Calmodulinopathy Registry</strong> showing broader phenotype spectrum and somewhat improved outcomes with modern management; (2) updated mechanistic syntheses linking variant effects to altered <strong>CaV1.2 CDI</strong> and <strong>RyR2</strong> regulation; and (3) a <strong>2024 antisense oligonucleotide (ASO)</strong> proof-of-concept showing that selective depletion of one mutant CALM gene can rescue cellular/animal phenotypes while preserving overall CaM protein through redundancy of the remaining CALM genes. (crotti2023clinicalpresentationof pages 3-4, bortolin2024antisenseoligonucleotidetherapy pages 1-3, bortolin2024antisenseoligonucleotidetherapy pages 3-5)</td>
+<td>In 2024 ASO study, CALM1-targeting ASO reduced mutant-gene transcript, <strong>normalized repolarization</strong> in patient iPSC-cardiomyocytes, and <strong>alleviated bidirectional VT</strong> in mice <strong>without reducing total CaM protein</strong>. (bortolin2024antisenseoligonucleotidetherapy pages 1-3, bortolin2024antisenseoligonucleotidetherapy pages 3-5)</td>
+<td>Bortolin et al. 2024, <em>Circulation</em> — https://doi.org/10.1161/circulationaha.123.068111; Crotti et al. 2023, <em>European Heart Journal</em> — https://doi.org/10.1093/eurheartj/ehad418</td>
+</tr>
+<tr>
+<td>Data highlights</td>
+<td>Recent human and experimental datasets support a <strong>C-lobe/EF-hand vulnerability model</strong>: disease-associated variants disproportionately affect the C-lobe and Ca2+-coordinating residues, with consequences for CaV1.2 and RyR2 regulation. Emerging neuropsychiatric work also suggests non-cardiac phenotypic expansion for some CALM variants, though cardiac calmodulinopathy remains the best-established disease context. (jensen2024calmodulinvariantsin pages 10-12, jensen2024calmodulinvariantsin pages 3-5, crotti2023clinicalpresentationof pages 12-13)</td>
+<td>In a 2024 schizophrenia sequencing analysis, <strong>7</strong> CALM missense variants were found in cases vs <strong>20</strong> in controls, and all case variants mapped to the <strong>C-lobe</strong>; reported OR for carrying a C-lobe variant was <strong>5.6</strong>. These findings are preliminary relative to established cardiac evidence. (jensen2024calmodulinvariantsin pages 10-12, jensen2024calmodulinvariantsin pages 3-5)</td>
+<td>Jensen et al. 2024, <em>medRxiv</em> — https://doi.org/10.1101/2024.05.22.24307674; Crotti et al. 2023, <em>European Heart Journal</em> — https://doi.org/10.1093/eurheartj/ehad418</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes verified identity, molecular function, pathways, localization, disease relevance, applications, and recent 2023-2024 developments for human CALM3/calmodulin. It is designed as a compact evidence map with quantitative findings and source URLs.</em></p>
+<h3 id="9-practical-functional-annotation-statement-for-databasescuration">9) Practical functional annotation statement (for databases/curation)</h3>
+<p><strong>CALM3 encodes calmodulin (CaM), a ubiquitous intracellular EF-hand Ca2+ sensor that binds four Ca2+ ions via two lobes (N and C) and regulates diverse target proteins through Ca2+-dependent conformational switching and frequent apoCaM pre-association. High-confidence regulated pathways include CaV1.2/CaV1.3 calcium-dependent inactivation/facilitation, RyR2 inhibition and Ca2+ release termination, SK channel gating, and Ca2+/CaM-dependent enzyme pathways (CaMKII, calcineurin/NFAT). Dominant missense variants—often in C-lobe EF-hands—cause calmodulinopathy (LQTS/CPVT) with high arrhythmic event rates; recent registry data quantify phenotype distributions and improving outcomes, and 2024 work provides proof-of-concept for gene-specific ASO depletion therapy exploiting redundancy across CALM genes.</strong> (hussey2023calmodulinmutationsin pages 2-4, hussey2023calmodulinmutationsin pages 9-11, hussey2023calmodulinmutationsin pages 4-6, crotti2023clinicalpresentationof pages 2-3, bortolin2024antisenseoligonucleotidetherapy pages 1-3)</p>
+<h3 id="10-limitations-of-this-report">10) Limitations of this report</h3>
+<ul>
+<li>The evidence set is strong for <strong>calmodulin’s molecular function</strong> and for <strong>clinical calmodulinopathy statistics</strong> (ICalmR), but does not include UniProt/GO text excerpts directly (the report relies on primary/review literature retrieved here). </li>
+<li>Some emerging non-cardiac associations (e.g., schizophrenia) are from <strong>preprint literature</strong> and should be treated as provisional until peer-reviewed replication. (jensen2024calmodulinvariantsin pages 10-12)</li>
+</ul>
+<p>References</p>
+<ol>
+<li>
+<p>(hussey2023calmodulinmutationsin pages 1-2): John W. Hussey, Worawan B. Limpitikul, and Ivy E. Dick. Calmodulin mutations in human disease. Channels, Jan 2023. URL: https://doi.org/10.1080/19336950.2023.2165278, doi:10.1080/19336950.2023.2165278. This article has 54 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(jensen2024calmodulinvariantsin pages 10-12): PhD Helene Halkjær Jensen, PhD Malene Brohus, BSc John W. Hussey III, Ana-Octavia Busuioc MSc, MSc Emil Drivsholm Iversen, MSc Faezeh Darki, MSc Gabriela Dobromirova Nikolova, MSc Amalie El-ton Baisgaard, PhD Palle Duun Rohde, Ida Elisabeth, M. D. Gad Holm, PhD Andrew McQuillin, PhD Tor-ben Moos, PhD Ivy E. Dick, PhD Michael Toft Overgaard, and M. Nyegaard. Calmodulin variants in schizophrenia patients display gain-of-function or loss-of-function effects. MedRxiv, May 2024. URL: https://doi.org/10.1101/2024.05.22.24307674, doi:10.1101/2024.05.22.24307674. This article has 2 citations.</p>
+</li>
+<li>
+<p>(sobue2024calmodulinahighly pages 1-2): Kenji Sobue. Calmodulin: a highly conserved and ubiquitous ca2+ sensor. Proceedings of the Japan Academy. Series B, Physical and Biological Sciences, 100:368-386, Jul 2024. URL: https://doi.org/10.2183/pjab.100.025, doi:10.2183/pjab.100.025. This article has 6 citations.</p>
+</li>
+<li>
+<p>(denesyuk2023canonicalstructuralbindingmodes pages 24-27): Alexander I. Denesyuk, Sergei E. Permyakov, Eugene A. Permyakov, Mark S. Johnson, Konstantin Denessiouk, and Vladimir N. Uversky. Canonical structural-binding modes in the calmodulin–target protein complexes. Journal of Biomolecular Structure and Dynamics, 41:7582-7594, Sep 2023. URL: https://doi.org/10.1080/07391102.2022.2123391, doi:10.1080/07391102.2022.2123391. This article has 6 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(hussey2023calmodulinmutationsin pages 2-4): John W. Hussey, Worawan B. Limpitikul, and Ivy E. Dick. Calmodulin mutations in human disease. Channels, Jan 2023. URL: https://doi.org/10.1080/19336950.2023.2165278, doi:10.1080/19336950.2023.2165278. This article has 54 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(hussey2023calmodulinmutationsin pages 9-11): John W. Hussey, Worawan B. Limpitikul, and Ivy E. Dick. Calmodulin mutations in human disease. Channels, Jan 2023. URL: https://doi.org/10.1080/19336950.2023.2165278, doi:10.1080/19336950.2023.2165278. This article has 54 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(hussey2023calmodulinmutationsin pages 4-6): John W. Hussey, Worawan B. Limpitikul, and Ivy E. Dick. Calmodulin mutations in human disease. Channels, Jan 2023. URL: https://doi.org/10.1080/19336950.2023.2165278, doi:10.1080/19336950.2023.2165278. This article has 54 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(crotti2023clinicalpresentationof pages 8-9): Lia Crotti, Carla Spazzolini, Mette Nyegaard, Michael T Overgaard, Maria-Christina Kotta, Federica Dagradi, Luca Sala, Takeshi Aiba, Mark D Ayers, Anwar Baban, Julien Barc, Cheyenne M Beach, Elijah R Behr, J Martijn Bos, Marina Cerrone, Peter Covi, Bettina Cuneo, Isabelle Denjoy, Birgit Donner, Adrienne Elbert, Håkan Eliasson, Susan P Etheridge, Megumi Fukuyama, Francesca Girolami, Robert Hamilton, Minoru Horie, Maria Iascone, Juan Jiménez Jaimez, Henrik Kjærulf Jensen, Prince J Kannankeril, Juan P Kaski, Naomasa Makita, Carmen Muñoz-Esparza, Hans H Odland, Seiko Ohno, John Papagiannis, Alessandra Pia Porretta, Christopher Prandstetter, Vincent Probst, Tomas Robyns, Eric Rosenthal, Ferran Rosés-Noguer, Nicole Sekarski, Anoop Singh, Georgia Spentzou, Fridrike Stute, Jacob Tfelt-Hansen, Jan Till, Kathryn E Tobert, Jeffrey M Vinocur, Gregory Webster, Arthur A M Wilde, Cordula M Wolf, Michael J Ackerman, and Peter J Schwartz. Clinical presentation of calmodulin mutations: the international calmodulinopathy registry. European Heart Journal, 44:3357-3370, Aug 2023. URL: https://doi.org/10.1093/eurheartj/ehad418, doi:10.1093/eurheartj/ehad418. This article has 66 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(crotti2023clinicalpresentationof pages 2-3): Lia Crotti, Carla Spazzolini, Mette Nyegaard, Michael T Overgaard, Maria-Christina Kotta, Federica Dagradi, Luca Sala, Takeshi Aiba, Mark D Ayers, Anwar Baban, Julien Barc, Cheyenne M Beach, Elijah R Behr, J Martijn Bos, Marina Cerrone, Peter Covi, Bettina Cuneo, Isabelle Denjoy, Birgit Donner, Adrienne Elbert, Håkan Eliasson, Susan P Etheridge, Megumi Fukuyama, Francesca Girolami, Robert Hamilton, Minoru Horie, Maria Iascone, Juan Jiménez Jaimez, Henrik Kjærulf Jensen, Prince J Kannankeril, Juan P Kaski, Naomasa Makita, Carmen Muñoz-Esparza, Hans H Odland, Seiko Ohno, John Papagiannis, Alessandra Pia Porretta, Christopher Prandstetter, Vincent Probst, Tomas Robyns, Eric Rosenthal, Ferran Rosés-Noguer, Nicole Sekarski, Anoop Singh, Georgia Spentzou, Fridrike Stute, Jacob Tfelt-Hansen, Jan Till, Kathryn E Tobert, Jeffrey M Vinocur, Gregory Webster, Arthur A M Wilde, Cordula M Wolf, Michael J Ackerman, and Peter J Schwartz. Clinical presentation of calmodulin mutations: the international calmodulinopathy registry. European Heart Journal, 44:3357-3370, Aug 2023. URL: https://doi.org/10.1093/eurheartj/ehad418, doi:10.1093/eurheartj/ehad418. This article has 66 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(crotti2023clinicalpresentationof pages 3-4): Lia Crotti, Carla Spazzolini, Mette Nyegaard, Michael T Overgaard, Maria-Christina Kotta, Federica Dagradi, Luca Sala, Takeshi Aiba, Mark D Ayers, Anwar Baban, Julien Barc, Cheyenne M Beach, Elijah R Behr, J Martijn Bos, Marina Cerrone, Peter Covi, Bettina Cuneo, Isabelle Denjoy, Birgit Donner, Adrienne Elbert, Håkan Eliasson, Susan P Etheridge, Megumi Fukuyama, Francesca Girolami, Robert Hamilton, Minoru Horie, Maria Iascone, Juan Jiménez Jaimez, Henrik Kjærulf Jensen, Prince J Kannankeril, Juan P Kaski, Naomasa Makita, Carmen Muñoz-Esparza, Hans H Odland, Seiko Ohno, John Papagiannis, Alessandra Pia Porretta, Christopher Prandstetter, Vincent Probst, Tomas Robyns, Eric Rosenthal, Ferran Rosés-Noguer, Nicole Sekarski, Anoop Singh, Georgia Spentzou, Fridrike Stute, Jacob Tfelt-Hansen, Jan Till, Kathryn E Tobert, Jeffrey M Vinocur, Gregory Webster, Arthur A M Wilde, Cordula M Wolf, Michael J Ackerman, and Peter J Schwartz. Clinical presentation of calmodulin mutations: the international calmodulinopathy registry. European Heart Journal, 44:3357-3370, Aug 2023. URL: https://doi.org/10.1093/eurheartj/ehad418, doi:10.1093/eurheartj/ehad418. This article has 66 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(crotti2023clinicalpresentationof pages 12-13): Lia Crotti, Carla Spazzolini, Mette Nyegaard, Michael T Overgaard, Maria-Christina Kotta, Federica Dagradi, Luca Sala, Takeshi Aiba, Mark D Ayers, Anwar Baban, Julien Barc, Cheyenne M Beach, Elijah R Behr, J Martijn Bos, Marina Cerrone, Peter Covi, Bettina Cuneo, Isabelle Denjoy, Birgit Donner, Adrienne Elbert, Håkan Eliasson, Susan P Etheridge, Megumi Fukuyama, Francesca Girolami, Robert Hamilton, Minoru Horie, Maria Iascone, Juan Jiménez Jaimez, Henrik Kjærulf Jensen, Prince J Kannankeril, Juan P Kaski, Naomasa Makita, Carmen Muñoz-Esparza, Hans H Odland, Seiko Ohno, John Papagiannis, Alessandra Pia Porretta, Christopher Prandstetter, Vincent Probst, Tomas Robyns, Eric Rosenthal, Ferran Rosés-Noguer, Nicole Sekarski, Anoop Singh, Georgia Spentzou, Fridrike Stute, Jacob Tfelt-Hansen, Jan Till, Kathryn E Tobert, Jeffrey M Vinocur, Gregory Webster, Arthur A M Wilde, Cordula M Wolf, Michael J Ackerman, and Peter J Schwartz. Clinical presentation of calmodulin mutations: the international calmodulinopathy registry. European Heart Journal, 44:3357-3370, Aug 2023. URL: https://doi.org/10.1093/eurheartj/ehad418, doi:10.1093/eurheartj/ehad418. This article has 66 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(jensen2024calmodulinvariantsin pages 3-5): PhD Helene Halkjær Jensen, PhD Malene Brohus, BSc John W. Hussey III, Ana-Octavia Busuioc MSc, MSc Emil Drivsholm Iversen, MSc Faezeh Darki, MSc Gabriela Dobromirova Nikolova, MSc Amalie El-ton Baisgaard, PhD Palle Duun Rohde, Ida Elisabeth, M. D. Gad Holm, PhD Andrew McQuillin, PhD Tor-ben Moos, PhD Ivy E. Dick, PhD Michael Toft Overgaard, and M. Nyegaard. Calmodulin variants in schizophrenia patients display gain-of-function or loss-of-function effects. MedRxiv, May 2024. URL: https://doi.org/10.1101/2024.05.22.24307674, doi:10.1101/2024.05.22.24307674. This article has 2 citations.</p>
+</li>
+<li>
+<p>(crotti2023clinicalpresentationof pages 4-4): Lia Crotti, Carla Spazzolini, Mette Nyegaard, Michael T Overgaard, Maria-Christina Kotta, Federica Dagradi, Luca Sala, Takeshi Aiba, Mark D Ayers, Anwar Baban, Julien Barc, Cheyenne M Beach, Elijah R Behr, J Martijn Bos, Marina Cerrone, Peter Covi, Bettina Cuneo, Isabelle Denjoy, Birgit Donner, Adrienne Elbert, Håkan Eliasson, Susan P Etheridge, Megumi Fukuyama, Francesca Girolami, Robert Hamilton, Minoru Horie, Maria Iascone, Juan Jiménez Jaimez, Henrik Kjærulf Jensen, Prince J Kannankeril, Juan P Kaski, Naomasa Makita, Carmen Muñoz-Esparza, Hans H Odland, Seiko Ohno, John Papagiannis, Alessandra Pia Porretta, Christopher Prandstetter, Vincent Probst, Tomas Robyns, Eric Rosenthal, Ferran Rosés-Noguer, Nicole Sekarski, Anoop Singh, Georgia Spentzou, Fridrike Stute, Jacob Tfelt-Hansen, Jan Till, Kathryn E Tobert, Jeffrey M Vinocur, Gregory Webster, Arthur A M Wilde, Cordula M Wolf, Michael J Ackerman, and Peter J Schwartz. Clinical presentation of calmodulin mutations: the international calmodulinopathy registry. European Heart Journal, 44:3357-3370, Aug 2023. URL: https://doi.org/10.1093/eurheartj/ehad418, doi:10.1093/eurheartj/ehad418. This article has 66 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(bortolin2024antisenseoligonucleotidetherapy pages 1-3): Raul H. Bortolin, Farina Nawar, Chaehyoung Park, Michael A. Trembley, Maksymilian Prondzynski, Mason E. Sweat, Peizhe Wang, Jiehui Chen, Fujian Lu, Carter Liou, Paul Berkson, Erin M. Keating, Daisuke Yoshinaga, Nikoleta Pavlaki, Thomas Samenuk, Cecilia B. Cavazzoni, Peter T. Sage, Qing Ma, Robert D. Whitehill, Dominic J. Abrams, Chrystalle Katte Carreon, Juan Putra, Sanda Alexandrescu, Shuai Guo, Wen-Chin Tsai, Michael Rubart, Dieter A. Kubli, Adam E. Mullick, Vassilios J. Bezzerides, and William T. Pu. Antisense oligonucleotide therapy for calmodulinopathy. Circulation, 150:1199-1210, Oct 2024. URL: https://doi.org/10.1161/circulationaha.123.068111, doi:10.1161/circulationaha.123.068111. This article has 14 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(hussey2023calmodulinmutationsin pages 11-13): John W. Hussey, Worawan B. Limpitikul, and Ivy E. Dick. Calmodulin mutations in human disease. Channels, Jan 2023. URL: https://doi.org/10.1080/19336950.2023.2165278, doi:10.1080/19336950.2023.2165278. This article has 54 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(hussey2023calmodulinmutationsin pages 13-15): John W. Hussey, Worawan B. Limpitikul, and Ivy E. Dick. Calmodulin mutations in human disease. Channels, Jan 2023. URL: https://doi.org/10.1080/19336950.2023.2165278, doi:10.1080/19336950.2023.2165278. This article has 54 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(sobue2024calmodulinahighly pages 6-19): Kenji Sobue. Calmodulin: a highly conserved and ubiquitous ca2+ sensor. Proceedings of the Japan Academy. Series B, Physical and Biological Sciences, 100:368-386, Jul 2024. URL: https://doi.org/10.2183/pjab.100.025, doi:10.2183/pjab.100.025. This article has 6 citations.</p>
+</li>
+<li>
+<p>(crotti2023clinicalpresentationof pages 10-11): Lia Crotti, Carla Spazzolini, Mette Nyegaard, Michael T Overgaard, Maria-Christina Kotta, Federica Dagradi, Luca Sala, Takeshi Aiba, Mark D Ayers, Anwar Baban, Julien Barc, Cheyenne M Beach, Elijah R Behr, J Martijn Bos, Marina Cerrone, Peter Covi, Bettina Cuneo, Isabelle Denjoy, Birgit Donner, Adrienne Elbert, Håkan Eliasson, Susan P Etheridge, Megumi Fukuyama, Francesca Girolami, Robert Hamilton, Minoru Horie, Maria Iascone, Juan Jiménez Jaimez, Henrik Kjærulf Jensen, Prince J Kannankeril, Juan P Kaski, Naomasa Makita, Carmen Muñoz-Esparza, Hans H Odland, Seiko Ohno, John Papagiannis, Alessandra Pia Porretta, Christopher Prandstetter, Vincent Probst, Tomas Robyns, Eric Rosenthal, Ferran Rosés-Noguer, Nicole Sekarski, Anoop Singh, Georgia Spentzou, Fridrike Stute, Jacob Tfelt-Hansen, Jan Till, Kathryn E Tobert, Jeffrey M Vinocur, Gregory Webster, Arthur A M Wilde, Cordula M Wolf, Michael J Ackerman, and Peter J Schwartz. Clinical presentation of calmodulin mutations: the international calmodulinopathy registry. European Heart Journal, 44:3357-3370, Aug 2023. URL: https://doi.org/10.1093/eurheartj/ehad418, doi:10.1093/eurheartj/ehad418. This article has 66 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(hussey2023calmodulinmutationsin pages 17-18): John W. Hussey, Worawan B. Limpitikul, and Ivy E. Dick. Calmodulin mutations in human disease. Channels, Jan 2023. URL: https://doi.org/10.1080/19336950.2023.2165278, doi:10.1080/19336950.2023.2165278. This article has 54 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(bortolin2024antisenseoligonucleotidetherapy pages 3-5): Raul H. Bortolin, Farina Nawar, Chaehyoung Park, Michael A. Trembley, Maksymilian Prondzynski, Mason E. Sweat, Peizhe Wang, Jiehui Chen, Fujian Lu, Carter Liou, Paul Berkson, Erin M. Keating, Daisuke Yoshinaga, Nikoleta Pavlaki, Thomas Samenuk, Cecilia B. Cavazzoni, Peter T. Sage, Qing Ma, Robert D. Whitehill, Dominic J. Abrams, Chrystalle Katte Carreon, Juan Putra, Sanda Alexandrescu, Shuai Guo, Wen-Chin Tsai, Michael Rubart, Dieter A. Kubli, Adam E. Mullick, Vassilios J. Bezzerides, and William T. Pu. Antisense oligonucleotide therapy for calmodulinopathy. Circulation, 150:1199-1210, Oct 2024. URL: https://doi.org/10.1161/circulationaha.123.068111, doi:10.1161/circulationaha.123.068111. This article has 14 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>hussey2023calmodulinmutationsin pages 1-2</li>
+<li>denesyuk2023canonicalstructuralbindingmodes pages 24-27</li>
+<li>sobue2024calmodulinahighly pages 1-2</li>
+<li>hussey2023calmodulinmutationsin pages 2-4</li>
+<li>hussey2023calmodulinmutationsin pages 9-11</li>
+<li>hussey2023calmodulinmutationsin pages 4-6</li>
+<li>crotti2023clinicalpresentationof pages 2-3</li>
+<li>crotti2023clinicalpresentationof pages 3-4</li>
+<li>crotti2023clinicalpresentationof pages 8-9</li>
+<li>crotti2023clinicalpresentationof pages 12-13</li>
+<li>crotti2023clinicalpresentationof pages 4-4</li>
+<li>bortolin2024antisenseoligonucleotidetherapy pages 1-3</li>
+<li>jensen2024calmodulinvariantsin pages 10-12</li>
+<li>jensen2024calmodulinvariantsin pages 3-5</li>
+<li>hussey2023calmodulinmutationsin pages 11-13</li>
+<li>hussey2023calmodulinmutationsin pages 13-15</li>
+<li>sobue2024calmodulinahighly pages 6-19</li>
+<li>crotti2023clinicalpresentationof pages 10-11</li>
+<li>hussey2023calmodulinmutationsin pages 17-18</li>
+<li>bortolin2024antisenseoligonucleotidetherapy pages 3-5</li>
+<li>https://doi.org/10.1080/19336950.2023.2165278;</li>
+<li>https://doi.org/10.1101/2024.05.22.24307674</li>
+<li>https://doi.org/10.2183/pjab.100.025;</li>
+<li>https://doi.org/10.1080/07391102.2022.2123391</li>
+<li>https://doi.org/10.2183/pjab.100.025</li>
+<li>https://doi.org/10.1093/eurheartj/ehad418;</li>
+<li>https://doi.org/10.1080/19336950.2023.2165278</li>
+<li>https://doi.org/10.1161/circulationaha.123.068111;</li>
+<li>https://doi.org/10.1093/eurheartj/ehad418</li>
+<li>https://doi.org/10.1101/2024.05.22.24307674;</li>
+<li>https://doi.org/10.1080/19336950.2023.2165278,</li>
+<li>https://doi.org/10.1101/2024.05.22.24307674,</li>
+<li>https://doi.org/10.2183/pjab.100.025,</li>
+<li>https://doi.org/10.1080/07391102.2022.2123391,</li>
+<li>https://doi.org/10.1093/eurheartj/ehad418,</li>
+<li>https://doi.org/10.1161/circulationaha.123.068111,</li>
+</ol>
+            </div>
+        </details>
+
         <details class="markdown-section">
             <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
                 <div style="flex: 1;">
@@ -8021,6 +8489,9 @@ existing_annotations:
     summary: Core calcium-binding function through 4 EF-hand domains
     action: ACCEPT
     reason: Core calmodulin function or localization
+    supported_by:
+    - reference_id: file:human/CALM3/CALM3-deep-research-falcon.md
+      supporting_text: CaM has two homologous globular domains (N- and C-lobes) connected by a flexible central helix; each lobe contains two canonical EF-hand helix-loop-helix motifs, yielding four Ca2+ binding sites per CaM molecule.
 - term:
     id: GO:0005634
     label: nucleus
@@ -8049,6 +8520,9 @@ existing_annotations:
     summary: Core calcium sensing function
     action: ACCEPT
     reason: Core calmodulin function or localization
+    supported_by:
+    - reference_id: file:human/CALM3/CALM3-deep-research-falcon.md
+      supporting_text: Calmodulin is a ubiquitously expressed Ca2+ sensor that transduces intracellular Ca2+ changes into functional regulation of diverse target proteins.
 - term:
     id: GO:0097720
     label: calcineurin-mediated signaling
@@ -8103,6 +8577,9 @@ existing_annotations:
     summary: Regulates L-type calcium channels and ryanodine receptors
     action: ACCEPT
     reason: Core calmodulin function or localization
+    supported_by:
+    - reference_id: file:human/CALM3/CALM3-deep-research-falcon.md
+      supporting_text: CaM is pre-associated with CaV1.2, and C-lobe EF-hand mutations that reduce Ca2+ binding can blunt calcium-dependent inactivation, increasing Ca2+ entry and prolonging action potentials.
 - term:
     id: GO:0005509
     label: calcium ion binding
@@ -9159,6 +9636,11 @@ references:
 - id: file:human/CALM3/CALM3-notes.md
   title: Curator notes for CALM3 review
   findings: []
+- id: file:human/CALM3/CALM3-deep-research-falcon.md
+  title: Falcon deep research report for CALM3
+  findings:
+  - statement: Falcon research supports CALM3 as one of three human genes encoding identical calmodulin, a four-EF-hand calcium sensor that regulates target proteins including CaMKII, calcineurin, voltage-gated calcium channels, and ryanodine receptors.
+    supporting_text: three distinct human genes (CALM1, CALM2, CALM3) encode identical 149-aa calmodulin (CaM) protein sequences
 core_functions:
 - description: Primary intracellular calcium sensor. CALM3-encoded calmodulin binds
     calcium through four EF-hand motifs and converts calcium fluctuations into target-protein
@@ -9178,6 +9660,8 @@ core_functions:
       for a perfectly conserved sequence of amino acids
   - reference_id: PMID:23040497
     supporting_text: Both CALM1 substitutions demonstrated compromised calcium binding
+  - reference_id: file:human/CALM3/CALM3-deep-research-falcon.md
+    supporting_text: CaM has two homologous globular domains (N- and C-lobes) connected by a flexible central helix; each lobe contains two canonical EF-hand helix-loop-helix motifs, yielding four Ca2+ binding sites per CaM molecule.
 - description: Core calcium-dependent signal-transduction adaptor for kinase and phosphatase
     regulation, especially CaMK and calcineurin pathways.
   molecular_function:
@@ -9199,6 +9683,8 @@ core_functions:
   - reference_id: PMID:8631777
     supporting_text: Blocking the Ca2+-induced conformational transitions in calmodulin
       with disulfide bonds.
+  - reference_id: file:human/CALM3/CALM3-deep-research-falcon.md
+    supporting_text: Ca2+/CaM activates CaMKII and calcineurin, linking CaM to phosphorylation/dephosphorylation cascades.
 - description: Regulator of cardiac and other excitable-cell calcium channels, especially
     RyR2 and high-voltage-gated calcium-channel pathways.
   molecular_function:
@@ -9222,6 +9708,8 @@ core_functions:
     supporting_text: Human-induced pluripotent stem cell-derived cardiomyocytes overexpressing
       mutant or wild-type CaM showed that both mutants impaired Ca2+-dependent inactivation
       of L-type Ca2+ channels and prolonged action potential duration
+  - reference_id: file:human/CALM3/CALM3-deep-research-falcon.md
+    supporting_text: CaM regulates intracellular Ca2+ release channels. Notably, RyR2 is inhibited by both apoCaM and Ca2+/CaM.
 - description: Centrosome-associated regulator of late cytokinesis through CP110/centrin-containing
     cell-division machinery.
   molecular_function:

--- a/genes/human/CALM3/CALM3-ai-review.html
+++ b/genes/human/CALM3/CALM3-ai-review.html
@@ -737,7 +737,7 @@
                 <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
             </span>
         </div>
-        <p>CALM3 encodes one of the three human calmodulin genes and produces the same 149 aa calmodulin protein encoded by CALM1 and CALM2. The protein is a ubiquitous calcium sensor with four EF-hand motifs that binds calcium and regulates ion channels, protein kinases, protein phosphatases, and cell-division machinery. For this review, annotations were interpreted at the protein level: core calcium-sensing functions transfer well across the calmodulin family because the encoded protein sequence is identical, whereas tissue-specific neuronal, cardiac, and subcellular-context terms are kept as non-core when they likely reflect expression or recruitment differences rather than a CALM3-specific biochemical difference. CALM3 variants contribute to calmodulinopathy, including CPVT and long-QT phenotypes driven by dysregulated calcium-channel signaling.</p>
+        <p>CALM3 encodes one of the three human calmodulin genes and produces the same 149 aa calmodulin protein encoded by CALM1 and CALM2. The protein is a ubiquitous calcium sensor with four EF-hand motifs that binds calcium and regulates ion channels, protein kinases, protein phosphatases, and cell-division machinery. For this review, annotations were interpreted at the protein level: core calcium-sensing functions transfer well across the calmodulin family because the encoded protein sequence is identical. Direct channel- and sarcoplasmic-reticulum calcium-release regulation can be retained as core even when assayed in cardiac cells, whereas broader cardiac electrophysiology or tissue-context terms are kept as non-core when they reflect downstream physiology or recruitment rather than a CALM3-specific biochemical difference. CALM3 variants contribute to calmodulinopathy, including CPVT and long-QT phenotypes driven by dysregulated calcium-channel signaling.</p>
     </div>
     
 
@@ -1293,7 +1293,7 @@
                         
                         
                         <div>
-                            <strong>Reason:</strong> Core calmodulin function or localization
+                            <strong>Reason:</strong> Retained as core because the annotation reflects direct calmodulin control of cardiac ion-channel and calcium-release machinery; broader downstream electrophysiology terms are kept non-core separately.
                         </div>
                         
                         
@@ -1717,7 +1717,7 @@
                         
                         
                         <div>
-                            <strong>Reason:</strong> Core calmodulin function or localization
+                            <strong>Reason:</strong> Retained as core because regulation of sequestered calcium release maps directly to calmodulin-RyR/SR calcium-release control, a core channel-regulatory mechanism despite the cardiac wording.
                         </div>
                         
                         
@@ -3932,7 +3932,7 @@
                         
                         
                         <div>
-                            <strong>Reason:</strong> Core calmodulin function or localization
+                            <strong>Reason:</strong> Retained as core because PMID:23040497 directly supports calmodulin regulation of RyR-mediated sarcoplasmic-reticulum calcium release; broader cardiac electrophysiology phenotypes are treated as non-core.
                         </div>
                         
                         
@@ -3994,7 +3994,7 @@
                         
                         
                         <div>
-                            <strong>Reason:</strong> Tissue-specific or specialized function
+                            <strong>Reason:</strong> Kept non-core because cardiac electrical coupling is a downstream tissue-level conduction phenotype rather than the direct calmodulin biochemical mechanism, which is captured by calcium/channel regulatory terms.
                         </div>
                         
                         
@@ -4614,7 +4614,7 @@
                         
                         
                         <div>
-                            <strong>Reason:</strong> Tissue-specific or specialized function
+                            <strong>Reason:</strong> Kept non-core because action-potential regulation is a cardiac electrophysiology endpoint downstream of calmodulin control of CaV/RyR channels, not a distinct core molecular function.
                         </div>
                         
                         
@@ -4660,10 +4660,10 @@
                         
                     </td>
                     <td>
-                        <span class="action-badge action-keepasnoncore">
-                            KEEP AS NON CORE
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="P0DP25" data-a="GO:1901842" data-r="PMID:31454269" data-act="KEEP_AS_NON_CORE">
+                        <span class="vote-buttons" data-g="P0DP25" data-a="GO:1901842" data-r="PMID:31454269" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -4676,7 +4676,7 @@
                         
                         
                         <div>
-                            <strong>Reason:</strong> Tissue-specific or specialized function
+                            <strong>Reason:</strong> Accepted as direct channel regulation because PMID:31454269 supports impaired calcium-dependent inactivation of L-type calcium channels by calmodulin variants; this is closer to the core mechanism than the downstream action-potential phenotype.
                         </div>
                         
                         
@@ -6908,7 +6908,7 @@
                         
                         
                         <div>
-                            <strong>Reason:</strong> Core calmodulin function or localization
+                            <strong>Reason:</strong> Retained as core because the evidence links calmodulin to cardiac contraction through direct RyR/calcium-channel regulation; broader tissue-level electrical-conduction phenotypes remain non-core.
                         </div>
                         
                         
@@ -8303,7 +8303,7 @@ this with annotations you find in gene/protein databases, but these can be outda
 <p><strong>CALM3 encodes calmodulin (CaM), a ubiquitous intracellular EF-hand Ca2+ sensor that binds four Ca2+ ions via two lobes (N and C) and regulates diverse target proteins through Ca2+-dependent conformational switching and frequent apoCaM pre-association. High-confidence regulated pathways include CaV1.2/CaV1.3 calcium-dependent inactivation/facilitation, RyR2 inhibition and Ca2+ release termination, SK channel gating, and Ca2+/CaM-dependent enzyme pathways (CaMKII, calcineurin/NFAT). Dominant missense variants—often in C-lobe EF-hands—cause calmodulinopathy (LQTS/CPVT) with high arrhythmic event rates; recent registry data quantify phenotype distributions and improving outcomes, and 2024 work provides proof-of-concept for gene-specific ASO depletion therapy exploiting redundancy across CALM genes.</strong> (hussey2023calmodulinmutationsin pages 2-4, hussey2023calmodulinmutationsin pages 9-11, hussey2023calmodulinmutationsin pages 4-6, crotti2023clinicalpresentationof pages 2-3, bortolin2024antisenseoligonucleotidetherapy pages 1-3)</p>
 <h3 id="10-limitations-of-this-report">10) Limitations of this report</h3>
 <ul>
-<li>The evidence set is strong for <strong>calmodulin’s molecular function</strong> and for <strong>clinical calmodulinopathy statistics</strong> (ICalmR), but does not include UniProt/GO text excerpts directly (the report relies on primary/review literature retrieved here). </li>
+<li>The evidence set is strong for <strong>calmodulin’s molecular function</strong> and for <strong>clinical calmodulinopathy statistics</strong> (ICalmR), but does not include UniProt/GO text excerpts directly (the report relies on primary/review literature retrieved here).</li>
 <li>Some emerging non-cardiac associations (e.g., schizophrenia) are from <strong>preprint literature</strong> and should be treated as provisional until peer-reviewed replication. (jensen2024calmodulinvariantsin pages 10-12)</li>
 </ul>
 <p>References</p>
@@ -8465,11 +8465,12 @@ description: &#39;CALM3 encodes one of the three human calmodulin genes and prod
   protein kinases, protein phosphatases, and cell-division machinery. For this review,
   annotations were interpreted at the protein level: core calcium-sensing functions
   transfer well across the calmodulin family because the encoded protein sequence
-  is identical, whereas tissue-specific neuronal, cardiac, and subcellular-context
-  terms are kept as non-core when they likely reflect expression or recruitment differences
-  rather than a CALM3-specific biochemical difference. CALM3 variants contribute to
-  calmodulinopathy, including CPVT and long-QT phenotypes driven by dysregulated calcium-channel
-  signaling.&#39;
+  is identical. Direct channel- and sarcoplasmic-reticulum calcium-release regulation
+  can be retained as core even when assayed in cardiac cells, whereas broader cardiac
+  electrophysiology or tissue-context terms are kept as non-core when they reflect
+  downstream physiology or recruitment rather than a CALM3-specific biochemical
+  difference. CALM3 variants contribute to calmodulinopathy, including CPVT and
+  long-QT phenotypes driven by dysregulated calcium-channel signaling.&#39;
 existing_annotations:
 - term:
     id: GO:0005737
@@ -8567,7 +8568,7 @@ existing_annotations:
   review:
     summary: Heart rate regulation through ion channel modulation
     action: ACCEPT
-    reason: Core calmodulin function or localization
+    reason: Retained as core because the annotation reflects direct calmodulin control of cardiac ion-channel and calcium-release machinery; broader downstream electrophysiology terms are kept non-core separately.
 - term:
     id: GO:0005246
     label: calcium channel regulator activity
@@ -8643,7 +8644,7 @@ existing_annotations:
   review:
     summary: Cardiac calcium-induced calcium release regulation
     action: ACCEPT
-    reason: Core calmodulin function or localization
+    reason: Retained as core because regulation of sequestered calcium release maps directly to calmodulin-RyR/SR calcium-release control, a core channel-regulatory mechanism despite the cardiac wording.
 - term:
     id: GO:0019901
     label: protein kinase binding
@@ -9042,7 +9043,7 @@ existing_annotations:
   review:
     summary: Cardiac calcium-induced calcium release regulation
     action: ACCEPT
-    reason: Core calmodulin function or localization
+    reason: Retained as core because PMID:23040497 directly supports calmodulin regulation of RyR-mediated sarcoplasmic-reticulum calcium release; broader cardiac electrophysiology phenotypes are treated as non-core.
 - term:
     id: GO:1901844
     label: regulation of cell communication by electrical coupling involved in cardiac
@@ -9052,7 +9053,7 @@ existing_annotations:
   review:
     summary: Cardiac electrical coupling regulation
     action: KEEP_AS_NON_CORE
-    reason: Tissue-specific or specialized function
+    reason: Kept non-core because cardiac electrical coupling is a downstream tissue-level conduction phenotype rather than the direct calmodulin biochemical mechanism, which is captured by calcium/channel regulatory terms.
 - term:
     id: GO:0005246
     label: calcium channel regulator activity
@@ -9145,7 +9146,7 @@ existing_annotations:
   review:
     summary: Cardiac action potential regulation
     action: KEEP_AS_NON_CORE
-    reason: Tissue-specific or specialized function
+    reason: Kept non-core because action-potential regulation is a cardiac electrophysiology endpoint downstream of calmodulin control of CaV/RyR channels, not a distinct core molecular function.
 - term:
     id: GO:1901842
     label: negative regulation of high voltage-gated calcium channel activity
@@ -9153,8 +9154,8 @@ existing_annotations:
   original_reference_id: PMID:31454269
   review:
     summary: Calcium channel activity regulation
-    action: KEEP_AS_NON_CORE
-    reason: Tissue-specific or specialized function
+    action: ACCEPT
+    reason: Accepted as direct channel regulation because PMID:31454269 supports impaired calcium-dependent inactivation of L-type calcium channels by calmodulin variants; this is closer to the core mechanism than the downstream action-potential phenotype.
 - term:
     id: GO:0010856
     label: adenylate cyclase activator activity
@@ -9492,7 +9493,7 @@ existing_annotations:
   review:
     summary: Cardiac contraction through calcium channel regulation
     action: ACCEPT
-    reason: Core calmodulin function or localization
+    reason: Retained as core because the evidence links calmodulin to cardiac contraction through direct RyR/calcium-channel regulation; broader tissue-level electrical-conduction phenotypes remain non-core.
 - term:
     id: GO:0072542
     label: protein phosphatase activator activity

--- a/genes/human/CALM3/CALM3-ai-review.yaml
+++ b/genes/human/CALM3/CALM3-ai-review.yaml
@@ -35,6 +35,9 @@ existing_annotations:
     summary: Core calcium-binding function through 4 EF-hand domains
     action: ACCEPT
     reason: Core calmodulin function or localization
+    supported_by:
+    - reference_id: file:human/CALM3/CALM3-deep-research-falcon.md
+      supporting_text: CaM has two homologous globular domains (N- and C-lobes) connected by a flexible central helix; each lobe contains two canonical EF-hand helix-loop-helix motifs, yielding four Ca2+ binding sites per CaM molecule.
 - term:
     id: GO:0005634
     label: nucleus
@@ -63,6 +66,9 @@ existing_annotations:
     summary: Core calcium sensing function
     action: ACCEPT
     reason: Core calmodulin function or localization
+    supported_by:
+    - reference_id: file:human/CALM3/CALM3-deep-research-falcon.md
+      supporting_text: Calmodulin is a ubiquitously expressed Ca2+ sensor that transduces intracellular Ca2+ changes into functional regulation of diverse target proteins.
 - term:
     id: GO:0097720
     label: calcineurin-mediated signaling
@@ -117,6 +123,9 @@ existing_annotations:
     summary: Regulates L-type calcium channels and ryanodine receptors
     action: ACCEPT
     reason: Core calmodulin function or localization
+    supported_by:
+    - reference_id: file:human/CALM3/CALM3-deep-research-falcon.md
+      supporting_text: CaM is pre-associated with CaV1.2, and C-lobe EF-hand mutations that reduce Ca2+ binding can blunt calcium-dependent inactivation, increasing Ca2+ entry and prolonging action potentials.
 - term:
     id: GO:0005509
     label: calcium ion binding
@@ -1173,6 +1182,11 @@ references:
 - id: file:human/CALM3/CALM3-notes.md
   title: Curator notes for CALM3 review
   findings: []
+- id: file:human/CALM3/CALM3-deep-research-falcon.md
+  title: Falcon deep research report for CALM3
+  findings:
+  - statement: Falcon research supports CALM3 as one of three human genes encoding identical calmodulin, a four-EF-hand calcium sensor that regulates target proteins including CaMKII, calcineurin, voltage-gated calcium channels, and ryanodine receptors.
+    supporting_text: three distinct human genes (CALM1, CALM2, CALM3) encode identical 149-aa calmodulin (CaM) protein sequences
 core_functions:
 - description: Primary intracellular calcium sensor. CALM3-encoded calmodulin binds
     calcium through four EF-hand motifs and converts calcium fluctuations into target-protein
@@ -1192,6 +1206,8 @@ core_functions:
       for a perfectly conserved sequence of amino acids
   - reference_id: PMID:23040497
     supporting_text: Both CALM1 substitutions demonstrated compromised calcium binding
+  - reference_id: file:human/CALM3/CALM3-deep-research-falcon.md
+    supporting_text: CaM has two homologous globular domains (N- and C-lobes) connected by a flexible central helix; each lobe contains two canonical EF-hand helix-loop-helix motifs, yielding four Ca2+ binding sites per CaM molecule.
 - description: Core calcium-dependent signal-transduction adaptor for kinase and phosphatase
     regulation, especially CaMK and calcineurin pathways.
   molecular_function:
@@ -1213,6 +1229,8 @@ core_functions:
   - reference_id: PMID:8631777
     supporting_text: Blocking the Ca2+-induced conformational transitions in calmodulin
       with disulfide bonds.
+  - reference_id: file:human/CALM3/CALM3-deep-research-falcon.md
+    supporting_text: Ca2+/CaM activates CaMKII and calcineurin, linking CaM to phosphorylation/dephosphorylation cascades.
 - description: Regulator of cardiac and other excitable-cell calcium channels, especially
     RyR2 and high-voltage-gated calcium-channel pathways.
   molecular_function:
@@ -1236,6 +1254,8 @@ core_functions:
     supporting_text: Human-induced pluripotent stem cell-derived cardiomyocytes overexpressing
       mutant or wild-type CaM showed that both mutants impaired Ca2+-dependent inactivation
       of L-type Ca2+ channels and prolonged action potential duration
+  - reference_id: file:human/CALM3/CALM3-deep-research-falcon.md
+    supporting_text: CaM regulates intracellular Ca2+ release channels. Notably, RyR2 is inhibited by both apoCaM and Ca2+/CaM.
 - description: Centrosome-associated regulator of late cytokinesis through CP110/centrin-containing
     cell-division machinery.
   molecular_function:

--- a/genes/human/CALM3/CALM3-ai-review.yaml
+++ b/genes/human/CALM3/CALM3-ai-review.yaml
@@ -11,11 +11,12 @@ description: 'CALM3 encodes one of the three human calmodulin genes and produces
   protein kinases, protein phosphatases, and cell-division machinery. For this review,
   annotations were interpreted at the protein level: core calcium-sensing functions
   transfer well across the calmodulin family because the encoded protein sequence
-  is identical, whereas tissue-specific neuronal, cardiac, and subcellular-context
-  terms are kept as non-core when they likely reflect expression or recruitment differences
-  rather than a CALM3-specific biochemical difference. CALM3 variants contribute to
-  calmodulinopathy, including CPVT and long-QT phenotypes driven by dysregulated calcium-channel
-  signaling.'
+  is identical. Direct channel- and sarcoplasmic-reticulum calcium-release regulation
+  can be retained as core even when assayed in cardiac cells, whereas broader cardiac
+  electrophysiology or tissue-context terms are kept as non-core when they reflect
+  downstream physiology or recruitment rather than a CALM3-specific biochemical
+  difference. CALM3 variants contribute to calmodulinopathy, including CPVT and
+  long-QT phenotypes driven by dysregulated calcium-channel signaling.'
 existing_annotations:
 - term:
     id: GO:0005737
@@ -113,7 +114,7 @@ existing_annotations:
   review:
     summary: Heart rate regulation through ion channel modulation
     action: ACCEPT
-    reason: Core calmodulin function or localization
+    reason: Retained as core because the annotation reflects direct calmodulin control of cardiac ion-channel and calcium-release machinery; broader downstream electrophysiology terms are kept non-core separately.
 - term:
     id: GO:0005246
     label: calcium channel regulator activity
@@ -189,7 +190,7 @@ existing_annotations:
   review:
     summary: Cardiac calcium-induced calcium release regulation
     action: ACCEPT
-    reason: Core calmodulin function or localization
+    reason: Retained as core because regulation of sequestered calcium release maps directly to calmodulin-RyR/SR calcium-release control, a core channel-regulatory mechanism despite the cardiac wording.
 - term:
     id: GO:0019901
     label: protein kinase binding
@@ -588,7 +589,7 @@ existing_annotations:
   review:
     summary: Cardiac calcium-induced calcium release regulation
     action: ACCEPT
-    reason: Core calmodulin function or localization
+    reason: Retained as core because PMID:23040497 directly supports calmodulin regulation of RyR-mediated sarcoplasmic-reticulum calcium release; broader cardiac electrophysiology phenotypes are treated as non-core.
 - term:
     id: GO:1901844
     label: regulation of cell communication by electrical coupling involved in cardiac
@@ -598,7 +599,7 @@ existing_annotations:
   review:
     summary: Cardiac electrical coupling regulation
     action: KEEP_AS_NON_CORE
-    reason: Tissue-specific or specialized function
+    reason: Kept non-core because cardiac electrical coupling is a downstream tissue-level conduction phenotype rather than the direct calmodulin biochemical mechanism, which is captured by calcium/channel regulatory terms.
 - term:
     id: GO:0005246
     label: calcium channel regulator activity
@@ -691,7 +692,7 @@ existing_annotations:
   review:
     summary: Cardiac action potential regulation
     action: KEEP_AS_NON_CORE
-    reason: Tissue-specific or specialized function
+    reason: Kept non-core because action-potential regulation is a cardiac electrophysiology endpoint downstream of calmodulin control of CaV/RyR channels, not a distinct core molecular function.
 - term:
     id: GO:1901842
     label: negative regulation of high voltage-gated calcium channel activity
@@ -699,8 +700,8 @@ existing_annotations:
   original_reference_id: PMID:31454269
   review:
     summary: Calcium channel activity regulation
-    action: KEEP_AS_NON_CORE
-    reason: Tissue-specific or specialized function
+    action: ACCEPT
+    reason: Accepted as direct channel regulation because PMID:31454269 supports impaired calcium-dependent inactivation of L-type calcium channels by calmodulin variants; this is closer to the core mechanism than the downstream action-potential phenotype.
 - term:
     id: GO:0010856
     label: adenylate cyclase activator activity
@@ -1038,7 +1039,7 @@ existing_annotations:
   review:
     summary: Cardiac contraction through calcium channel regulation
     action: ACCEPT
-    reason: Core calmodulin function or localization
+    reason: Retained as core because the evidence links calmodulin to cardiac contraction through direct RyR/calcium-channel regulation; broader tissue-level electrical-conduction phenotypes remain non-core.
 - term:
     id: GO:0072542
     label: protein phosphatase activator activity

--- a/genes/human/CALM3/CALM3-deep-research-falcon.md
+++ b/genes/human/CALM3/CALM3-deep-research-falcon.md
@@ -1,0 +1,343 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-10T19:59:57.145758'
+end_time: '2026-05-10T20:11:51.248458'
+duration_seconds: 714.1
+template_file: templates/gene_research_go_focused.md
+template_variables:
+  organism: human
+  gene_id: CALM3
+  gene_symbol: CALM3
+  uniprot_accession: P0DP25
+  protein_description: 'RecName: Full=Calmodulin-3 {ECO:0000312|HGNC:HGNC:1449};'
+  gene_info: Name=CALM3 {ECO:0000312|HGNC:HGNC:1449}; Synonyms=CALML2, CAM3, CAMC,
+    CAMIII;
+  organism_full: Homo sapiens (Human).
+  protein_family: Belongs to the calmodulin family. .
+  protein_domains: CALM/Myosin/TropC-like. (IPR050230); EF-hand-dom_pair. (IPR011992);
+    EF_Hand_1_Ca_BS. (IPR018247); EF_hand_dom. (IPR002048); EF-hand_7 (PF13499)
+provider_config:
+  timeout: 600
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 36
+---
+
+## Question
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** P0DP25
+- **Protein Description:** RecName: Full=Calmodulin-3 {ECO:0000312|HGNC:HGNC:1449};
+- **Gene Information:** Name=CALM3 {ECO:0000312|HGNC:HGNC:1449}; Synonyms=CALML2, CAM3, CAMC, CAMIII;
+- **Organism (full):** Homo sapiens (Human).
+- **Protein Family:** Belongs to the calmodulin family. .
+- **Key Domains:** CALM/Myosin/TropC-like. (IPR050230); EF-hand-dom_pair. (IPR011992); EF_Hand_1_Ca_BS. (IPR018247); EF_hand_dom. (IPR002048); EF-hand_7 (PF13499)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "CALM3" matches the protein description above**
+2. **Verify the organism is correct:** Homo sapiens (Human).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'CALM3' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **CALM3** (gene ID: CALM3, UniProt: P0DP25) in human.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** P0DP25
+- **Protein Description:** RecName: Full=Calmodulin-3 {ECO:0000312|HGNC:HGNC:1449};
+- **Gene Information:** Name=CALM3 {ECO:0000312|HGNC:HGNC:1449}; Synonyms=CALML2, CAM3, CAMC, CAMIII;
+- **Organism (full):** Homo sapiens (Human).
+- **Protein Family:** Belongs to the calmodulin family. .
+- **Key Domains:** CALM/Myosin/TropC-like. (IPR050230); EF-hand-dom_pair. (IPR011992); EF_Hand_1_Ca_BS. (IPR018247); EF_hand_dom. (IPR002048); EF-hand_7 (PF13499)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "CALM3" matches the protein description above**
+2. **Verify the organism is correct:** Homo sapiens (Human).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'CALM3' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **CALM3** (gene ID: CALM3, UniProt: P0DP25) in human.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Research report: Human **CALM3** (UniProt **P0DP25**) — functional annotation, pathways, and clinical relevance
+
+### 0) Verification of correct gene/protein identity (critical)
+CALM3 (UniProt accession P0DP25) corresponds to **human calmodulin-3**, a canonical member of the **calmodulin family** (EF-hand Ca2+-binding protein). Multiple authoritative sources explicitly state that **three distinct human genes (CALM1, CALM2, CALM3) encode identical 149-aa calmodulin (CaM) protein sequences**, despite being located on different chromosomes. This resolves gene-symbol ambiguity and confirms that literature discussing human “calmodulin/CaM” protein function generally applies directly to CALM3’s protein product. (hussey2023calmodulinmutationsin pages 1-2, jensen2024calmodulinvariantsin pages 10-12)
+
+### 1) Key concepts and definitions (current understanding)
+
+#### 1.1 What CALM3 encodes: a Ca2+ sensor (not an enzyme)
+Calmodulin (CaM) is a **ubiquitously expressed Ca2+ sensor** that transduces intracellular Ca2+ changes into functional regulation of diverse target proteins; it does **not catalyze** a chemical reaction. It is a small (~17 kDa), **149-amino-acid** protein present in essentially all eukaryotic cells. (hussey2023calmodulinmutationsin pages 1-2)
+
+#### 1.2 Core structural definition: EF-hands and two lobes
+CaM has **two homologous globular domains (N- and C-lobes)** connected by a flexible central helix; each lobe contains **two canonical EF-hand helix–loop–helix motifs**, yielding **four Ca2+ binding sites per CaM molecule**. (hussey2023calmodulinmutationsin pages 1-2, sobue2024calmodulinahighly pages 1-2)
+
+A structural analysis of many CaM–target complexes emphasizes conserved target-recognition principles (hydrophobic anchor residues in targets and methionine-rich interaction surfaces in CaM), supporting how CaM can bind many different partners using common physical interaction modes. (denesyuk2023canonicalstructuralbindingmodes pages 24-27)
+
+#### 1.3 Calcium-binding mechanism and Ca2+-triggered switching
+In resting cells, cytosolic free Ca2+ is ~10^-7 M, whereas extracellular Ca2+ is ~10^-3 M (a ~10,000-fold gradient). Upon stimulation, cytosolic Ca2+ can rise to ~10^-6–10^-5 M. These Ca2+ rises are the physiological signals that CaM detects via its EF-hands. (sobue2024calmodulinahighly pages 1-2)
+
+Ca2+ saturation of CaM is associated with conformational changes that expose hydrophobic surfaces and enable productive binding to target proteins, providing a mechanistic link between Ca2+ signals and downstream regulation. (sobue2024calmodulinahighly pages 1-2)
+
+#### 1.4 Quantitative Ca2+ binding properties (biophysical “definition” of lobe asymmetry)
+A mechanistically important feature is that the N- and C-lobes differ in Ca2+ affinity. One recent review reports approximate dissociation constants (KD) of ~16 µM (N-lobe) and ~2.4 µM (C-lobe), enabling partially separable “lobe-specific” regulation of targets. (hussey2023calmodulinmutationsin pages 1-2)
+
+Another recent review summarizes CaM Ca2+ affinity in the ~5×10^-7 to 5×10^-6 M range and estimates intracellular CaM concentrations in mammalian cells at ~2–10 µM, placing CaM in the concentration regime where it can act as a high-capacity Ca2+ signal decoder. (sobue2024calmodulinahighly pages 1-2)
+
+### 2) Primary biological function, pathways, and mechanisms of action
+
+#### 2.1 Primary function: regulate targets by apoCaM pre-association and Ca2+-dependent switching
+A central modern concept is that many targets are **pre-associated with Ca2+-free calmodulin (apoCaM)**, so CaM acts as a “resident” Ca2+ sensor at the target. Upon Ca2+ binding, CaM changes binding mode and/or conformation, producing functional modulation such as feedback inhibition or facilitation. (hussey2023calmodulinmutationsin pages 2-4)
+
+Disease-associated EF-hand mutations can **alter Ca2+ binding without disrupting the Ca2+-free structure**, preserving apo-association but impairing Ca2+-dependent regulation—an important mechanistic explanation for dominant-negative effects in heterozygous patients. (hussey2023calmodulinmutationsin pages 2-4)
+
+#### 2.2 Canonical and high-confidence pathways/targets relevant to functional annotation
+
+**Voltage-gated Ca2+ channels (CaV1.x / CaV2.x)**: CaM frequently binds an IQ motif in the channel C-terminus. Ca2+ binding to CaM then drives **calcium-dependent inactivation (CDI)** and/or **calcium-dependent facilitation (CDF)**, with strong lobe-specificity in several channels (e.g., CaV2.2/2.3 CDI driven by N-lobe; L-type channels can involve either lobe depending on context). (hussey2023calmodulinmutationsin pages 2-4)
+
+**CaV1.2 (cardiac L-type Ca2+ channel)** is emphasized as a key pathogenic substrate in calmodulinopathy: CaM is pre-associated with CaV1.2, and C-lobe EF-hand mutations that reduce Ca2+ binding can blunt CDI, increasing Ca2+ entry and prolonging action potentials (a mechanistic route to LQTS). (hussey2023calmodulinmutationsin pages 9-11)
+
+**Ryanodine receptors (RyR1/RyR2)**: CaM regulates intracellular Ca2+ release channels. Notably, RyR2 (cardiac) is inhibited by both apoCaM and Ca2+/CaM; the C-lobe of Ca2+/CaM can increase the termination threshold of spontaneous Ca2+ release, indicating state- and lobe-specific control of Ca2+ sparks/waves. (hussey2023calmodulinmutationsin pages 4-6)
+
+**SK (small-conductance Ca2+-activated K+) channels**: CaM is constitutively associated and required for gating; one review notes **four CaM molecules per channel** and indicates that CaM’s N-lobe drives Ca2+ dependence for SK2. (hussey2023calmodulinmutationsin pages 2-4, hussey2023calmodulinmutationsin pages 4-6)
+
+**CaMKII and calcineurin/NFAT signaling**: Ca2+/CaM activates CaMKII and calcineurin, linking CaM to phosphorylation/dephosphorylation cascades. CaMKII phosphorylates proteins central to excitation–contraction coupling (e.g., RyR2, L-type channels, phospholamban/SERCA regulation), and calcineurin can drive NFAT dephosphorylation and transcriptional signaling. (hussey2023calmodulinmutationsin pages 2-4, hussey2023calmodulinmutationsin pages 1-2)
+
+**IP3 receptors (IP3R)**: CaM can decrease IP3 sensitivity in type I IP3R, with both apoCaM and Ca2+/CaM reported to reduce receptor sensitivity. (hussey2023calmodulinmutationsin pages 4-6)
+
+**Broader interaction landscape**: A structural survey of CaM–target complexes (spanning apo and Ca2+-bound states) includes many relevant targets (e.g., CaMKII, calcineurin/PP2B, NaV1.5, RyR2, SK channels, MLCK), reinforcing the concept that CaM uses a conserved physical binding toolkit to regulate diverse pathways. (denesyuk2023canonicalstructuralbindingmodes pages 24-27)
+
+### 3) Subcellular localization: where CALM3’s protein product acts
+CaM is an **intracellular protein** and functions at the **cytosolic faces of target proteins** (e.g., cytosolic C-tails of ion channels) and at intracellular membranes where channels like RyR/IP3R reside. It is broadly distributed across tissues (and by implication across many cellular compartments where its targets are located), with estimated intracellular concentration ~2–10 µM. (sobue2024calmodulinahighly pages 1-2, hussey2023calmodulinmutationsin pages 4-6, hussey2023calmodulinmutationsin pages 2-4)
+
+### 4) Disease relevance of CALM3: calmodulinopathy and variant mechanisms
+
+#### 4.1 Disease entity and phenotypes
+Dominant pathogenic variants in any of CALM1/2/3 (including **CALM3**) cause **calmodulinopathy**, classically presenting as **CALM-LQTS** and/or **CALM-CPVT**, with additional presentations including idiopathic ventricular fibrillation and syndromic features. (hussey2023calmodulinmutationsin pages 4-6, crotti2023clinicalpresentationof pages 8-9)
+
+A large 2023 update from the **International Calmodulinopathy Registry (ICalmR)** (European Heart Journal; published Aug 2023) provides the most authoritative recent clinical synthesis:
+- **N = 140 subjects** total (97 index cases, 43 family members); median age **10.8** years (IQR 5–19). (crotti2023clinicalpresentationof pages 2-3)
+- Phenotype proportions: **CALM-LQTS 74 (53%)**, **CALM-CPVT 36 (26%)**, **LQTS/CPVT overlap 10 (7%)**, **IVF 7 (5%)**, **uncertain diagnosis 11 (8%)**, atypical 2 (1%). (crotti2023clinicalpresentationof pages 3-4)
+- **Symptomatic/arrhythmic events**: 103 symptomatic patients (**74%**). (crotti2023clinicalpresentationof pages 2-3)
+- Compared with an earlier 2019 cohort, **all cardiac events decreased 85% → 61% (P=0.001)** and **sudden death decreased 27% → 9% (P=0.008)**, suggesting improving outcomes with broader recognition and management, while emphasizing that disease remains high-risk. (crotti2023clinicalpresentationof pages 2-3)
+
+#### 4.2 Variant clustering and molecular interpretation
+In ICalmR, **58/62 variants** were classified pathogenic/likely pathogenic by ACMG curation, and **49/58 (84%)** clustered in **exons 5–6**, consistent with enrichment in C-lobe EF-hand regions central to Ca2+ chelation and target regulation. (crotti2023clinicalpresentationof pages 8-9)
+
+Mechanistically, the registry notes that many LQTS-associated CALM variants map to EF-hands III/IV and reduce C-domain Ca2+ binding, impairing CaM-mediated CaV1.2 CDI (prolonging repolarization). (crotti2023clinicalpresentationof pages 12-13)
+
+#### 4.3 Extra-cardiac manifestations (interpretation and caution)
+ICalmR also documents neurological involvement: among 111 evaluable patients, 35 had neurological disorders, including 20 primary neurological manifestations (not attributable to post-anoxic injury). (crotti2023clinicalpresentationof pages 3-4, crotti2023clinicalpresentationof pages 2-3)
+
+Separately, a 2024 preprint reported enrichment of ultra-rare CALM missense variants in schizophrenia cases vs controls, with all case variants in the C-lobe and an estimated odds ratio ~5.6 for carrying a C-lobe variant; the authors also identify functional classes (reduced vs increased Ca2+ affinity). This is not yet as clinically established as the cardiac calmodulinopathy literature and should be interpreted as emerging evidence. (jensen2024calmodulinvariantsin pages 10-12, jensen2024calmodulinvariantsin pages 3-5)
+
+### 5) Current applications and real-world implementations
+
+#### 5.1 Diagnostic implementation: genetic testing and registry-guided practice
+A major real-world development is the formalization and expansion of the **International Calmodulinopathy Registry**, which has nearly doubled enrolled cases since its initial report and is used to clarify genotype–phenotype variability and outcomes. (crotti2023clinicalpresentationof pages 4-4, crotti2023clinicalpresentationof pages 2-3)
+
+The ICalmR authors state that **CALM1–3 are definitively associated with LQTS and CPVT and “should be screened in all LQTS and CPVT patients,”** supporting routine inclusion of CALM genes on clinical genetic testing panels. (crotti2023clinicalpresentationof pages 4-4)
+
+#### 5.2 Management approaches documented in contemporary cohorts
+ICalmR reports that contemporary management commonly includes **pharmacological and surgical antiadrenergic interventions**, frequent use of **sodium channel blockers**, and **implantable cardioverter–defibrillators (ICDs)**; however, the authors emphasize that therapy data remain insufficient for definitive recommendations. (crotti2023clinicalpresentationof pages 2-3)
+
+### 6) Recent developments and latest research (prioritizing 2023–2024)
+
+#### 6.1 2024 therapeutic innovation: antisense oligonucleotide (ASO) depletion strategy (proof-of-concept)
+A 2024 Circulation study demonstrates a precision strategy that leverages the unusual redundancy that **CALM1/2/3 encode identical protein**: selectively depleting one affected gene can ameliorate phenotype while preserving total CaM protein. (bortolin2024antisenseoligonucleotidetherapy pages 1-3)
+
+Key results:
+- In **human CALM1F142L/+ iPSC-derived cardiomyocytes**, CALM1 knockout or **CALM1-depleting ASOs normalized repolarization duration** without altering overall CaM protein level. (bortolin2024antisenseoligonucleotidetherapy pages 1-3)
+- In mice, an ASO targeting murine Calm1 reduced Calm1 transcript without reducing CaM protein, and **alleviated drug-induced bidirectional ventricular tachycardia** in Calm1N98S/+ animals without adverse cardiac electrical/contractile effects. (bortolin2024antisenseoligonucleotidetherapy pages 1-3)
+
+While this work targeted CALM1 experimentally, the underlying principle is directly relevant to CALM3 because it depends on the **three-gene/identical-protein architecture** of human calmodulin. (bortolin2024antisenseoligonucleotidetherapy pages 1-3)
+
+#### 6.2 2023–2024 mechanistic consolidation
+Recent 2023 reviews synthesize evidence that calmodulinopathic variants disproportionately disrupt Ca2+ binding in EF-hands and thereby perturb key pre-associated targets such as CaV1.2 (via CDI failure) and RyR2 (via altered inhibition), providing a molecular explanation for how heterozygous variants cause severe arrhythmias. (hussey2023calmodulinmutationsin pages 4-6, hussey2023calmodulinmutationsin pages 9-11)
+
+### 7) Expert opinion and authoritative analysis (what experts emphasize)
+Across the highest-authority clinical source (ICalmR) and mechanistic reviews, the convergent expert view is:
+1) **CALM variants cause severe, early-onset arrhythmia syndromes** with high event rates, but phenotypic variability is broad and includes milder familial forms. (crotti2023clinicalpresentationof pages 2-3)
+2) The **C-lobe EF-hands (EF3/EF4) are a mechanistic hotspot**, because impaired Ca2+ binding there undermines regulation of pre-associated targets (especially CaV1.2 CDI), producing dominant effects even when wild-type CaM is abundant. (hussey2023calmodulinmutationsin pages 9-11, crotti2023clinicalpresentationof pages 12-13)
+3) **Registries and systematic genetic screening** are essential because of rarity, heterogeneity, and management uncertainty; improved outcomes over time likely reflect increased recognition and multi-modality care, but evidence remains insufficient for definitive, variant-specific treatment rules. (crotti2023clinicalpresentationof pages 2-3, crotti2023clinicalpresentationof pages 4-4)
+
+### 8) Summary evidence map (table)
+| Topic | Key points | Quantitative data (if any) | Key sources (author year journal) and URLs |
+|---|---|---|---|
+| Identity | **Verified target:** human **CALM3** encodes **calmodulin-3**, one of three human genes (**CALM1/2/3**) that encode the **identical 149-aa calmodulin protein**. CALM3 is a canonical calmodulin-family member, matching UniProt P0DP25 and the EF-hand calcium-sensor annotation. In heart, CALM3 transcript abundance is reported as relatively high among CALM genes, although newer expression analyses suggest gene contributions are tissue-dependent. (hussey2023calmodulinmutationsin pages 1-2, jensen2024calmodulinvariantsin pages 10-12) | 149 aa protein; CALM genes on distinct chromosomes; CALM3 reported as highest relative abundance in human heart in one review. (hussey2023calmodulinmutationsin pages 1-2) | Hussey et al. 2023, *Channels* — https://doi.org/10.1080/19336950.2023.2165278; Jensen et al. 2024, *medRxiv* — https://doi.org/10.1101/2024.05.22.24307674 |
+| Structure | Calmodulin is a small, highly conserved Ca2+ sensor with **two globular lobes (N and C)** linked by a flexible central helix; **each lobe contains two EF-hand motifs** for a total of **four Ca2+-binding sites**. Ca2+ binding exposes hydrophobic surfaces that enable target engagement; methionine-rich surfaces contribute importantly to target recognition. (hussey2023calmodulinmutationsin pages 1-2, sobue2024calmodulinahighly pages 1-2, denesyuk2023canonicalstructuralbindingmodes pages 24-27) | N-lobe Kd ~**16 µM** and C-lobe Kd ~**2.4 µM** in one review; overall Ca2+ affinity reported in the ~**5×10^-7 to 5×10^-6 M** range; intracellular CaM concentration ~**2–10 µM**. (hussey2023calmodulinmutationsin pages 1-2, sobue2024calmodulinahighly pages 1-2) | Hussey et al. 2023, *Channels* — https://doi.org/10.1080/19336950.2023.2165278; Sobue 2024, *Proc Jpn Acad Ser B* — https://doi.org/10.2183/pjab.100.025; Denesyuk et al. 2023, *J Biomol Struct Dyn* — https://doi.org/10.1080/07391102.2022.2123391 |
+| Mechanism | CALM3/calmodulin is a **signal transducer, not an enzyme**: it **binds Ca2+** and converts Ca2+ transients into conformational changes that regulate partner proteins. Many targets are **pre-associated with apoCaM**, and Ca2+ loading of one or both lobes triggers altered binding and target control. Disease mutations often preserve apo-binding but disrupt Ca2+-dependent switching. (hussey2023calmodulinmutationsin pages 2-4, hussey2023calmodulinmutationsin pages 11-13, hussey2023calmodulinmutationsin pages 9-11) | Resting cytosolic Ca2+ ~**10^-7 M**; stimulated intracellular Ca2+ rises to **10^-6–10^-5 M**; extracellular Ca2+ ~**10^-3 M**. (sobue2024calmodulinahighly pages 1-2) | Hussey et al. 2023, *Channels* — https://doi.org/10.1080/19336950.2023.2165278; Sobue 2024, *Proc Jpn Acad Ser B* — https://doi.org/10.2183/pjab.100.025 |
+| Pathways | Key pathways/targets include **L-type Ca2+ channels (CaV1.2/CaV1.3)**, **RyR2**, **SK channels**, **NaV1.5**, **CaMKII**, and **calcineurin/NFAT**. Mechanistically, CaM mediates **calcium-dependent inactivation/facilitation (CDI/CDF)** of CaV channels, suppresses/reshapes **RyR2** opening, enables **SK** gating, and activates **CaMKII** and **calcineurin**, linking it to excitation–contraction coupling, membrane excitability, transcriptional responses, and neuronal plasticity. (hussey2023calmodulinmutationsin pages 2-4, hussey2023calmodulinmutationsin pages 9-11, hussey2023calmodulinmutationsin pages 13-15, hussey2023calmodulinmutationsin pages 4-6, sobue2024calmodulinahighly pages 6-19) | SK channels can bind **4 CaM molecules/channel**; lobe-specific regulation documented for several channels. (hussey2023calmodulinmutationsin pages 2-4, hussey2023calmodulinmutationsin pages 4-6) | Hussey et al. 2023, *Channels* — https://doi.org/10.1080/19336950.2023.2165278; Sobue 2024, *Proc Jpn Acad Ser B* — https://doi.org/10.2183/pjab.100.025 |
+| Localization | Calmodulin is **ubiquitous and intracellular**, functioning in the **cytosol** and on **cytosolic faces of membrane proteins** rather than as a secreted factor. It localizes functionally near plasma-membrane ion channels, intracellular Ca2+ release channels (e.g., **RyR2**, **IP3R**), and signaling complexes in heart, brain, immune cells, and muscle. CALM1-3 transcripts are also robustly expressed in brain cell types. (hussey2023calmodulinmutationsin pages 4-6, jensen2024calmodulinvariantsin pages 3-5, hussey2023calmodulinmutationsin pages 2-4, sobue2024calmodulinahighly pages 1-2) | Broad tissue distribution; mammalian intracellular CaM estimated at **2–10 µM**. (sobue2024calmodulinahighly pages 1-2) | Sobue 2024, *Proc Jpn Acad Ser B* — https://doi.org/10.2183/pjab.100.025; Hussey et al. 2023, *Channels* — https://doi.org/10.1080/19336950.2023.2165278; Jensen et al. 2024, *medRxiv* — https://doi.org/10.1101/2024.05.22.24307674 |
+| Disease | Pathogenic variants in **CALM1/2/3**, including **CALM3**, cause **calmodulinopathy**, especially **long QT syndrome (CALM-LQTS)** and **catecholaminergic polymorphic ventricular tachycardia (CALM-CPVT)**; variants cluster strongly in **EF-hand/C-lobe** regions that impair Ca2+ binding and downstream regulation of **CaV1.2** and/or **RyR2**. Structural heart disease and neurological manifestations can also occur. (hussey2023calmodulinmutationsin pages 4-6, crotti2023clinicalpresentationof pages 10-11, crotti2023clinicalpresentationof pages 8-9, crotti2023clinicalpresentationof pages 12-13) | Registry: **140** subjects total; phenotypes **LQTS 74 (53%)**, **CPVT 36 (26%)**, **LQTS/CPVT overlap 10 (7%)**, **IVF 7 (5%)**, **uncertain 11 (8%)**; structural cardiac abnormalities in **30%**; symptomatic/arrhythmic event burden **74%**; sudden death reduced from **27%** in earlier cohort to **9%** in updated cohort. Most P/LP variants (**49/58, 84%**) cluster in **exons 5–6**. (crotti2023clinicalpresentationof pages 3-4, crotti2023clinicalpresentationof pages 8-9, crotti2023clinicalpresentationof pages 2-3) | Crotti et al. 2023, *European Heart Journal* — https://doi.org/10.1093/eurheartj/ehad418; Hussey et al. 2023, *Channels* — https://doi.org/10.1080/19336950.2023.2165278 |
+| Applications | **Current real-world implementation:** CALM genes are now recognized as definitive arrhythmia genes and should be included in **genetic testing/panel screening** for LQTS/CPVT and in some genotype-negative arrest survivors. The **International Calmodulinopathy Registry** is a major clinical infrastructure for diagnosis, genotype–phenotype correlation, and management refinement. Standard care remains antiadrenergic therapy, sodium-channel blockers in some cases, and ICD/other interventions when needed. (crotti2023clinicalpresentationof pages 4-4, crotti2023clinicalpresentationof pages 2-3, hussey2023calmodulinmutationsin pages 17-18) | Registry nearly doubled from earlier reports to **140** enrolled subjects; **103 (74%)** had cardiac events. (crotti2023clinicalpresentationof pages 4-4, crotti2023clinicalpresentationof pages 2-3) | Crotti et al. 2023, *European Heart Journal* — https://doi.org/10.1093/eurheartj/ehad418; Hussey et al. 2023, *Channels* — https://doi.org/10.1080/19336950.2023.2165278 |
+| Recent developments (2023–2024) | Major recent advances include: (1) expanded **International Calmodulinopathy Registry** showing broader phenotype spectrum and somewhat improved outcomes with modern management; (2) updated mechanistic syntheses linking variant effects to altered **CaV1.2 CDI** and **RyR2** regulation; and (3) a **2024 antisense oligonucleotide (ASO)** proof-of-concept showing that selective depletion of one mutant CALM gene can rescue cellular/animal phenotypes while preserving overall CaM protein through redundancy of the remaining CALM genes. (crotti2023clinicalpresentationof pages 3-4, bortolin2024antisenseoligonucleotidetherapy pages 1-3, bortolin2024antisenseoligonucleotidetherapy pages 3-5) | In 2024 ASO study, CALM1-targeting ASO reduced mutant-gene transcript, **normalized repolarization** in patient iPSC-cardiomyocytes, and **alleviated bidirectional VT** in mice **without reducing total CaM protein**. (bortolin2024antisenseoligonucleotidetherapy pages 1-3, bortolin2024antisenseoligonucleotidetherapy pages 3-5) | Bortolin et al. 2024, *Circulation* — https://doi.org/10.1161/circulationaha.123.068111; Crotti et al. 2023, *European Heart Journal* — https://doi.org/10.1093/eurheartj/ehad418 |
+| Data highlights | Recent human and experimental datasets support a **C-lobe/EF-hand vulnerability model**: disease-associated variants disproportionately affect the C-lobe and Ca2+-coordinating residues, with consequences for CaV1.2 and RyR2 regulation. Emerging neuropsychiatric work also suggests non-cardiac phenotypic expansion for some CALM variants, though cardiac calmodulinopathy remains the best-established disease context. (jensen2024calmodulinvariantsin pages 10-12, jensen2024calmodulinvariantsin pages 3-5, crotti2023clinicalpresentationof pages 12-13) | In a 2024 schizophrenia sequencing analysis, **7** CALM missense variants were found in cases vs **20** in controls, and all case variants mapped to the **C-lobe**; reported OR for carrying a C-lobe variant was **5.6**. These findings are preliminary relative to established cardiac evidence. (jensen2024calmodulinvariantsin pages 10-12, jensen2024calmodulinvariantsin pages 3-5) | Jensen et al. 2024, *medRxiv* — https://doi.org/10.1101/2024.05.22.24307674; Crotti et al. 2023, *European Heart Journal* — https://doi.org/10.1093/eurheartj/ehad418 |
+
+
+*Table: This table summarizes verified identity, molecular function, pathways, localization, disease relevance, applications, and recent 2023-2024 developments for human CALM3/calmodulin. It is designed as a compact evidence map with quantitative findings and source URLs.*
+
+### 9) Practical functional annotation statement (for databases/curation)
+**CALM3 encodes calmodulin (CaM), a ubiquitous intracellular EF-hand Ca2+ sensor that binds four Ca2+ ions via two lobes (N and C) and regulates diverse target proteins through Ca2+-dependent conformational switching and frequent apoCaM pre-association. High-confidence regulated pathways include CaV1.2/CaV1.3 calcium-dependent inactivation/facilitation, RyR2 inhibition and Ca2+ release termination, SK channel gating, and Ca2+/CaM-dependent enzyme pathways (CaMKII, calcineurin/NFAT). Dominant missense variants—often in C-lobe EF-hands—cause calmodulinopathy (LQTS/CPVT) with high arrhythmic event rates; recent registry data quantify phenotype distributions and improving outcomes, and 2024 work provides proof-of-concept for gene-specific ASO depletion therapy exploiting redundancy across CALM genes.** (hussey2023calmodulinmutationsin pages 2-4, hussey2023calmodulinmutationsin pages 9-11, hussey2023calmodulinmutationsin pages 4-6, crotti2023clinicalpresentationof pages 2-3, bortolin2024antisenseoligonucleotidetherapy pages 1-3)
+
+### 10) Limitations of this report
+- The evidence set is strong for **calmodulin’s molecular function** and for **clinical calmodulinopathy statistics** (ICalmR), but does not include UniProt/GO text excerpts directly (the report relies on primary/review literature retrieved here).
+- Some emerging non-cardiac associations (e.g., schizophrenia) are from **preprint literature** and should be treated as provisional until peer-reviewed replication. (jensen2024calmodulinvariantsin pages 10-12)
+
+
+References
+
+1. (hussey2023calmodulinmutationsin pages 1-2): John W. Hussey, Worawan B. Limpitikul, and Ivy E. Dick. Calmodulin mutations in human disease. Channels, Jan 2023. URL: https://doi.org/10.1080/19336950.2023.2165278, doi:10.1080/19336950.2023.2165278. This article has 54 citations and is from a peer-reviewed journal.
+
+2. (jensen2024calmodulinvariantsin pages 10-12): PhD Helene Halkjær Jensen, PhD Malene Brohus, BSc John W. Hussey III, Ana-Octavia Busuioc MSc, MSc Emil Drivsholm Iversen, MSc Faezeh Darki, MSc Gabriela Dobromirova Nikolova, MSc Amalie El-ton Baisgaard, PhD Palle Duun Rohde, Ida Elisabeth, M. D. Gad Holm, PhD Andrew McQuillin, PhD Tor-ben Moos, PhD Ivy E. Dick, PhD Michael Toft Overgaard, and M. Nyegaard. Calmodulin variants in schizophrenia patients display gain-of-function or loss-of-function effects. MedRxiv, May 2024. URL: https://doi.org/10.1101/2024.05.22.24307674, doi:10.1101/2024.05.22.24307674. This article has 2 citations.
+
+3. (sobue2024calmodulinahighly pages 1-2): Kenji Sobue. Calmodulin: a highly conserved and ubiquitous ca2+ sensor. Proceedings of the Japan Academy. Series B, Physical and Biological Sciences, 100:368-386, Jul 2024. URL: https://doi.org/10.2183/pjab.100.025, doi:10.2183/pjab.100.025. This article has 6 citations.
+
+4. (denesyuk2023canonicalstructuralbindingmodes pages 24-27): Alexander I. Denesyuk, Sergei E. Permyakov, Eugene A. Permyakov, Mark S. Johnson, Konstantin Denessiouk, and Vladimir N. Uversky. Canonical structural-binding modes in the calmodulin–target protein complexes. Journal of Biomolecular Structure and Dynamics, 41:7582-7594, Sep 2023. URL: https://doi.org/10.1080/07391102.2022.2123391, doi:10.1080/07391102.2022.2123391. This article has 6 citations and is from a peer-reviewed journal.
+
+5. (hussey2023calmodulinmutationsin pages 2-4): John W. Hussey, Worawan B. Limpitikul, and Ivy E. Dick. Calmodulin mutations in human disease. Channels, Jan 2023. URL: https://doi.org/10.1080/19336950.2023.2165278, doi:10.1080/19336950.2023.2165278. This article has 54 citations and is from a peer-reviewed journal.
+
+6. (hussey2023calmodulinmutationsin pages 9-11): John W. Hussey, Worawan B. Limpitikul, and Ivy E. Dick. Calmodulin mutations in human disease. Channels, Jan 2023. URL: https://doi.org/10.1080/19336950.2023.2165278, doi:10.1080/19336950.2023.2165278. This article has 54 citations and is from a peer-reviewed journal.
+
+7. (hussey2023calmodulinmutationsin pages 4-6): John W. Hussey, Worawan B. Limpitikul, and Ivy E. Dick. Calmodulin mutations in human disease. Channels, Jan 2023. URL: https://doi.org/10.1080/19336950.2023.2165278, doi:10.1080/19336950.2023.2165278. This article has 54 citations and is from a peer-reviewed journal.
+
+8. (crotti2023clinicalpresentationof pages 8-9): Lia Crotti, Carla Spazzolini, Mette Nyegaard, Michael T Overgaard, Maria-Christina Kotta, Federica Dagradi, Luca Sala, Takeshi Aiba, Mark D Ayers, Anwar Baban, Julien Barc, Cheyenne M Beach, Elijah R Behr, J Martijn Bos, Marina Cerrone, Peter Covi, Bettina Cuneo, Isabelle Denjoy, Birgit Donner, Adrienne Elbert, Håkan Eliasson, Susan P Etheridge, Megumi Fukuyama, Francesca Girolami, Robert Hamilton, Minoru Horie, Maria Iascone, Juan Jiménez Jaimez, Henrik Kjærulf Jensen, Prince J Kannankeril, Juan P Kaski, Naomasa Makita, Carmen Muñoz-Esparza, Hans H Odland, Seiko Ohno, John Papagiannis, Alessandra Pia Porretta, Christopher Prandstetter, Vincent Probst, Tomas Robyns, Eric Rosenthal, Ferran Rosés-Noguer, Nicole Sekarski, Anoop Singh, Georgia Spentzou, Fridrike Stute, Jacob Tfelt-Hansen, Jan Till, Kathryn E Tobert, Jeffrey M Vinocur, Gregory Webster, Arthur A M Wilde, Cordula M Wolf, Michael J Ackerman, and Peter J Schwartz. Clinical presentation of calmodulin mutations: the international calmodulinopathy registry. European Heart Journal, 44:3357-3370, Aug 2023. URL: https://doi.org/10.1093/eurheartj/ehad418, doi:10.1093/eurheartj/ehad418. This article has 66 citations and is from a highest quality peer-reviewed journal.
+
+9. (crotti2023clinicalpresentationof pages 2-3): Lia Crotti, Carla Spazzolini, Mette Nyegaard, Michael T Overgaard, Maria-Christina Kotta, Federica Dagradi, Luca Sala, Takeshi Aiba, Mark D Ayers, Anwar Baban, Julien Barc, Cheyenne M Beach, Elijah R Behr, J Martijn Bos, Marina Cerrone, Peter Covi, Bettina Cuneo, Isabelle Denjoy, Birgit Donner, Adrienne Elbert, Håkan Eliasson, Susan P Etheridge, Megumi Fukuyama, Francesca Girolami, Robert Hamilton, Minoru Horie, Maria Iascone, Juan Jiménez Jaimez, Henrik Kjærulf Jensen, Prince J Kannankeril, Juan P Kaski, Naomasa Makita, Carmen Muñoz-Esparza, Hans H Odland, Seiko Ohno, John Papagiannis, Alessandra Pia Porretta, Christopher Prandstetter, Vincent Probst, Tomas Robyns, Eric Rosenthal, Ferran Rosés-Noguer, Nicole Sekarski, Anoop Singh, Georgia Spentzou, Fridrike Stute, Jacob Tfelt-Hansen, Jan Till, Kathryn E Tobert, Jeffrey M Vinocur, Gregory Webster, Arthur A M Wilde, Cordula M Wolf, Michael J Ackerman, and Peter J Schwartz. Clinical presentation of calmodulin mutations: the international calmodulinopathy registry. European Heart Journal, 44:3357-3370, Aug 2023. URL: https://doi.org/10.1093/eurheartj/ehad418, doi:10.1093/eurheartj/ehad418. This article has 66 citations and is from a highest quality peer-reviewed journal.
+
+10. (crotti2023clinicalpresentationof pages 3-4): Lia Crotti, Carla Spazzolini, Mette Nyegaard, Michael T Overgaard, Maria-Christina Kotta, Federica Dagradi, Luca Sala, Takeshi Aiba, Mark D Ayers, Anwar Baban, Julien Barc, Cheyenne M Beach, Elijah R Behr, J Martijn Bos, Marina Cerrone, Peter Covi, Bettina Cuneo, Isabelle Denjoy, Birgit Donner, Adrienne Elbert, Håkan Eliasson, Susan P Etheridge, Megumi Fukuyama, Francesca Girolami, Robert Hamilton, Minoru Horie, Maria Iascone, Juan Jiménez Jaimez, Henrik Kjærulf Jensen, Prince J Kannankeril, Juan P Kaski, Naomasa Makita, Carmen Muñoz-Esparza, Hans H Odland, Seiko Ohno, John Papagiannis, Alessandra Pia Porretta, Christopher Prandstetter, Vincent Probst, Tomas Robyns, Eric Rosenthal, Ferran Rosés-Noguer, Nicole Sekarski, Anoop Singh, Georgia Spentzou, Fridrike Stute, Jacob Tfelt-Hansen, Jan Till, Kathryn E Tobert, Jeffrey M Vinocur, Gregory Webster, Arthur A M Wilde, Cordula M Wolf, Michael J Ackerman, and Peter J Schwartz. Clinical presentation of calmodulin mutations: the international calmodulinopathy registry. European Heart Journal, 44:3357-3370, Aug 2023. URL: https://doi.org/10.1093/eurheartj/ehad418, doi:10.1093/eurheartj/ehad418. This article has 66 citations and is from a highest quality peer-reviewed journal.
+
+11. (crotti2023clinicalpresentationof pages 12-13): Lia Crotti, Carla Spazzolini, Mette Nyegaard, Michael T Overgaard, Maria-Christina Kotta, Federica Dagradi, Luca Sala, Takeshi Aiba, Mark D Ayers, Anwar Baban, Julien Barc, Cheyenne M Beach, Elijah R Behr, J Martijn Bos, Marina Cerrone, Peter Covi, Bettina Cuneo, Isabelle Denjoy, Birgit Donner, Adrienne Elbert, Håkan Eliasson, Susan P Etheridge, Megumi Fukuyama, Francesca Girolami, Robert Hamilton, Minoru Horie, Maria Iascone, Juan Jiménez Jaimez, Henrik Kjærulf Jensen, Prince J Kannankeril, Juan P Kaski, Naomasa Makita, Carmen Muñoz-Esparza, Hans H Odland, Seiko Ohno, John Papagiannis, Alessandra Pia Porretta, Christopher Prandstetter, Vincent Probst, Tomas Robyns, Eric Rosenthal, Ferran Rosés-Noguer, Nicole Sekarski, Anoop Singh, Georgia Spentzou, Fridrike Stute, Jacob Tfelt-Hansen, Jan Till, Kathryn E Tobert, Jeffrey M Vinocur, Gregory Webster, Arthur A M Wilde, Cordula M Wolf, Michael J Ackerman, and Peter J Schwartz. Clinical presentation of calmodulin mutations: the international calmodulinopathy registry. European Heart Journal, 44:3357-3370, Aug 2023. URL: https://doi.org/10.1093/eurheartj/ehad418, doi:10.1093/eurheartj/ehad418. This article has 66 citations and is from a highest quality peer-reviewed journal.
+
+12. (jensen2024calmodulinvariantsin pages 3-5): PhD Helene Halkjær Jensen, PhD Malene Brohus, BSc John W. Hussey III, Ana-Octavia Busuioc MSc, MSc Emil Drivsholm Iversen, MSc Faezeh Darki, MSc Gabriela Dobromirova Nikolova, MSc Amalie El-ton Baisgaard, PhD Palle Duun Rohde, Ida Elisabeth, M. D. Gad Holm, PhD Andrew McQuillin, PhD Tor-ben Moos, PhD Ivy E. Dick, PhD Michael Toft Overgaard, and M. Nyegaard. Calmodulin variants in schizophrenia patients display gain-of-function or loss-of-function effects. MedRxiv, May 2024. URL: https://doi.org/10.1101/2024.05.22.24307674, doi:10.1101/2024.05.22.24307674. This article has 2 citations.
+
+13. (crotti2023clinicalpresentationof pages 4-4): Lia Crotti, Carla Spazzolini, Mette Nyegaard, Michael T Overgaard, Maria-Christina Kotta, Federica Dagradi, Luca Sala, Takeshi Aiba, Mark D Ayers, Anwar Baban, Julien Barc, Cheyenne M Beach, Elijah R Behr, J Martijn Bos, Marina Cerrone, Peter Covi, Bettina Cuneo, Isabelle Denjoy, Birgit Donner, Adrienne Elbert, Håkan Eliasson, Susan P Etheridge, Megumi Fukuyama, Francesca Girolami, Robert Hamilton, Minoru Horie, Maria Iascone, Juan Jiménez Jaimez, Henrik Kjærulf Jensen, Prince J Kannankeril, Juan P Kaski, Naomasa Makita, Carmen Muñoz-Esparza, Hans H Odland, Seiko Ohno, John Papagiannis, Alessandra Pia Porretta, Christopher Prandstetter, Vincent Probst, Tomas Robyns, Eric Rosenthal, Ferran Rosés-Noguer, Nicole Sekarski, Anoop Singh, Georgia Spentzou, Fridrike Stute, Jacob Tfelt-Hansen, Jan Till, Kathryn E Tobert, Jeffrey M Vinocur, Gregory Webster, Arthur A M Wilde, Cordula M Wolf, Michael J Ackerman, and Peter J Schwartz. Clinical presentation of calmodulin mutations: the international calmodulinopathy registry. European Heart Journal, 44:3357-3370, Aug 2023. URL: https://doi.org/10.1093/eurheartj/ehad418, doi:10.1093/eurheartj/ehad418. This article has 66 citations and is from a highest quality peer-reviewed journal.
+
+14. (bortolin2024antisenseoligonucleotidetherapy pages 1-3): Raul H. Bortolin, Farina Nawar, Chaehyoung Park, Michael A. Trembley, Maksymilian Prondzynski, Mason E. Sweat, Peizhe Wang, Jiehui Chen, Fujian Lu, Carter Liou, Paul Berkson, Erin M. Keating, Daisuke Yoshinaga, Nikoleta Pavlaki, Thomas Samenuk, Cecilia B. Cavazzoni, Peter T. Sage, Qing Ma, Robert D. Whitehill, Dominic J. Abrams, Chrystalle Katte Carreon, Juan Putra, Sanda Alexandrescu, Shuai Guo, Wen-Chin Tsai, Michael Rubart, Dieter A. Kubli, Adam E. Mullick, Vassilios J. Bezzerides, and William T. Pu. Antisense oligonucleotide therapy for calmodulinopathy. Circulation, 150:1199-1210, Oct 2024. URL: https://doi.org/10.1161/circulationaha.123.068111, doi:10.1161/circulationaha.123.068111. This article has 14 citations and is from a highest quality peer-reviewed journal.
+
+15. (hussey2023calmodulinmutationsin pages 11-13): John W. Hussey, Worawan B. Limpitikul, and Ivy E. Dick. Calmodulin mutations in human disease. Channels, Jan 2023. URL: https://doi.org/10.1080/19336950.2023.2165278, doi:10.1080/19336950.2023.2165278. This article has 54 citations and is from a peer-reviewed journal.
+
+16. (hussey2023calmodulinmutationsin pages 13-15): John W. Hussey, Worawan B. Limpitikul, and Ivy E. Dick. Calmodulin mutations in human disease. Channels, Jan 2023. URL: https://doi.org/10.1080/19336950.2023.2165278, doi:10.1080/19336950.2023.2165278. This article has 54 citations and is from a peer-reviewed journal.
+
+17. (sobue2024calmodulinahighly pages 6-19): Kenji Sobue. Calmodulin: a highly conserved and ubiquitous ca2+ sensor. Proceedings of the Japan Academy. Series B, Physical and Biological Sciences, 100:368-386, Jul 2024. URL: https://doi.org/10.2183/pjab.100.025, doi:10.2183/pjab.100.025. This article has 6 citations.
+
+18. (crotti2023clinicalpresentationof pages 10-11): Lia Crotti, Carla Spazzolini, Mette Nyegaard, Michael T Overgaard, Maria-Christina Kotta, Federica Dagradi, Luca Sala, Takeshi Aiba, Mark D Ayers, Anwar Baban, Julien Barc, Cheyenne M Beach, Elijah R Behr, J Martijn Bos, Marina Cerrone, Peter Covi, Bettina Cuneo, Isabelle Denjoy, Birgit Donner, Adrienne Elbert, Håkan Eliasson, Susan P Etheridge, Megumi Fukuyama, Francesca Girolami, Robert Hamilton, Minoru Horie, Maria Iascone, Juan Jiménez Jaimez, Henrik Kjærulf Jensen, Prince J Kannankeril, Juan P Kaski, Naomasa Makita, Carmen Muñoz-Esparza, Hans H Odland, Seiko Ohno, John Papagiannis, Alessandra Pia Porretta, Christopher Prandstetter, Vincent Probst, Tomas Robyns, Eric Rosenthal, Ferran Rosés-Noguer, Nicole Sekarski, Anoop Singh, Georgia Spentzou, Fridrike Stute, Jacob Tfelt-Hansen, Jan Till, Kathryn E Tobert, Jeffrey M Vinocur, Gregory Webster, Arthur A M Wilde, Cordula M Wolf, Michael J Ackerman, and Peter J Schwartz. Clinical presentation of calmodulin mutations: the international calmodulinopathy registry. European Heart Journal, 44:3357-3370, Aug 2023. URL: https://doi.org/10.1093/eurheartj/ehad418, doi:10.1093/eurheartj/ehad418. This article has 66 citations and is from a highest quality peer-reviewed journal.
+
+19. (hussey2023calmodulinmutationsin pages 17-18): John W. Hussey, Worawan B. Limpitikul, and Ivy E. Dick. Calmodulin mutations in human disease. Channels, Jan 2023. URL: https://doi.org/10.1080/19336950.2023.2165278, doi:10.1080/19336950.2023.2165278. This article has 54 citations and is from a peer-reviewed journal.
+
+20. (bortolin2024antisenseoligonucleotidetherapy pages 3-5): Raul H. Bortolin, Farina Nawar, Chaehyoung Park, Michael A. Trembley, Maksymilian Prondzynski, Mason E. Sweat, Peizhe Wang, Jiehui Chen, Fujian Lu, Carter Liou, Paul Berkson, Erin M. Keating, Daisuke Yoshinaga, Nikoleta Pavlaki, Thomas Samenuk, Cecilia B. Cavazzoni, Peter T. Sage, Qing Ma, Robert D. Whitehill, Dominic J. Abrams, Chrystalle Katte Carreon, Juan Putra, Sanda Alexandrescu, Shuai Guo, Wen-Chin Tsai, Michael Rubart, Dieter A. Kubli, Adam E. Mullick, Vassilios J. Bezzerides, and William T. Pu. Antisense oligonucleotide therapy for calmodulinopathy. Circulation, 150:1199-1210, Oct 2024. URL: https://doi.org/10.1161/circulationaha.123.068111, doi:10.1161/circulationaha.123.068111. This article has 14 citations and is from a highest quality peer-reviewed journal.
+
+## Citations
+
+1. hussey2023calmodulinmutationsin pages 1-2
+2. denesyuk2023canonicalstructuralbindingmodes pages 24-27
+3. sobue2024calmodulinahighly pages 1-2
+4. hussey2023calmodulinmutationsin pages 2-4
+5. hussey2023calmodulinmutationsin pages 9-11
+6. hussey2023calmodulinmutationsin pages 4-6
+7. crotti2023clinicalpresentationof pages 2-3
+8. crotti2023clinicalpresentationof pages 3-4
+9. crotti2023clinicalpresentationof pages 8-9
+10. crotti2023clinicalpresentationof pages 12-13
+11. crotti2023clinicalpresentationof pages 4-4
+12. bortolin2024antisenseoligonucleotidetherapy pages 1-3
+13. jensen2024calmodulinvariantsin pages 10-12
+14. jensen2024calmodulinvariantsin pages 3-5
+15. hussey2023calmodulinmutationsin pages 11-13
+16. hussey2023calmodulinmutationsin pages 13-15
+17. sobue2024calmodulinahighly pages 6-19
+18. crotti2023clinicalpresentationof pages 10-11
+19. hussey2023calmodulinmutationsin pages 17-18
+20. bortolin2024antisenseoligonucleotidetherapy pages 3-5
+21. https://doi.org/10.1080/19336950.2023.2165278;
+22. https://doi.org/10.1101/2024.05.22.24307674
+23. https://doi.org/10.2183/pjab.100.025;
+24. https://doi.org/10.1080/07391102.2022.2123391
+25. https://doi.org/10.2183/pjab.100.025
+26. https://doi.org/10.1093/eurheartj/ehad418;
+27. https://doi.org/10.1080/19336950.2023.2165278
+28. https://doi.org/10.1161/circulationaha.123.068111;
+29. https://doi.org/10.1093/eurheartj/ehad418
+30. https://doi.org/10.1101/2024.05.22.24307674;
+31. https://doi.org/10.1080/19336950.2023.2165278,
+32. https://doi.org/10.1101/2024.05.22.24307674,
+33. https://doi.org/10.2183/pjab.100.025,
+34. https://doi.org/10.1080/07391102.2022.2123391,
+35. https://doi.org/10.1093/eurheartj/ehad418,
+36. https://doi.org/10.1161/circulationaha.123.068111,

--- a/genes/human/CFAP61/CFAP61-ai-review.html
+++ b/genes/human/CFAP61/CFAP61-ai-review.html
@@ -766,8 +766,8 @@
 
             
             <p><strong>Parent term:</strong>
-                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030286" target="_blank" class="term-link">
-                    dynein complex
+                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005930" target="_blank" class="term-link">
+                    axoneme
                 </a>
             </p>
             
@@ -3913,8 +3913,8 @@ proposed_new_terms:
     currently exists for this complex. Having a term would allow annotation of CFAP61,
     CFAP91, and CFAP251 as part_of the CSC.
   proposed_parent:
-    id: GO:0030286
-    label: dynein complex
+    id: GO:0005930
+    label: axoneme
   supported_by:
   - reference_id: PMID:21613541
     supporting_text: &gt;-

--- a/genes/human/CFAP61/CFAP61-ai-review.html
+++ b/genes/human/CFAP61/CFAP61-ai-review.html
@@ -2025,6 +2025,17 @@
                                 
                             </div>
                             
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/CFAP61/CFAP61-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">CFAP61 is best supported as a structural/assembly and stabilization factor for the sperm flagellar axoneme, acting through the CSC-radial spoke system.</div>
+
+                            </div>
+
                         </div>
                         
                     </td>
@@ -2118,6 +2129,17 @@
                                 
                             </div>
                             
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/CFAP61/CFAP61-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Its pathogenic loss disrupts assembly and/or maintenance of radial spokes and associated axonemal complexes, producing axoneme instability and disorganization.</div>
+
+                            </div>
+
                         </div>
                         
                     </td>
@@ -2252,6 +2274,17 @@
                         
                     </li>
                     
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/CFAP61/CFAP61-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">CFAP61 is currently understood as a mammalian component of the calmodulin- and spoke-associated complex that is physically and functionally associated with the radial spoke system.</div>
+
+                    </li>
+
                 </ul>
             </div>
             
@@ -2358,6 +2391,17 @@
                         
                     </li>
                     
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/CFAP61/CFAP61-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">Biallelic CFAP61 loss-of-function variants are an established cause of multiple morphological abnormalities of the flagella.</div>
+
+                    </li>
+
                 </ul>
             </div>
             
@@ -2733,6 +2777,31 @@
                 
             </div>
             
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/CFAP61/CFAP61-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research report for CFAP61</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Falcon research supports CFAP61 as a non-enzymatic axonemal CSC/radial-spoke structural factor needed for sperm flagellum assembly, radial spoke assembly, and sperm motility.</div>
+
+                        <div class="finding-text">"CFAP61 is best supported as a structural/assembly and stabilization factor for the sperm flagellar axoneme, acting through the CSC-radial spoke system."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
         </div>
     </div>
     
@@ -2841,6 +2910,313 @@
     <div class="section">
         <h2 class="section-title">📚 Additional Documentation</h2>
         
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Deep Research Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(CFAP61-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q8NHU2" data-a="DOC: Deep Research Falcon" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <hr />
+<p>provider: falcon<br />
+model: Edison Scientific Literature<br />
+cached: true<br />
+start_time: '2026-05-10T20:13:45.760478'<br />
+end_time: '2026-05-10T20:13:45.762530'<br />
+duration_seconds: 0.0<br />
+template_file: templates/gene_research_go_focused.md<br />
+template_variables:<br />
+  organism: human<br />
+  gene_id: CFAP61<br />
+  gene_symbol: CFAP61<br />
+  uniprot_accession: Q8NHU2<br />
+  protein_description: 'RecName: Full=Cilia- and flagella-associated protein 61 {ECO:0000312|HGNC:HGNC:15872};'<br />
+  gene_info: Name=CFAP61 {ECO:0000312|HGNC:HGNC:15872}; Synonyms=C20orf26 {ECO:0000312|HGNC:HGNC:15872};<br />
+  organism_full: Homo sapiens (Human).<br />
+  protein_family: Not specified in UniProt<br />
+  protein_domains: CFAP61. (IPR038884); CFAP61_dimer. (IPR056299); CFAP61_N. (IPR032151);<br />
+    FAD/NAD-bd_sf. (IPR036188); CFAP61_dimer (PF23150)<br />
+provider_config:<br />
+  timeout: 600<br />
+  max_retries: 3<br />
+  parameters:<br />
+    allowed_domains: []<br />
+    temperature: 0.1<br />
+citation_count: 17</p>
+<hr />
+<h2 id="question">Question</h2>
+<h1 id="gene-research-for-functional-annotation">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> Q8NHU2</li>
+<li><strong>Protein Description:</strong> RecName: Full=Cilia- and flagella-associated protein 61 {ECO:0000312|HGNC:HGNC:15872};</li>
+<li><strong>Gene Information:</strong> Name=CFAP61 {ECO:0000312|HGNC:HGNC:15872}; Synonyms=C20orf26 {ECO:0000312|HGNC:HGNC:15872};</li>
+<li><strong>Organism (full):</strong> Homo sapiens (Human).</li>
+<li><strong>Protein Family:</strong> Not specified in UniProt</li>
+<li><strong>Key Domains:</strong> CFAP61. (IPR038884); CFAP61_dimer. (IPR056299); CFAP61_N. (IPR032151); FAD/NAD-bd_sf. (IPR036188); CFAP61_dimer (PF23150)</li>
+</ul>
+<h3 id="mandatory-verification-steps">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "CFAP61" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Homo sapiens (Human).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'CFAP61' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>CFAP61</strong> (gene ID: CFAP61, UniProt: Q8NHU2) in human.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="output">Output</h2>
+<p>Question: You are an expert researcher providing comprehensive, well-cited information.</p>
+<p>Provide detailed information focusing on:<br />
+1. Key concepts and definitions with current understanding<br />
+2. Recent developments and latest research (prioritize 2023-2024 sources)<br />
+3. Current applications and real-world implementations<br />
+4. Expert opinions and analysis from authoritative sources<br />
+5. Relevant statistics and data from recent studies</p>
+<p>Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.<br />
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.</p>
+<h1 id="gene-research-for-functional-annotation_1">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context_1">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot_1">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> Q8NHU2</li>
+<li><strong>Protein Description:</strong> RecName: Full=Cilia- and flagella-associated protein 61 {ECO:0000312|HGNC:HGNC:15872};</li>
+<li><strong>Gene Information:</strong> Name=CFAP61 {ECO:0000312|HGNC:HGNC:15872}; Synonyms=C20orf26 {ECO:0000312|HGNC:HGNC:15872};</li>
+<li><strong>Organism (full):</strong> Homo sapiens (Human).</li>
+<li><strong>Protein Family:</strong> Not specified in UniProt</li>
+<li><strong>Key Domains:</strong> CFAP61. (IPR038884); CFAP61_dimer. (IPR056299); CFAP61_N. (IPR032151); FAD/NAD-bd_sf. (IPR036188); CFAP61_dimer (PF23150)</li>
+</ul>
+<h3 id="mandatory-verification-steps_1">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "CFAP61" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Homo sapiens (Human).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature_1">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'CFAP61' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target_1">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>CFAP61</strong> (gene ID: CFAP61, UniProt: Q8NHU2) in human.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="research-report-human-cfap61-uniprot-q8nhu2functional-annotation-in-motile-ciliaflagella">Research report: Human <strong>CFAP61</strong> (UniProt <strong>Q8NHU2</strong>)—functional annotation in motile cilia/flagella</h1>
+<h2 id="0-geneprotein-verification-critical-identity-check">0) Gene/protein verification (critical identity check)</h2>
+<p>The literature reviewed consistently refers to <strong>CFAP61</strong>, also known as <strong>C20orf26</strong>, as “cilia- and flagella-associated protein 61” in <strong>Homo sapiens</strong>, and links it to motile cilia/flagella axonemal structures and male infertility phenotypes (MMAF). This matches the target UniProt accession <strong>Q8NHU2</strong> and the provided UniProt description (CFAP61/C20orf26, human). (liu2021cfap61isrequired pages 9-12, barbotin2024identificationofa pages 4-6)</p>
+<h2 id="1-key-concepts-and-definitions-current-understanding">1) Key concepts and definitions (current understanding)</h2>
+<h3 id="11-motile-axoneme-radial-spokes-rs-and-the-calmodulin-and-spoke-associated-complex-csc">1.1 Motile axoneme, radial spokes (RS), and the calmodulin- and spoke-associated complex (CSC)</h3>
+<p>Motile cilia and flagella contain a microtubule-based <strong>axoneme</strong> whose beat is coordinated by periodic regulatory and structural modules. <strong>Radial spokes (RS)</strong> are multi-protein complexes projecting from outer doublet microtubules toward the central pair apparatus and are implicated in mechanochemical regulation of dynein activity and waveform control. <strong>CFAP61</strong> is currently understood as a mammalian component of the <strong>calmodulin- and spoke-associated complex (CSC)</strong> that is physically and functionally associated with the radial spoke system, particularly at the RS base/stalk region. (liu2021cfap61isrequired pages 12-16, liu2021cfap61isrequired pages 5-9)</p>
+<h3 id="12-clinical-phenotype-mmaf">1.2 Clinical phenotype: MMAF</h3>
+<p><strong>Multiple morphological abnormalities of the flagella (MMAF)</strong> is a severe sperm flagellar phenotype characterized by absent, short, coiled, bent, and/or irregular-caliber flagella, typically associated with reduced or absent sperm motility and male infertility. Biallelic <strong>CFAP61</strong> loss-of-function variants are an established cause of MMAF. (ma2022biallelicvariantsin pages 5-7, barbotin2024identificationofa pages 4-6)</p>
+<h2 id="2-molecular-function-localization-and-pathwaysprocesses">2) Molecular function, localization, and pathways/processes</h2>
+<h3 id="21-primary-molecular-role">2.1 Primary molecular role</h3>
+<p>Across functional genetics (human + mouse), protein interaction experiments, and ultrastructural analyses, <strong>CFAP61 is best supported as a structural/assembly and stabilization factor for the sperm flagellar axoneme</strong>, acting through the <strong>CSC–radial spoke system</strong>. It is not characterized as an enzyme with a defined catalytic reaction/substrate; rather, its pathogenic loss disrupts assembly and/or maintenance of radial spokes and associated axonemal complexes, producing axoneme instability and disorganization. (liu2021cfap61isrequired pages 12-16, liu2021cfap61isrequired pages 5-9)</p>
+<h3 id="22-interacting-partners-mechanistic-evidence">2.2 Interacting partners (mechanistic evidence)</h3>
+<p>A key primary functional study used IP–mass spectrometry and targeted co-immunoprecipitation approaches and reported that CFAP61 associates with:<br />
+- CSC component <strong>MAATS1</strong> (CFAP91) (liu2021cfap61isrequired pages 9-12)<br />
+- Radial spoke proteins including RS stalk components <strong>ARMC4 (RSPH8)</strong> and <strong>RSPH3</strong>, RS-associated <strong>ROPN1/ROPN1L</strong> (RSPH11), and RS head protein <strong>RSPH9</strong> (liu2021cfap61isrequired pages 9-12, liu2021cfap61isrequired pages 12-16)<br />
+- Dynein/tubulin-associated proteins including <strong>DYNCLI2</strong>, <strong>DYNLT1A</strong>, and <strong>TUBB3</strong> (liu2021cfap61isrequired pages 9-12, liu2021cfap61isrequired pages 12-16)<br />
+- Intraflagellar transport (IFT)-related proteins (e.g., <strong>WDR35, IFT22, IFT81</strong>) with evidence of disrupted IFT distribution upon Cfap61 loss in spermatids (liu2021cfap61isrequired pages 12-16)</p>
+<p>Functionally, the association of CFAP61 with both RS and CSC proteins is consistent with a role in <strong>late-stage RS assembly and axonemal stabilization</strong> during spermiogenesis. (liu2021cfap61isrequired pages 5-9, zhou2024themolecularbasis pages 8-9)</p>
+<h3 id="23-subcellular-localization">2.3 Subcellular localization</h3>
+<p>CFAP61 is reported to be <strong>testis-enriched</strong> and to <strong>localize along spermatid/sperm flagella</strong> by immunofluorescence, with biochemical fractionation consistent with axonemal association (Triton-resistant, SDS-soluble pool described in a primary study). (liu2021cfap61isrequired pages 9-12)</p>
+<p>A spermatid-stage localization to the <strong>manchette</strong> (a transient microtubule structure involved in sperm head shaping and tail assembly) was also reported in the same functional work, consistent with a role during flagellum assembly/trafficking. (liu2021cfap61isrequired pages 12-16)</p>
+<h3 id="24-placement-within-rsaxonemal-architecture-structural-modeling">2.4 Placement within RS/axonemal architecture (structural modeling)</h3>
+<p>A 2024 cryo-EM/cryo-ET structural study that builds models for mammalian RS complexes reports that “<strong>Cfap251/Cfap61/Cfap91</strong>” can be fit in the <strong>“stalk and base region”</strong> of the proposed mammalian <strong>RS3</strong> model, while noting that this RS3 model requires future high-resolution validation. This supports the working hypothesis that CFAP61 is positioned in the RS3 stalk/base (consistent with CSC association). (meng2024multiscalestructuresof pages 9-10)</p>
+<h3 id="25-tissue-specificity-sperm-flagellum-vs-airway-cilia">2.5 Tissue specificity (sperm flagellum vs airway cilia)</h3>
+<p>In a primary mouse knockout study, loss of Cfap61 produced severe sperm defects but the authors report <strong>no detectable impairment of respiratory cilia structure/function</strong>, supporting <strong>organ/tissue-specific requirement</strong> for CFAP61 in sperm flagellum formation/stability (as opposed to a classic primary ciliary dyskinesia phenotype in airway multiciliated cells). (liu2021cfap61isrequired pages 12-16, liu2021cfap61isrequired pages 9-12)</p>
+<h2 id="3-human-genetics-and-disease-associations">3) Human genetics and disease associations</h2>
+<h3 id="31-pathogenic-variant-classes-and-mechanisms">3.1 Pathogenic variant classes and mechanisms</h3>
+<p>Human CFAP61 pathogenic variants reported to cause MMAF include <strong>splice-altering variants</strong> and <strong>truncating variants</strong> (frameshift/nonsense), generally interpreted as loss-of-function (loss of full-length protein and/or nonsense-mediated decay). A 2024 clinical case report emphasizes that among reported CFAP61 MMAF variants, a majority are truncating/splice variants and the remaining missense variants are predicted to destabilize the protein (loss-of-function-like). (barbotin2024identificationofa pages 4-6)</p>
+<p><strong>Splicing validation example (2024):</strong> A novel homozygous splice-region variant (<strong>c.1245+6T&gt;C</strong>) was predicted to disrupt splicing by SpliceAI and was experimentally validated by a minigene assay showing a shorter RT-PCR product and cDNA evidence of <strong>exon 12 skipping</strong>. (barbotin2024identificationofa pages 4-6, barbotin2024identificationofa media 5058cfe3)</p>
+<h3 id="32-phenotypes-and-quantitative-data-from-human-studies">3.2 Phenotypes and quantitative data from human studies</h3>
+<p><strong>(i) Human splice variant with detailed semen/flagellar morphology (2021):</strong><br />
+A homozygous CFAP61 splice-site variant (<strong>c.143+5G&gt;A</strong>) was associated with MMAF, with reported semen parameters and morphology quantification: semen volume <strong>3 mL</strong>, concentration <strong>40 M/mL</strong>, progressive motility <strong>20%</strong>, and flagellar defect proportions including <strong>36% bent</strong>, <strong>18% no tail</strong>, <strong>12% short tail</strong>, <strong>50% irregular shape</strong>, and <strong>30% coiled tail</strong>. (liu2021cfap61isrequired pages 9-12)</p>
+<p><strong>(ii) Multi-family case series with ultrastructure quantification (2022):</strong><br />
+In 3 Pakistani families (11 infertile men) with recessive truncating CFAP61 variants (<strong>c.451_452del</strong>; <strong>c.847C&gt;T p.R283</strong><em>), immunofluorescence showed </em><em>absence of CFAP61</em><em> in sperm tails and a </em><em>secondary loss of CFAP251</em><em> signal, consistent with CSC disruption. TEM showed severe axonemal disorganization (loss of microtubules, RS, dynein arms, CP defects). Quantitative TEM rates of abnormal cross-sections were reported (averages): midpiece </em><em>63.2±28.4% (n=34)</em><em>, principal piece </em><em>71.9±17.7% (n=218)</em><em>, end piece </em><em>69.4±21.1% (n=121)</em><em>; </em><em>misoriented central pair 17.2±13.9% (n=113)</em>*. (ma2022biallelicvariantsin pages 5-7)</p>
+<p><strong>(iii) 2024 clinical report with assisted reproduction outcomes (real-world implementation):</strong><br />
+The 2024 report provides an example of assisted reproduction management (ICSI). In one cycle: <strong>21</strong> oocytes retrieved, <strong>18</strong> injected, <strong>15</strong> fertilized, <strong>3</strong> blastocysts, <strong>2</strong> usable blastocysts; outcomes included <strong>early pregnancy loss</strong> and <strong>no pregnancy</strong> in subsequent transfer, highlighting variable clinical outcomes even with ICSI. (barbotin2024identificationofa pages 4-6)</p>
+<h3 id="33-ultrastructural-phenotype-visual-evidence">3.3 Ultrastructural phenotype (visual evidence)</h3>
+<p>Transmission electron microscopy images in the 2024 report document axonemal and midpiece abnormalities consistent with MMAF, including disrupted axoneme patterning (e.g., loss of central pair architecture) and midpiece/mitochondrial sheath defects. (barbotin2024identificationofa media 9271260a)</p>
+<h2 id="4-recent-developments-and-latest-research-prioritizing-20232024">4) Recent developments and latest research (prioritizing 2023–2024)</h2>
+<h3 id="41-2024-expansion-of-pathogenic-variant-spectrum-with-functional-splicing-assays">4.1 2024: Expansion of pathogenic variant spectrum with functional splicing assays</h3>
+<p>The 2024 JARG report expands the mutational spectrum of CFAP61-related MMAF by describing a novel homozygous splicing variant and directly validating its splicing consequence by minigene assay and cDNA sequencing—strengthening clinical variant interpretation practice for CFAP61. (barbotin2024identificationofa pages 4-6, barbotin2024identificationofa media 5058cfe3)</p>
+<h3 id="42-2024-structural-biology-placing-cfap61-in-rs3-stalkbase-models">4.2 2024: Structural biology placing CFAP61 in RS3 stalk/base models</h3>
+<p>The 2024 <em>Nature Communications</em> radial spoke structural work provides a mechanistic placement of Cfap61 together with Cfap251/Cfap91 in RS3 stalk/base modeling, connecting genotype-phenotype evidence (MMAF) to a specific axonemal substructure and supporting a CSC-at-RS-base model (with explicit acknowledgement that RS3 modeling needs further validation). (meng2024multiscalestructuresof pages 9-10)</p>
+<h3 id="43-2024-expert-synthesis-linking-cfap61-to-csc-and-late-stage-rs-assembly">4.3 2024: Expert synthesis linking CFAP61 to CSC and late-stage RS assembly</h3>
+<p>A 2024 review focused on MMAF summarizes CFAP61 as a <strong>CSC component</strong> and compiles reported CFAP61 variants with associated phenotypes (typical MMAF, motility loss, central pair/RS defects, midpiece malformations), framing CFAP61 within a broader clinical genetics and assisted reproduction context. (zhou2024themolecularbasis pages 8-9, zhou2024themolecularbasis pages 1-2)</p>
+<h2 id="5-current-applications-and-real-world-implementations">5) Current applications and real-world implementations</h2>
+<h3 id="51-genetic-diagnosis-and-counseling-for-male-infertilitymmaf">5.1 Genetic diagnosis and counseling for male infertility/MMAF</h3>
+<p>CFAP61 is a validated gene for <strong>recessive MMAF-associated male infertility</strong>, and the evidence base supports inclusion on MMAF/flagellar gene panels and interpretation of biallelic loss-of-function variants as likely pathogenic when consistent phenotyping (sperm morphology + ultrastructure) is present. (ma2022biallelicvariantsin pages 5-7, barbotin2024identificationofa pages 4-6)</p>
+<h3 id="52-assisted-reproduction-icsi">5.2 Assisted reproduction (ICSI)</h3>
+<p>ICSI is often considered for severe sperm motility/morphology disorders. A 2024 CFAP61 case report documents ICSI cycle metrics and mixed outcomes (early pregnancy loss, then no pregnancy), emphasizing the need for individualized counseling and expectation management. (barbotin2024identificationofa pages 4-6)</p>
+<h2 id="6-expert-opinions-and-analysis-authoritative-sources">6) Expert opinions and analysis (authoritative sources)</h2>
+<h3 id="61-strength-of-genedisease-validity">6.1 Strength of gene–disease validity</h3>
+<p>The 2024 clinical report explicitly notes that CFAP61 was not included in a 2020 validated monogenic infertility list, but under gene–disease assessment recommendations the CFAP61–MMAF relationship would be considered <strong>strong</strong>, based on multiple unrelated probands, variant types, and functional/model organism evidence. (barbotin2024identificationofa pages 4-6)</p>
+<h3 id="62-mechanistic-consensus">6.2 Mechanistic consensus</h3>
+<p>Across primary genetic studies and expert review synthesis, the mechanistic consensus is that CFAP61 contributes to the integrity/assembly of the sperm axoneme via the CSC/radial spoke system, and that its loss causes ultrastructural breakdown (RS/CP/IDA perturbations) consistent with the profound motility and morphology defects observed clinically. (liu2021cfap61isrequired pages 12-16, zhou2024themolecularbasis pages 8-9)</p>
+<h2 id="7-key-statistics-and-data-recent-andor-quantitative">7) Key statistics and data (recent and/or quantitative)</h2>
+<ul>
+<li>Human semen parameters for a CFAP61 splice variant case: <strong>3 mL</strong>, <strong>40 M/mL</strong>, <strong>20%</strong> progressive motility; morphology distribution quantified across defect types (bent/no tail/short/irregular/coiled). (liu2021cfap61isrequired pages 9-12)</li>
+<li>Human TEM quantitative abnormalities in CFAP61 truncating variant families: abnormal cross-sections midpiece <strong>63.2±28.4%</strong>, principal <strong>71.9±17.7%</strong>, end <strong>69.4±21.1%</strong>; misoriented central pair <strong>17.2±13.9%</strong>. (ma2022biallelicvariantsin pages 5-7)</li>
+<li>Mouse KO sperm concentration difference (functional model): WT <strong>23.15±1.998</strong> vs KO <strong>4.593±1.760</strong>; KO morphology breakdown includes absent/short/coiled/angulation/irregular caliber percentages, with <strong>0%</strong> normal-flagella sperm in KO. (liu2021cfap61isrequired pages 44-52)</li>
+<li>2024 ICSI cycle metrics in a CFAP61 case: <strong>21</strong> retrieved oocytes, <strong>18</strong> injected, <strong>15</strong> fertilized, <strong>3</strong> blastocysts, <strong>2</strong> usable; outcomes included early loss and no pregnancy. (barbotin2024identificationofa pages 4-6)</li>
+</ul>
+<h2 id="8-evidence-summary-table">8) Evidence summary table</h2>
+<p>The following table consolidates the main human CFAP61 evidence (variants, experimental validation, phenotypes, and mechanistic conclusions).</p>
+<table>
+<thead>
+<tr>
+<th>Study</th>
+<th>Variant(s) reported</th>
+<th>Experimental validation</th>
+<th>Key phenotype(s) and quantitative data</th>
+<th>Main mechanistic conclusion</th>
+<th>URL / date</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Liu et al., 2021, <em>bioRxiv</em></td>
+<td>Homozygous splice-site variant <strong>c.143+5G&gt;A</strong> causing exon 2 skipping/frameshift in human CFAP61</td>
+<td>Exome reanalysis; minigene splicing assay; co-IP/IP-MS; western blot; immunofluorescence; TEM/SEM; CRISPR <strong>Cfap61-/-</strong> mouse validation (liu2021cfap61isrequired pages 9-12, liu2021cfap61isrequired pages 5-9)</td>
+<td>Human patient: semen volume <strong>3 mL</strong>, sperm concentration <strong>40 M/mL</strong>, progressive motility <strong>20%</strong>; flagellar defects included <strong>36% bent</strong>, <strong>18% no tail</strong>, <strong>12% short tail</strong>, <strong>50% irregular shape</strong>, <strong>30% coiled tail</strong>. Mouse KO: sperm concentration fell from <strong>23.15±1.998</strong> to <strong>4.593±1.760</strong>; WT normal flagella <strong>81.165±1.895%</strong> vs <strong>0%</strong> in KO; KO absent <strong>12.085±1.852%</strong>, short <strong>31.969±0.654%</strong>, coiled <strong>31.542±1.317%</strong>, angulation <strong>15.833±2.125%</strong>, irregular caliber <strong>8.570±0.940%</strong> (liu2021cfap61isrequired pages 9-12, liu2021cfap61isrequired pages 44-52)</td>
+<td>CFAP61 is a conserved <strong>calmodulin- and spoke-associated complex (CSC)</strong> and <strong>radial spoke (RS)</strong> component that interacts with <strong>MAATS1/CFAP91, ARMC4/RSPH8, RSPH3, ROPN1/ROPN1L, RSPH9</strong>, plus dynein/tubulin-associated proteins; required for RS assembly/axoneme stabilization in sperm, with organ specificity favoring flagella over respiratory cilia (liu2021cfap61isrequired pages 9-12, liu2021cfap61isrequired pages 12-16)</td>
+<td>https://doi.org/10.1101/2021.03.04.433881 ; Mar 2021</td>
+</tr>
+<tr>
+<td>Ma et al., 2022, <em>Frontiers in Cell and Developmental Biology</em></td>
+<td>Homozygous truncating variants <strong>c.451_452del (p.I151Nfs*4)</strong> and <strong>c.847C&gt;T (p.R283*)</strong> in 3 Pakistani families</td>
+<td>WES + Sanger segregation; immunofluorescence showing absent CFAP61 and CFAP251 in sperm tails; TEM ultrastructure analysis (ma2022biallelicvariantsin pages 5-7, ma2022biallelicvariantsin pages 1-2, ma2022biallelicvariantsin pages 2-4)</td>
+<td><strong>11 infertile men</strong> with MMAF. TEM cross-sections abnormal: midpiece <strong>63.2±28.4% (n=34)</strong>, principal piece <strong>71.9±17.7% (n=218)</strong>, end piece <strong>69.4±21.1% (n=121)</strong>; misoriented central pair <strong>17.2±13.9% (n=113)</strong>. Severe axonemal disorganization with loss of central pair, RSs, and inner dynein arms; markedly reduced motility/progressive motility in patients (ma2022biallelicvariantsin pages 5-7, ma2022biallelicvariantsin pages 2-4)</td>
+<td>Human CFAP61 is essential for normal sperm flagellar ultrastructure and motility; loss of CFAP61 causes secondary loss of <strong>CFAP251</strong>, supporting CFAP61 as a <strong>CSC-associated factor</strong> necessary for RS/axonemal integrity (ma2022biallelicvariantsin pages 5-7, ma2022biallelicvariantsin pages 1-2)</td>
+<td>https://doi.org/10.3389/fcell.2021.803818 ; Jan 2022</td>
+</tr>
+<tr>
+<td>Barbotin et al., 2024, <em>Journal of Assisted Reproduction and Genetics</em></td>
+<td>Novel homozygous splice variant <strong>c.1245+6T&gt;C</strong>; allele frequency <strong>6.56e-6</strong> (AC=1)</td>
+<td>In silico splice prediction (<strong>SpliceAI donor loss 0.83; acceptor loss 0.81</strong>); minigene RT-PCR showing <strong>320 bp WT vs 280 bp mutant</strong>; cDNA Sanger confirming <strong>exon 12 skipping</strong>; TEM; literature-integrated functional interpretation (barbotin2024identificationofa pages 4-6, barbotin2024identificationofa media 5058cfe3)</td>
+<td>Patient had classic MMAF with severely disorganized axoneme, abnormal mitochondrial sheath, and cytoplasmic excess; TEM included <strong>9+0 axoneme</strong>, supernumerary doublets, and midpiece/mitochondrial sheath defects. ICSI cycle: <strong>21</strong> oocytes retrieved, <strong>18</strong> injected, <strong>15</strong> fertilized, <strong>3</strong> blastocysts, <strong>2</strong> usable blastocysts; outcomes were <strong>early pregnancy loss</strong> then <strong>no pregnancy</strong> (barbotin2024identificationofa pages 4-6, barbotin2024identificationofa media 9271260a)</td>
+<td>Supports CFAP61 as a <strong>CSC component</strong> in ciliated tissues/localized along mature sperm; pathogenic variants often truncate/destabilize CFAP61 and can cause secondary <strong>CFAP251 loss</strong>, reinforcing CSC dysfunction as the disease mechanism (barbotin2024identificationofa pages 4-6)</td>
+<td>https://doi.org/10.1007/s10815-024-03139-0 ; May 2024</td>
+</tr>
+<tr>
+<td>Zhou et al., 2024, <em>Genes</em> (review)</td>
+<td>Expert synthesis of reported CFAP61 variants including <strong>c.143+5G&gt;A</strong>, <strong>c.451_452del</strong>, <strong>c.847C&gt;T</strong>, <strong>c.1654C&gt;T</strong>, <strong>c.2911G&gt;A</strong>, <strong>c.144-2A&gt;G</strong>, <strong>c.1666G&gt;A</strong>, <strong>c.1245+6T&gt;C</strong></td>
+<td>Narrative/review synthesis of human and mouse studies; no new primary experiments (zhou2024themolecularbasis pages 8-9, zhou2024themolecularbasis pages 1-2)</td>
+<td>Summarizes CFAP61-associated phenotypes as <strong>typical MMAF</strong>, impaired sperm motility, separated microtubules/ODFs in KO mice, absence of central pair microtubules, RS defects, and midpiece malformation; emphasizes that MMAF is genetically heterogeneous and many patients remain molecularly unresolved (zhou2024themolecularbasis pages 8-9, zhou2024themolecularbasis pages 1-2)</td>
+<td>Reviews CFAP61 as a <strong>main component of the CSC</strong> acting in <strong>late RS assembly</strong>; loss disrupts central pair/RS/IDA-linked architecture and is clinically relevant for MMAF genetics and assisted reproduction counseling (zhou2024themolecularbasis pages 8-9, zhou2024themolecularbasis pages 1-2)</td>
+<td>https://doi.org/10.3390/genes15101315 ; Oct 2024</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the core human CFAP61 (Q8NHU2) evidence base across primary studies and a recent expert review, emphasizing pathogenic variants, experimental validation, quantitative phenotypes, and the mechanistic interpretation of CFAP61 as a CSC/radial spoke factor in sperm flagellar biology.</em></p>
+<h2 id="9-notes-on-limitations-and-open-questions">9) Notes on limitations and open questions</h2>
+<ul>
+<li>High-resolution <strong>RS3</strong> placement of CFAP61 is supported by structural fitting in 2024, but the authors explicitly state that the RS3 model requires future validation by a high-resolution structure of mammalian RS3. (meng2024multiscalestructuresof pages 9-10)</li>
+<li>Evidence from a primary mouse study suggests respiratory cilia may be spared despite severe sperm flagellum defects; however, the extent to which CFAP61 contributes to human airway cilia under all conditions remains incompletely resolved in the provided evidence set. (liu2021cfap61isrequired pages 12-16)</li>
+</ul>
+<h2 id="10-key-cited-sources-urls-and-publication-dates">10) Key cited sources (URLs and publication dates)</h2>
+<ul>
+<li>Barbotin et al. “Identification of a novel CFAP61 homozygous splicing variant…” <em>J Assist Reprod Genet</em> <strong>May 2024</strong>. https://doi.org/10.1007/s10815-024-03139-0 (barbotin2024identificationofa pages 4-6)</li>
+<li>Zhou et al. “The Molecular Basis of MMAF and Its Impact on Clinical Practice.” <em>Genes</em> <strong>Oct 2024</strong>. https://doi.org/10.3390/genes15101315 (zhou2024themolecularbasis pages 8-9, zhou2024themolecularbasis pages 1-2)</li>
+<li>Ma et al. “Biallelic Variants in CFAP61 Cause MMAF and Male Infertility.” <em>Frontiers in Cell and Developmental Biology</em> <strong>Jan 2022</strong>. https://doi.org/10.3389/fcell.2021.803818 (ma2022biallelicvariantsin pages 5-7, ma2022biallelicvariantsin pages 1-2)</li>
+<li>Liu et al. “CFAP61 is required for sperm flagellum formation and male fertility in human and mouse.” <em>bioRxiv</em> <strong>Mar 2021</strong>. https://doi.org/10.1101/2021.03.04.433881 (liu2021cfap61isrequired pages 9-12, liu2021cfap61isrequired pages 12-16)</li>
+<li>Meng et al. “Multi-scale structures of the mammalian radial spoke…” <em>Nature Communications</em> <strong>Jan 2024</strong>. https://doi.org/10.1038/s41467-023-44577-1 (meng2024multiscalestructuresof pages 9-10)</li>
+</ul>
+<p>References</p>
+<ol>
+<li>
+<p>(liu2021cfap61isrequired pages 9-12): Siyu Liu, Jintao Zhang, Zine Eddine Kherraf, Shuya Sun, Xin Zhang, Caroline Cazin, Charles Coutton, Raoudha Zouari, Shuqin Zhao, Fan Hu, Selima Fourati Ben Mustapha, Christophe Arnoult, Pierre F Ray, and Mingxi Liu. Cfap61 is required for sperm flagellum formation and male fertility in human and mouse. BioRxiv, Mar 2021. URL: https://doi.org/10.1101/2021.03.04.433881, doi:10.1101/2021.03.04.433881. This article has 52 citations.</p>
+</li>
+<li>
+<p>(barbotin2024identificationofa pages 4-6): Anne-Laure Barbotin, Angèle Boursier, Anne-Sophie Jourdain, Alexandre Moerman, Baptiste Rabat, Mariam Chehimi, Caroline Thuillier, Jamal Ghoumid, and Thomas Smol. Identification of a novel cfap61 homozygous splicing variant associated with multiple morphological abnormalities of the flagella. Journal of assisted reproduction and genetics, 41:1499-1505, May 2024. URL: https://doi.org/10.1007/s10815-024-03139-0, doi:10.1007/s10815-024-03139-0. This article has 6 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(liu2021cfap61isrequired pages 12-16): Siyu Liu, Jintao Zhang, Zine Eddine Kherraf, Shuya Sun, Xin Zhang, Caroline Cazin, Charles Coutton, Raoudha Zouari, Shuqin Zhao, Fan Hu, Selima Fourati Ben Mustapha, Christophe Arnoult, Pierre F Ray, and Mingxi Liu. Cfap61 is required for sperm flagellum formation and male fertility in human and mouse. BioRxiv, Mar 2021. URL: https://doi.org/10.1101/2021.03.04.433881, doi:10.1101/2021.03.04.433881. This article has 52 citations.</p>
+</li>
+<li>
+<p>(liu2021cfap61isrequired pages 5-9): Siyu Liu, Jintao Zhang, Zine Eddine Kherraf, Shuya Sun, Xin Zhang, Caroline Cazin, Charles Coutton, Raoudha Zouari, Shuqin Zhao, Fan Hu, Selima Fourati Ben Mustapha, Christophe Arnoult, Pierre F Ray, and Mingxi Liu. Cfap61 is required for sperm flagellum formation and male fertility in human and mouse. BioRxiv, Mar 2021. URL: https://doi.org/10.1101/2021.03.04.433881, doi:10.1101/2021.03.04.433881. This article has 52 citations.</p>
+</li>
+<li>
+<p>(ma2022biallelicvariantsin pages 5-7): Ao Ma, Aurang Zeb, Imtiaz Ali, Daren Zhao, Asad Khan, Beibei Zhang, Jianteng Zhou, Ranjha Khan, Huan Zhang, Yuanwei Zhang, Ihsan Khan, Wasim Shah, Haider Ali, Abdul Rafay Javed, Hui Ma, and Qinghua Shi. Biallelic variants in cfap61 cause multiple morphological abnormalities of the flagella and male infertility. Frontiers in Cell and Developmental Biology, Jan 2022. URL: https://doi.org/10.3389/fcell.2021.803818, doi:10.3389/fcell.2021.803818. This article has 29 citations.</p>
+</li>
+<li>
+<p>(zhou2024themolecularbasis pages 8-9): Yujie Zhou, Songyan Yu, and Wenyong Zhang. The molecular basis of multiple morphological abnormalities of sperm flagella and its impact on clinical practice. Genes, 15:1315, Oct 2024. URL: https://doi.org/10.3390/genes15101315, doi:10.3390/genes15101315. This article has 12 citations.</p>
+</li>
+<li>
+<p>(meng2024multiscalestructuresof pages 9-10): Xueming Meng, Cong Xu, Jiawei Li, Benhua Qiu, Jiajun Luo, Qin Hong, Yujie Tong, Chuyu Fang, Yanyan Feng, Rui Ma, Xiangyi Shi, Cheng Lin, Chen Pan, Xueliang Zhu, Xiumin Yan, and Yao Cong. Multi-scale structures of the mammalian radial spoke and divergence of axonemal complexes in ependymal cilia. Nature Communications, 15:1-16, Jan 2024. URL: https://doi.org/10.1038/s41467-023-44577-1, doi:10.1038/s41467-023-44577-1. This article has 30 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(barbotin2024identificationofa media 5058cfe3): Anne-Laure Barbotin, Angèle Boursier, Anne-Sophie Jourdain, Alexandre Moerman, Baptiste Rabat, Mariam Chehimi, Caroline Thuillier, Jamal Ghoumid, and Thomas Smol. Identification of a novel cfap61 homozygous splicing variant associated with multiple morphological abnormalities of the flagella. Journal of assisted reproduction and genetics, 41:1499-1505, May 2024. URL: https://doi.org/10.1007/s10815-024-03139-0, doi:10.1007/s10815-024-03139-0. This article has 6 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(barbotin2024identificationofa media 9271260a): Anne-Laure Barbotin, Angèle Boursier, Anne-Sophie Jourdain, Alexandre Moerman, Baptiste Rabat, Mariam Chehimi, Caroline Thuillier, Jamal Ghoumid, and Thomas Smol. Identification of a novel cfap61 homozygous splicing variant associated with multiple morphological abnormalities of the flagella. Journal of assisted reproduction and genetics, 41:1499-1505, May 2024. URL: https://doi.org/10.1007/s10815-024-03139-0, doi:10.1007/s10815-024-03139-0. This article has 6 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(zhou2024themolecularbasis pages 1-2): Yujie Zhou, Songyan Yu, and Wenyong Zhang. The molecular basis of multiple morphological abnormalities of sperm flagella and its impact on clinical practice. Genes, 15:1315, Oct 2024. URL: https://doi.org/10.3390/genes15101315, doi:10.3390/genes15101315. This article has 12 citations.</p>
+</li>
+<li>
+<p>(liu2021cfap61isrequired pages 44-52): Siyu Liu, Jintao Zhang, Zine Eddine Kherraf, Shuya Sun, Xin Zhang, Caroline Cazin, Charles Coutton, Raoudha Zouari, Shuqin Zhao, Fan Hu, Selima Fourati Ben Mustapha, Christophe Arnoult, Pierre F Ray, and Mingxi Liu. Cfap61 is required for sperm flagellum formation and male fertility in human and mouse. BioRxiv, Mar 2021. URL: https://doi.org/10.1101/2021.03.04.433881, doi:10.1101/2021.03.04.433881. This article has 52 citations.</p>
+</li>
+<li>
+<p>(ma2022biallelicvariantsin pages 1-2): Ao Ma, Aurang Zeb, Imtiaz Ali, Daren Zhao, Asad Khan, Beibei Zhang, Jianteng Zhou, Ranjha Khan, Huan Zhang, Yuanwei Zhang, Ihsan Khan, Wasim Shah, Haider Ali, Abdul Rafay Javed, Hui Ma, and Qinghua Shi. Biallelic variants in cfap61 cause multiple morphological abnormalities of the flagella and male infertility. Frontiers in Cell and Developmental Biology, Jan 2022. URL: https://doi.org/10.3389/fcell.2021.803818, doi:10.3389/fcell.2021.803818. This article has 29 citations.</p>
+</li>
+<li>
+<p>(ma2022biallelicvariantsin pages 2-4): Ao Ma, Aurang Zeb, Imtiaz Ali, Daren Zhao, Asad Khan, Beibei Zhang, Jianteng Zhou, Ranjha Khan, Huan Zhang, Yuanwei Zhang, Ihsan Khan, Wasim Shah, Haider Ali, Abdul Rafay Javed, Hui Ma, and Qinghua Shi. Biallelic variants in cfap61 cause multiple morphological abnormalities of the flagella and male infertility. Frontiers in Cell and Developmental Biology, Jan 2022. URL: https://doi.org/10.3389/fcell.2021.803818, doi:10.3389/fcell.2021.803818. This article has 29 citations.</p>
+</li>
+</ol>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>meng2024multiscalestructuresof pages 9-10</li>
+<li>barbotin2024identificationofa pages 4-6</li>
+<li>ma2022biallelicvariantsin pages 5-7</li>
+<li>zhou2024themolecularbasis pages 8-9</li>
+<li>zhou2024themolecularbasis pages 1-2</li>
+<li>ma2022biallelicvariantsin pages 1-2</li>
+<li>ma2022biallelicvariantsin pages 2-4</li>
+<li>https://doi.org/10.1101/2021.03.04.433881</li>
+<li>https://doi.org/10.3389/fcell.2021.803818</li>
+<li>https://doi.org/10.1007/s10815-024-03139-0</li>
+<li>https://doi.org/10.3390/genes15101315</li>
+<li>https://doi.org/10.1038/s41467-023-44577-1</li>
+<li>https://doi.org/10.1101/2021.03.04.433881,</li>
+<li>https://doi.org/10.1007/s10815-024-03139-0,</li>
+<li>https://doi.org/10.3389/fcell.2021.803818,</li>
+<li>https://doi.org/10.3390/genes15101315,</li>
+<li>https://doi.org/10.1038/s41467-023-44577-1,</li>
+</ol>
+            </div>
+        </details>
+
         <details class="markdown-section">
             <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
                 <div style="flex: 1;">
@@ -3404,6 +3780,8 @@ existing_annotations:
         ...CFAP61 is a conserved component of the calmodulin- and radial spoke-associated
         complex (CSC) of cilia... CFAP61 interacts with the CSC, radial spoke stalk
         and head...
+    - reference_id: file:human/CFAP61/CFAP61-deep-research-falcon.md
+      supporting_text: CFAP61 is best supported as a structural/assembly and stabilization factor for the sperm flagellar axoneme, acting through the CSC-radial spoke system.
 
 - term:
     id: GO:0062177
@@ -3437,6 +3815,8 @@ existing_annotations:
         ...During early stages of Cfap61-/- spermatid development, the assembly of
         radial
         spoke components is impaired...
+    - reference_id: file:human/CFAP61/CFAP61-deep-research-falcon.md
+      supporting_text: Its pathogenic loss disrupts assembly and/or maintenance of radial spokes and associated axonemal complexes, producing axoneme instability and disorganization.
 
 core_functions:
 - description: &gt;-
@@ -3480,6 +3860,8 @@ core_functions:
     supporting_text: &gt;-
       ...the CSC connects three major axonemal complexes involved in dynein
       regulation: RS2, the nexin-dynein regulatory complex (N-DRC), and RS3S...
+  - reference_id: file:human/CFAP61/CFAP61-deep-research-falcon.md
+    supporting_text: CFAP61 is currently understood as a mammalian component of the calmodulin- and spoke-associated complex that is physically and functionally associated with the radial spoke system.
 
 - description: &gt;-
     In sperm, CFAP61 is essential for flagellum morphogenesis and motility.
@@ -3511,6 +3893,8 @@ core_functions:
     supporting_text: &gt;-
       ...CFAP61 and CFAP251 signals were absent from sperm tails of the patients,
       which suggested the loss of functional CSC in sperm flagella...
+  - reference_id: file:human/CFAP61/CFAP61-deep-research-falcon.md
+    supporting_text: Biallelic CFAP61 loss-of-function variants are an established cause of multiple morphological abnormalities of the flagella.
 
 proposed_new_terms:
 - proposed_name: calmodulin- and spoke-associated complex
@@ -3749,6 +4133,11 @@ references:
       that functions as a structural scaffold, not an enzyme. The BioReason-Pro paper
       highlights this as an example of a domain that could mislead automated annotation
       pipelines into predicting enzymatic function.
+- id: file:human/CFAP61/CFAP61-deep-research-falcon.md
+  title: Falcon deep research report for CFAP61
+  findings:
+  - statement: Falcon research supports CFAP61 as a non-enzymatic axonemal CSC/radial-spoke structural factor needed for sperm flagellum assembly, radial spoke assembly, and sperm motility.
+    supporting_text: CFAP61 is best supported as a structural/assembly and stabilization factor for the sperm flagellar axoneme, acting through the CSC-radial spoke system.
 </code></pre>
             </div>
         </details>

--- a/genes/human/CFAP61/CFAP61-ai-review.yaml
+++ b/genes/human/CFAP61/CFAP61-ai-review.yaml
@@ -473,6 +473,8 @@ existing_annotations:
         ...CFAP61 is a conserved component of the calmodulin- and radial spoke-associated
         complex (CSC) of cilia... CFAP61 interacts with the CSC, radial spoke stalk
         and head...
+    - reference_id: file:human/CFAP61/CFAP61-deep-research-falcon.md
+      supporting_text: CFAP61 is best supported as a structural/assembly and stabilization factor for the sperm flagellar axoneme, acting through the CSC-radial spoke system.
 
 - term:
     id: GO:0062177
@@ -506,6 +508,8 @@ existing_annotations:
         ...During early stages of Cfap61-/- spermatid development, the assembly of
         radial
         spoke components is impaired...
+    - reference_id: file:human/CFAP61/CFAP61-deep-research-falcon.md
+      supporting_text: Its pathogenic loss disrupts assembly and/or maintenance of radial spokes and associated axonemal complexes, producing axoneme instability and disorganization.
 
 core_functions:
 - description: >-
@@ -549,6 +553,8 @@ core_functions:
     supporting_text: >-
       ...the CSC connects three major axonemal complexes involved in dynein
       regulation: RS2, the nexin-dynein regulatory complex (N-DRC), and RS3S...
+  - reference_id: file:human/CFAP61/CFAP61-deep-research-falcon.md
+    supporting_text: CFAP61 is currently understood as a mammalian component of the calmodulin- and spoke-associated complex that is physically and functionally associated with the radial spoke system.
 
 - description: >-
     In sperm, CFAP61 is essential for flagellum morphogenesis and motility.
@@ -580,6 +586,8 @@ core_functions:
     supporting_text: >-
       ...CFAP61 and CFAP251 signals were absent from sperm tails of the patients,
       which suggested the loss of functional CSC in sperm flagella...
+  - reference_id: file:human/CFAP61/CFAP61-deep-research-falcon.md
+    supporting_text: Biallelic CFAP61 loss-of-function variants are an established cause of multiple morphological abnormalities of the flagella.
 
 proposed_new_terms:
 - proposed_name: calmodulin- and spoke-associated complex
@@ -818,3 +826,8 @@ references:
       that functions as a structural scaffold, not an enzyme. The BioReason-Pro paper
       highlights this as an example of a domain that could mislead automated annotation
       pipelines into predicting enzymatic function.
+- id: file:human/CFAP61/CFAP61-deep-research-falcon.md
+  title: Falcon deep research report for CFAP61
+  findings:
+  - statement: Falcon research supports CFAP61 as a non-enzymatic axonemal CSC/radial-spoke structural factor needed for sperm flagellum assembly, radial spoke assembly, and sperm motility.
+    supporting_text: CFAP61 is best supported as a structural/assembly and stabilization factor for the sperm flagellar axoneme, acting through the CSC-radial spoke system.

--- a/genes/human/CFAP61/CFAP61-ai-review.yaml
+++ b/genes/human/CFAP61/CFAP61-ai-review.yaml
@@ -606,8 +606,8 @@ proposed_new_terms:
     currently exists for this complex. Having a term would allow annotation of CFAP61,
     CFAP91, and CFAP251 as part_of the CSC.
   proposed_parent:
-    id: GO:0030286
-    label: dynein complex
+    id: GO:0005930
+    label: axoneme
   supported_by:
   - reference_id: PMID:21613541
     supporting_text: >-

--- a/genes/human/CFAP61/CFAP61-deep-research-falcon.md
+++ b/genes/human/CFAP61/CFAP61-deep-research-falcon.md
@@ -1,0 +1,300 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: true
+start_time: '2026-05-10T20:13:45.760478'
+end_time: '2026-05-10T20:13:45.762530'
+duration_seconds: 0.0
+template_file: templates/gene_research_go_focused.md
+template_variables:
+  organism: human
+  gene_id: CFAP61
+  gene_symbol: CFAP61
+  uniprot_accession: Q8NHU2
+  protein_description: 'RecName: Full=Cilia- and flagella-associated protein 61 {ECO:0000312|HGNC:HGNC:15872};'
+  gene_info: Name=CFAP61 {ECO:0000312|HGNC:HGNC:15872}; Synonyms=C20orf26 {ECO:0000312|HGNC:HGNC:15872};
+  organism_full: Homo sapiens (Human).
+  protein_family: Not specified in UniProt
+  protein_domains: CFAP61. (IPR038884); CFAP61_dimer. (IPR056299); CFAP61_N. (IPR032151);
+    FAD/NAD-bd_sf. (IPR036188); CFAP61_dimer (PF23150)
+provider_config:
+  timeout: 600
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 17
+---
+
+## Question
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** Q8NHU2
+- **Protein Description:** RecName: Full=Cilia- and flagella-associated protein 61 {ECO:0000312|HGNC:HGNC:15872};
+- **Gene Information:** Name=CFAP61 {ECO:0000312|HGNC:HGNC:15872}; Synonyms=C20orf26 {ECO:0000312|HGNC:HGNC:15872};
+- **Organism (full):** Homo sapiens (Human).
+- **Protein Family:** Not specified in UniProt
+- **Key Domains:** CFAP61. (IPR038884); CFAP61_dimer. (IPR056299); CFAP61_N. (IPR032151); FAD/NAD-bd_sf. (IPR036188); CFAP61_dimer (PF23150)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "CFAP61" matches the protein description above**
+2. **Verify the organism is correct:** Homo sapiens (Human).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'CFAP61' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **CFAP61** (gene ID: CFAP61, UniProt: Q8NHU2) in human.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** Q8NHU2
+- **Protein Description:** RecName: Full=Cilia- and flagella-associated protein 61 {ECO:0000312|HGNC:HGNC:15872};
+- **Gene Information:** Name=CFAP61 {ECO:0000312|HGNC:HGNC:15872}; Synonyms=C20orf26 {ECO:0000312|HGNC:HGNC:15872};
+- **Organism (full):** Homo sapiens (Human).
+- **Protein Family:** Not specified in UniProt
+- **Key Domains:** CFAP61. (IPR038884); CFAP61_dimer. (IPR056299); CFAP61_N. (IPR032151); FAD/NAD-bd_sf. (IPR036188); CFAP61_dimer (PF23150)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "CFAP61" matches the protein description above**
+2. **Verify the organism is correct:** Homo sapiens (Human).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'CFAP61' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **CFAP61** (gene ID: CFAP61, UniProt: Q8NHU2) in human.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+# Research report: Human **CFAP61** (UniProt **Q8NHU2**)—functional annotation in motile cilia/flagella
+
+## 0) Gene/protein verification (critical identity check)
+The literature reviewed consistently refers to **CFAP61**, also known as **C20orf26**, as “cilia- and flagella-associated protein 61” in **Homo sapiens**, and links it to motile cilia/flagella axonemal structures and male infertility phenotypes (MMAF). This matches the target UniProt accession **Q8NHU2** and the provided UniProt description (CFAP61/C20orf26, human). (liu2021cfap61isrequired pages 9-12, barbotin2024identificationofa pages 4-6)
+
+## 1) Key concepts and definitions (current understanding)
+
+### 1.1 Motile axoneme, radial spokes (RS), and the calmodulin- and spoke-associated complex (CSC)
+Motile cilia and flagella contain a microtubule-based **axoneme** whose beat is coordinated by periodic regulatory and structural modules. **Radial spokes (RS)** are multi-protein complexes projecting from outer doublet microtubules toward the central pair apparatus and are implicated in mechanochemical regulation of dynein activity and waveform control. **CFAP61** is currently understood as a mammalian component of the **calmodulin- and spoke-associated complex (CSC)** that is physically and functionally associated with the radial spoke system, particularly at the RS base/stalk region. (liu2021cfap61isrequired pages 12-16, liu2021cfap61isrequired pages 5-9)
+
+### 1.2 Clinical phenotype: MMAF
+**Multiple morphological abnormalities of the flagella (MMAF)** is a severe sperm flagellar phenotype characterized by absent, short, coiled, bent, and/or irregular-caliber flagella, typically associated with reduced or absent sperm motility and male infertility. Biallelic **CFAP61** loss-of-function variants are an established cause of MMAF. (ma2022biallelicvariantsin pages 5-7, barbotin2024identificationofa pages 4-6)
+
+## 2) Molecular function, localization, and pathways/processes
+
+### 2.1 Primary molecular role
+Across functional genetics (human + mouse), protein interaction experiments, and ultrastructural analyses, **CFAP61 is best supported as a structural/assembly and stabilization factor for the sperm flagellar axoneme**, acting through the **CSC–radial spoke system**. It is not characterized as an enzyme with a defined catalytic reaction/substrate; rather, its pathogenic loss disrupts assembly and/or maintenance of radial spokes and associated axonemal complexes, producing axoneme instability and disorganization. (liu2021cfap61isrequired pages 12-16, liu2021cfap61isrequired pages 5-9)
+
+### 2.2 Interacting partners (mechanistic evidence)
+A key primary functional study used IP–mass spectrometry and targeted co-immunoprecipitation approaches and reported that CFAP61 associates with:
+- CSC component **MAATS1** (CFAP91) (liu2021cfap61isrequired pages 9-12)
+- Radial spoke proteins including RS stalk components **ARMC4 (RSPH8)** and **RSPH3**, RS-associated **ROPN1/ROPN1L** (RSPH11), and RS head protein **RSPH9** (liu2021cfap61isrequired pages 9-12, liu2021cfap61isrequired pages 12-16)
+- Dynein/tubulin-associated proteins including **DYNCLI2**, **DYNLT1A**, and **TUBB3** (liu2021cfap61isrequired pages 9-12, liu2021cfap61isrequired pages 12-16)
+- Intraflagellar transport (IFT)-related proteins (e.g., **WDR35, IFT22, IFT81**) with evidence of disrupted IFT distribution upon Cfap61 loss in spermatids (liu2021cfap61isrequired pages 12-16)
+
+Functionally, the association of CFAP61 with both RS and CSC proteins is consistent with a role in **late-stage RS assembly and axonemal stabilization** during spermiogenesis. (liu2021cfap61isrequired pages 5-9, zhou2024themolecularbasis pages 8-9)
+
+### 2.3 Subcellular localization
+CFAP61 is reported to be **testis-enriched** and to **localize along spermatid/sperm flagella** by immunofluorescence, with biochemical fractionation consistent with axonemal association (Triton-resistant, SDS-soluble pool described in a primary study). (liu2021cfap61isrequired pages 9-12)
+
+A spermatid-stage localization to the **manchette** (a transient microtubule structure involved in sperm head shaping and tail assembly) was also reported in the same functional work, consistent with a role during flagellum assembly/trafficking. (liu2021cfap61isrequired pages 12-16)
+
+### 2.4 Placement within RS/axonemal architecture (structural modeling)
+A 2024 cryo-EM/cryo-ET structural study that builds models for mammalian RS complexes reports that “**Cfap251/Cfap61/Cfap91**” can be fit in the **“stalk and base region”** of the proposed mammalian **RS3** model, while noting that this RS3 model requires future high-resolution validation. This supports the working hypothesis that CFAP61 is positioned in the RS3 stalk/base (consistent with CSC association). (meng2024multiscalestructuresof pages 9-10)
+
+### 2.5 Tissue specificity (sperm flagellum vs airway cilia)
+In a primary mouse knockout study, loss of Cfap61 produced severe sperm defects but the authors report **no detectable impairment of respiratory cilia structure/function**, supporting **organ/tissue-specific requirement** for CFAP61 in sperm flagellum formation/stability (as opposed to a classic primary ciliary dyskinesia phenotype in airway multiciliated cells). (liu2021cfap61isrequired pages 12-16, liu2021cfap61isrequired pages 9-12)
+
+## 3) Human genetics and disease associations
+
+### 3.1 Pathogenic variant classes and mechanisms
+Human CFAP61 pathogenic variants reported to cause MMAF include **splice-altering variants** and **truncating variants** (frameshift/nonsense), generally interpreted as loss-of-function (loss of full-length protein and/or nonsense-mediated decay). A 2024 clinical case report emphasizes that among reported CFAP61 MMAF variants, a majority are truncating/splice variants and the remaining missense variants are predicted to destabilize the protein (loss-of-function-like). (barbotin2024identificationofa pages 4-6)
+
+**Splicing validation example (2024):** A novel homozygous splice-region variant (**c.1245+6T>C**) was predicted to disrupt splicing by SpliceAI and was experimentally validated by a minigene assay showing a shorter RT-PCR product and cDNA evidence of **exon 12 skipping**. (barbotin2024identificationofa pages 4-6, barbotin2024identificationofa media 5058cfe3)
+
+### 3.2 Phenotypes and quantitative data from human studies
+
+**(i) Human splice variant with detailed semen/flagellar morphology (2021):**
+A homozygous CFAP61 splice-site variant (**c.143+5G>A**) was associated with MMAF, with reported semen parameters and morphology quantification: semen volume **3 mL**, concentration **40 M/mL**, progressive motility **20%**, and flagellar defect proportions including **36% bent**, **18% no tail**, **12% short tail**, **50% irregular shape**, and **30% coiled tail**. (liu2021cfap61isrequired pages 9-12)
+
+**(ii) Multi-family case series with ultrastructure quantification (2022):**
+In 3 Pakistani families (11 infertile men) with recessive truncating CFAP61 variants (**c.451_452del**; **c.847C>T p.R283***), immunofluorescence showed **absence of CFAP61** in sperm tails and a **secondary loss of CFAP251** signal, consistent with CSC disruption. TEM showed severe axonemal disorganization (loss of microtubules, RS, dynein arms, CP defects). Quantitative TEM rates of abnormal cross-sections were reported (averages): midpiece **63.2±28.4% (n=34)**, principal piece **71.9±17.7% (n=218)**, end piece **69.4±21.1% (n=121)**; **misoriented central pair 17.2±13.9% (n=113)**. (ma2022biallelicvariantsin pages 5-7)
+
+**(iii) 2024 clinical report with assisted reproduction outcomes (real-world implementation):**
+The 2024 report provides an example of assisted reproduction management (ICSI). In one cycle: **21** oocytes retrieved, **18** injected, **15** fertilized, **3** blastocysts, **2** usable blastocysts; outcomes included **early pregnancy loss** and **no pregnancy** in subsequent transfer, highlighting variable clinical outcomes even with ICSI. (barbotin2024identificationofa pages 4-6)
+
+### 3.3 Ultrastructural phenotype (visual evidence)
+Transmission electron microscopy images in the 2024 report document axonemal and midpiece abnormalities consistent with MMAF, including disrupted axoneme patterning (e.g., loss of central pair architecture) and midpiece/mitochondrial sheath defects. (barbotin2024identificationofa media 9271260a)
+
+## 4) Recent developments and latest research (prioritizing 2023–2024)
+
+### 4.1 2024: Expansion of pathogenic variant spectrum with functional splicing assays
+The 2024 JARG report expands the mutational spectrum of CFAP61-related MMAF by describing a novel homozygous splicing variant and directly validating its splicing consequence by minigene assay and cDNA sequencing—strengthening clinical variant interpretation practice for CFAP61. (barbotin2024identificationofa pages 4-6, barbotin2024identificationofa media 5058cfe3)
+
+### 4.2 2024: Structural biology placing CFAP61 in RS3 stalk/base models
+The 2024 *Nature Communications* radial spoke structural work provides a mechanistic placement of Cfap61 together with Cfap251/Cfap91 in RS3 stalk/base modeling, connecting genotype-phenotype evidence (MMAF) to a specific axonemal substructure and supporting a CSC-at-RS-base model (with explicit acknowledgement that RS3 modeling needs further validation). (meng2024multiscalestructuresof pages 9-10)
+
+### 4.3 2024: Expert synthesis linking CFAP61 to CSC and late-stage RS assembly
+A 2024 review focused on MMAF summarizes CFAP61 as a **CSC component** and compiles reported CFAP61 variants with associated phenotypes (typical MMAF, motility loss, central pair/RS defects, midpiece malformations), framing CFAP61 within a broader clinical genetics and assisted reproduction context. (zhou2024themolecularbasis pages 8-9, zhou2024themolecularbasis pages 1-2)
+
+## 5) Current applications and real-world implementations
+
+### 5.1 Genetic diagnosis and counseling for male infertility/MMAF
+CFAP61 is a validated gene for **recessive MMAF-associated male infertility**, and the evidence base supports inclusion on MMAF/flagellar gene panels and interpretation of biallelic loss-of-function variants as likely pathogenic when consistent phenotyping (sperm morphology + ultrastructure) is present. (ma2022biallelicvariantsin pages 5-7, barbotin2024identificationofa pages 4-6)
+
+### 5.2 Assisted reproduction (ICSI)
+ICSI is often considered for severe sperm motility/morphology disorders. A 2024 CFAP61 case report documents ICSI cycle metrics and mixed outcomes (early pregnancy loss, then no pregnancy), emphasizing the need for individualized counseling and expectation management. (barbotin2024identificationofa pages 4-6)
+
+## 6) Expert opinions and analysis (authoritative sources)
+
+### 6.1 Strength of gene–disease validity
+The 2024 clinical report explicitly notes that CFAP61 was not included in a 2020 validated monogenic infertility list, but under gene–disease assessment recommendations the CFAP61–MMAF relationship would be considered **strong**, based on multiple unrelated probands, variant types, and functional/model organism evidence. (barbotin2024identificationofa pages 4-6)
+
+### 6.2 Mechanistic consensus
+Across primary genetic studies and expert review synthesis, the mechanistic consensus is that CFAP61 contributes to the integrity/assembly of the sperm axoneme via the CSC/radial spoke system, and that its loss causes ultrastructural breakdown (RS/CP/IDA perturbations) consistent with the profound motility and morphology defects observed clinically. (liu2021cfap61isrequired pages 12-16, zhou2024themolecularbasis pages 8-9)
+
+## 7) Key statistics and data (recent and/or quantitative)
+- Human semen parameters for a CFAP61 splice variant case: **3 mL**, **40 M/mL**, **20%** progressive motility; morphology distribution quantified across defect types (bent/no tail/short/irregular/coiled). (liu2021cfap61isrequired pages 9-12)
+- Human TEM quantitative abnormalities in CFAP61 truncating variant families: abnormal cross-sections midpiece **63.2±28.4%**, principal **71.9±17.7%**, end **69.4±21.1%**; misoriented central pair **17.2±13.9%**. (ma2022biallelicvariantsin pages 5-7)
+- Mouse KO sperm concentration difference (functional model): WT **23.15±1.998** vs KO **4.593±1.760**; KO morphology breakdown includes absent/short/coiled/angulation/irregular caliber percentages, with **0%** normal-flagella sperm in KO. (liu2021cfap61isrequired pages 44-52)
+- 2024 ICSI cycle metrics in a CFAP61 case: **21** retrieved oocytes, **18** injected, **15** fertilized, **3** blastocysts, **2** usable; outcomes included early loss and no pregnancy. (barbotin2024identificationofa pages 4-6)
+
+## 8) Evidence summary table
+The following table consolidates the main human CFAP61 evidence (variants, experimental validation, phenotypes, and mechanistic conclusions).
+
+| Study | Variant(s) reported | Experimental validation | Key phenotype(s) and quantitative data | Main mechanistic conclusion | URL / date |
+|---|---|---|---|---|---|
+| Liu et al., 2021, *bioRxiv* | Homozygous splice-site variant **c.143+5G>A** causing exon 2 skipping/frameshift in human CFAP61 | Exome reanalysis; minigene splicing assay; co-IP/IP-MS; western blot; immunofluorescence; TEM/SEM; CRISPR **Cfap61-/-** mouse validation (liu2021cfap61isrequired pages 9-12, liu2021cfap61isrequired pages 5-9) | Human patient: semen volume **3 mL**, sperm concentration **40 M/mL**, progressive motility **20%**; flagellar defects included **36% bent**, **18% no tail**, **12% short tail**, **50% irregular shape**, **30% coiled tail**. Mouse KO: sperm concentration fell from **23.15±1.998** to **4.593±1.760**; WT normal flagella **81.165±1.895%** vs **0%** in KO; KO absent **12.085±1.852%**, short **31.969±0.654%**, coiled **31.542±1.317%**, angulation **15.833±2.125%**, irregular caliber **8.570±0.940%** (liu2021cfap61isrequired pages 9-12, liu2021cfap61isrequired pages 44-52) | CFAP61 is a conserved **calmodulin- and spoke-associated complex (CSC)** and **radial spoke (RS)** component that interacts with **MAATS1/CFAP91, ARMC4/RSPH8, RSPH3, ROPN1/ROPN1L, RSPH9**, plus dynein/tubulin-associated proteins; required for RS assembly/axoneme stabilization in sperm, with organ specificity favoring flagella over respiratory cilia (liu2021cfap61isrequired pages 9-12, liu2021cfap61isrequired pages 12-16) | https://doi.org/10.1101/2021.03.04.433881 ; Mar 2021 |
+| Ma et al., 2022, *Frontiers in Cell and Developmental Biology* | Homozygous truncating variants **c.451_452del (p.I151Nfs*4)** and **c.847C>T (p.R283*)** in 3 Pakistani families | WES + Sanger segregation; immunofluorescence showing absent CFAP61 and CFAP251 in sperm tails; TEM ultrastructure analysis (ma2022biallelicvariantsin pages 5-7, ma2022biallelicvariantsin pages 1-2, ma2022biallelicvariantsin pages 2-4) | **11 infertile men** with MMAF. TEM cross-sections abnormal: midpiece **63.2±28.4% (n=34)**, principal piece **71.9±17.7% (n=218)**, end piece **69.4±21.1% (n=121)**; misoriented central pair **17.2±13.9% (n=113)**. Severe axonemal disorganization with loss of central pair, RSs, and inner dynein arms; markedly reduced motility/progressive motility in patients (ma2022biallelicvariantsin pages 5-7, ma2022biallelicvariantsin pages 2-4) | Human CFAP61 is essential for normal sperm flagellar ultrastructure and motility; loss of CFAP61 causes secondary loss of **CFAP251**, supporting CFAP61 as a **CSC-associated factor** necessary for RS/axonemal integrity (ma2022biallelicvariantsin pages 5-7, ma2022biallelicvariantsin pages 1-2) | https://doi.org/10.3389/fcell.2021.803818 ; Jan 2022 |
+| Barbotin et al., 2024, *Journal of Assisted Reproduction and Genetics* | Novel homozygous splice variant **c.1245+6T>C**; allele frequency **6.56e-6** (AC=1) | In silico splice prediction (**SpliceAI donor loss 0.83; acceptor loss 0.81**); minigene RT-PCR showing **320 bp WT vs 280 bp mutant**; cDNA Sanger confirming **exon 12 skipping**; TEM; literature-integrated functional interpretation (barbotin2024identificationofa pages 4-6, barbotin2024identificationofa media 5058cfe3) | Patient had classic MMAF with severely disorganized axoneme, abnormal mitochondrial sheath, and cytoplasmic excess; TEM included **9+0 axoneme**, supernumerary doublets, and midpiece/mitochondrial sheath defects. ICSI cycle: **21** oocytes retrieved, **18** injected, **15** fertilized, **3** blastocysts, **2** usable blastocysts; outcomes were **early pregnancy loss** then **no pregnancy** (barbotin2024identificationofa pages 4-6, barbotin2024identificationofa media 9271260a) | Supports CFAP61 as a **CSC component** in ciliated tissues/localized along mature sperm; pathogenic variants often truncate/destabilize CFAP61 and can cause secondary **CFAP251 loss**, reinforcing CSC dysfunction as the disease mechanism (barbotin2024identificationofa pages 4-6) | https://doi.org/10.1007/s10815-024-03139-0 ; May 2024 |
+| Zhou et al., 2024, *Genes* (review) | Expert synthesis of reported CFAP61 variants including **c.143+5G>A**, **c.451_452del**, **c.847C>T**, **c.1654C>T**, **c.2911G>A**, **c.144-2A>G**, **c.1666G>A**, **c.1245+6T>C** | Narrative/review synthesis of human and mouse studies; no new primary experiments (zhou2024themolecularbasis pages 8-9, zhou2024themolecularbasis pages 1-2) | Summarizes CFAP61-associated phenotypes as **typical MMAF**, impaired sperm motility, separated microtubules/ODFs in KO mice, absence of central pair microtubules, RS defects, and midpiece malformation; emphasizes that MMAF is genetically heterogeneous and many patients remain molecularly unresolved (zhou2024themolecularbasis pages 8-9, zhou2024themolecularbasis pages 1-2) | Reviews CFAP61 as a **main component of the CSC** acting in **late RS assembly**; loss disrupts central pair/RS/IDA-linked architecture and is clinically relevant for MMAF genetics and assisted reproduction counseling (zhou2024themolecularbasis pages 8-9, zhou2024themolecularbasis pages 1-2) | https://doi.org/10.3390/genes15101315 ; Oct 2024 |
+
+
+*Table: This table summarizes the core human CFAP61 (Q8NHU2) evidence base across primary studies and a recent expert review, emphasizing pathogenic variants, experimental validation, quantitative phenotypes, and the mechanistic interpretation of CFAP61 as a CSC/radial spoke factor in sperm flagellar biology.*
+
+## 9) Notes on limitations and open questions
+- High-resolution **RS3** placement of CFAP61 is supported by structural fitting in 2024, but the authors explicitly state that the RS3 model requires future validation by a high-resolution structure of mammalian RS3. (meng2024multiscalestructuresof pages 9-10)
+- Evidence from a primary mouse study suggests respiratory cilia may be spared despite severe sperm flagellum defects; however, the extent to which CFAP61 contributes to human airway cilia under all conditions remains incompletely resolved in the provided evidence set. (liu2021cfap61isrequired pages 12-16)
+
+## 10) Key cited sources (URLs and publication dates)
+- Barbotin et al. “Identification of a novel CFAP61 homozygous splicing variant…” *J Assist Reprod Genet* **May 2024**. https://doi.org/10.1007/s10815-024-03139-0 (barbotin2024identificationofa pages 4-6)
+- Zhou et al. “The Molecular Basis of MMAF and Its Impact on Clinical Practice.” *Genes* **Oct 2024**. https://doi.org/10.3390/genes15101315 (zhou2024themolecularbasis pages 8-9, zhou2024themolecularbasis pages 1-2)
+- Ma et al. “Biallelic Variants in CFAP61 Cause MMAF and Male Infertility.” *Frontiers in Cell and Developmental Biology* **Jan 2022**. https://doi.org/10.3389/fcell.2021.803818 (ma2022biallelicvariantsin pages 5-7, ma2022biallelicvariantsin pages 1-2)
+- Liu et al. “CFAP61 is required for sperm flagellum formation and male fertility in human and mouse.” *bioRxiv* **Mar 2021**. https://doi.org/10.1101/2021.03.04.433881 (liu2021cfap61isrequired pages 9-12, liu2021cfap61isrequired pages 12-16)
+- Meng et al. “Multi-scale structures of the mammalian radial spoke…” *Nature Communications* **Jan 2024**. https://doi.org/10.1038/s41467-023-44577-1 (meng2024multiscalestructuresof pages 9-10)
+
+
+References
+
+1. (liu2021cfap61isrequired pages 9-12): Siyu Liu, Jintao Zhang, Zine Eddine Kherraf, Shuya Sun, Xin Zhang, Caroline Cazin, Charles Coutton, Raoudha Zouari, Shuqin Zhao, Fan Hu, Selima Fourati Ben Mustapha, Christophe Arnoult, Pierre F Ray, and Mingxi Liu. Cfap61 is required for sperm flagellum formation and male fertility in human and mouse. BioRxiv, Mar 2021. URL: https://doi.org/10.1101/2021.03.04.433881, doi:10.1101/2021.03.04.433881. This article has 52 citations.
+
+2. (barbotin2024identificationofa pages 4-6): Anne-Laure Barbotin, Angèle Boursier, Anne-Sophie Jourdain, Alexandre Moerman, Baptiste Rabat, Mariam Chehimi, Caroline Thuillier, Jamal Ghoumid, and Thomas Smol. Identification of a novel cfap61 homozygous splicing variant associated with multiple morphological abnormalities of the flagella. Journal of assisted reproduction and genetics, 41:1499-1505, May 2024. URL: https://doi.org/10.1007/s10815-024-03139-0, doi:10.1007/s10815-024-03139-0. This article has 6 citations and is from a peer-reviewed journal.
+
+3. (liu2021cfap61isrequired pages 12-16): Siyu Liu, Jintao Zhang, Zine Eddine Kherraf, Shuya Sun, Xin Zhang, Caroline Cazin, Charles Coutton, Raoudha Zouari, Shuqin Zhao, Fan Hu, Selima Fourati Ben Mustapha, Christophe Arnoult, Pierre F Ray, and Mingxi Liu. Cfap61 is required for sperm flagellum formation and male fertility in human and mouse. BioRxiv, Mar 2021. URL: https://doi.org/10.1101/2021.03.04.433881, doi:10.1101/2021.03.04.433881. This article has 52 citations.
+
+4. (liu2021cfap61isrequired pages 5-9): Siyu Liu, Jintao Zhang, Zine Eddine Kherraf, Shuya Sun, Xin Zhang, Caroline Cazin, Charles Coutton, Raoudha Zouari, Shuqin Zhao, Fan Hu, Selima Fourati Ben Mustapha, Christophe Arnoult, Pierre F Ray, and Mingxi Liu. Cfap61 is required for sperm flagellum formation and male fertility in human and mouse. BioRxiv, Mar 2021. URL: https://doi.org/10.1101/2021.03.04.433881, doi:10.1101/2021.03.04.433881. This article has 52 citations.
+
+5. (ma2022biallelicvariantsin pages 5-7): Ao Ma, Aurang Zeb, Imtiaz Ali, Daren Zhao, Asad Khan, Beibei Zhang, Jianteng Zhou, Ranjha Khan, Huan Zhang, Yuanwei Zhang, Ihsan Khan, Wasim Shah, Haider Ali, Abdul Rafay Javed, Hui Ma, and Qinghua Shi. Biallelic variants in cfap61 cause multiple morphological abnormalities of the flagella and male infertility. Frontiers in Cell and Developmental Biology, Jan 2022. URL: https://doi.org/10.3389/fcell.2021.803818, doi:10.3389/fcell.2021.803818. This article has 29 citations.
+
+6. (zhou2024themolecularbasis pages 8-9): Yujie Zhou, Songyan Yu, and Wenyong Zhang. The molecular basis of multiple morphological abnormalities of sperm flagella and its impact on clinical practice. Genes, 15:1315, Oct 2024. URL: https://doi.org/10.3390/genes15101315, doi:10.3390/genes15101315. This article has 12 citations.
+
+7. (meng2024multiscalestructuresof pages 9-10): Xueming Meng, Cong Xu, Jiawei Li, Benhua Qiu, Jiajun Luo, Qin Hong, Yujie Tong, Chuyu Fang, Yanyan Feng, Rui Ma, Xiangyi Shi, Cheng Lin, Chen Pan, Xueliang Zhu, Xiumin Yan, and Yao Cong. Multi-scale structures of the mammalian radial spoke and divergence of axonemal complexes in ependymal cilia. Nature Communications, 15:1-16, Jan 2024. URL: https://doi.org/10.1038/s41467-023-44577-1, doi:10.1038/s41467-023-44577-1. This article has 30 citations and is from a highest quality peer-reviewed journal.
+
+8. (barbotin2024identificationofa media 5058cfe3): Anne-Laure Barbotin, Angèle Boursier, Anne-Sophie Jourdain, Alexandre Moerman, Baptiste Rabat, Mariam Chehimi, Caroline Thuillier, Jamal Ghoumid, and Thomas Smol. Identification of a novel cfap61 homozygous splicing variant associated with multiple morphological abnormalities of the flagella. Journal of assisted reproduction and genetics, 41:1499-1505, May 2024. URL: https://doi.org/10.1007/s10815-024-03139-0, doi:10.1007/s10815-024-03139-0. This article has 6 citations and is from a peer-reviewed journal.
+
+9. (barbotin2024identificationofa media 9271260a): Anne-Laure Barbotin, Angèle Boursier, Anne-Sophie Jourdain, Alexandre Moerman, Baptiste Rabat, Mariam Chehimi, Caroline Thuillier, Jamal Ghoumid, and Thomas Smol. Identification of a novel cfap61 homozygous splicing variant associated with multiple morphological abnormalities of the flagella. Journal of assisted reproduction and genetics, 41:1499-1505, May 2024. URL: https://doi.org/10.1007/s10815-024-03139-0, doi:10.1007/s10815-024-03139-0. This article has 6 citations and is from a peer-reviewed journal.
+
+10. (zhou2024themolecularbasis pages 1-2): Yujie Zhou, Songyan Yu, and Wenyong Zhang. The molecular basis of multiple morphological abnormalities of sperm flagella and its impact on clinical practice. Genes, 15:1315, Oct 2024. URL: https://doi.org/10.3390/genes15101315, doi:10.3390/genes15101315. This article has 12 citations.
+
+11. (liu2021cfap61isrequired pages 44-52): Siyu Liu, Jintao Zhang, Zine Eddine Kherraf, Shuya Sun, Xin Zhang, Caroline Cazin, Charles Coutton, Raoudha Zouari, Shuqin Zhao, Fan Hu, Selima Fourati Ben Mustapha, Christophe Arnoult, Pierre F Ray, and Mingxi Liu. Cfap61 is required for sperm flagellum formation and male fertility in human and mouse. BioRxiv, Mar 2021. URL: https://doi.org/10.1101/2021.03.04.433881, doi:10.1101/2021.03.04.433881. This article has 52 citations.
+
+12. (ma2022biallelicvariantsin pages 1-2): Ao Ma, Aurang Zeb, Imtiaz Ali, Daren Zhao, Asad Khan, Beibei Zhang, Jianteng Zhou, Ranjha Khan, Huan Zhang, Yuanwei Zhang, Ihsan Khan, Wasim Shah, Haider Ali, Abdul Rafay Javed, Hui Ma, and Qinghua Shi. Biallelic variants in cfap61 cause multiple morphological abnormalities of the flagella and male infertility. Frontiers in Cell and Developmental Biology, Jan 2022. URL: https://doi.org/10.3389/fcell.2021.803818, doi:10.3389/fcell.2021.803818. This article has 29 citations.
+
+13. (ma2022biallelicvariantsin pages 2-4): Ao Ma, Aurang Zeb, Imtiaz Ali, Daren Zhao, Asad Khan, Beibei Zhang, Jianteng Zhou, Ranjha Khan, Huan Zhang, Yuanwei Zhang, Ihsan Khan, Wasim Shah, Haider Ali, Abdul Rafay Javed, Hui Ma, and Qinghua Shi. Biallelic variants in cfap61 cause multiple morphological abnormalities of the flagella and male infertility. Frontiers in Cell and Developmental Biology, Jan 2022. URL: https://doi.org/10.3389/fcell.2021.803818, doi:10.3389/fcell.2021.803818. This article has 29 citations.
+
+## Citations
+
+1. meng2024multiscalestructuresof pages 9-10
+2. barbotin2024identificationofa pages 4-6
+3. ma2022biallelicvariantsin pages 5-7
+4. zhou2024themolecularbasis pages 8-9
+5. zhou2024themolecularbasis pages 1-2
+6. ma2022biallelicvariantsin pages 1-2
+7. ma2022biallelicvariantsin pages 2-4
+8. https://doi.org/10.1101/2021.03.04.433881
+9. https://doi.org/10.3389/fcell.2021.803818
+10. https://doi.org/10.1007/s10815-024-03139-0
+11. https://doi.org/10.3390/genes15101315
+12. https://doi.org/10.1038/s41467-023-44577-1
+13. https://doi.org/10.1101/2021.03.04.433881,
+14. https://doi.org/10.1007/s10815-024-03139-0,
+15. https://doi.org/10.3389/fcell.2021.803818,
+16. https://doi.org/10.3390/genes15101315,
+17. https://doi.org/10.1038/s41467-023-44577-1,

--- a/genes/human/CHCHD4/CHCHD4-ai-review.html
+++ b/genes/human/CHCHD4/CHCHD4-ai-review.html
@@ -1,0 +1,4203 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CHCHD4 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>CHCHD4</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q8N4Q1" target="_blank" class="term-link">
+                        Q8N4Q1
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-initialized">
+                    INITIALIZED
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "CHCHD4";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q8N4Q1" data-a="DESCRIPTION: Mitochondrial oxidoreductase (human ortholog of ye..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>Mitochondrial oxidoreductase (human ortholog of yeast Mia40) that operates in the disulfide relay system of the intermembrane space (IMS). CHCHD4 introduces disulfide bonds into IMS-destined proteins bearing twin CX3C or CX9C motifs, trapping them in the IMS after translocation through the TOM complex. Uses a CPC active-site motif to form transient intermolecular disulfides with substrates. Is re-oxidized by GFER (ALR/Erv1). Also required for respiratory chain complex assembly through import of IMS assembly factors, and interacts with AIFM1 (AIF).</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045041" target="_blank" class="term-link">
+                                    GO:0045041
+                                </a>
+                            </span>
+                            <span class="term-label">protein import into mitochondrial intermembrane space</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8N4Q1" data-a="GO:0045041" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> CHCHD4 is the central oxidoreductase of the MIA pathway that drives import of CX3C/CX9C proteins into the IMS. Core BP annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/CHCHD4/CHCHD4-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The mitochondrial IMS contains a dedicated protein import route in which import is coupled to oxidative folding, commonly termed the mitochondrial intermembrane space import and assembly pathway or disulfide relay system.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051604" target="_blank" class="term-link">
+                                    GO:0051604
+                                </a>
+                            </span>
+                            <span class="term-label">protein maturation</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q8N4Q1" data-a="GO:0051604" data-r="GO_REF:0000033" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> CHCHD4 catalyzes oxidative folding (disulfide bond introduction) of IMS substrates, which is a form of protein maturation. However this is very generic. The more specific disulfide relay system term is more informative.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Too generic; the specific disulfide relay system annotation is more informative.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005758" target="_blank" class="term-link">
+                                    GO:0005758
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial intermembrane space</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8N4Q1" data-a="GO:0005758" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> CHCHD4 is a soluble IMS protein. Confirmed experimentally in human cells (PMID:16185709, PMID:23676665). Core CC annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/CHCHD4/CHCHD4-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">CHCHD4 is localized to the mitochondrial intermembrane space.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015035" target="_blank" class="term-link">
+                                    GO:0015035
+                                </a>
+                            </span>
+                            <span class="term-label">protein-disulfide reductase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="Q8N4Q1" data-a="GO:0015035" data-r="GO_REF:0000033" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> CHCHD4/Mia40 is an oxidoreductase with a CPC active site that catalyzes disulfide bond formation in substrates. The term protein-disulfide reductase describes the reverse reaction. CHCHD4 actually functions as an oxidase (introduces disulfides) not a reductase. However, the active site cycles between oxidized and reduced states. The IBA annotation follows yeast Mia40.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> CHCHD4 primarily acts as a disulfide oxidase/isomerase, introducing disulfide bonds into substrates. Disulfide reductase describes the reverse.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015036" target="_blank" class="term-link">
+                                    disulfide oxidoreductase activity
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/CHCHD4/CHCHD4-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">CHCHD4 is defined as the IMS-localized oxidoreductase/import receptor that forms a transient intermolecular disulfide with substrates via its CPC motif.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q8N4Q1" data-a="GO:0005739" data-r="GO_REF:0000117" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Too general — CHCHD4 specifically localizes to the IMS.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Subsumed by mitochondrial intermembrane space annotation.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005758" target="_blank" class="term-link">
+                                    GO:0005758
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial intermembrane space</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8N4Q1" data-a="GO:0005758" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct. Redundant with IBA and experimental evidence for same term.
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015035" target="_blank" class="term-link">
+                                    GO:0015035
+                                </a>
+                            </span>
+                            <span class="term-label">protein-disulfide reductase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="Q8N4Q1" data-a="GO:0015035" data-r="GO_REF:0000002" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Same concern as IBA — CHCHD4 is primarily an oxidase, not a reductase.
+                        </div>
+
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015036" target="_blank" class="term-link">
+                                    disulfide oxidoreductase activity
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0033108" target="_blank" class="term-link">
+                                    GO:0033108
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial respiratory chain complex assembly</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q8N4Q1" data-a="GO:0033108" data-r="GO_REF:0000117" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> CHCHD4 imports IMS assembly factors (e.g., NDUFB10, COA7) required for respiratory chain complexes. This is a downstream consequence of its import function, not its primary activity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Secondary effect of CHCHD4 import function, not its direct activity.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045041" target="_blank" class="term-link">
+                                    GO:0045041
+                                </a>
+                            </span>
+                            <span class="term-label">protein import into mitochondrial intermembrane space</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8N4Q1" data-a="GO:0045041" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct. Redundant with IBA for same term.
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26387864" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:26387864
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The Ca(2+)-Dependent Release of the Mia40-Induced MICU1-MICU...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="Q8N4Q1" data-a="GO:0005515" data-r="PMID:26387864" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Petrungaro et al. 2015 showed Mia40-dependent release of MICU1-MICU2 dimer from MCU. Protein binding is uninformative per guidelines.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Protein binding is uninformative. The MICU1/MICU2 interaction reflects CHCHD4 substrate oxidative folding function.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000052
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q8N4Q1" data-a="GO:0005739" data-r="GO_REF:0000052" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Too general — IMS localization is well-established and more specific.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Subsumed by mitochondrial intermembrane space annotation.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0160203" target="_blank" class="term-link">
+                                    GO:0160203
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial disulfide relay system</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16185709" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16185709
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Functional and mutational characterization of human MIA40 ac...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8N4Q1" data-a="GO:0160203" data-r="PMID:16185709" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Hofmann et al. 2005 showed that human MIA40 depletion specifically reduced levels of small IMS proteins (DDP1, TIM10A), demonstrating its role in the disulfide relay system. Core BP annotation.
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015035" target="_blank" class="term-link">
+                                    GO:0015035
+                                </a>
+                            </span>
+                            <span class="term-label">protein-disulfide reductase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/23676665" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:23676665
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Protein import and oxidative folding in the mitochondrial in...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="Q8N4Q1" data-a="GO:0015035" data-r="PMID:23676665" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Fischer et al. 2013 confirmed oxidative folding activity in intact mammalian cells. Same concern about reductase vs oxidase terminology.
+                        </div>
+
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015036" target="_blank" class="term-link">
+                                    disulfide oxidoreductase activity
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0160203" target="_blank" class="term-link">
+                                    GO:0160203
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial disulfide relay system</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/21059946" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:21059946
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Molecular chaperone function of Mia40 triggers consecutive i...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8N4Q1" data-a="GO:0160203" data-r="PMID:21059946" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Stojanovski et al. 2010 showed Mia40 triggers consecutive induced folding steps during import. Core BP annotation.
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0160203" target="_blank" class="term-link">
+                                    GO:0160203
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial disulfide relay system</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/23676665" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:23676665
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Protein import and oxidative folding in the mitochondrial in...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8N4Q1" data-a="GO:0160203" data-r="PMID:23676665" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Fischer et al. 2013 confirmed the disulfide relay operates in intact mammalian cells. Core BP annotation.
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0160203" target="_blank" class="term-link">
+                                    GO:0160203
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial disulfide relay system</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/37159021" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:37159021
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A two-step mitochondrial import pathway couples the disulfid...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8N4Q1" data-a="GO:0160203" data-r="PMID:37159021" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Habich et al. 2023 described a two-step import pathway coupling the disulfide relay with matrix complex I biogenesis. Core BP annotation.
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HTP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:34800366
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Quantitative high-confidence human mitochondrial proteome an...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q8N4Q1" data-a="GO:0005739" data-r="PMID:34800366" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> HTP proteome confirms mitochondrial localization. Too general.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Subsumed by mitochondrial intermembrane space annotation.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005758" target="_blank" class="term-link">
+                                    GO:0005758
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial intermembrane space</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/37159021" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:37159021
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A two-step mitochondrial import pathway couples the disulfid...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8N4Q1" data-a="GO:0005758" data-r="PMID:37159021" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Habich et al. 2023 confirmed IMS localization in two-step import study.
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015035" target="_blank" class="term-link">
+                                    GO:0015035
+                                </a>
+                            </span>
+                            <span class="term-label">protein-disulfide reductase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/37159021" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:37159021
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A two-step mitochondrial import pathway couples the disulfid...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="Q8N4Q1" data-a="GO:0015035" data-r="PMID:37159021" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Same concern about reductase vs oxidase terminology.
+                        </div>
+
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015036" target="_blank" class="term-link">
+                                    disulfide oxidoreductase activity
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005758" target="_blank" class="term-link">
+                                    GO:0005758
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial intermembrane space</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/23676665" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:23676665
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Protein import and oxidative folding in the mitochondrial in...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8N4Q1" data-a="GO:0005758" data-r="PMID:23676665" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Fischer et al. 2013 directly demonstrated CHCHD4 in the IMS of intact mammalian cells. Core CC.
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28040730" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28040730
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mutations in the accessory subunit NDUFB10 result in isolate...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="Q8N4Q1" data-a="GO:0005515" data-r="PMID:28040730" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Friederich et al. 2017 showed NDUFB10 mutations affect CHCHD4-dependent import. Protein binding is uninformative.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Protein binding uninformative. NDUFB10 is a CHCHD4 substrate.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26004228" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:26004228
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Interaction between AIF and CHCHD4 Regulates Respiratory Cha...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="Q8N4Q1" data-a="GO:0005515" data-r="PMID:26004228" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Hangen et al. 2015 showed AIF-CHCHD4 interaction regulates respiratory chain biogenesis. Protein binding is uninformative.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Protein binding uninformative. AIF interaction is better captured by respiratory chain complex assembly annotation.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005758" target="_blank" class="term-link">
+                                    GO:0005758
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial intermembrane space</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26004228" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:26004228
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Interaction between AIF and CHCHD4 Regulates Respiratory Cha...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8N4Q1" data-a="GO:0005758" data-r="PMID:26004228" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Hangen et al. confirmed IMS localization by immunofluorescence.
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0033108" target="_blank" class="term-link">
+                                    GO:0033108
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial respiratory chain complex assembly</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26004228" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:26004228
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Interaction between AIF and CHCHD4 Regulates Respiratory Cha...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q8N4Q1" data-a="GO:0033108" data-r="PMID:26004228" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Hangen et al. 2015 showed AIF-CHCHD4 interaction required for respiratory chain biogenesis. This is a downstream consequence of CHCHD4 import function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Downstream of CHCHD4 core import/oxidative folding function.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/30885959" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:30885959
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Inhibition of proteasome rescues a pathogenic variant of res...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="Q8N4Q1" data-a="GO:0005515" data-r="PMID:30885959" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Mohanraj et al. 2019 showed COA7 is a CHCHD4 substrate rescued by proteasome inhibition. Protein binding is uninformative.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Protein binding uninformative. COA7 is a CHCHD4 import substrate.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/23676665" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:23676665
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Protein import and oxidative folding in the mitochondrial in...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="Q8N4Q1" data-a="GO:0005515" data-r="PMID:23676665" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Fischer et al. 2013 studied CHCHD4 substrate interactions in intact cells. Protein binding is uninformative.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Protein binding uninformative. Reflects transient enzyme-substrate disulfide intermediates.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/23676665" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:23676665
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Protein import and oxidative folding in the mitochondrial in...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q8N4Q1" data-a="GO:0005739" data-r="PMID:23676665" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Too general — IMS is more specific and well-supported.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Subsumed by mitochondrial intermembrane space annotation.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015035" target="_blank" class="term-link">
+                                    GO:0015035
+                                </a>
+                            </span>
+                            <span class="term-label">protein-disulfide reductase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26387864" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:26387864
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The Ca(2+)-Dependent Release of the Mia40-Induced MICU1-MICU...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="Q8N4Q1" data-a="GO:0015035" data-r="PMID:26387864" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Petrungaro et al. 2015 showed CHCHD4 oxidoreductase activity on MICU1-MICU2 substrates. Same terminology concern.
+                        </div>
+
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015036" target="_blank" class="term-link">
+                                    disulfide oxidoreductase activity
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/24101517" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:24101517
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mitochondrial disulfide relay mediates translocation of p53 ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q8N4Q1" data-a="GO:0005739" data-r="PMID:24101517" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Zhuang et al. 2013 showed CHCHD4 mediates p53 translocation to mitochondria. Too general CC term.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Subsumed by mitochondrial intermembrane space annotation.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005758" target="_blank" class="term-link">
+                                    GO:0005758
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial intermembrane space</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16185709" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16185709
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Functional and mutational characterization of human MIA40 ac...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8N4Q1" data-a="GO:0005758" data-r="PMID:16185709" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Hofmann et al. 2005 directly showed human MIA40 forms soluble complexes in the IMS. Foundational evidence for IMS localization.
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015035" target="_blank" class="term-link">
+                                    GO:0015035
+                                </a>
+                            </span>
+                            <span class="term-label">protein-disulfide reductase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19182799" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19182799
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    MIA40 is an oxidoreductase that catalyzes oxidative protein ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="Q8N4Q1" data-a="GO:0015035" data-r="PMID:19182799" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Banci et al. 2009 determined MIA40 solution structure and demonstrated it is an oxidoreductase with a CPC active site. Landmark paper establishing the enzymatic mechanism. Same terminology concern about reductase vs oxidase.
+                        </div>
+
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015036" target="_blank" class="term-link">
+                                    disulfide oxidoreductase activity
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>CHCHD4 (human Mia40) is the central oxidoreductase of the mitochondrial disulfide relay system in the intermembrane space. It uses a CPC active-site motif to form transient intermolecular disulfide bonds with IMS-destined substrates bearing twin CX3C or CX9C motifs, catalyzing their oxidative folding and trapping them in the IMS. CHCHD4 is re-oxidized by GFER (Erv1/ALR), completing the relay. Substrates include small Tim chaperones, Cox17, CHCHD2/10, MICU1/2, NDUFB10, and COA7.</h3>
+                <span class="vote-buttons" data-g="Q8N4Q1" data-a="FUNCTION: CHCHD4 (human Mia40) is the central oxidoreductase..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015036" target="_blank" class="term-link">
+                            disulfide oxidoreductase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0160203" target="_blank" class="term-link">
+                                mitochondrial disulfide relay system
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045041" target="_blank" class="term-link">
+                                protein import into mitochondrial intermembrane space
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005758" target="_blank" class="term-link">
+                                mitochondrial intermembrane space
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19182799" target="_blank" class="term-link">
+                                PMID:19182799
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">MIA40 has a key role in oxidative protein folding in the mitochondrial intermembrane space. We present the solution structure of human MIA40 and its mechanism as a catalyst of oxidative folding.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16185709" target="_blank" class="term-link">
+                                PMID:16185709
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Depletion of MIA40 in human cells by RNA interference specifically affected steady-state levels of small and cysteine-containing intermembrane space proteins like DDP1 and TIM10A.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/23676665" target="_blank" class="term-link">
+                                PMID:23676665
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Oxidation of cysteine residues to disulfides drives import of many proteins into the intermembrane space of mitochondria.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/CHCHD4/CHCHD4-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">Mechanistically, substrates interact with CHCHD4 through a sliding-docking model followed by transient disulfide formation and substrate oxidative folding.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000052.md" target="_blank" class="term-link">
+                            GO_REF:0000052
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on curation of immunofluorescence data</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
+                            GO_REF:0000117
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/16185709" target="_blank" class="term-link">
+                            PMID:16185709
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Functional and mutational characterization of human MIA40 acting during import into the mitochondrial intermembrane space.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/19182799" target="_blank" class="term-link">
+                            PMID:19182799
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">MIA40 is an oxidoreductase that catalyzes oxidative protein folding in mitochondria.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/21059946" target="_blank" class="term-link">
+                            PMID:21059946
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Molecular chaperone function of Mia40 triggers consecutive induced folding steps of the substrate in mitochondrial protein import.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/23676665" target="_blank" class="term-link">
+                            PMID:23676665
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Protein import and oxidative folding in the mitochondrial intermembrane space of intact mammalian cells.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/24101517" target="_blank" class="term-link">
+                            PMID:24101517
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Mitochondrial disulfide relay mediates translocation of p53 and partitions its subcellular activity.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/26004228" target="_blank" class="term-link">
+                            PMID:26004228
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Interaction between AIF and CHCHD4 Regulates Respiratory Chain Biogenesis.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/26387864" target="_blank" class="term-link">
+                            PMID:26387864
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The Ca(2+)-Dependent Release of the Mia40-Induced MICU1-MICU2 Dimer from MCU Regulates Mitochondrial Ca(2+) Uptake.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/28040730" target="_blank" class="term-link">
+                            PMID:28040730
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Mutations in the accessory subunit NDUFB10 result in isolated complex I deficiency and illustrate the critical role of intermembrane space import for complex I holoenzyme assembly.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/30885959" target="_blank" class="term-link">
+                            PMID:30885959
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Inhibition of proteasome rescues a pathogenic variant of respiratory chain assembly factor COA7.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link">
+                            PMID:34800366
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Quantitative high-confidence human mitochondrial proteome and its dynamics in cellular context.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/37159021" target="_blank" class="term-link">
+                            PMID:37159021
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A two-step mitochondrial import pathway couples the disulfide relay with matrix complex I biogenesis.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/CHCHD4/CHCHD4-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research report for CHCHD4</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Falcon research supports CHCHD4/MIA40 as the central mitochondrial intermembrane-space oxidoreductase/import receptor for the MIA disulfide relay.</div>
+
+                        <div class="finding-text">"CHCHD4 is defined as the IMS-localized oxidoreductase/import receptor that recognizes IMS-targeting signals in substrates, forms a transient intermolecular disulfide with substrates via its CPC motif, and catalyzes formation of intramolecular disulfides."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Deep Research Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(CHCHD4-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q8N4Q1" data-a="DOC: Deep Research Falcon" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <hr />
+<p>provider: falcon<br />
+model: Edison Scientific Literature<br />
+cached: false<br />
+start_time: '2026-05-10T20:19:10.257736'<br />
+end_time: '2026-05-10T20:27:27.929928'<br />
+duration_seconds: 497.67<br />
+template_file: templates/gene_research_go_focused.md<br />
+template_variables:<br />
+  organism: human<br />
+  gene_id: CHCHD4<br />
+  gene_symbol: CHCHD4<br />
+  uniprot_accession: Q8N4Q1<br />
+  protein_description: 'RecName: Full=Mitochondrial intermembrane space import and<br />
+    assembly protein 40; AltName: Full=Coiled-coil-helix-coiled-coil-helix domain-containing<br />
+    protein 4;'<br />
+  gene_info: Name=CHCHD4; Synonyms=MIA40;<br />
+  organism_full: Homo sapiens (Human).<br />
+  protein_family: Not specified in UniProt<br />
+  protein_domains: CHCH. (IPR010625); CHCHD4. (IPR039289); CHCH (PF06747)<br />
+provider_config:<br />
+  timeout: 600<br />
+  max_retries: 3<br />
+  parameters:<br />
+    allowed_domains: []<br />
+    temperature: 0.1<br />
+citation_count: 19</p>
+<hr />
+<h2 id="question">Question</h2>
+<h1 id="gene-research-for-functional-annotation">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> Q8N4Q1</li>
+<li><strong>Protein Description:</strong> RecName: Full=Mitochondrial intermembrane space import and assembly protein 40; AltName: Full=Coiled-coil-helix-coiled-coil-helix domain-containing protein 4;</li>
+<li><strong>Gene Information:</strong> Name=CHCHD4; Synonyms=MIA40;</li>
+<li><strong>Organism (full):</strong> Homo sapiens (Human).</li>
+<li><strong>Protein Family:</strong> Not specified in UniProt</li>
+<li><strong>Key Domains:</strong> CHCH. (IPR010625); CHCHD4. (IPR039289); CHCH (PF06747)</li>
+</ul>
+<h3 id="mandatory-verification-steps">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "CHCHD4" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Homo sapiens (Human).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'CHCHD4' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>CHCHD4</strong> (gene ID: CHCHD4, UniProt: Q8N4Q1) in human.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="output">Output</h2>
+<p>Question: You are an expert researcher providing comprehensive, well-cited information.</p>
+<p>Provide detailed information focusing on:<br />
+1. Key concepts and definitions with current understanding<br />
+2. Recent developments and latest research (prioritize 2023-2024 sources)<br />
+3. Current applications and real-world implementations<br />
+4. Expert opinions and analysis from authoritative sources<br />
+5. Relevant statistics and data from recent studies</p>
+<p>Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.<br />
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.</p>
+<h1 id="gene-research-for-functional-annotation_1">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context_1">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot_1">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> Q8N4Q1</li>
+<li><strong>Protein Description:</strong> RecName: Full=Mitochondrial intermembrane space import and assembly protein 40; AltName: Full=Coiled-coil-helix-coiled-coil-helix domain-containing protein 4;</li>
+<li><strong>Gene Information:</strong> Name=CHCHD4; Synonyms=MIA40;</li>
+<li><strong>Organism (full):</strong> Homo sapiens (Human).</li>
+<li><strong>Protein Family:</strong> Not specified in UniProt</li>
+<li><strong>Key Domains:</strong> CHCH. (IPR010625); CHCHD4. (IPR039289); CHCH (PF06747)</li>
+</ul>
+<h3 id="mandatory-verification-steps_1">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "CHCHD4" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Homo sapiens (Human).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature_1">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'CHCHD4' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target_1">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>CHCHD4</strong> (gene ID: CHCHD4, UniProt: Q8N4Q1) in human.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="comprehensive-research-report-human-chchd4-mia40-uniprot-q8n4q1">Comprehensive Research Report: Human <strong>CHCHD4 (MIA40)</strong> (UniProt Q8N4Q1)</h1>
+<h2 id="0-target-verification-mandatory">0) Target verification (mandatory)</h2>
+<p>The research target is <strong>human CHCHD4</strong>, also known as <strong>MIA40</strong>, encoding “mitochondrial intermembrane space import and assembly protein 40.” Multiple authoritative reviews identify <strong>CHCHD4/MIA40</strong> as the central oxidoreductase of the mitochondrial intermembrane space (IMS) <strong>disulfide relay / MIA pathway</strong>, with characteristic <strong>CPC</strong> redox motif and <strong>twin CX9C</strong> motifs in a CHCH fold, confirming concordance with UniProt Q8N4Q1 and the CHCH domain context provided. (alhabib2021chchd4(mia40)and pages 2-4, alhabib2021chchd4(mia40)and pages 1-2, modjtahedi2016mitochondrialproteinscontaining pages 3-5)</p>
+<h2 id="1-key-concepts-and-current-definitions">1) Key concepts and current definitions</h2>
+<h3 id="11-the-mitochondrial-ims-disulfide-relay-miadrs">1.1 The mitochondrial IMS disulfide relay (MIA/DRS)</h3>
+<p>The mitochondrial IMS contains a dedicated protein import route in which import is <strong>coupled to oxidative folding</strong>: cysteine-containing precursors enter through TOM and are trapped in the IMS after CHCHD4-catalyzed disulfide formation, a process commonly termed the <strong>mitochondrial intermembrane space import and assembly (MIA) pathway</strong> or <strong>disulfide relay system (DRS)</strong>. (alhabib2021chchd4(mia40)and pages 2-4, dicksonmurray2021themia40chchd4oxidative pages 4-5)</p>
+<h3 id="12-chchd4mia40functional-definition">1.2 CHCHD4/MIA40—functional definition</h3>
+<p>CHCHD4 is defined as the IMS-localized <strong>oxidoreductase/import receptor</strong> that (i) recognizes IMS-targeting signals in substrates, (ii) forms a transient intermolecular disulfide with substrates via its CPC motif, and (iii) catalyzes formation of intramolecular disulfides that stabilize folded IMS proteins. (alhabib2021chchd4(mia40)and pages 1-2, dicksonmurray2021themia40chchd4oxidative pages 4-5)</p>
+<h3 id="13-chch-domains-and-substrate-motifs">1.3 CHCH domains and substrate motifs</h3>
+<p>A major client class comprises small IMS proteins bearing paired cysteine motifs such as <strong>(CX9C)2</strong> and <strong>(CX3C)2</strong> (CHCH-type motifs), which frequently become disulfide-bonded upon import and folding; canonical examples include <strong>COX17</strong>, <strong>COX19</strong>, and <strong>TRIAP1</strong>. (modjtahedi2016mitochondrialproteinscontaining pages 2-3, alhabib2021chchd4(mia40)and pages 1-2)</p>
+<h2 id="2-protein-features-domains-localization-and-mechanism">2) Protein features: domains, localization, and mechanism</h2>
+<h3 id="21-domain-architecture-and-key-motifs">2.1 Domain architecture and key motifs</h3>
+<p>CHCHD4 is a ~16 kDa protein with a redox-active <strong>CPC</strong> motif and structural <strong>twin CX9C</strong> motifs forming a helix–loop–helix CHCH fold stabilized by disulfides; the catalytic cysteine within CPC (noted as <strong>Cys55</strong> in a recent synthesis) is the nucleophilic cysteine that engages substrates transiently. (balasco2025chchd4oxidoreductaseactivity pages 14-15, dicksonmurray2021themia40chchd4oxidative pages 4-5)</p>
+<h3 id="22-subcellular-localization-and-import-route">2.2 Subcellular localization and import route</h3>
+<p>CHCHD4 is localized to the <strong>mitochondrial intermembrane space</strong> and, unlike yeast Mia40, is described as lacking a classical N-terminal targeting presequence; its import/localization is linked to interaction with the inner-membrane-associated flavoprotein <strong>AIF</strong> (apoptosis-inducing factor), with NADH reported to enhance the CHCHD4–AIF interaction. (modjtahedi2016mitochondrialproteinscontaining pages 3-5, balasco2025chchd4oxidoreductaseactivity pages 4-5)</p>
+<h3 id="23-core-biochemical-function-oxidative-folding-coupled-to-import">2.3 Core biochemical function: oxidative folding coupled to import</h3>
+<p>Mechanistically, substrates interact with CHCHD4 through a “<strong>sliding–docking</strong>” model: substrates bearing an IMS-targeting signal (ITS/MISS) first bind noncovalently to a hydrophobic cleft on CHCHD4, followed by formation of a <strong>transient intermolecular disulfide</strong> between CHCHD4’s CPC motif and a substrate cysteine; subsequent thiol–disulfide exchange yields an <strong>intramolecular substrate disulfide</strong>, resulting in oxidative folding and IMS retention (“trapping”). (dicksonmurray2021themia40chchd4oxidative pages 4-5, alhabib2021chchd4(mia40)and pages 1-2)</p>
+<h3 id="24-reoxidation-of-chchd4-alrgfer-and-terminal-electron-acceptors">2.4 Reoxidation of CHCHD4: ALR/GFER and terminal electron acceptors</h3>
+<p>Reduced CHCHD4 is reoxidized by <strong>ALR/GFER</strong> (mammalian homolog of yeast Erv1), an FAD-dependent sulfhydryl oxidase. Electron transfer downstream is described as proceeding preferentially to <strong>cytochrome c/complex IV</strong>, with an alternative branch to <strong>O2</strong> that can generate <strong>H2O2</strong>, linking the pathway to respiratory-chain redox and reactive oxygen species biology. (alhabib2021chchd4(mia40)and pages 2-4, dicksonmurray2021themia40chchd4oxidative pages 4-5)</p>
+<h2 id="3-substrates-and-substrate-recognition">3) Substrates and substrate recognition</h2>
+<h3 id="31-recognition-logic-itsmiss-cysteine-chemistry">3.1 Recognition logic (ITS/MISS + cysteine chemistry)</h3>
+<p>Substrate selection is described as relying on both (i) noncovalent interactions with an ITS/MISS (often an amphipathic helix) and (ii) covalent chemistry via transient disulfide formation with the CPC motif, rather than cysteine content alone. (alhabib2021chchd4(mia40)and pages 2-4, dicksonmurray2021themia40chchd4oxidative pages 4-5)</p>
+<h3 id="32-representative-substrates-and-functional-implications">3.2 Representative substrates and functional implications</h3>
+<p>Reviews compile many CHCHD4 substrates as IMS factors impacting respiratory chain assembly and mitochondrial function, including proteins with (CX9C)2 motifs (e.g., <strong>COX17</strong>, <strong>CHCHD2</strong>, assembly factors such as <strong>CMC1/CMC2</strong> and <strong>COA4–6</strong>) and (CX3C)2 motifs (e.g., <strong>TRIAP1</strong>). These substrate classes connect CHCHD4 activity to respiratory complex biogenesis, mitochondrial ultrastructure, and signaling. (modjtahedi2016mitochondrialproteinscontaining pages 2-3, modjtahedi2016mitochondrialproteinscontaining pages 3-5)</p>
+<p>A concrete example is <strong>COX17</strong>, described as a small (67 aa) (CX9C…CX9C) protein and a validated CHCHD4 substrate in a substrate-focused synthesis. (balasco2025chchd4oxidoreductaseactivity pages 5-8)</p>
+<h2 id="4-recent-developments-prioritizing-20232024">4) Recent developments (prioritizing 2023–2024)</h2>
+<h3 id="41-2024-chchd4triap1-axis-links-mitochondrial-import-to-innate-immunity-and-exercise-adaptation">4.1 2024: CHCHD4–TRIAP1 axis links mitochondrial import to innate immunity and exercise adaptation</h3>
+<p>A 2024 Cell Reports study reports that <strong>exercise training downregulates CHCHD4</strong> in skeletal muscle, reducing mitochondrial import of <strong>TRIAP1</strong>. In their model, reduced TRIAP1 is linked to decreased cardiolipin, increased <strong>VDAC oligomerization</strong>, and <strong>mtDNA release</strong>, which activates <strong>cGAS–STING</strong> and canonical <strong>NFKB</strong> signaling. This signaling is connected to muscle fiber adaptation (slow-twitch/type I shift) and metabolic outcomes. (ma2024chchd4triap1regulationof pages 1-3, ma2024chchd4triap1regulationof pages 10-11)</p>
+<p><strong>Quantitative outcomes</strong> reported in the same work include improved treadmill performance in <strong>CHCHD4+/−</strong> mice relative to WT (68% vs 58% improvement) and reduced blood lactate increases following submaximal exercise (37% vs 90%), alongside age-associated body composition differences (less fat accumulation). (ma2024chchd4triap1regulationof pages 10-11)</p>
+<p>A key visual summary of this pathway is provided in <strong>Figure 7F</strong> (schematic) with supporting data in Figure 7A–E. (ma2024chchd4triap1regulationof media f1db45ec)</p>
+<h3 id="42-2023-mitochondrial-import-machinery-as-a-stress-signaling-hub-context-for-chchd4">4.2 2023: mitochondrial import machinery as a stress-signaling hub (context for CHCHD4)</h3>
+<p>A 2023 review frames mitochondrial protein import systems, including the MIA pathway where Mia40 is CHCHD4 in humans, as a broader <strong>cellular signaling hub</strong> that integrates proteostasis and metabolic stress responses—context relevant when interpreting CHCHD4-regulated signaling axes such as the 2024 exercise/innate immunity pathway. (balasco2025chchd4oxidoreductaseactivity pages 5-8)</p>
+<h3 id="43-2024-chemical-biologysmall-molecule-modulation-of-the-chchd4-reoxidation-step">4.3 2024: chemical biology—small-molecule modulation of the CHCHD4 reoxidation step</h3>
+<p>A 2024 study characterizing a “MitoBlock” small-molecule library reports that compounds targeting <strong>ALR</strong> can alter MIA pathway dynamics; mechanistic studies show that one compound (MB-6) can lock a precursor in a CHCHD4-bound state by blocking reoxidation of CHCHD4 by ALR, providing a set of probes useful for mechanistic interrogation of the redox-regulated import pathway in model systems. (muzzioli2024theinteractionand pages 1-2)</p>
+<h2 id="5-current-applications-and-real-world-implementations">5) Current applications and real-world implementations</h2>
+<h3 id="51-chemical-probes-to-dissect-import-chemistry-and-redox-coupling">5.1 Chemical probes to dissect import chemistry and redox coupling</h3>
+<p>The ALR-targeting “MitoBlock” compounds are an example of a current, real-world implementation of CHCHD4-pathway knowledge: they are used as <strong>mechanistic probes</strong> to perturb the CHCHD4↔ALR reoxidation cycle and thereby study precursor trapping and pathway kinetics in mitochondria. (muzzioli2024theinteractionand pages 1-2)</p>
+<h3 id="52-translational-concepts-emerging-rather-than-established">5.2 Translational concepts (emerging rather than established)</h3>
+<p>Authoritative reviews emphasize that CHCHD4 and its substrates connect to mitochondrial dysfunction, cancer biology, and hypoxia-linked phenotypes, motivating translational hypotheses (e.g., targeting IMS redox/import nodes), but <strong>clinical-grade CHCHD4-targeted therapies</strong> are not established in the evidence retrieved here. (alhabib2021chchd4(mia40)and pages 2-4, dicksonmurray2021themia40chchd4oxidative pages 4-5)</p>
+<h2 id="6-expert-synthesis-and-analysis-authoritative-perspectives">6) Expert synthesis and analysis (authoritative perspectives)</h2>
+<h3 id="61-why-chchd4-is-central-a-chemical-trapping-import-receptor">6.1 Why CHCHD4 is central: a “chemical trapping” import receptor</h3>
+<p>Expert reviews converge on the concept that CHCHD4 provides a unique import mechanism among mitochondrial pathways: it not only recognizes substrates but also <strong>chemically modifies</strong> them (disulfide installation) to create an energetically favorable retention mechanism in the IMS. This establishes CHCHD4 as a node at the interface of mitochondrial biogenesis and redox signaling. (alhabib2021chchd4(mia40)and pages 2-4, dicksonmurray2021themia40chchd4oxidative pages 4-5)</p>
+<h3 id="62-system-level-coupling-respiratory-chain-redox-and-ros">6.2 System-level coupling: respiratory chain, redox, and ROS</h3>
+<p>The coupling of CHCHD4 reoxidation (via ALR) to cytochrome c/complex IV, with an alternative oxygen branch producing H2O2, provides a mechanistic rationale for why IMS oxidative folding is sensitive to—and can influence—mitochondrial respiratory and redox states. (alhabib2021chchd4(mia40)and pages 2-4, dicksonmurray2021themia40chchd4oxidative pages 4-5)</p>
+<h3 id="63-emerging-physiological-integration-2024-mitochondrial-import-as-an-immune-regulatory-lever">6.3 Emerging physiological integration (2024): mitochondrial import as an immune-regulatory lever</h3>
+<p>The 2024 CHCHD4–TRIAP1 study extends CHCHD4 biology beyond mitochondrial proteostasis: it proposes that modulating import efficiency can tune cardiolipin/VDAC state and mtDNA release, thereby coupling mitochondrial import to <strong>innate immune signaling</strong> (cGAS–STING–NFKB) and tissue adaptation. This represents a notable expansion of CHCHD4 functional annotation into inter-organelle communication and immunometabolism. (ma2024chchd4triap1regulationof pages 1-3, ma2024chchd4triap1regulationof media f1db45ec)</p>
+<h2 id="7-key-statistics-and-data-points-from-recent-and-authoritative-sources">7) Key statistics and data points (from recent and authoritative sources)</h2>
+<ul>
+<li><strong>Protein size:</strong> CHCHD4 is described as ~<strong>16 kDa</strong>. (dicksonmurray2021themia40chchd4oxidative pages 4-5)</li>
+<li><strong>Typical substrate size class:</strong> substrates are often described as <strong>&lt;25 kDa</strong>. (modjtahedi2016mitochondrialproteinscontaining pages 3-5)</li>
+<li><strong>Exercise/physiology (mouse):</strong> CHCHD4+/− treadmill improvement <strong>68% vs 58%</strong> (WT); lactate increase after submaximal exercise <strong>37% vs 90%</strong> (WT). (ma2024chchd4triap1regulationof pages 10-11)</li>
+</ul>
+<h2 id="8-consolidated-evidence-map">8) Consolidated evidence map</h2>
+<p>The following table consolidates identity, motifs, localization, stepwise mechanism, representative substrates, and key recent (2024) quantitative physiology findings.</p>
+<table>
+<thead>
+<tr>
+<th>Item</th>
+<th>Key details</th>
+<th>Evidence/source (author year)</th>
+<th>URL</th>
+<th>Notes</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Identity</td>
+<td>Human <strong>CHCHD4</strong> encodes mitochondrial intermembrane space import and assembly protein 40 (<strong>MIA40</strong>); UniProt <strong>Q8N4Q1</strong>; central oxidoreductase of the mitochondrial disulfide relay / MIA pathway in the IMS (alhabib2021chchd4(mia40)and pages 2-4, alhabib2021chchd4(mia40)and pages 1-2)</td>
+<td>Al-Habib &amp; Ashcroft 2021</td>
+<td>https://doi.org/10.1042/bst20190232</td>
+<td>Human homolog of yeast Mia40; CHCH-domain protein</td>
+</tr>
+<tr>
+<td>Domains / motifs</td>
+<td>CHCHD4 contains a redox-active <strong>CPC</strong> motif and structural <strong>twin CX9C</strong> motifs; folded domain has two α-helices stabilized by two disulfide bonds; reactive catalytic cysteine is <strong>Cys55</strong> in the CPC motif (alhabib2021chchd4(mia40)and pages 2-4, balasco2025chchd4oxidoreductaseactivity pages 14-15, muzzioli2024theinteractionand pages 1-2)</td>
+<td>Al-Habib &amp; Ashcroft 2021; Balasco et al. 2025; Muzzioli &amp; Gallo 2024</td>
+<td>https://doi.org/10.1042/bst20190232; https://doi.org/10.3390/molecules30102117; https://doi.org/10.3390/ijms25021174</td>
+<td>CHCHD4 is ~16 kDa and soluble in the IMS in humans</td>
+</tr>
+<tr>
+<td>Localization</td>
+<td>Localized to the <strong>mitochondrial intermembrane space (IMS)</strong>; unlike yeast Mia40, human CHCHD4 lacks a classical N-terminal mitochondrial targeting presequence and is imported/localized through interaction with <strong>AIF/AIFM1</strong> (balasco2025chchd4oxidoreductaseactivity pages 4-5, modjtahedi2016mitochondrialproteinscontaining pages 3-5, dicksonmurray2021themia40chchd4oxidative pages 4-5)</td>
+<td>Modjtahedi et al. 2016; Dickson-Murray et al. 2021; Balasco et al. 2025</td>
+<td>https://doi.org/10.1016/j.tibs.2015.12.004; https://doi.org/10.3390/antiox10040592; https://doi.org/10.3390/molecules30102117</td>
+<td>N-terminal ~27 residues mediate AIF interaction; NADH enhances CHCHD4–AIF binding</td>
+</tr>
+<tr>
+<td>Mechanism 1: precursor entry</td>
+<td>Nuclear-encoded IMS substrates first pass through the <strong>TOM complex</strong> in a reduced/unfolded state before engaging oxidized CHCHD4 in the IMS (alhabib2021chchd4(mia40)and pages 2-4, alhabib2021chchd4(mia40)and pages 1-2)</td>
+<td>Al-Habib &amp; Ashcroft 2021</td>
+<td>https://doi.org/10.1042/bst20190232</td>
+<td>Typical substrates are small cysteine-rich proteins, often &lt;25 kDa</td>
+</tr>
+<tr>
+<td>Mechanism 2: recognition / sliding</td>
+<td>Substrates carry an <strong>ITS/MISS</strong> (IMS-targeting / mitochondrial IMS sorting signal), typically an amphipathic helix that docks into a hydrophobic cleft on CHCHD4 in a non-covalent <strong>sliding</strong> step (alhabib2021chchd4(mia40)and pages 1-2, modjtahedi2016mitochondrialproteinscontaining pages 3-5, dicksonmurray2021themia40chchd4oxidative pages 4-5)</td>
+<td>Modjtahedi et al. 2016; Dickson-Murray et al. 2021; Al-Habib &amp; Ashcroft 2021</td>
+<td>https://doi.org/10.1016/j.tibs.2015.12.004; https://doi.org/10.3390/antiox10040592; https://doi.org/10.1042/bst20190232</td>
+<td>Recognition is not based solely on cysteine content; hydrophobic docking is important</td>
+</tr>
+<tr>
+<td>Mechanism 3: docking / intermolecular disulfide</td>
+<td>In the <strong>docking</strong> step, CHCHD4 forms a <strong>transient intermolecular disulfide</strong> between its CPC motif and a substrate cysteine (alhabib2021chchd4(mia40)and pages 1-2, balasco2025chchd4oxidoreductaseactivity pages 14-15, dicksonmurray2021themia40chchd4oxidative pages 4-5)</td>
+<td>Dickson-Murray et al. 2021; Balasco et al. 2025</td>
+<td>https://doi.org/10.3390/antiox10040592; https://doi.org/10.3390/molecules30102117</td>
+<td>Human CHCHD4 Cys55 is the key nucleophilic cysteine for substrate engagement</td>
+</tr>
+<tr>
+<td>Mechanism 4: oxidative folding / trapping</td>
+<td>A second substrate cysteine attacks to generate an <strong>intramolecular disulfide</strong> within the substrate, promoting oxidative folding, stability, and <strong>retention in the IMS</strong> (balasco2025chchd4oxidoreductaseactivity pages 4-5, dicksonmurray2021themia40chchd4oxidative pages 4-5)</td>
+<td>Dickson-Murray et al. 2021; Balasco et al. 2025</td>
+<td>https://doi.org/10.3390/antiox10040592; https://doi.org/10.3390/molecules30102117</td>
+<td>Oxidative folding acts as a trapping mechanism for IMS residency</td>
+</tr>
+<tr>
+<td>Mechanism 5: CHCHD4 reoxidation</td>
+<td>Reduced CHCHD4 is reoxidized by <strong>ALR/GFER</strong> (mammalian Erv1 homolog), an FAD-dependent sulfhydryl oxidase that interacts with the CHCHD4 hydrophobic groove (alhabib2021chchd4(mia40)and pages 2-4, balasco2025chchd4oxidoreductaseactivity pages 14-15, muzzioli2024theinteractionand pages 1-2)</td>
+<td>Al-Habib &amp; Ashcroft 2021; Balasco et al. 2025; Muzzioli &amp; Gallo 2024</td>
+<td>https://doi.org/10.1042/bst20190232; https://doi.org/10.3390/molecules30102117; https://doi.org/10.3390/ijms25021174</td>
+<td>CHCHD4 F68E disrupts efficient reoxidation by ALR</td>
+</tr>
+<tr>
+<td>Mechanism 6: electron acceptors</td>
+<td>Electrons are transferred from CHCHD4 to ALR/GFER and then preferentially to <strong>cytochrome c / complex IV</strong>, or alternatively to <strong>O2</strong>, which can generate <strong>H2O2</strong> (alhabib2021chchd4(mia40)and pages 2-4, modjtahedi2016mitochondrialproteinscontaining pages 3-5, dicksonmurray2021themia40chchd4oxidative pages 4-5)</td>
+<td>Al-Habib &amp; Ashcroft 2021; Modjtahedi et al. 2016; Dickson-Murray et al. 2021</td>
+<td>https://doi.org/10.1042/bst20190232; https://doi.org/10.1016/j.tibs.2015.12.004; https://doi.org/10.3390/antiox10040592</td>
+<td>Links the MIA pathway to respiratory-chain redox state</td>
+</tr>
+<tr>
+<td>Representative substrates: canonical CHCH proteins</td>
+<td>Major substrate class comprises proteins with <strong>(CX9C)2</strong> or <strong>(CX3C)2</strong> motifs / CHCH domains, including <strong>COX17</strong>, <strong>COX19</strong>, <strong>TRIAP1</strong>, <strong>CHCHD2</strong>, <strong>CHCHD7</strong>, and assembly factors such as <strong>CMC1/CMC2/COA4-6</strong> (modjtahedi2016mitochondrialproteinscontaining pages 2-3, alhabib2021chchd4(mia40)and pages 1-2, modjtahedi2016mitochondrialproteinscontaining pages 3-5)</td>
+<td>Modjtahedi et al. 2016; Al-Habib &amp; Ashcroft 2021</td>
+<td>https://doi.org/10.1016/j.tibs.2015.12.004; https://doi.org/10.1042/bst20190232</td>
+<td>These proteins participate in respiratory-chain biogenesis, lipid homeostasis, and mitochondrial organization</td>
+</tr>
+<tr>
+<td>Representative substrate detail: COX17</td>
+<td><strong>COX17</strong> is a validated CHCHD4 substrate; Balasco et al. list COX17 as a <strong>67 aa</strong> protein with motif <strong>CX9C-X8-CX9C</strong> and docked cysteine <strong>C45</strong> (balasco2025chchd4oxidoreductaseactivity pages 5-8)</td>
+<td>Balasco et al. 2025</td>
+<td>https://doi.org/10.3390/molecules30102117</td>
+<td>Useful example of a classical cysteine-rich IMS copper-chaperone substrate</td>
+</tr>
+<tr>
+<td>Representative substrate detail: TRIAP1</td>
+<td><strong>TRIAP1</strong> is a CHCHD4-dependent imported substrate that links the disulfide relay to <strong>cardiolipin homeostasis</strong> and mitochondrial signaling in muscle physiology (ma2024chchd4triap1regulationof pages 1-3, ma2024chchd4triap1regulationof pages 10-11)</td>
+<td>Ma et al. 2024</td>
+<td>https://doi.org/10.1016/j.celrep.2023.113626</td>
+<td>In the exercise study, TRIAP1 is presented as the critical signal mediator downstream of CHCHD4</td>
+</tr>
+<tr>
+<td>Substrate repertoire breadth</td>
+<td>A recent synthesis reports <strong>34 experimentally validated CHCHD4 substrates</strong>, including canonical twin-CX9C proteins and increasing numbers of <strong>non-canonical</strong> redox-regulated substrates (balasco2025chchd4oxidoreductaseactivity pages 1-2, balasco2025chchd4oxidoreductaseactivity pages 5-8)</td>
+<td>Balasco et al. 2025</td>
+<td>https://doi.org/10.3390/molecules30102117</td>
+<td>Review uses PDB/AlphaFold-based structural classification; see Figure 1 and Table 2</td>
+</tr>
+<tr>
+<td>Recent 2024 physiology</td>
+<td>In exercised muscle, lower CHCHD4 reduces TRIAP1 import, decreases cardiolipin, promotes <strong>VDAC oligomerization</strong> and <strong>mtDNA release</strong>, activating <strong>cGAS–STING–NFKB</strong> signaling and slow-twitch fiber adaptation; in mice, <strong>CHCHD4+/−</strong> animals showed greater treadmill improvement (<strong>68% vs 58%</strong> WT) and lower blood-lactate rise after submaximal exercise (<strong>37% vs 90%</strong> WT) (ma2024chchd4triap1regulationof pages 1-3, ma2024chchd4triap1regulationof pages 10-11, ma2024chchd4triap1regulationof media f1db45ec)</td>
+<td>Ma et al. 2024</td>
+<td>https://doi.org/10.1016/j.celrep.2023.113626</td>
+<td>Figure 7A–F summarizes the model and phenotypes; data are from mouse physiology, but they reveal a new CHCHD4-regulated signaling axis</td>
+</tr>
+<tr>
+<td>Disease / systems relevance</td>
+<td>Beyond import chemistry, CHCHD4 is implicated in <strong>hypoxia responses</strong>, <strong>cancer metabolism</strong>, Fe–S handling, and mitochondrial stress signaling; dysregulation of CHCHD4 or partners such as <strong>AIF</strong> and <strong>ALR</strong> is linked to disease (alhabib2021chchd4(mia40)and pages 2-4, balasco2025chchd4oxidoreductaseactivity pages 4-5, balasco2025chchd4oxidoreductaseactivity pages 5-8)</td>
+<td>Al-Habib &amp; Ashcroft 2021; Balasco et al. 2025</td>
+<td>https://doi.org/10.1042/bst20190232; https://doi.org/10.3390/molecules30102117</td>
+<td>For this report, the strongest recent mechanistic advance retrieved was the 2024 CHCHD4–TRIAP1 exercise/innate-immunity axis</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes verified identity, motifs, localization, core MIA/disulfide-relay steps, representative substrate classes, and a notable 2024 physiology finding for human CHCHD4/MIA40. It is useful as a compact evidence map linking molecular mechanism to recent in vivo function.</em></p>
+<h2 id="9-conclusions-functional-annotation">9) Conclusions (functional annotation)</h2>
+<p>CHCHD4 (MIA40; UniProt Q8N4Q1) is a human mitochondrial IMS oxidoreductase and import receptor that catalyzes oxidative folding (intramolecular disulfide formation) of cysteine-containing IMS proteins, thereby coupling TOM-mediated translocation to IMS retention via a disulfide relay with ALR/GFER and downstream electron acceptors. (alhabib2021chchd4(mia40)and pages 1-2, dicksonmurray2021themia40chchd4oxidative pages 4-5)</p>
+<p>Recent 2024 evidence expands its functional annotation to include a CHCHD4-dependent signaling axis in vivo (CHCHD4→TRIAP1 import→cardiolipin/VDAC→mtDNA release→cGAS–STING–NFKB) that mediates skeletal muscle adaptation to exercise, with quantifiable performance and metabolic phenotypes in mice. (ma2024chchd4triap1regulationof pages 10-11, ma2024chchd4triap1regulationof media f1db45ec)</p>
+<h2 id="10-urls-and-publication-dates-key-sources-cited">10) URLs and publication dates (key sources cited)</h2>
+<ul>
+<li>Al-Habib H, Ashcroft M. <strong>Biochemical Society Transactions</strong>. <strong>2021-02</strong>. “CHCHD4 (MIA40) and the mitochondrial disulfide relay system.” https://doi.org/10.1042/bst20190232 (alhabib2021chchd4(mia40)and pages 2-4)</li>
+<li>Dickson-Murray E, et al. <strong>Antioxidants</strong>. <strong>2021-04</strong>. “The Mia40/CHCHD4 Oxidative Folding System…” https://doi.org/10.3390/antiox10040592 (dicksonmurray2021themia40chchd4oxidative pages 4-5)</li>
+<li>Modjtahedi N, et al. <strong>Trends in Biochemical Sciences</strong>. <strong>2016-03</strong>. “Mitochondrial proteins containing CHCH domains…” https://doi.org/10.1016/j.tibs.2015.12.004 (modjtahedi2016mitochondrialproteinscontaining pages 3-5)</li>
+<li>Ma J, et al. <strong>Cell Reports</strong>. <strong>2024-01</strong>. “CHCHD4-TRIAP1 regulation of innate immune signaling mediates skeletal muscle adaptation to exercise.” https://doi.org/10.1016/j.celrep.2023.113626 (ma2024chchd4triap1regulationof pages 10-11)</li>
+<li>Muzzioli R, Gallo A. <strong>International Journal of Molecular Sciences</strong>. <strong>2024-01</strong>. “The Interaction and Effect of a Small MitoBlock Library…” https://doi.org/10.3390/ijms25021174 (muzzioli2024theinteractionand pages 1-2)</li>
+</ul>
+<h2 id="11-limitations-of-this-synthesis">11) Limitations of this synthesis</h2>
+<p>While reviews cited here discuss CHCHD4 in hypoxia/cancer contexts, the retrieved evidence set contains limited 2023–2024 primary data directly addressing CHCHD4 in human cancer/hypoxia models; the most detailed 2024 primary evidence obtained concerns exercise/innate immunity in mice and chemical probe modulation of the pathway. Accordingly, cancer/hypoxia-related claims are kept at the review-supported level rather than extended with new quantitative human oncology datasets. (alhabib2021chchd4(mia40)and pages 2-4, dicksonmurray2021themia40chchd4oxidative pages 4-5)</p>
+<p>References</p>
+<ol>
+<li>
+<p>(alhabib2021chchd4(mia40)and pages 2-4): Hasan Al-Habib and Margaret Ashcroft. Chchd4 (mia40) and the mitochondrial disulfide relay system. Biochemical Society Transactions, 49:17-27, Feb 2021. URL: https://doi.org/10.1042/bst20190232, doi:10.1042/bst20190232. This article has 37 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(alhabib2021chchd4(mia40)and pages 1-2): Hasan Al-Habib and Margaret Ashcroft. Chchd4 (mia40) and the mitochondrial disulfide relay system. Biochemical Society Transactions, 49:17-27, Feb 2021. URL: https://doi.org/10.1042/bst20190232, doi:10.1042/bst20190232. This article has 37 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(modjtahedi2016mitochondrialproteinscontaining pages 3-5): Nazanine Modjtahedi, Kostas Tokatlidis, Philippe Dessen, and Guido Kroemer. Mitochondrial proteins containing coiled-coil-helix-coiled-coil-helix (chch) domains in health and disease. Trends in biochemical sciences, 41 3:245-260, Mar 2016. URL: https://doi.org/10.1016/j.tibs.2015.12.004, doi:10.1016/j.tibs.2015.12.004. This article has 165 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(dicksonmurray2021themia40chchd4oxidative pages 4-5): Eleanor Dickson-Murray, Kenza Nedara, Nazanine Modjtahedi, and Kostas Tokatlidis. The mia40/chchd4 oxidative folding system: redox regulation and signaling in the mitochondrial intermembrane space. Antioxidants, 10:592, Apr 2021. URL: https://doi.org/10.3390/antiox10040592, doi:10.3390/antiox10040592. This article has 37 citations.</p>
+</li>
+<li>
+<p>(modjtahedi2016mitochondrialproteinscontaining pages 2-3): Nazanine Modjtahedi, Kostas Tokatlidis, Philippe Dessen, and Guido Kroemer. Mitochondrial proteins containing coiled-coil-helix-coiled-coil-helix (chch) domains in health and disease. Trends in biochemical sciences, 41 3:245-260, Mar 2016. URL: https://doi.org/10.1016/j.tibs.2015.12.004, doi:10.1016/j.tibs.2015.12.004. This article has 165 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(balasco2025chchd4oxidoreductaseactivity pages 14-15): Nicole Balasco, Nazanine Modjtahedi, Alessandra Monti, Menotti Ruvo, Luigi Vitagliano, and Nunzianna Doti. Chchd4 oxidoreductase activity: a comprehensive analysis of the molecular, functional, and structural properties of its redox-regulated substrates. Molecules, 30:2117, May 2025. URL: https://doi.org/10.3390/molecules30102117, doi:10.3390/molecules30102117. This article has 3 citations.</p>
+</li>
+<li>
+<p>(balasco2025chchd4oxidoreductaseactivity pages 4-5): Nicole Balasco, Nazanine Modjtahedi, Alessandra Monti, Menotti Ruvo, Luigi Vitagliano, and Nunzianna Doti. Chchd4 oxidoreductase activity: a comprehensive analysis of the molecular, functional, and structural properties of its redox-regulated substrates. Molecules, 30:2117, May 2025. URL: https://doi.org/10.3390/molecules30102117, doi:10.3390/molecules30102117. This article has 3 citations.</p>
+</li>
+<li>
+<p>(balasco2025chchd4oxidoreductaseactivity pages 5-8): Nicole Balasco, Nazanine Modjtahedi, Alessandra Monti, Menotti Ruvo, Luigi Vitagliano, and Nunzianna Doti. Chchd4 oxidoreductase activity: a comprehensive analysis of the molecular, functional, and structural properties of its redox-regulated substrates. Molecules, 30:2117, May 2025. URL: https://doi.org/10.3390/molecules30102117, doi:10.3390/molecules30102117. This article has 3 citations.</p>
+</li>
+<li>
+<p>(ma2024chchd4triap1regulationof pages 1-3): Jin Ma, Ping-yuan Wang, Jie Zhuang, Annie Y. Son, Alexander K. Karius, Abu Mohammad Syed, Masahiro Nishi, Zhichao Wu, Mateus P. Mori, Young-Chae Kim, and Paul M. Hwang. Chchd4-triap1 regulation of innate immune signaling mediates skeletal muscle adaptation to exercise. Cell Reports, 43:113626, Jan 2024. URL: https://doi.org/10.1016/j.celrep.2023.113626, doi:10.1016/j.celrep.2023.113626. This article has 16 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ma2024chchd4triap1regulationof pages 10-11): Jin Ma, Ping-yuan Wang, Jie Zhuang, Annie Y. Son, Alexander K. Karius, Abu Mohammad Syed, Masahiro Nishi, Zhichao Wu, Mateus P. Mori, Young-Chae Kim, and Paul M. Hwang. Chchd4-triap1 regulation of innate immune signaling mediates skeletal muscle adaptation to exercise. Cell Reports, 43:113626, Jan 2024. URL: https://doi.org/10.1016/j.celrep.2023.113626, doi:10.1016/j.celrep.2023.113626. This article has 16 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ma2024chchd4triap1regulationof media f1db45ec): Jin Ma, Ping-yuan Wang, Jie Zhuang, Annie Y. Son, Alexander K. Karius, Abu Mohammad Syed, Masahiro Nishi, Zhichao Wu, Mateus P. Mori, Young-Chae Kim, and Paul M. Hwang. Chchd4-triap1 regulation of innate immune signaling mediates skeletal muscle adaptation to exercise. Cell Reports, 43:113626, Jan 2024. URL: https://doi.org/10.1016/j.celrep.2023.113626, doi:10.1016/j.celrep.2023.113626. This article has 16 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(muzzioli2024theinteractionand pages 1-2): Riccardo Muzzioli and Angelo Gallo. The interaction and effect of a small mitoblock library as inhibitor of alr protein–protein interaction pathway. International Journal of Molecular Sciences, 25:1174, Jan 2024. URL: https://doi.org/10.3390/ijms25021174, doi:10.3390/ijms25021174. This article has 3 citations.</p>
+</li>
+<li>
+<p>(balasco2025chchd4oxidoreductaseactivity pages 1-2): Nicole Balasco, Nazanine Modjtahedi, Alessandra Monti, Menotti Ruvo, Luigi Vitagliano, and Nunzianna Doti. Chchd4 oxidoreductase activity: a comprehensive analysis of the molecular, functional, and structural properties of its redox-regulated substrates. Molecules, 30:2117, May 2025. URL: https://doi.org/10.3390/molecules30102117, doi:10.3390/molecules30102117. This article has 3 citations.</p>
+</li>
+</ol>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>muzzioli2024theinteractionand pages 1-2</li>
+<li>modjtahedi2016mitochondrialproteinscontaining pages 3-5</li>
+<li>modjtahedi2016mitochondrialproteinscontaining pages 2-3</li>
+<li>https://doi.org/10.1042/bst20190232</li>
+<li>https://doi.org/10.1042/bst20190232;</li>
+<li>https://doi.org/10.3390/molecules30102117;</li>
+<li>https://doi.org/10.3390/ijms25021174</li>
+<li>https://doi.org/10.1016/j.tibs.2015.12.004;</li>
+<li>https://doi.org/10.3390/antiox10040592;</li>
+<li>https://doi.org/10.3390/molecules30102117</li>
+<li>https://doi.org/10.3390/antiox10040592</li>
+<li>https://doi.org/10.1016/j.celrep.2023.113626</li>
+<li>https://doi.org/10.1016/j.tibs.2015.12.004</li>
+<li>https://doi.org/10.1042/bst20190232,</li>
+<li>https://doi.org/10.1016/j.tibs.2015.12.004,</li>
+<li>https://doi.org/10.3390/antiox10040592,</li>
+<li>https://doi.org/10.3390/molecules30102117,</li>
+<li>https://doi.org/10.1016/j.celrep.2023.113626,</li>
+<li>https://doi.org/10.3390/ijms25021174,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q8N4Q1
+gene_symbol: CHCHD4
+product_type: PROTEIN
+status: INITIALIZED
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: Mitochondrial oxidoreductase (human ortholog of yeast Mia40) that operates
+  in the disulfide relay system of the intermembrane space (IMS). CHCHD4 introduces
+  disulfide bonds into IMS-destined proteins bearing twin CX3C or CX9C motifs,
+  trapping them in the IMS after translocation through the TOM complex. Uses a CPC
+  active-site motif to form transient intermolecular disulfides with substrates. Is
+  re-oxidized by GFER (ALR/Erv1). Also required for respiratory chain complex assembly
+  through import of IMS assembly factors, and interacts with AIFM1 (AIF).
+alternative_products:
+- name: &#39;1&#39;
+  id: Q8N4Q1-1
+- name: &#39;2&#39;
+  id: Q8N4Q1-2
+  sequence_note: VSP_018433
+existing_annotations:
+- term:
+    id: GO:0045041
+    label: protein import into mitochondrial intermembrane space
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: CHCHD4 is the central oxidoreductase of the MIA pathway that drives
+      import of CX3C/CX9C proteins into the IMS. Core BP annotation.
+    action: ACCEPT
+    supported_by:
+    - reference_id: file:human/CHCHD4/CHCHD4-deep-research-falcon.md
+      supporting_text: The mitochondrial IMS contains a dedicated protein import route in which import is coupled to oxidative folding, commonly termed the mitochondrial intermembrane space import and assembly pathway or disulfide relay system.
+- term:
+    id: GO:0051604
+    label: protein maturation
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: CHCHD4 catalyzes oxidative folding (disulfide bond introduction) of IMS
+      substrates, which is a form of protein maturation. However this is very generic.
+      The more specific disulfide relay system term is more informative.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Too generic; the specific disulfide relay system annotation is more informative.
+- term:
+    id: GO:0005758
+    label: mitochondrial intermembrane space
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: CHCHD4 is a soluble IMS protein. Confirmed experimentally in human
+      cells (PMID:16185709, PMID:23676665). Core CC annotation.
+    action: ACCEPT
+    supported_by:
+    - reference_id: file:human/CHCHD4/CHCHD4-deep-research-falcon.md
+      supporting_text: CHCHD4 is localized to the mitochondrial intermembrane space.
+- term:
+    id: GO:0015035
+    label: protein-disulfide reductase activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: CHCHD4/Mia40 is an oxidoreductase with a CPC active site that catalyzes
+      disulfide bond formation in substrates. The term protein-disulfide reductase
+      describes the reverse reaction. CHCHD4 actually functions as an oxidase
+      (introduces disulfides) not a reductase. However, the active site cycles
+      between oxidized and reduced states. The IBA annotation follows yeast Mia40.
+    action: MODIFY
+    reason: CHCHD4 primarily acts as a disulfide oxidase/isomerase, introducing
+      disulfide bonds into substrates. Disulfide reductase describes the reverse.
+    proposed_replacement_terms:
+    - id: GO:0015036
+      label: disulfide oxidoreductase activity
+    supported_by:
+    - reference_id: file:human/CHCHD4/CHCHD4-deep-research-falcon.md
+      supporting_text: CHCHD4 is defined as the IMS-localized oxidoreductase/import receptor that forms a transient intermolecular disulfide with substrates via its CPC motif.
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  review:
+    summary: Too general — CHCHD4 specifically localizes to the IMS.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Subsumed by mitochondrial intermembrane space annotation.
+- term:
+    id: GO:0005758
+    label: mitochondrial intermembrane space
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  review:
+    summary: Correct. Redundant with IBA and experimental evidence for same term.
+    action: ACCEPT
+- term:
+    id: GO:0015035
+    label: protein-disulfide reductase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  review:
+    summary: Same concern as IBA — CHCHD4 is primarily an oxidase, not a reductase.
+    action: MODIFY
+    proposed_replacement_terms:
+    - id: GO:0015036
+      label: disulfide oxidoreductase activity
+- term:
+    id: GO:0033108
+    label: mitochondrial respiratory chain complex assembly
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  review:
+    summary: CHCHD4 imports IMS assembly factors (e.g., NDUFB10, COA7) required for
+      respiratory chain complexes. This is a downstream consequence of its import
+      function, not its primary activity.
+    action: KEEP_AS_NON_CORE
+    reason: Secondary effect of CHCHD4 import function, not its direct activity.
+- term:
+    id: GO:0045041
+    label: protein import into mitochondrial intermembrane space
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  review:
+    summary: Correct. Redundant with IBA for same term.
+    action: ACCEPT
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:26387864
+  review:
+    summary: Petrungaro et al. 2015 showed Mia40-dependent release of MICU1-MICU2
+      dimer from MCU. Protein binding is uninformative per guidelines.
+    action: REMOVE
+    reason: Protein binding is uninformative. The MICU1/MICU2 interaction reflects
+      CHCHD4 substrate oxidative folding function.
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IDA
+  original_reference_id: GO_REF:0000052
+  review:
+    summary: Too general — IMS localization is well-established and more specific.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Subsumed by mitochondrial intermembrane space annotation.
+- term:
+    id: GO:0160203
+    label: mitochondrial disulfide relay system
+  evidence_type: IMP
+  original_reference_id: PMID:16185709
+  review:
+    summary: Hofmann et al. 2005 showed that human MIA40 depletion specifically reduced
+      levels of small IMS proteins (DDP1, TIM10A), demonstrating its role in the
+      disulfide relay system. Core BP annotation.
+    action: ACCEPT
+- term:
+    id: GO:0015035
+    label: protein-disulfide reductase activity
+  evidence_type: IMP
+  original_reference_id: PMID:23676665
+  review:
+    summary: Fischer et al. 2013 confirmed oxidative folding activity in intact
+      mammalian cells. Same concern about reductase vs oxidase terminology.
+    action: MODIFY
+    proposed_replacement_terms:
+    - id: GO:0015036
+      label: disulfide oxidoreductase activity
+- term:
+    id: GO:0160203
+    label: mitochondrial disulfide relay system
+  evidence_type: IMP
+  original_reference_id: PMID:21059946
+  review:
+    summary: Stojanovski et al. 2010 showed Mia40 triggers consecutive induced
+      folding steps during import. Core BP annotation.
+    action: ACCEPT
+- term:
+    id: GO:0160203
+    label: mitochondrial disulfide relay system
+  evidence_type: IMP
+  original_reference_id: PMID:23676665
+  review:
+    summary: Fischer et al. 2013 confirmed the disulfide relay operates in intact
+      mammalian cells. Core BP annotation.
+    action: ACCEPT
+- term:
+    id: GO:0160203
+    label: mitochondrial disulfide relay system
+  evidence_type: IMP
+  original_reference_id: PMID:37159021
+  review:
+    summary: Habich et al. 2023 described a two-step import pathway coupling the
+      disulfide relay with matrix complex I biogenesis. Core BP annotation.
+    action: ACCEPT
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: HTP
+  original_reference_id: PMID:34800366
+  review:
+    summary: HTP proteome confirms mitochondrial localization. Too general.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Subsumed by mitochondrial intermembrane space annotation.
+- term:
+    id: GO:0005758
+    label: mitochondrial intermembrane space
+  evidence_type: IMP
+  original_reference_id: PMID:37159021
+  review:
+    summary: Habich et al. 2023 confirmed IMS localization in two-step import study.
+    action: ACCEPT
+- term:
+    id: GO:0015035
+    label: protein-disulfide reductase activity
+  evidence_type: IMP
+  original_reference_id: PMID:37159021
+  review:
+    summary: Same concern about reductase vs oxidase terminology.
+    action: MODIFY
+    proposed_replacement_terms:
+    - id: GO:0015036
+      label: disulfide oxidoreductase activity
+- term:
+    id: GO:0005758
+    label: mitochondrial intermembrane space
+  evidence_type: EXP
+  original_reference_id: PMID:23676665
+  review:
+    summary: Fischer et al. 2013 directly demonstrated CHCHD4 in the IMS of intact
+      mammalian cells. Core CC.
+    action: ACCEPT
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:28040730
+  review:
+    summary: Friederich et al. 2017 showed NDUFB10 mutations affect CHCHD4-dependent
+      import. Protein binding is uninformative.
+    action: REMOVE
+    reason: Protein binding uninformative. NDUFB10 is a CHCHD4 substrate.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:26004228
+  review:
+    summary: Hangen et al. 2015 showed AIF-CHCHD4 interaction regulates respiratory
+      chain biogenesis. Protein binding is uninformative.
+    action: REMOVE
+    reason: Protein binding uninformative. AIF interaction is better captured by
+      respiratory chain complex assembly annotation.
+- term:
+    id: GO:0005758
+    label: mitochondrial intermembrane space
+  evidence_type: IDA
+  original_reference_id: PMID:26004228
+  review:
+    summary: Hangen et al. confirmed IMS localization by immunofluorescence.
+    action: ACCEPT
+- term:
+    id: GO:0033108
+    label: mitochondrial respiratory chain complex assembly
+  evidence_type: IMP
+  original_reference_id: PMID:26004228
+  review:
+    summary: Hangen et al. 2015 showed AIF-CHCHD4 interaction required for respiratory
+      chain biogenesis. This is a downstream consequence of CHCHD4 import function.
+    action: KEEP_AS_NON_CORE
+    reason: Downstream of CHCHD4 core import/oxidative folding function.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:30885959
+  review:
+    summary: Mohanraj et al. 2019 showed COA7 is a CHCHD4 substrate rescued by
+      proteasome inhibition. Protein binding is uninformative.
+    action: REMOVE
+    reason: Protein binding uninformative. COA7 is a CHCHD4 import substrate.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:23676665
+  review:
+    summary: Fischer et al. 2013 studied CHCHD4 substrate interactions in intact
+      cells. Protein binding is uninformative.
+    action: REMOVE
+    reason: Protein binding uninformative. Reflects transient enzyme-substrate
+      disulfide intermediates.
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IDA
+  original_reference_id: PMID:23676665
+  review:
+    summary: Too general — IMS is more specific and well-supported.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Subsumed by mitochondrial intermembrane space annotation.
+- term:
+    id: GO:0015035
+    label: protein-disulfide reductase activity
+  evidence_type: IDA
+  original_reference_id: PMID:26387864
+  review:
+    summary: Petrungaro et al. 2015 showed CHCHD4 oxidoreductase activity on
+      MICU1-MICU2 substrates. Same terminology concern.
+    action: MODIFY
+    proposed_replacement_terms:
+    - id: GO:0015036
+      label: disulfide oxidoreductase activity
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IDA
+  original_reference_id: PMID:24101517
+  review:
+    summary: Zhuang et al. 2013 showed CHCHD4 mediates p53 translocation to
+      mitochondria. Too general CC term.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Subsumed by mitochondrial intermembrane space annotation.
+- term:
+    id: GO:0005758
+    label: mitochondrial intermembrane space
+  evidence_type: IDA
+  original_reference_id: PMID:16185709
+  review:
+    summary: Hofmann et al. 2005 directly showed human MIA40 forms soluble complexes
+      in the IMS. Foundational evidence for IMS localization.
+    action: ACCEPT
+- term:
+    id: GO:0015035
+    label: protein-disulfide reductase activity
+  evidence_type: IMP
+  original_reference_id: PMID:19182799
+  review:
+    summary: Banci et al. 2009 determined MIA40 solution structure and demonstrated
+      it is an oxidoreductase with a CPC active site. Landmark paper establishing
+      the enzymatic mechanism. Same terminology concern about reductase vs oxidase.
+    action: MODIFY
+    proposed_replacement_terms:
+    - id: GO:0015036
+      label: disulfide oxidoreductase activity
+core_functions:
+- molecular_function:
+    id: GO:0015036
+    label: disulfide oxidoreductase activity
+  description: &gt;-
+    CHCHD4 (human Mia40) is the central oxidoreductase of the mitochondrial disulfide
+    relay system in the intermembrane space. It uses a CPC active-site motif to form
+    transient intermolecular disulfide bonds with IMS-destined substrates bearing twin
+    CX3C or CX9C motifs, catalyzing their oxidative folding and trapping them in the
+    IMS. CHCHD4 is re-oxidized by GFER (Erv1/ALR), completing the relay. Substrates
+    include small Tim chaperones, Cox17, CHCHD2/10, MICU1/2, NDUFB10, and COA7.
+  directly_involved_in:
+  - id: GO:0160203
+    label: mitochondrial disulfide relay system
+  - id: GO:0045041
+    label: protein import into mitochondrial intermembrane space
+  locations:
+  - id: GO:0005758
+    label: mitochondrial intermembrane space
+  supported_by:
+  - reference_id: PMID:19182799
+    supporting_text: &gt;-
+      MIA40 has a key role in oxidative protein folding in the mitochondrial
+      intermembrane space. We present the solution structure of human MIA40 and its
+      mechanism as a catalyst of oxidative folding.
+  - reference_id: PMID:16185709
+    supporting_text: &gt;-
+      Depletion of MIA40 in human cells by RNA interference specifically affected
+      steady-state levels of small and cysteine-containing intermembrane space
+      proteins like DDP1 and TIM10A.
+  - reference_id: PMID:23676665
+    supporting_text: &gt;-
+      Oxidation of cysteine residues to disulfides drives import of many proteins
+      into the intermembrane space of mitochondria.
+  - reference_id: file:human/CHCHD4/CHCHD4-deep-research-falcon.md
+    supporting_text: Mechanistically, substrates interact with CHCHD4 through a sliding-docking model followed by transient disulfide formation and substrate oxidative folding.
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: GO_REF:0000052
+  title: Gene Ontology annotation based on curation of immunofluorescence data
+  findings: []
+- id: GO_REF:0000117
+  title: Electronic Gene Ontology annotations created by ARBA machine learning models
+  findings: []
+- id: PMID:16185709
+  title: Functional and mutational characterization of human MIA40 acting during import
+    into the mitochondrial intermembrane space.
+  findings: []
+- id: PMID:19182799
+  title: MIA40 is an oxidoreductase that catalyzes oxidative protein folding in mitochondria.
+  findings: []
+- id: PMID:21059946
+  title: Molecular chaperone function of Mia40 triggers consecutive induced folding
+    steps of the substrate in mitochondrial protein import.
+  findings: []
+- id: PMID:23676665
+  title: Protein import and oxidative folding in the mitochondrial intermembrane space
+    of intact mammalian cells.
+  findings: []
+- id: PMID:24101517
+  title: Mitochondrial disulfide relay mediates translocation of p53 and partitions
+    its subcellular activity.
+  findings: []
+- id: PMID:26004228
+  title: Interaction between AIF and CHCHD4 Regulates Respiratory Chain Biogenesis.
+  findings: []
+- id: PMID:26387864
+  title: The Ca(2+)-Dependent Release of the Mia40-Induced MICU1-MICU2 Dimer from
+    MCU Regulates Mitochondrial Ca(2+) Uptake.
+  findings: []
+- id: PMID:28040730
+  title: Mutations in the accessory subunit NDUFB10 result in isolated complex I deficiency
+    and illustrate the critical role of intermembrane space import for complex I holoenzyme
+    assembly.
+  findings: []
+- id: PMID:30885959
+  title: Inhibition of proteasome rescues a pathogenic variant of respiratory chain
+    assembly factor COA7.
+  findings: []
+- id: PMID:34800366
+  title: Quantitative high-confidence human mitochondrial proteome and its dynamics
+    in cellular context.
+  findings: []
+- id: PMID:37159021
+  title: A two-step mitochondrial import pathway couples the disulfide relay with
+    matrix complex I biogenesis.
+  findings: []
+- id: file:human/CHCHD4/CHCHD4-deep-research-falcon.md
+  title: Falcon deep research report for CHCHD4
+  findings:
+  - statement: Falcon research supports CHCHD4/MIA40 as the central mitochondrial intermembrane-space oxidoreductase/import receptor for the MIA disulfide relay.
+    supporting_text: CHCHD4 is defined as the IMS-localized oxidoreductase/import receptor that recognizes IMS-targeting signals in substrates, forms a transient intermolecular disulfide with substrates via its CPC motif, and catalyzes formation of intramolecular disulfides.
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/human/CHCHD4/CHCHD4-ai-review.yaml
+++ b/genes/human/CHCHD4/CHCHD4-ai-review.yaml
@@ -28,6 +28,9 @@ existing_annotations:
     summary: CHCHD4 is the central oxidoreductase of the MIA pathway that drives
       import of CX3C/CX9C proteins into the IMS. Core BP annotation.
     action: ACCEPT
+    supported_by:
+    - reference_id: file:human/CHCHD4/CHCHD4-deep-research-falcon.md
+      supporting_text: The mitochondrial IMS contains a dedicated protein import route in which import is coupled to oxidative folding, commonly termed the mitochondrial intermembrane space import and assembly pathway or disulfide relay system.
 - term:
     id: GO:0051604
     label: protein maturation
@@ -48,6 +51,9 @@ existing_annotations:
     summary: CHCHD4 is a soluble IMS protein. Confirmed experimentally in human
       cells (PMID:16185709, PMID:23676665). Core CC annotation.
     action: ACCEPT
+    supported_by:
+    - reference_id: file:human/CHCHD4/CHCHD4-deep-research-falcon.md
+      supporting_text: CHCHD4 is localized to the mitochondrial intermembrane space.
 - term:
     id: GO:0015035
     label: protein-disulfide reductase activity
@@ -65,6 +71,9 @@ existing_annotations:
     proposed_replacement_terms:
     - id: GO:0015036
       label: disulfide oxidoreductase activity
+    supported_by:
+    - reference_id: file:human/CHCHD4/CHCHD4-deep-research-falcon.md
+      supporting_text: CHCHD4 is defined as the IMS-localized oxidoreductase/import receptor that forms a transient intermolecular disulfide with substrates via its CPC motif.
 - term:
     id: GO:0005739
     label: mitochondrion
@@ -354,8 +363,8 @@ core_functions:
   - reference_id: PMID:19182799
     supporting_text: >-
       MIA40 has a key role in oxidative protein folding in the mitochondrial
-      intermembrane space. MIA40 represents a thioredoxin-unrelated, minimal
-      oxidoreductase, with a facile disulfide exchange mechanism.
+      intermembrane space. We present the solution structure of human MIA40 and its
+      mechanism as a catalyst of oxidative folding.
   - reference_id: PMID:16185709
     supporting_text: >-
       Depletion of MIA40 in human cells by RNA interference specifically affected
@@ -365,6 +374,8 @@ core_functions:
     supporting_text: >-
       Oxidation of cysteine residues to disulfides drives import of many proteins
       into the intermembrane space of mitochondria.
+  - reference_id: file:human/CHCHD4/CHCHD4-deep-research-falcon.md
+    supporting_text: Mechanistically, substrates interact with CHCHD4 through a sliding-docking model followed by transient disulfide formation and substrate oxidative folding.
 references:
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO
@@ -427,3 +438,8 @@ references:
   title: A two-step mitochondrial import pathway couples the disulfide relay with
     matrix complex I biogenesis.
   findings: []
+- id: file:human/CHCHD4/CHCHD4-deep-research-falcon.md
+  title: Falcon deep research report for CHCHD4
+  findings:
+  - statement: Falcon research supports CHCHD4/MIA40 as the central mitochondrial intermembrane-space oxidoreductase/import receptor for the MIA disulfide relay.
+    supporting_text: CHCHD4 is defined as the IMS-localized oxidoreductase/import receptor that recognizes IMS-targeting signals in substrates, forms a transient intermolecular disulfide with substrates via its CPC motif, and catalyzes formation of intramolecular disulfides.

--- a/genes/human/CHCHD4/CHCHD4-deep-research-falcon.md
+++ b/genes/human/CHCHD4/CHCHD4-deep-research-falcon.md
@@ -1,0 +1,305 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-10T20:19:10.257736'
+end_time: '2026-05-10T20:27:27.929928'
+duration_seconds: 497.67
+template_file: templates/gene_research_go_focused.md
+template_variables:
+  organism: human
+  gene_id: CHCHD4
+  gene_symbol: CHCHD4
+  uniprot_accession: Q8N4Q1
+  protein_description: 'RecName: Full=Mitochondrial intermembrane space import and
+    assembly protein 40; AltName: Full=Coiled-coil-helix-coiled-coil-helix domain-containing
+    protein 4;'
+  gene_info: Name=CHCHD4; Synonyms=MIA40;
+  organism_full: Homo sapiens (Human).
+  protein_family: Not specified in UniProt
+  protein_domains: CHCH. (IPR010625); CHCHD4. (IPR039289); CHCH (PF06747)
+provider_config:
+  timeout: 600
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 19
+---
+
+## Question
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** Q8N4Q1
+- **Protein Description:** RecName: Full=Mitochondrial intermembrane space import and assembly protein 40; AltName: Full=Coiled-coil-helix-coiled-coil-helix domain-containing protein 4;
+- **Gene Information:** Name=CHCHD4; Synonyms=MIA40;
+- **Organism (full):** Homo sapiens (Human).
+- **Protein Family:** Not specified in UniProt
+- **Key Domains:** CHCH. (IPR010625); CHCHD4. (IPR039289); CHCH (PF06747)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "CHCHD4" matches the protein description above**
+2. **Verify the organism is correct:** Homo sapiens (Human).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'CHCHD4' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **CHCHD4** (gene ID: CHCHD4, UniProt: Q8N4Q1) in human.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** Q8N4Q1
+- **Protein Description:** RecName: Full=Mitochondrial intermembrane space import and assembly protein 40; AltName: Full=Coiled-coil-helix-coiled-coil-helix domain-containing protein 4;
+- **Gene Information:** Name=CHCHD4; Synonyms=MIA40;
+- **Organism (full):** Homo sapiens (Human).
+- **Protein Family:** Not specified in UniProt
+- **Key Domains:** CHCH. (IPR010625); CHCHD4. (IPR039289); CHCH (PF06747)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "CHCHD4" matches the protein description above**
+2. **Verify the organism is correct:** Homo sapiens (Human).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'CHCHD4' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **CHCHD4** (gene ID: CHCHD4, UniProt: Q8N4Q1) in human.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+# Comprehensive Research Report: Human **CHCHD4 (MIA40)** (UniProt Q8N4Q1)
+
+## 0) Target verification (mandatory)
+The research target is **human CHCHD4**, also known as **MIA40**, encoding “mitochondrial intermembrane space import and assembly protein 40.” Multiple authoritative reviews identify **CHCHD4/MIA40** as the central oxidoreductase of the mitochondrial intermembrane space (IMS) **disulfide relay / MIA pathway**, with characteristic **CPC** redox motif and **twin CX9C** motifs in a CHCH fold, confirming concordance with UniProt Q8N4Q1 and the CHCH domain context provided. (alhabib2021chchd4(mia40)and pages 2-4, alhabib2021chchd4(mia40)and pages 1-2, modjtahedi2016mitochondrialproteinscontaining pages 3-5)
+
+## 1) Key concepts and current definitions
+
+### 1.1 The mitochondrial IMS disulfide relay (MIA/DRS)
+The mitochondrial IMS contains a dedicated protein import route in which import is **coupled to oxidative folding**: cysteine-containing precursors enter through TOM and are trapped in the IMS after CHCHD4-catalyzed disulfide formation, a process commonly termed the **mitochondrial intermembrane space import and assembly (MIA) pathway** or **disulfide relay system (DRS)**. (alhabib2021chchd4(mia40)and pages 2-4, dicksonmurray2021themia40chchd4oxidative pages 4-5)
+
+### 1.2 CHCHD4/MIA40—functional definition
+CHCHD4 is defined as the IMS-localized **oxidoreductase/import receptor** that (i) recognizes IMS-targeting signals in substrates, (ii) forms a transient intermolecular disulfide with substrates via its CPC motif, and (iii) catalyzes formation of intramolecular disulfides that stabilize folded IMS proteins. (alhabib2021chchd4(mia40)and pages 1-2, dicksonmurray2021themia40chchd4oxidative pages 4-5)
+
+### 1.3 CHCH domains and substrate motifs
+A major client class comprises small IMS proteins bearing paired cysteine motifs such as **(CX9C)2** and **(CX3C)2** (CHCH-type motifs), which frequently become disulfide-bonded upon import and folding; canonical examples include **COX17**, **COX19**, and **TRIAP1**. (modjtahedi2016mitochondrialproteinscontaining pages 2-3, alhabib2021chchd4(mia40)and pages 1-2)
+
+## 2) Protein features: domains, localization, and mechanism
+
+### 2.1 Domain architecture and key motifs
+CHCHD4 is a ~16 kDa protein with a redox-active **CPC** motif and structural **twin CX9C** motifs forming a helix–loop–helix CHCH fold stabilized by disulfides; the catalytic cysteine within CPC (noted as **Cys55** in a recent synthesis) is the nucleophilic cysteine that engages substrates transiently. (balasco2025chchd4oxidoreductaseactivity pages 14-15, dicksonmurray2021themia40chchd4oxidative pages 4-5)
+
+### 2.2 Subcellular localization and import route
+CHCHD4 is localized to the **mitochondrial intermembrane space** and, unlike yeast Mia40, is described as lacking a classical N-terminal targeting presequence; its import/localization is linked to interaction with the inner-membrane-associated flavoprotein **AIF** (apoptosis-inducing factor), with NADH reported to enhance the CHCHD4–AIF interaction. (modjtahedi2016mitochondrialproteinscontaining pages 3-5, balasco2025chchd4oxidoreductaseactivity pages 4-5)
+
+### 2.3 Core biochemical function: oxidative folding coupled to import
+Mechanistically, substrates interact with CHCHD4 through a “**sliding–docking**” model: substrates bearing an IMS-targeting signal (ITS/MISS) first bind noncovalently to a hydrophobic cleft on CHCHD4, followed by formation of a **transient intermolecular disulfide** between CHCHD4’s CPC motif and a substrate cysteine; subsequent thiol–disulfide exchange yields an **intramolecular substrate disulfide**, resulting in oxidative folding and IMS retention (“trapping”). (dicksonmurray2021themia40chchd4oxidative pages 4-5, alhabib2021chchd4(mia40)and pages 1-2)
+
+### 2.4 Reoxidation of CHCHD4: ALR/GFER and terminal electron acceptors
+Reduced CHCHD4 is reoxidized by **ALR/GFER** (mammalian homolog of yeast Erv1), an FAD-dependent sulfhydryl oxidase. Electron transfer downstream is described as proceeding preferentially to **cytochrome c/complex IV**, with an alternative branch to **O2** that can generate **H2O2**, linking the pathway to respiratory-chain redox and reactive oxygen species biology. (alhabib2021chchd4(mia40)and pages 2-4, dicksonmurray2021themia40chchd4oxidative pages 4-5)
+
+## 3) Substrates and substrate recognition
+
+### 3.1 Recognition logic (ITS/MISS + cysteine chemistry)
+Substrate selection is described as relying on both (i) noncovalent interactions with an ITS/MISS (often an amphipathic helix) and (ii) covalent chemistry via transient disulfide formation with the CPC motif, rather than cysteine content alone. (alhabib2021chchd4(mia40)and pages 2-4, dicksonmurray2021themia40chchd4oxidative pages 4-5)
+
+### 3.2 Representative substrates and functional implications
+Reviews compile many CHCHD4 substrates as IMS factors impacting respiratory chain assembly and mitochondrial function, including proteins with (CX9C)2 motifs (e.g., **COX17**, **CHCHD2**, assembly factors such as **CMC1/CMC2** and **COA4–6**) and (CX3C)2 motifs (e.g., **TRIAP1**). These substrate classes connect CHCHD4 activity to respiratory complex biogenesis, mitochondrial ultrastructure, and signaling. (modjtahedi2016mitochondrialproteinscontaining pages 2-3, modjtahedi2016mitochondrialproteinscontaining pages 3-5)
+
+A concrete example is **COX17**, described as a small (67 aa) (CX9C…CX9C) protein and a validated CHCHD4 substrate in a substrate-focused synthesis. (balasco2025chchd4oxidoreductaseactivity pages 5-8)
+
+## 4) Recent developments (prioritizing 2023–2024)
+
+### 4.1 2024: CHCHD4–TRIAP1 axis links mitochondrial import to innate immunity and exercise adaptation
+A 2024 Cell Reports study reports that **exercise training downregulates CHCHD4** in skeletal muscle, reducing mitochondrial import of **TRIAP1**. In their model, reduced TRIAP1 is linked to decreased cardiolipin, increased **VDAC oligomerization**, and **mtDNA release**, which activates **cGAS–STING** and canonical **NFKB** signaling. This signaling is connected to muscle fiber adaptation (slow-twitch/type I shift) and metabolic outcomes. (ma2024chchd4triap1regulationof pages 1-3, ma2024chchd4triap1regulationof pages 10-11)
+
+**Quantitative outcomes** reported in the same work include improved treadmill performance in **CHCHD4+/−** mice relative to WT (68% vs 58% improvement) and reduced blood lactate increases following submaximal exercise (37% vs 90%), alongside age-associated body composition differences (less fat accumulation). (ma2024chchd4triap1regulationof pages 10-11)
+
+A key visual summary of this pathway is provided in **Figure 7F** (schematic) with supporting data in Figure 7A–E. (ma2024chchd4triap1regulationof media f1db45ec)
+
+### 4.2 2023: mitochondrial import machinery as a stress-signaling hub (context for CHCHD4)
+A 2023 review frames mitochondrial protein import systems, including the MIA pathway where Mia40 is CHCHD4 in humans, as a broader **cellular signaling hub** that integrates proteostasis and metabolic stress responses—context relevant when interpreting CHCHD4-regulated signaling axes such as the 2024 exercise/innate immunity pathway. (balasco2025chchd4oxidoreductaseactivity pages 5-8)
+
+### 4.3 2024: chemical biology—small-molecule modulation of the CHCHD4 reoxidation step
+A 2024 study characterizing a “MitoBlock” small-molecule library reports that compounds targeting **ALR** can alter MIA pathway dynamics; mechanistic studies show that one compound (MB-6) can lock a precursor in a CHCHD4-bound state by blocking reoxidation of CHCHD4 by ALR, providing a set of probes useful for mechanistic interrogation of the redox-regulated import pathway in model systems. (muzzioli2024theinteractionand pages 1-2)
+
+## 5) Current applications and real-world implementations
+
+### 5.1 Chemical probes to dissect import chemistry and redox coupling
+The ALR-targeting “MitoBlock” compounds are an example of a current, real-world implementation of CHCHD4-pathway knowledge: they are used as **mechanistic probes** to perturb the CHCHD4↔ALR reoxidation cycle and thereby study precursor trapping and pathway kinetics in mitochondria. (muzzioli2024theinteractionand pages 1-2)
+
+### 5.2 Translational concepts (emerging rather than established)
+Authoritative reviews emphasize that CHCHD4 and its substrates connect to mitochondrial dysfunction, cancer biology, and hypoxia-linked phenotypes, motivating translational hypotheses (e.g., targeting IMS redox/import nodes), but **clinical-grade CHCHD4-targeted therapies** are not established in the evidence retrieved here. (alhabib2021chchd4(mia40)and pages 2-4, dicksonmurray2021themia40chchd4oxidative pages 4-5)
+
+## 6) Expert synthesis and analysis (authoritative perspectives)
+
+### 6.1 Why CHCHD4 is central: a “chemical trapping” import receptor
+Expert reviews converge on the concept that CHCHD4 provides a unique import mechanism among mitochondrial pathways: it not only recognizes substrates but also **chemically modifies** them (disulfide installation) to create an energetically favorable retention mechanism in the IMS. This establishes CHCHD4 as a node at the interface of mitochondrial biogenesis and redox signaling. (alhabib2021chchd4(mia40)and pages 2-4, dicksonmurray2021themia40chchd4oxidative pages 4-5)
+
+### 6.2 System-level coupling: respiratory chain, redox, and ROS
+The coupling of CHCHD4 reoxidation (via ALR) to cytochrome c/complex IV, with an alternative oxygen branch producing H2O2, provides a mechanistic rationale for why IMS oxidative folding is sensitive to—and can influence—mitochondrial respiratory and redox states. (alhabib2021chchd4(mia40)and pages 2-4, dicksonmurray2021themia40chchd4oxidative pages 4-5)
+
+### 6.3 Emerging physiological integration (2024): mitochondrial import as an immune-regulatory lever
+The 2024 CHCHD4–TRIAP1 study extends CHCHD4 biology beyond mitochondrial proteostasis: it proposes that modulating import efficiency can tune cardiolipin/VDAC state and mtDNA release, thereby coupling mitochondrial import to **innate immune signaling** (cGAS–STING–NFKB) and tissue adaptation. This represents a notable expansion of CHCHD4 functional annotation into inter-organelle communication and immunometabolism. (ma2024chchd4triap1regulationof pages 1-3, ma2024chchd4triap1regulationof media f1db45ec)
+
+## 7) Key statistics and data points (from recent and authoritative sources)
+
+- **Protein size:** CHCHD4 is described as ~**16 kDa**. (dicksonmurray2021themia40chchd4oxidative pages 4-5)
+- **Typical substrate size class:** substrates are often described as **<25 kDa**. (modjtahedi2016mitochondrialproteinscontaining pages 3-5)
+- **Exercise/physiology (mouse):** CHCHD4+/− treadmill improvement **68% vs 58%** (WT); lactate increase after submaximal exercise **37% vs 90%** (WT). (ma2024chchd4triap1regulationof pages 10-11)
+
+## 8) Consolidated evidence map
+The following table consolidates identity, motifs, localization, stepwise mechanism, representative substrates, and key recent (2024) quantitative physiology findings.
+
+| Item | Key details | Evidence/source (author year) | URL | Notes |
+|---|---|---|---|---|
+| Identity | Human **CHCHD4** encodes mitochondrial intermembrane space import and assembly protein 40 (**MIA40**); UniProt **Q8N4Q1**; central oxidoreductase of the mitochondrial disulfide relay / MIA pathway in the IMS (alhabib2021chchd4(mia40)and pages 2-4, alhabib2021chchd4(mia40)and pages 1-2) | Al-Habib & Ashcroft 2021 | https://doi.org/10.1042/bst20190232 | Human homolog of yeast Mia40; CHCH-domain protein |
+| Domains / motifs | CHCHD4 contains a redox-active **CPC** motif and structural **twin CX9C** motifs; folded domain has two α-helices stabilized by two disulfide bonds; reactive catalytic cysteine is **Cys55** in the CPC motif (alhabib2021chchd4(mia40)and pages 2-4, balasco2025chchd4oxidoreductaseactivity pages 14-15, muzzioli2024theinteractionand pages 1-2) | Al-Habib & Ashcroft 2021; Balasco et al. 2025; Muzzioli & Gallo 2024 | https://doi.org/10.1042/bst20190232; https://doi.org/10.3390/molecules30102117; https://doi.org/10.3390/ijms25021174 | CHCHD4 is ~16 kDa and soluble in the IMS in humans |
+| Localization | Localized to the **mitochondrial intermembrane space (IMS)**; unlike yeast Mia40, human CHCHD4 lacks a classical N-terminal mitochondrial targeting presequence and is imported/localized through interaction with **AIF/AIFM1** (balasco2025chchd4oxidoreductaseactivity pages 4-5, modjtahedi2016mitochondrialproteinscontaining pages 3-5, dicksonmurray2021themia40chchd4oxidative pages 4-5) | Modjtahedi et al. 2016; Dickson-Murray et al. 2021; Balasco et al. 2025 | https://doi.org/10.1016/j.tibs.2015.12.004; https://doi.org/10.3390/antiox10040592; https://doi.org/10.3390/molecules30102117 | N-terminal ~27 residues mediate AIF interaction; NADH enhances CHCHD4–AIF binding |
+| Mechanism 1: precursor entry | Nuclear-encoded IMS substrates first pass through the **TOM complex** in a reduced/unfolded state before engaging oxidized CHCHD4 in the IMS (alhabib2021chchd4(mia40)and pages 2-4, alhabib2021chchd4(mia40)and pages 1-2) | Al-Habib & Ashcroft 2021 | https://doi.org/10.1042/bst20190232 | Typical substrates are small cysteine-rich proteins, often <25 kDa |
+| Mechanism 2: recognition / sliding | Substrates carry an **ITS/MISS** (IMS-targeting / mitochondrial IMS sorting signal), typically an amphipathic helix that docks into a hydrophobic cleft on CHCHD4 in a non-covalent **sliding** step (alhabib2021chchd4(mia40)and pages 1-2, modjtahedi2016mitochondrialproteinscontaining pages 3-5, dicksonmurray2021themia40chchd4oxidative pages 4-5) | Modjtahedi et al. 2016; Dickson-Murray et al. 2021; Al-Habib & Ashcroft 2021 | https://doi.org/10.1016/j.tibs.2015.12.004; https://doi.org/10.3390/antiox10040592; https://doi.org/10.1042/bst20190232 | Recognition is not based solely on cysteine content; hydrophobic docking is important |
+| Mechanism 3: docking / intermolecular disulfide | In the **docking** step, CHCHD4 forms a **transient intermolecular disulfide** between its CPC motif and a substrate cysteine (alhabib2021chchd4(mia40)and pages 1-2, balasco2025chchd4oxidoreductaseactivity pages 14-15, dicksonmurray2021themia40chchd4oxidative pages 4-5) | Dickson-Murray et al. 2021; Balasco et al. 2025 | https://doi.org/10.3390/antiox10040592; https://doi.org/10.3390/molecules30102117 | Human CHCHD4 Cys55 is the key nucleophilic cysteine for substrate engagement |
+| Mechanism 4: oxidative folding / trapping | A second substrate cysteine attacks to generate an **intramolecular disulfide** within the substrate, promoting oxidative folding, stability, and **retention in the IMS** (balasco2025chchd4oxidoreductaseactivity pages 4-5, dicksonmurray2021themia40chchd4oxidative pages 4-5) | Dickson-Murray et al. 2021; Balasco et al. 2025 | https://doi.org/10.3390/antiox10040592; https://doi.org/10.3390/molecules30102117 | Oxidative folding acts as a trapping mechanism for IMS residency |
+| Mechanism 5: CHCHD4 reoxidation | Reduced CHCHD4 is reoxidized by **ALR/GFER** (mammalian Erv1 homolog), an FAD-dependent sulfhydryl oxidase that interacts with the CHCHD4 hydrophobic groove (alhabib2021chchd4(mia40)and pages 2-4, balasco2025chchd4oxidoreductaseactivity pages 14-15, muzzioli2024theinteractionand pages 1-2) | Al-Habib & Ashcroft 2021; Balasco et al. 2025; Muzzioli & Gallo 2024 | https://doi.org/10.1042/bst20190232; https://doi.org/10.3390/molecules30102117; https://doi.org/10.3390/ijms25021174 | CHCHD4 F68E disrupts efficient reoxidation by ALR |
+| Mechanism 6: electron acceptors | Electrons are transferred from CHCHD4 to ALR/GFER and then preferentially to **cytochrome c / complex IV**, or alternatively to **O2**, which can generate **H2O2** (alhabib2021chchd4(mia40)and pages 2-4, modjtahedi2016mitochondrialproteinscontaining pages 3-5, dicksonmurray2021themia40chchd4oxidative pages 4-5) | Al-Habib & Ashcroft 2021; Modjtahedi et al. 2016; Dickson-Murray et al. 2021 | https://doi.org/10.1042/bst20190232; https://doi.org/10.1016/j.tibs.2015.12.004; https://doi.org/10.3390/antiox10040592 | Links the MIA pathway to respiratory-chain redox state |
+| Representative substrates: canonical CHCH proteins | Major substrate class comprises proteins with **(CX9C)2** or **(CX3C)2** motifs / CHCH domains, including **COX17**, **COX19**, **TRIAP1**, **CHCHD2**, **CHCHD7**, and assembly factors such as **CMC1/CMC2/COA4-6** (modjtahedi2016mitochondrialproteinscontaining pages 2-3, alhabib2021chchd4(mia40)and pages 1-2, modjtahedi2016mitochondrialproteinscontaining pages 3-5) | Modjtahedi et al. 2016; Al-Habib & Ashcroft 2021 | https://doi.org/10.1016/j.tibs.2015.12.004; https://doi.org/10.1042/bst20190232 | These proteins participate in respiratory-chain biogenesis, lipid homeostasis, and mitochondrial organization |
+| Representative substrate detail: COX17 | **COX17** is a validated CHCHD4 substrate; Balasco et al. list COX17 as a **67 aa** protein with motif **CX9C-X8-CX9C** and docked cysteine **C45** (balasco2025chchd4oxidoreductaseactivity pages 5-8) | Balasco et al. 2025 | https://doi.org/10.3390/molecules30102117 | Useful example of a classical cysteine-rich IMS copper-chaperone substrate |
+| Representative substrate detail: TRIAP1 | **TRIAP1** is a CHCHD4-dependent imported substrate that links the disulfide relay to **cardiolipin homeostasis** and mitochondrial signaling in muscle physiology (ma2024chchd4triap1regulationof pages 1-3, ma2024chchd4triap1regulationof pages 10-11) | Ma et al. 2024 | https://doi.org/10.1016/j.celrep.2023.113626 | In the exercise study, TRIAP1 is presented as the critical signal mediator downstream of CHCHD4 |
+| Substrate repertoire breadth | A recent synthesis reports **34 experimentally validated CHCHD4 substrates**, including canonical twin-CX9C proteins and increasing numbers of **non-canonical** redox-regulated substrates (balasco2025chchd4oxidoreductaseactivity pages 1-2, balasco2025chchd4oxidoreductaseactivity pages 5-8) | Balasco et al. 2025 | https://doi.org/10.3390/molecules30102117 | Review uses PDB/AlphaFold-based structural classification; see Figure 1 and Table 2 |
+| Recent 2024 physiology | In exercised muscle, lower CHCHD4 reduces TRIAP1 import, decreases cardiolipin, promotes **VDAC oligomerization** and **mtDNA release**, activating **cGAS–STING–NFKB** signaling and slow-twitch fiber adaptation; in mice, **CHCHD4+/−** animals showed greater treadmill improvement (**68% vs 58%** WT) and lower blood-lactate rise after submaximal exercise (**37% vs 90%** WT) (ma2024chchd4triap1regulationof pages 1-3, ma2024chchd4triap1regulationof pages 10-11, ma2024chchd4triap1regulationof media f1db45ec) | Ma et al. 2024 | https://doi.org/10.1016/j.celrep.2023.113626 | Figure 7A–F summarizes the model and phenotypes; data are from mouse physiology, but they reveal a new CHCHD4-regulated signaling axis |
+| Disease / systems relevance | Beyond import chemistry, CHCHD4 is implicated in **hypoxia responses**, **cancer metabolism**, Fe–S handling, and mitochondrial stress signaling; dysregulation of CHCHD4 or partners such as **AIF** and **ALR** is linked to disease (alhabib2021chchd4(mia40)and pages 2-4, balasco2025chchd4oxidoreductaseactivity pages 4-5, balasco2025chchd4oxidoreductaseactivity pages 5-8) | Al-Habib & Ashcroft 2021; Balasco et al. 2025 | https://doi.org/10.1042/bst20190232; https://doi.org/10.3390/molecules30102117 | For this report, the strongest recent mechanistic advance retrieved was the 2024 CHCHD4–TRIAP1 exercise/innate-immunity axis |
+
+
+*Table: This table summarizes verified identity, motifs, localization, core MIA/disulfide-relay steps, representative substrate classes, and a notable 2024 physiology finding for human CHCHD4/MIA40. It is useful as a compact evidence map linking molecular mechanism to recent in vivo function.*
+
+## 9) Conclusions (functional annotation)
+CHCHD4 (MIA40; UniProt Q8N4Q1) is a human mitochondrial IMS oxidoreductase and import receptor that catalyzes oxidative folding (intramolecular disulfide formation) of cysteine-containing IMS proteins, thereby coupling TOM-mediated translocation to IMS retention via a disulfide relay with ALR/GFER and downstream electron acceptors. (alhabib2021chchd4(mia40)and pages 1-2, dicksonmurray2021themia40chchd4oxidative pages 4-5)
+
+Recent 2024 evidence expands its functional annotation to include a CHCHD4-dependent signaling axis in vivo (CHCHD4→TRIAP1 import→cardiolipin/VDAC→mtDNA release→cGAS–STING–NFKB) that mediates skeletal muscle adaptation to exercise, with quantifiable performance and metabolic phenotypes in mice. (ma2024chchd4triap1regulationof pages 10-11, ma2024chchd4triap1regulationof media f1db45ec)
+
+## 10) URLs and publication dates (key sources cited)
+- Al-Habib H, Ashcroft M. **Biochemical Society Transactions**. **2021-02**. “CHCHD4 (MIA40) and the mitochondrial disulfide relay system.” https://doi.org/10.1042/bst20190232 (alhabib2021chchd4(mia40)and pages 2-4)
+- Dickson-Murray E, et al. **Antioxidants**. **2021-04**. “The Mia40/CHCHD4 Oxidative Folding System…” https://doi.org/10.3390/antiox10040592 (dicksonmurray2021themia40chchd4oxidative pages 4-5)
+- Modjtahedi N, et al. **Trends in Biochemical Sciences**. **2016-03**. “Mitochondrial proteins containing CHCH domains…” https://doi.org/10.1016/j.tibs.2015.12.004 (modjtahedi2016mitochondrialproteinscontaining pages 3-5)
+- Ma J, et al. **Cell Reports**. **2024-01**. “CHCHD4-TRIAP1 regulation of innate immune signaling mediates skeletal muscle adaptation to exercise.” https://doi.org/10.1016/j.celrep.2023.113626 (ma2024chchd4triap1regulationof pages 10-11)
+- Muzzioli R, Gallo A. **International Journal of Molecular Sciences**. **2024-01**. “The Interaction and Effect of a Small MitoBlock Library…” https://doi.org/10.3390/ijms25021174 (muzzioli2024theinteractionand pages 1-2)
+
+## 11) Limitations of this synthesis
+While reviews cited here discuss CHCHD4 in hypoxia/cancer contexts, the retrieved evidence set contains limited 2023–2024 primary data directly addressing CHCHD4 in human cancer/hypoxia models; the most detailed 2024 primary evidence obtained concerns exercise/innate immunity in mice and chemical probe modulation of the pathway. Accordingly, cancer/hypoxia-related claims are kept at the review-supported level rather than extended with new quantitative human oncology datasets. (alhabib2021chchd4(mia40)and pages 2-4, dicksonmurray2021themia40chchd4oxidative pages 4-5)
+
+References
+
+1. (alhabib2021chchd4(mia40)and pages 2-4): Hasan Al-Habib and Margaret Ashcroft. Chchd4 (mia40) and the mitochondrial disulfide relay system. Biochemical Society Transactions, 49:17-27, Feb 2021. URL: https://doi.org/10.1042/bst20190232, doi:10.1042/bst20190232. This article has 37 citations and is from a peer-reviewed journal.
+
+2. (alhabib2021chchd4(mia40)and pages 1-2): Hasan Al-Habib and Margaret Ashcroft. Chchd4 (mia40) and the mitochondrial disulfide relay system. Biochemical Society Transactions, 49:17-27, Feb 2021. URL: https://doi.org/10.1042/bst20190232, doi:10.1042/bst20190232. This article has 37 citations and is from a peer-reviewed journal.
+
+3. (modjtahedi2016mitochondrialproteinscontaining pages 3-5): Nazanine Modjtahedi, Kostas Tokatlidis, Philippe Dessen, and Guido Kroemer. Mitochondrial proteins containing coiled-coil-helix-coiled-coil-helix (chch) domains in health and disease. Trends in biochemical sciences, 41 3:245-260, Mar 2016. URL: https://doi.org/10.1016/j.tibs.2015.12.004, doi:10.1016/j.tibs.2015.12.004. This article has 165 citations and is from a domain leading peer-reviewed journal.
+
+4. (dicksonmurray2021themia40chchd4oxidative pages 4-5): Eleanor Dickson-Murray, Kenza Nedara, Nazanine Modjtahedi, and Kostas Tokatlidis. The mia40/chchd4 oxidative folding system: redox regulation and signaling in the mitochondrial intermembrane space. Antioxidants, 10:592, Apr 2021. URL: https://doi.org/10.3390/antiox10040592, doi:10.3390/antiox10040592. This article has 37 citations.
+
+5. (modjtahedi2016mitochondrialproteinscontaining pages 2-3): Nazanine Modjtahedi, Kostas Tokatlidis, Philippe Dessen, and Guido Kroemer. Mitochondrial proteins containing coiled-coil-helix-coiled-coil-helix (chch) domains in health and disease. Trends in biochemical sciences, 41 3:245-260, Mar 2016. URL: https://doi.org/10.1016/j.tibs.2015.12.004, doi:10.1016/j.tibs.2015.12.004. This article has 165 citations and is from a domain leading peer-reviewed journal.
+
+6. (balasco2025chchd4oxidoreductaseactivity pages 14-15): Nicole Balasco, Nazanine Modjtahedi, Alessandra Monti, Menotti Ruvo, Luigi Vitagliano, and Nunzianna Doti. Chchd4 oxidoreductase activity: a comprehensive analysis of the molecular, functional, and structural properties of its redox-regulated substrates. Molecules, 30:2117, May 2025. URL: https://doi.org/10.3390/molecules30102117, doi:10.3390/molecules30102117. This article has 3 citations.
+
+7. (balasco2025chchd4oxidoreductaseactivity pages 4-5): Nicole Balasco, Nazanine Modjtahedi, Alessandra Monti, Menotti Ruvo, Luigi Vitagliano, and Nunzianna Doti. Chchd4 oxidoreductase activity: a comprehensive analysis of the molecular, functional, and structural properties of its redox-regulated substrates. Molecules, 30:2117, May 2025. URL: https://doi.org/10.3390/molecules30102117, doi:10.3390/molecules30102117. This article has 3 citations.
+
+8. (balasco2025chchd4oxidoreductaseactivity pages 5-8): Nicole Balasco, Nazanine Modjtahedi, Alessandra Monti, Menotti Ruvo, Luigi Vitagliano, and Nunzianna Doti. Chchd4 oxidoreductase activity: a comprehensive analysis of the molecular, functional, and structural properties of its redox-regulated substrates. Molecules, 30:2117, May 2025. URL: https://doi.org/10.3390/molecules30102117, doi:10.3390/molecules30102117. This article has 3 citations.
+
+9. (ma2024chchd4triap1regulationof pages 1-3): Jin Ma, Ping-yuan Wang, Jie Zhuang, Annie Y. Son, Alexander K. Karius, Abu Mohammad Syed, Masahiro Nishi, Zhichao Wu, Mateus P. Mori, Young-Chae Kim, and Paul M. Hwang. Chchd4-triap1 regulation of innate immune signaling mediates skeletal muscle adaptation to exercise. Cell Reports, 43:113626, Jan 2024. URL: https://doi.org/10.1016/j.celrep.2023.113626, doi:10.1016/j.celrep.2023.113626. This article has 16 citations and is from a highest quality peer-reviewed journal.
+
+10. (ma2024chchd4triap1regulationof pages 10-11): Jin Ma, Ping-yuan Wang, Jie Zhuang, Annie Y. Son, Alexander K. Karius, Abu Mohammad Syed, Masahiro Nishi, Zhichao Wu, Mateus P. Mori, Young-Chae Kim, and Paul M. Hwang. Chchd4-triap1 regulation of innate immune signaling mediates skeletal muscle adaptation to exercise. Cell Reports, 43:113626, Jan 2024. URL: https://doi.org/10.1016/j.celrep.2023.113626, doi:10.1016/j.celrep.2023.113626. This article has 16 citations and is from a highest quality peer-reviewed journal.
+
+11. (ma2024chchd4triap1regulationof media f1db45ec): Jin Ma, Ping-yuan Wang, Jie Zhuang, Annie Y. Son, Alexander K. Karius, Abu Mohammad Syed, Masahiro Nishi, Zhichao Wu, Mateus P. Mori, Young-Chae Kim, and Paul M. Hwang. Chchd4-triap1 regulation of innate immune signaling mediates skeletal muscle adaptation to exercise. Cell Reports, 43:113626, Jan 2024. URL: https://doi.org/10.1016/j.celrep.2023.113626, doi:10.1016/j.celrep.2023.113626. This article has 16 citations and is from a highest quality peer-reviewed journal.
+
+12. (muzzioli2024theinteractionand pages 1-2): Riccardo Muzzioli and Angelo Gallo. The interaction and effect of a small mitoblock library as inhibitor of alr protein–protein interaction pathway. International Journal of Molecular Sciences, 25:1174, Jan 2024. URL: https://doi.org/10.3390/ijms25021174, doi:10.3390/ijms25021174. This article has 3 citations.
+
+13. (balasco2025chchd4oxidoreductaseactivity pages 1-2): Nicole Balasco, Nazanine Modjtahedi, Alessandra Monti, Menotti Ruvo, Luigi Vitagliano, and Nunzianna Doti. Chchd4 oxidoreductase activity: a comprehensive analysis of the molecular, functional, and structural properties of its redox-regulated substrates. Molecules, 30:2117, May 2025. URL: https://doi.org/10.3390/molecules30102117, doi:10.3390/molecules30102117. This article has 3 citations.
+
+## Citations
+
+1. muzzioli2024theinteractionand pages 1-2
+2. modjtahedi2016mitochondrialproteinscontaining pages 3-5
+3. modjtahedi2016mitochondrialproteinscontaining pages 2-3
+4. https://doi.org/10.1042/bst20190232
+5. https://doi.org/10.1042/bst20190232;
+6. https://doi.org/10.3390/molecules30102117;
+7. https://doi.org/10.3390/ijms25021174
+8. https://doi.org/10.1016/j.tibs.2015.12.004;
+9. https://doi.org/10.3390/antiox10040592;
+10. https://doi.org/10.3390/molecules30102117
+11. https://doi.org/10.3390/antiox10040592
+12. https://doi.org/10.1016/j.celrep.2023.113626
+13. https://doi.org/10.1016/j.tibs.2015.12.004
+14. https://doi.org/10.1042/bst20190232,
+15. https://doi.org/10.1016/j.tibs.2015.12.004,
+16. https://doi.org/10.3390/antiox10040592,
+17. https://doi.org/10.3390/molecules30102117,
+18. https://doi.org/10.1016/j.celrep.2023.113626,
+19. https://doi.org/10.3390/ijms25021174,

--- a/genes/human/EIF2AK3/EIF2AK3-ai-review.html
+++ b/genes/human/EIF2AK3/EIF2AK3-ai-review.html
@@ -1155,6 +1155,17 @@
                                 
                             </div>
                             
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/EIF2AK3/EIF2AK3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">PERK&#39;s primary enzymatic function is to phosphorylate eukaryotic translation initiation factor 2 subunit alpha (eIF2alpha; gene EIF2S1) at Ser51.</div>
+
+                            </div>
+
                         </div>
                         
                     </td>
@@ -5009,6 +5020,17 @@
                                 
                             </div>
                             
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/EIF2AK3/EIF2AK3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A canonical pathway is ER stress, PERK activation, eIF2alpha(Ser51) phosphorylation, reduced global translation plus preferential ATF4 translation, adaptive gene expression, and CHOP induction if prolonged.</div>
+
+                            </div>
+
                         </div>
                         
                     </td>
@@ -7479,6 +7501,17 @@
                         
                     </li>
                     
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/EIF2AK3/EIF2AK3-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">PERK&#39;s primary enzymatic function is to phosphorylate eukaryotic translation initiation factor 2 subunit alpha (eIF2alpha; gene EIF2S1) at Ser51.</div>
+
+                    </li>
+
                 </ul>
             </div>
             
@@ -8229,6 +8262,31 @@
                 
             </div>
             
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/EIF2AK3/EIF2AK3-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research report for EIF2AK3</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Falcon research supports EIF2AK3/PERK as an ER-membrane stress sensor kinase that phosphorylates EIF2S1/eIF2alpha at Ser51 to attenuate translation and activate the PERK arm of the UPR/ISR.</div>
+
+                        <div class="finding-text">"PERK&#39;s primary enzymatic function is to phosphorylate eukaryotic translation initiation factor 2 subunit alpha (eIF2alpha; gene EIF2S1) at Ser51."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
         </div>
     </div>
     
@@ -8248,6 +8306,338 @@
     <div class="section">
         <h2 class="section-title">📚 Additional Documentation</h2>
         
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Deep Research Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(EIF2AK3-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q9NZJ5" data-a="DOC: Deep Research Falcon" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <hr />
+<p>provider: falcon<br />
+model: Edison Scientific Literature<br />
+cached: false<br />
+start_time: '2026-05-10T20:28:15.514374'<br />
+end_time: '2026-05-10T20:47:28.795002'<br />
+duration_seconds: 1153.28<br />
+template_file: templates/gene_research_go_focused.md<br />
+template_variables:<br />
+  organism: human<br />
+  gene_id: EIF2AK3<br />
+  gene_symbol: EIF2AK3<br />
+  uniprot_accession: Q9NZJ5<br />
+  protein_description: 'RecName: Full=Eukaryotic translation initiation factor 2-alpha<br />
+    kinase 3 {ECO:0000305}; EC=2.7.11.1 {ECO:0000269|PubMed:10026192, ECO:0000269|PubMed:10677345};<br />
+    AltName: Full=PRKR-like endoplasmic reticulum kinase {ECO:0000303|PubMed:23103912};<br />
+    AltName: Full=Pancreatic eIF2-alpha kinase {ECO:0000303|PubMed:10026192}; Short=HsPEK<br />
+    {ECO:0000303|PubMed:10026192}; AltName: Full=Protein tyrosine kinase EIF2AK3 {ECO:0000305};<br />
+    EC=2.7.10.2 {ECO:0000250|UniProtKB:Q9Z2B5}; Flags: Precursor;'<br />
+  gene_info: Name=EIF2AK3 {ECO:0000303|PubMed:10932183, ECO:0000312|HGNC:HGNC:3255};<br />
+    Synonyms=PEK {ECO:0000303|PubMed:10026192}, PERK {ECO:0000303|PubMed:23103912};<br />
+  organism_full: Homo sapiens (Human).<br />
+  protein_family: Belongs to the protein kinase superfamily. Ser/Thr protein<br />
+  protein_domains: CC_SR_Kinase. (IPR050339); Kinase-like_dom_sf. (IPR011009); Prot_kinase_dom.<br />
+    (IPR000719); Protein_kinase_ATP_BS. (IPR017441); Quinoprotein_ADH-like_sf. (IPR011047)<br />
+provider_config:<br />
+  timeout: 600<br />
+  max_retries: 3<br />
+  parameters:<br />
+    allowed_domains: []<br />
+    temperature: 0.1<br />
+citation_count: 26</p>
+<hr />
+<h2 id="question">Question</h2>
+<h1 id="gene-research-for-functional-annotation">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> Q9NZJ5</li>
+<li><strong>Protein Description:</strong> RecName: Full=Eukaryotic translation initiation factor 2-alpha kinase 3 {ECO:0000305}; EC=2.7.11.1 {ECO:0000269|PubMed:10026192, ECO:0000269|PubMed:10677345}; AltName: Full=PRKR-like endoplasmic reticulum kinase {ECO:0000303|PubMed:23103912}; AltName: Full=Pancreatic eIF2-alpha kinase {ECO:0000303|PubMed:10026192}; Short=HsPEK {ECO:0000303|PubMed:10026192}; AltName: Full=Protein tyrosine kinase EIF2AK3 {ECO:0000305}; EC=2.7.10.2 {ECO:0000250|UniProtKB:Q9Z2B5}; Flags: Precursor;</li>
+<li><strong>Gene Information:</strong> Name=EIF2AK3 {ECO:0000303|PubMed:10932183, ECO:0000312|HGNC:HGNC:3255}; Synonyms=PEK {ECO:0000303|PubMed:10026192}, PERK {ECO:0000303|PubMed:23103912};</li>
+<li><strong>Organism (full):</strong> Homo sapiens (Human).</li>
+<li><strong>Protein Family:</strong> Belongs to the protein kinase superfamily. Ser/Thr protein</li>
+<li><strong>Key Domains:</strong> CC_SR_Kinase. (IPR050339); Kinase-like_dom_sf. (IPR011009); Prot_kinase_dom. (IPR000719); Protein_kinase_ATP_BS. (IPR017441); Quinoprotein_ADH-like_sf. (IPR011047)</li>
+</ul>
+<h3 id="mandatory-verification-steps">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "EIF2AK3" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Homo sapiens (Human).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'EIF2AK3' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>EIF2AK3</strong> (gene ID: EIF2AK3, UniProt: Q9NZJ5) in human.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="output">Output</h2>
+<p>Question: You are an expert researcher providing comprehensive, well-cited information.</p>
+<p>Provide detailed information focusing on:<br />
+1. Key concepts and definitions with current understanding<br />
+2. Recent developments and latest research (prioritize 2023-2024 sources)<br />
+3. Current applications and real-world implementations<br />
+4. Expert opinions and analysis from authoritative sources<br />
+5. Relevant statistics and data from recent studies</p>
+<p>Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.<br />
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.</p>
+<h1 id="gene-research-for-functional-annotation_1">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context_1">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot_1">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> Q9NZJ5</li>
+<li><strong>Protein Description:</strong> RecName: Full=Eukaryotic translation initiation factor 2-alpha kinase 3 {ECO:0000305}; EC=2.7.11.1 {ECO:0000269|PubMed:10026192, ECO:0000269|PubMed:10677345}; AltName: Full=PRKR-like endoplasmic reticulum kinase {ECO:0000303|PubMed:23103912}; AltName: Full=Pancreatic eIF2-alpha kinase {ECO:0000303|PubMed:10026192}; Short=HsPEK {ECO:0000303|PubMed:10026192}; AltName: Full=Protein tyrosine kinase EIF2AK3 {ECO:0000305}; EC=2.7.10.2 {ECO:0000250|UniProtKB:Q9Z2B5}; Flags: Precursor;</li>
+<li><strong>Gene Information:</strong> Name=EIF2AK3 {ECO:0000303|PubMed:10932183, ECO:0000312|HGNC:HGNC:3255}; Synonyms=PEK {ECO:0000303|PubMed:10026192}, PERK {ECO:0000303|PubMed:23103912};</li>
+<li><strong>Organism (full):</strong> Homo sapiens (Human).</li>
+<li><strong>Protein Family:</strong> Belongs to the protein kinase superfamily. Ser/Thr protein</li>
+<li><strong>Key Domains:</strong> CC_SR_Kinase. (IPR050339); Kinase-like_dom_sf. (IPR011009); Prot_kinase_dom. (IPR000719); Protein_kinase_ATP_BS. (IPR017441); Quinoprotein_ADH-like_sf. (IPR011047)</li>
+</ul>
+<h3 id="mandatory-verification-steps_1">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "EIF2AK3" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Homo sapiens (Human).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature_1">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'EIF2AK3' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target_1">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>EIF2AK3</strong> (gene ID: EIF2AK3, UniProt: Q9NZJ5) in human.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="comprehensive-research-report-human-eif2ak3-perk-uniprot-q9nzj5-functional-annotation">Comprehensive research report: Human <strong>EIF2AK3 / PERK</strong> (UniProt <strong>Q9NZJ5</strong>) — functional annotation</h2>
+<h3 id="0-target-verification-mandatory">0) Target verification (mandatory)</h3>
+<p>The target is <strong>human EIF2AK3</strong>, encoding <strong>protein kinase RNA-like endoplasmic reticulum kinase (PERK; also called PEK)</strong>, a <strong>type I ER transmembrane serine/threonine protein kinase</strong> with an <strong>ER luminal stress-sensing N-terminus</strong> and a <strong>cytosolic C-terminal kinase domain</strong>. This identity matches the UniProt description provided and is explicitly stated in recent reviews and mechanistic studies (huang2023erstressthe pages 2-4, perea2023pharmacologicactivationof pages 1-4).</p>
+<h3 id="1-key-concepts-and-definitions-current-understanding">1) Key concepts and definitions (current understanding)</h3>
+<h4 id="11-er-stress-upr-and-isr-context">1.1 ER stress, UPR, and ISR context</h4>
+<p><strong>Endoplasmic reticulum (ER) stress</strong> arises when misfolded/unfolded proteins accumulate in the ER lumen. Cells respond through the <strong>unfolded protein response (UPR)</strong>, which is classically mediated by three ER sensors (PERK/EIF2AK3, IRE1/ERN1, and ATF6). PERK is also one of the four kinases that can trigger the <strong>integrated stress response (ISR)</strong> by converging on phosphorylation of eIF2α (huang2023erstressthe pages 2-4, perea2023pharmacologicactivationof pages 1-4).</p>
+<h4 id="12-what-perk-does-definition-of-primary-function">1.2 What PERK does (definition of primary function)</h4>
+<p>PERK’s <strong>primary enzymatic function</strong> is to phosphorylate <strong>eukaryotic translation initiation factor 2 subunit alpha (eIF2α; gene EIF2S1)</strong> at <strong>Ser51</strong>, which reduces global cap-dependent translation initiation to decrease protein-folding load in the ER while enabling selective translation of stress-adaptive mRNAs (huang2023erstressthe pages 2-4).</p>
+<h3 id="2-molecular-function-and-enzymology">2) Molecular function and enzymology</h3>
+<h4 id="21-catalyzed-reaction-and-substrate-specificity">2.1 Catalyzed reaction and substrate specificity</h4>
+<p>Under ER stress, activated PERK phosphorylates <strong>eIF2α at Ser51</strong>, initiating translational attenuation and ISR transcriptional programs (huang2023erstressthe pages 2-4). Selective translation includes <strong>ATF4</strong>, which coordinates adaptive outputs and can induce <strong>CHOP/DDIT3</strong> under sustained stress, promoting apoptosis (perea2023pharmacologicactivationof pages 1-4).</p>
+<h4 id="22-downstream-signaling-logic">2.2 Downstream signaling logic</h4>
+<p>A canonical pathway is:<br />
+<strong>ER stress → PERK activation → eIF2α(Ser51) phosphorylation → reduced global translation + preferential ATF4 translation → adaptive gene expression; if prolonged, CHOP induction and apoptosis</strong> (perea2023pharmacologicactivationof pages 1-4, huang2023erstressthe pages 2-4).</p>
+<p>PERK signaling also intersects with antioxidant programs, including <strong>NRF2-related signaling</strong> in multiple contexts (ghura2024geneticknockinof pages 1-2, ghura2024geneticknockinof pages 14-15).</p>
+<h3 id="3-subcellular-localization-and-activation-mechanism">3) Subcellular localization and activation mechanism</h3>
+<h4 id="31-localization">3.1 Localization</h4>
+<p>PERK is <strong>ER membrane localized</strong> (type I transmembrane) (huang2023erstressthe pages 2-4). Beyond general ER localization, PERK has been reported to function at <strong>ER–mitochondria contact sites</strong> and to influence mitochondrial remodeling and bioenergetics during stress responses (perea2023pharmacologicactivationof pages 1-4).</p>
+<h4 id="32-activation-mechanism">3.2 Activation mechanism</h4>
+<p>In basal conditions, PERK’s luminal domain is restrained by <strong>BiP/GRP78</strong>. During ER stress, BiP is titrated away by misfolded proteins, enabling PERK <strong>homodimerization/oligomerization</strong> and <strong>autophosphorylation</strong>, activating the cytosolic kinase domain (huang2023erstressthe pages 2-4). Recent 2024 structure–function work further emphasizes that disease-associated variants can perturb luminal-domain dimer/oligomer interfaces and alter signaling kinetics (park2024ethnicvariationand pages 5-9, park2024ethnicvariationand pages 9-13).</p>
+<h3 id="4-recent-developments-prioritizing-20232024">4) Recent developments (prioritizing 2023–2024)</h3>
+<h4 id="41-human-islet-biology-perk-inhibition-rescues-autophagy-and-insulin-phenotype-under-glucolipotoxicity-2024">4.1 Human islet biology: PERK inhibition rescues autophagy and insulin phenotype under glucolipotoxicity (2024)</h4>
+<p>In <strong>human islets</strong> from <strong>8 non-diabetic donors</strong> (mean age <strong>54.5±16.0 years</strong>, BMI <strong>25.6±3.6</strong>, HbA1c <strong>5.7%±0.3</strong>), glucolipotoxicity (<strong>20 mM glucose + 0.5 mM palmitate</strong>) increased <strong>PERK phosphorylation by ~70%</strong> and decreased <strong>insulin content by ~50%</strong>. Treatment with the PERK inhibitor <strong>GSK2606414</strong> (noted as <strong>40–80 nM</strong>) reversed these changes and increased <strong>glucose-stimulated insulin secretion by ~6-fold</strong>. Mechanistically, PERK inhibition increased autophagic flux (LC3 conversion and reduced p62 protein without changing p62 transcription) and required <strong>ATG7</strong> for the insulin-rescue phenotype (moon2024glucolipotoxicitysuppressedautophagy pages 1-2, moon2024glucolipotoxicitysuppressedautophagy pages 5-6).</p>
+<p>Figures supporting the PERK phosphorylation/autophagy/insulin phenotypes and ATG7 dependence are shown in the extracted image panels (moon2024glucolipotoxicitysuppressedautophagy media e6820203, moon2024glucolipotoxicitysuppressedautophagy media d4374739).</p>
+<h4 id="42-human-genetics-and-cognition-in-hiv-2024">4.2 Human genetics and cognition in HIV (2024)</h4>
+<p>A 2024 study analyzed EIF2AK3 SNVs in the CHARTER cohort using genome-wide data for <strong>1,047</strong> participants and targeted sequencing for <strong>992</strong>. The authors report associations between EIF2AK3 variants and neurocognitive outcomes. Frequencies for coding risk alleles were: <strong>30.9%</strong> with ≥1 risk allele for rs1805165 (G), <strong>30.9%</strong> for rs867529 (G), and <strong>41.2%</strong> for rs13045 (A). Homozygosity for all three coding SNVs was associated with worse global deficit score and more neurocognitive impairment (both <strong>p&lt;0.001</strong>). In multivariable models, rs13045 (A), current ART use, and depression score (BDI-II&gt;13) were independently associated with outcomes (<strong>p&lt;0.001</strong>) (akayespinoza2024geneticvariationsin pages 1-2).</p>
+<h4 id="43-common-coding-haplotypes-perk-a-vs-perk-b-activity-differences-under-er-stress-2024">4.3 Common-coding haplotypes: PERK-A vs PERK-B activity differences under ER stress (2024)</h4>
+<p>A 2024 knock-in model study focusing on the exonic SNVs (rs867529, rs13045, rs1805165) reports that PERK-B is present in ~<strong>28%</strong> of the global population, with ancestry variation estimated at <strong>~8% African</strong>, <strong>32% European</strong>, and <strong>~50% Asian.</strong> Functionally, PERK-B did not alter basal expression/activity but displayed <strong>higher kinase activity</strong> than PERK-A in a cell-free assay and in mouse liver homogenates, and PERK-B/B pancreas showed greater susceptibility to apoptosis under acute ER stress (ghura2024geneticknockinof pages 1-2, ghura2024geneticknockinof pages 10-11).</p>
+<h4 id="44-tauopathy-associated-alleles-structurefunction-interpretation-and-population-variation-2024">4.4 Tauopathy-associated alleles: structure–function interpretation and population variation (2024)</h4>
+<p>A 2024 study assembled EIF2AK3/PERK disease variant sets and used modeling/functional assays to argue that <strong>Wolcott–Rallison syndrome</strong> variants cluster mainly in the <strong>cytosolic kinase domain</strong>, whereas <strong>tauopathy-linked</strong> variants are enriched in the <strong>luminal domain</strong>, consistent with altered ER stress sensing and activation kinetics. The authors report substantial ethnic differences in frequencies of common tauopathy-linked alleles and demonstrate altered PERK signaling kinetics for disease variants in cell models (park2024ethnicvariationand pages 9-13, park2024ethnicvariationand pages 5-9).</p>
+<h4 id="45-viral-myocarditis-mechanism-trim29-stabilizes-perk-via-sumoylation-2024">4.5 Viral myocarditis mechanism: TRIM29 stabilizes PERK via SUMOylation (2024)</h4>
+<p>A 2024 Nature Communications study reports that <strong>TRIM29</strong> interacts with PERK and promotes <strong>SUMOylation</strong> to maintain PERK stability, enhancing PERK-mediated ER stress signaling in cardiomyocytes during viral infection. Pharmacologic PERK inhibition (reported with <strong>GSK2656157</strong>) disrupted the TRIM29–PERK axis and mitigated viral myocarditis phenotypes in vivo (wang2024lossoftrim29 pages 1-2).</p>
+<h3 id="5-current-applications-and-real-world-implementations">5) Current applications and real-world implementations</h3>
+<h4 id="51-perk-as-a-drug-target-and-experimental-handle">5.1 PERK as a drug target and experimental handle</h4>
+<p>PERK is actively targeted in translational research using:<br />
+- <strong>Inhibitors</strong> (e.g., GSK2606414; GSK2656157) to suppress the PERK arm of the UPR/ISR.<br />
+- <strong>Activators</strong> (e.g., CCT020312; and limited direct activators) or <strong>compensatory ISR activation</strong> approaches (e.g., activating alternative ISR kinases such as HRI or GCN2) to restore ISR outputs when PERK is deficient (perea2023pharmacologicactivationof pages 1-4, moon2024glucolipotoxicitysuppressedautophagy pages 1-2).</p>
+<p>A key implementation example is the use of PERK inhibition to modulate β-cell/islet function under metabolic stress, where low-nanomolar GSK2606414 improved insulin content/secretion in human islets under glucolipotoxicity in a manner linked to autophagy flux and ATG7 (moon2024glucolipotoxicitysuppressedautophagy pages 1-2, moon2024glucolipotoxicitysuppressedautophagy pages 5-6).</p>
+<h4 id="52-clinical-trial-landscape-from-tool-based-search">5.2 Clinical trial landscape (from tool-based search)</h4>
+<p>A clinical trials registry search using PERK/EIF2AK3 and major tool compounds did <strong>not</strong> retrieve a relevant PERK-focused interventional clinical trial in the current tool output; the retrieved record was unrelated to PERK biology (clinical trial retrieval not relevant; no citeable PERK trial record returned). Therefore, evidence in this run supports PERK modulation as <strong>preclinical/translational</strong> rather than established clinical intervention.</p>
+<h3 id="6-expert-opinions-analysis-and-methodological-caveats">6) Expert opinions / analysis and methodological caveats</h3>
+<h4 id="61-perk-signaling-is-context-dependent-adaptive-vs-terminal">6.1 PERK signaling is context-dependent (adaptive vs terminal)</h4>
+<p>Mechanistic synthesis across recent literature supports a dual role: PERK-eIF2α signaling can be <strong>adaptive</strong> (reducing translational load and restoring proteostasis) or contribute to <strong>terminal UPR</strong> and apoptosis through ATF4/CHOP under sustained stress (perea2023pharmacologicactivationof pages 1-4).</p>
+<h4 id="62-variant-to-phenotype-interpretation">6.2 Variant-to-phenotype interpretation</h4>
+<p>Recent human-genetic analyses emphasize that common EIF2AK3 variants/haplotypes (PERK-A vs PERK-B) and rarer disease alleles can alter PERK signaling kinetics and thereby modulate susceptibility to neurodegenerative and metabolic phenotypes, with important differences by ancestry (ghura2024geneticknockinof pages 10-11, park2024ethnicvariationand pages 9-13).</p>
+<h4 id="63-pharmacologic-specificity-considerations">6.3 Pharmacologic specificity considerations</h4>
+<p>Because this report is limited to the evidence retrieved in-tool, the principal caveat supported here is that PERK inhibitors/activators are widely used as <strong>chemical biology tools</strong>, but their interpretation should account for dose/context and for compensatory ISR activation by other eIF2α kinases (noted in PERK-deficient compensation studies) (perea2023pharmacologicactivationof pages 1-4).</p>
+<h3 id="7-key-statistics-and-data-20232024-emphasis">7) Key statistics and data (2023–2024 emphasis)</h3>
+<ul>
+<li><strong>Human islets (2024):</strong> glucolipotoxicity increased <strong>PERK phosphorylation by ~70%</strong> and decreased <strong>insulin content by ~50%</strong>; <strong>40–80 nM GSK2606414</strong> reversed these and increased GSIS by <strong>~6-fold</strong> (moon2024glucolipotoxicitysuppressedautophagy pages 1-2).</li>
+<li><strong>HIV CHARTER cohort (2024):</strong> n=<strong>1,047</strong> (genome-wide), n=<strong>992</strong> (targeted sequencing); ≥1 risk allele frequencies <strong>30.9%</strong>, <strong>30.9%</strong>, <strong>41.2%</strong> for rs1805165/rs867529/rs13045; homozygous risk across all three coding SNVs associated with worse outcomes (<strong>p&lt;0.001</strong>) (akayespinoza2024geneticvariationsin pages 1-2).</li>
+<li><strong>PERK haplotype prevalence (2024 synthesis/knock-in):</strong> PERK-B ~<strong>28%</strong> globally, with ancestry differences (~<strong>8% African</strong>, <strong>32% European</strong>, <strong>~50% Asian</strong>) (ghura2024geneticknockinof pages 10-11, ghura2024geneticknockinof pages 1-2).</li>
+</ul>
+<h3 id="8-concise-functional-annotation-summary-for-downstream-use">8) Concise functional annotation summary (for downstream use)</h3>
+<p>To support downstream functional annotation workflows, the table below compacts the most robust mechanistic claims (identity/domains, localization, activation, enzymology, pathway outputs, disease links, and 2024 quantitative highlights):</p>
+<table>
+<thead>
+<tr>
+<th>Category</th>
+<th>Summary</th>
+<th>Key citations / URL / publication date</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Identity/domains</td>
+<td><strong>EIF2AK3</strong> encodes <strong>PERK</strong> (PKR-like ER kinase; UniProt <strong>Q9NZJ5</strong>), an ER-stress-responsive <strong>type I transmembrane serine/threonine protein kinase</strong> with an <strong>N-terminal ER luminal stress-sensing domain</strong> and a <strong>C-terminal cytosolic kinase domain</strong>; this matches the UniProt-provided identity and kinase-family/domain context.</td>
+<td>(huang2023erstressthe pages 2-4, perea2023pharmacologicactivationof pages 1-4) https://doi.org/10.3390/biom13071050 (Jun 2023); https://doi.org/10.1101/2023.03.11.532186 (Mar 2023)</td>
+</tr>
+<tr>
+<td>Localization</td>
+<td>PERK is localized to the <strong>endoplasmic reticulum membrane</strong> and is also reported at <strong>ER–mitochondrial contact sites/MAMs</strong>, where it contributes to mitochondrial remodeling and bioenergetic adaptation during stress.</td>
+<td>(huang2023erstressthe pages 2-4, perea2023pharmacologicactivationof pages 1-4) https://doi.org/10.3390/biom13071050 (Jun 2023); https://doi.org/10.1101/2023.03.11.532186 (Mar 2023)</td>
+</tr>
+<tr>
+<td>Activation</td>
+<td>Under basal conditions, PERK is restrained by <strong>BiP/GRP78</strong> at its luminal domain. ER accumulation of unfolded proteins releases BiP, allowing <strong>PERK homodimerization/oligomerization</strong> and <strong>trans-autophosphorylation</strong>, which activates the kinase. Recent structure-function work indicates that some disease-associated variants alter <strong>luminal-domain dimer/tetramer interfaces</strong> and signaling kinetics.</td>
+<td>(huang2023erstressthe pages 2-4, park2024ethnicvariationand pages 9-13, park2024ethnicvariationand pages 5-9) https://doi.org/10.3390/biom13071050 (Jun 2023); https://doi.org/10.1002/ijch.202300173 (May 2024)</td>
+</tr>
+<tr>
+<td>Enzymatic reaction &amp; substrate</td>
+<td>PERK catalyzes phosphorylation of <strong>eIF2α/EIF2S1 at Ser51</strong>, the canonical ISR reaction that suppresses global cap-dependent translation while permitting selective translation of stress-adaptive mRNAs. PERK has also been described as able to phosphorylate <strong>NRF2</strong> in the PERK-NRF2 antioxidant branch.</td>
+<td>(huang2023erstressthe pages 2-4, perea2023pharmacologicactivationof pages 1-4) https://doi.org/10.3390/biom13071050 (Jun 2023); https://doi.org/10.1101/2023.03.11.532186 (Mar 2023)</td>
+</tr>
+<tr>
+<td>Downstream signaling</td>
+<td>The best-established downstream pathway is <strong>PERK → p-eIF2α → selective ATF4 translation</strong>, followed by induction of genes involved in adaptation and, under sustained stress, <strong>CHOP/DDIT3</strong>-linked apoptosis. PERK signaling also intersects with <strong>NRF2</strong>, autophagy programs, and broader ISR outputs.</td>
+<td>(perea2023pharmacologicactivationof pages 1-4, ghura2024geneticknockinof pages 1-2, ghura2024geneticknockinof pages 14-15) https://doi.org/10.1101/2023.03.11.532186 (Mar 2023); https://doi.org/10.1038/s41598-024-74362-z (Oct 2024)</td>
+</tr>
+<tr>
+<td>Mitochondria/contacts</td>
+<td>PERK helps coordinate <strong>mitochondrial morphology, cristae structure, respiration, and proteostasis</strong> during ER stress. In PERK-deficient cells, pharmacologic activation of alternative ISR kinases can partially rescue mitochondrial adaptation, supporting a central role for PERK in ER–mitochondria communication.</td>
+<td>(perea2023pharmacologicactivationof pages 1-4) https://doi.org/10.1101/2023.03.11.532186 (Mar 2023)</td>
+</tr>
+<tr>
+<td>Human genetics &amp; variants</td>
+<td>Rare <strong>loss-of-function EIF2AK3 variants</strong> cause <strong>Wolcott–Rallison syndrome (WRS)</strong>. Common coding SNVs <strong>rs867529, rs13045, rs1805165</strong> define <strong>PERK-B</strong> versus <strong>PERK-A</strong> haplotypes. Recent analyses report <strong>PERK-B ~28% globally</strong> (PERK-A ~64%), with ancestry differences and functional effects on stress signaling; WRS missense variants cluster mainly in the <strong>kinase domain</strong>, whereas tauopathy-linked variants are enriched in the <strong>luminal domain</strong>.</td>
+<td>(ghura2024geneticknockinof pages 1-2, ghura2024geneticknockinof pages 10-11, park2024ethnicvariationand pages 1-5, park2024ethnicvariationand pages 9-13, park2024ethnicvariationand pages 5-9) https://doi.org/10.1038/s41598-024-74362-z (Oct 2024); https://doi.org/10.1002/ijch.202300173 (May 2024)</td>
+</tr>
+<tr>
+<td>Disease links</td>
+<td>Authoritative recent literature links EIF2AK3/PERK to <strong>WRS</strong>, <strong>tauopathies/neurodegeneration</strong>, <strong>diabetes/β-cell stress</strong>, <strong>cancer progression or therapy resistance</strong>, and inflammatory or viral tissue injury. Recent mechanistic work shows TRIM29 stabilizes PERK via <strong>SUMOylation</strong> in <strong>viral myocarditis</strong>, while variant studies link EIF2AK3 to <strong>neurocognitive impairment in people with HIV</strong>.</td>
+<td>(wang2024lossoftrim29 pages 1-2, akayespinoza2024geneticvariationsin pages 1-2, ghura2024geneticknockinof pages 1-2, ghura2024geneticknockinof pages 14-15) https://doi.org/10.1038/s41467-024-44745-x (Apr 2024); https://doi.org/10.1007/s11481-024-10125-x (May 2024); https://doi.org/10.1038/s41598-024-74362-z (Oct 2024)</td>
+</tr>
+<tr>
+<td>Therapeutic modulation/applications</td>
+<td>PERK is being explored as a therapeutic node with <strong>inhibitors</strong> (e.g., <strong>GSK2606414</strong>, <strong>GSK2656157</strong>) and <strong>activators/ISR-compensation strategies</strong> (e.g., <strong>CCT020312</strong>, <strong>MK-28</strong>, HRI/GCN2 activation). However, published expert analyses caution that classic PERK inhibitors can have <strong>off-target kinase activities</strong> and specificity liabilities, so mechanistic interpretation requires care. No relevant registered clinical trials were identified in the retrieved evidence.</td>
+<td>(perea2023pharmacologicactivationof pages 1-4, wang2024lossoftrim29 pages 1-2, moon2024glucolipotoxicitysuppressedautophagy pages 1-2) https://doi.org/10.1101/2023.03.11.532186 (Mar 2023); https://doi.org/10.1038/s41467-024-44745-x (Apr 2024); https://doi.org/10.4093/dmj.2022.0366 (Mar 2024)</td>
+</tr>
+<tr>
+<td>Key quantitative data 2024</td>
+<td>Representative 2024 quantitative findings: <strong>PERK-B prevalence ~28% globally</strong> with ancestry estimates of <strong>~8% African, 32% European, ~50% Asian</strong> and prior odds ratios for neurocognitive impairment of <strong>1.8–2.36</strong> in cited cohort literature; in the CHARTER HIV cohort, genome-wide data were available for <strong>1,047</strong> participants and targeted sequencing for <strong>992</strong>, with <strong>30.9%</strong>, <strong>30.9%</strong>, and <strong>41.2%</strong> carrying ≥1 risk allele for <strong>rs1805165</strong>, <strong>rs867529</strong>, and <strong>rs13045</strong>, respectively; in human islets, glucolipotoxicity increased <strong>PERK phosphorylation by 70%</strong>, decreased <strong>insulin content by 50%</strong>, and <strong>40–80 nM GSK2606414</strong> restored insulin measures and increased GSIS by about <strong>6-fold</strong>.</td>
+<td>(ghura2024geneticknockinof pages 10-11, akayespinoza2024geneticvariationsin pages 1-2, moon2024glucolipotoxicitysuppressedautophagy pages 1-2, moon2024glucolipotoxicitysuppressedautophagy pages 4-5) https://doi.org/10.1038/s41598-024-74362-z (Oct 2024); https://doi.org/10.1007/s11481-024-10125-x (May 2024); https://doi.org/10.4093/dmj.2022.0366 (Mar 2024)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the verified functional annotation of human EIF2AK3/PERK (UniProt Q9NZJ5), including identity, mechanism, localization, signaling, genetics, disease relevance, and 2024 quantitative findings. It is useful as a compact evidence map for the final research report.</em></p>
+<h3 id="9-visual-evidence-from-recent-primary-data-2024">9) Visual evidence from recent primary data (2024)</h3>
+<p>Moon et al. (2024) provide figure-level experimental evidence linking PERK phosphorylation state to autophagy markers and insulin content/secretion under glucolipotoxicity, and show ATG7 dependence of the PERK inhibitor phenotype (moon2024glucolipotoxicitysuppressedautophagy media e6820203, moon2024glucolipotoxicitysuppressedautophagy media d4374739).</p>
+<h3 id="references-urls-and-dates">References (URLs and dates)</h3>
+<p>Key recent sources used here (all cited inline above):<br />
+- Huang et al., <em>Biomolecules</em> (2023-06). https://doi.org/10.3390/biom13071050 (huang2023erstressthe pages 2-4)<br />
+- Perea et al., <em>bioRxiv</em> (2023-03). https://doi.org/10.1101/2023.03.11.532186 (perea2023pharmacologicactivationof pages 1-4)<br />
+- Park et al., <em>Israel Journal of Chemistry</em> (2024-05). https://doi.org/10.1002/ijch.202300173 (park2024ethnicvariationand pages 9-13, park2024ethnicvariationand pages 5-9)<br />
+- Moon et al., <em>Diabetes &amp; Metabolism Journal</em> (2024-03). https://doi.org/10.4093/dmj.2022.0366 (moon2024glucolipotoxicitysuppressedautophagy pages 1-2, moon2024glucolipotoxicitysuppressedautophagy pages 5-6, moon2024glucolipotoxicitysuppressedautophagy media e6820203, moon2024glucolipotoxicitysuppressedautophagy media d4374739)<br />
+- Wang et al., <em>Nature Communications</em> (2024-04). https://doi.org/10.1038/s41467-024-44745-x (wang2024lossoftrim29 pages 1-2)<br />
+- Akay-Espinoza et al., <em>Journal of Neuroimmune Pharmacology</em> (2024-05). https://doi.org/10.1007/s11481-024-10125-x (akayespinoza2024geneticvariationsin pages 1-2)<br />
+- Ghura et al., <em>Scientific Reports</em> (2024-10). https://doi.org/10.1038/s41598-024-74362-z (ghura2024geneticknockinof pages 1-2, ghura2024geneticknockinof pages 10-11)</p>
+<p>References</p>
+<ol>
+<li>
+<p>(huang2023erstressthe pages 2-4): Wan-fang Huang, Yining Gong, and Liang Yan. Er stress, the unfolded protein response and osteoclastogenesis: a review. Biomolecules, 13:1050, Jun 2023. URL: https://doi.org/10.3390/biom13071050, doi:10.3390/biom13071050. This article has 57 citations.</p>
+</li>
+<li>
+<p>(perea2023pharmacologicactivationof pages 1-4): Valerie Perea, Kelsey R. Baron, V. Dolina, Giovanni Aviles, Grace Kim, Jessica D. Rosarda, Xiaoyan Guo, Martin Kampmann, and R. L. Wiseman. Pharmacologic activation of a compensatory integrated stress response kinase promotes mitochondrial remodeling in perk-deficient cells. bioRxiv, Mar 2023. URL: https://doi.org/10.1101/2023.03.11.532186, doi:10.1101/2023.03.11.532186. This article has 28 citations.</p>
+</li>
+<li>
+<p>(ghura2024geneticknockinof pages 1-2): Shivesh Ghura, Noah R. Beratan, Xinglong Shi, Elena Alvarez-Periel, Sarah E. Bond Newton, Cagla Akay-Espinoza, and Kelly L. Jordan-Sciutto. Genetic knock-in of eif2ak3 variants reveals differences in perk activity in mouse liver and pancreas under endoplasmic reticulum stress. Scientific Reports, Oct 2024. URL: https://doi.org/10.1038/s41598-024-74362-z, doi:10.1038/s41598-024-74362-z. This article has 3 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ghura2024geneticknockinof pages 14-15): Shivesh Ghura, Noah R. Beratan, Xinglong Shi, Elena Alvarez-Periel, Sarah E. Bond Newton, Cagla Akay-Espinoza, and Kelly L. Jordan-Sciutto. Genetic knock-in of eif2ak3 variants reveals differences in perk activity in mouse liver and pancreas under endoplasmic reticulum stress. Scientific Reports, Oct 2024. URL: https://doi.org/10.1038/s41598-024-74362-z, doi:10.1038/s41598-024-74362-z. This article has 3 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(park2024ethnicvariationand pages 5-9): Goonho Park, Angela Galdamez, Keon‐Hyoung Song, Masako Le, Kyle Kim, and Jonathan H. Lin. Ethnic variation and structure‐function analysis of tauopathy‐associated <i>perk</i> alleles. Israel Journal of Chemistry, May 2024. URL: https://doi.org/10.1002/ijch.202300173, doi:10.1002/ijch.202300173. This article has 0 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(park2024ethnicvariationand pages 9-13): Goonho Park, Angela Galdamez, Keon‐Hyoung Song, Masako Le, Kyle Kim, and Jonathan H. Lin. Ethnic variation and structure‐function analysis of tauopathy‐associated <i>perk</i> alleles. Israel Journal of Chemistry, May 2024. URL: https://doi.org/10.1002/ijch.202300173, doi:10.1002/ijch.202300173. This article has 0 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(moon2024glucolipotoxicitysuppressedautophagy pages 1-2): Seoil Moon, Ji Yoon Lim, Mirang Lee, Youngmin Han, Hongbeom Kim, Wooil Kwon, Jin-Young Jang, Mi Na Kim, Kyong Soo Park, and Hye Seung Jung. Glucolipotoxicity suppressed autophagy and insulin contents in human islets, and attenuation of perk activity enhanced them in an atg7-dependent manner. Diabetes &amp; Metabolism Journal, 48:231-241, Mar 2024. URL: https://doi.org/10.4093/dmj.2022.0366, doi:10.4093/dmj.2022.0366. This article has 7 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(moon2024glucolipotoxicitysuppressedautophagy pages 5-6): Seoil Moon, Ji Yoon Lim, Mirang Lee, Youngmin Han, Hongbeom Kim, Wooil Kwon, Jin-Young Jang, Mi Na Kim, Kyong Soo Park, and Hye Seung Jung. Glucolipotoxicity suppressed autophagy and insulin contents in human islets, and attenuation of perk activity enhanced them in an atg7-dependent manner. Diabetes &amp; Metabolism Journal, 48:231-241, Mar 2024. URL: https://doi.org/10.4093/dmj.2022.0366, doi:10.4093/dmj.2022.0366. This article has 7 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(moon2024glucolipotoxicitysuppressedautophagy media e6820203): Seoil Moon, Ji Yoon Lim, Mirang Lee, Youngmin Han, Hongbeom Kim, Wooil Kwon, Jin-Young Jang, Mi Na Kim, Kyong Soo Park, and Hye Seung Jung. Glucolipotoxicity suppressed autophagy and insulin contents in human islets, and attenuation of perk activity enhanced them in an atg7-dependent manner. Diabetes &amp; Metabolism Journal, 48:231-241, Mar 2024. URL: https://doi.org/10.4093/dmj.2022.0366, doi:10.4093/dmj.2022.0366. This article has 7 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(moon2024glucolipotoxicitysuppressedautophagy media d4374739): Seoil Moon, Ji Yoon Lim, Mirang Lee, Youngmin Han, Hongbeom Kim, Wooil Kwon, Jin-Young Jang, Mi Na Kim, Kyong Soo Park, and Hye Seung Jung. Glucolipotoxicity suppressed autophagy and insulin contents in human islets, and attenuation of perk activity enhanced them in an atg7-dependent manner. Diabetes &amp; Metabolism Journal, 48:231-241, Mar 2024. URL: https://doi.org/10.4093/dmj.2022.0366, doi:10.4093/dmj.2022.0366. This article has 7 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(akayespinoza2024geneticvariationsin pages 1-2): Cagla Akay-Espinoza, Sarah E.B. Newton, Beth A. Dombroski, Asha Kallianpur, Ajay Bharti, Donald R. Franklin, Gerard D. Schellenberg, Robert K. Heaton, Igor Grant, Ronald J. Ellis, Scott L. Letendre, and Kelly L. Jordan-Sciutto. Genetic variations in eif2ak3 are associated with neurocognitive impairment in people living with hiv. Journal of Neuroimmune Pharmacology, May 2024. URL: https://doi.org/10.1007/s11481-024-10125-x, doi:10.1007/s11481-024-10125-x. This article has 3 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ghura2024geneticknockinof pages 10-11): Shivesh Ghura, Noah R. Beratan, Xinglong Shi, Elena Alvarez-Periel, Sarah E. Bond Newton, Cagla Akay-Espinoza, and Kelly L. Jordan-Sciutto. Genetic knock-in of eif2ak3 variants reveals differences in perk activity in mouse liver and pancreas under endoplasmic reticulum stress. Scientific Reports, Oct 2024. URL: https://doi.org/10.1038/s41598-024-74362-z, doi:10.1038/s41598-024-74362-z. This article has 3 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(wang2024lossoftrim29 pages 1-2): Junying Wang, Wenting Lu, Jerry Zhang, Yong Du, Mingli Fang, Ao Zhang, Gabriel Sungcad, Samantha Chon, and Junji Xing. Loss of trim29 mitigates viral myocarditis by attenuating perk-driven er stress response in male mice. Nature Communications, Apr 2024. URL: https://doi.org/10.1038/s41467-024-44745-x, doi:10.1038/s41467-024-44745-x. This article has 96 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(park2024ethnicvariationand pages 1-5): Goonho Park, Angela Galdamez, Keon‐Hyoung Song, Masako Le, Kyle Kim, and Jonathan H. Lin. Ethnic variation and structure‐function analysis of tauopathy‐associated <i>perk</i> alleles. Israel Journal of Chemistry, May 2024. URL: https://doi.org/10.1002/ijch.202300173, doi:10.1002/ijch.202300173. This article has 0 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(moon2024glucolipotoxicitysuppressedautophagy pages 4-5): Seoil Moon, Ji Yoon Lim, Mirang Lee, Youngmin Han, Hongbeom Kim, Wooil Kwon, Jin-Young Jang, Mi Na Kim, Kyong Soo Park, and Hye Seung Jung. Glucolipotoxicity suppressed autophagy and insulin contents in human islets, and attenuation of perk activity enhanced them in an atg7-dependent manner. Diabetes &amp; Metabolism Journal, 48:231-241, Mar 2024. URL: https://doi.org/10.4093/dmj.2022.0366, doi:10.4093/dmj.2022.0366. This article has 7 citations and is from a peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>huang2023erstressthe pages 2-4</li>
+<li>perea2023pharmacologicactivationof pages 1-4</li>
+<li>akayespinoza2024geneticvariationsin pages 1-2</li>
+<li>moon2024glucolipotoxicitysuppressedautophagy pages 1-2</li>
+<li>ghura2024geneticknockinof pages 1-2</li>
+<li>ghura2024geneticknockinof pages 14-15</li>
+<li>park2024ethnicvariationand pages 5-9</li>
+<li>park2024ethnicvariationand pages 9-13</li>
+<li>moon2024glucolipotoxicitysuppressedautophagy pages 5-6</li>
+<li>ghura2024geneticknockinof pages 10-11</li>
+<li>park2024ethnicvariationand pages 1-5</li>
+<li>moon2024glucolipotoxicitysuppressedautophagy pages 4-5</li>
+<li>https://doi.org/10.3390/biom13071050</li>
+<li>https://doi.org/10.1101/2023.03.11.532186</li>
+<li>https://doi.org/10.1002/ijch.202300173</li>
+<li>https://doi.org/10.1038/s41598-024-74362-z</li>
+<li>https://doi.org/10.1038/s41467-024-44745-x</li>
+<li>https://doi.org/10.1007/s11481-024-10125-x</li>
+<li>https://doi.org/10.4093/dmj.2022.0366</li>
+<li>https://doi.org/10.3390/biom13071050,</li>
+<li>https://doi.org/10.1101/2023.03.11.532186,</li>
+<li>https://doi.org/10.1038/s41598-024-74362-z,</li>
+<li>https://doi.org/10.1002/ijch.202300173,</li>
+<li>https://doi.org/10.4093/dmj.2022.0366,</li>
+<li>https://doi.org/10.1007/s11481-024-10125-x,</li>
+<li>https://doi.org/10.1038/s41467-024-44745-x,</li>
+</ol>
+            </div>
+        </details>
+
         <details class="markdown-section">
             <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
                 <div style="flex: 1;">
@@ -8463,6 +8853,11 @@ references:
 - id: file:human/EIF2AK3/EIF2AK3-notes.md
   title: Curator notes for EIF2AK3 literature and PN review
   findings: []
+- id: file:human/EIF2AK3/EIF2AK3-deep-research-falcon.md
+  title: Falcon deep research report for EIF2AK3
+  findings:
+  - statement: Falcon research supports EIF2AK3/PERK as an ER-membrane stress sensor kinase that phosphorylates EIF2S1/eIF2alpha at Ser51 to attenuate translation and activate the PERK arm of the UPR/ISR.
+    supporting_text: PERK&#39;s primary enzymatic function is to phosphorylate eukaryotic translation initiation factor 2 subunit alpha (eIF2alpha; gene EIF2S1) at Ser51.
 existing_annotations:
 - term:
     id: GO:0004672
@@ -8544,6 +8939,8 @@ existing_annotations:
       supporting_text: ER stress increases PERK&#39;s protein-kinase activity and PERK phosphorylates eIF2alpha
         on serine residue 51, inhibiting translation of messenger RNA into protein.
       reference_section_type: ABSTRACT
+    - reference_id: file:human/EIF2AK3/EIF2AK3-deep-research-falcon.md
+      supporting_text: PERK&#39;s primary enzymatic function is to phosphorylate eukaryotic translation initiation factor 2 subunit alpha (eIF2alpha; gene EIF2S1) at Ser51.
 - term:
     id: GO:0004694
     label: eukaryotic translation initiation factor 2alpha kinase activity
@@ -9280,6 +9677,8 @@ existing_annotations:
         of PERK and its target eIF2α in cells. These results suggest that transient conversion from dimeric
         to tetrameric state may be a key regulatory step in UPR activation.
       reference_section_type: ABSTRACT
+    - reference_id: file:human/EIF2AK3/EIF2AK3-deep-research-falcon.md
+      supporting_text: A canonical pathway is ER stress, PERK activation, eIF2alpha(Ser51) phosphorylation, reduced global translation plus preferential ATF4 translation, adaptive gene expression, and CHOP induction if prolonged.
 - term:
     id: GO:0036499
     label: PERK-mediated unfolded protein response
@@ -9760,6 +10159,8 @@ core_functions:
       of PERK and its target eIF2α in cells. These results suggest that transient conversion from dimeric
       to tetrameric state may be a key regulatory step in UPR activation.
     reference_section_type: ABSTRACT
+  - reference_id: file:human/EIF2AK3/EIF2AK3-deep-research-falcon.md
+    supporting_text: PERK&#39;s primary enzymatic function is to phosphorylate eukaryotic translation initiation factor 2 subunit alpha (eIF2alpha; gene EIF2S1) at Ser51.
 - description: The PERK luminal domain directly recognizes misfolded proteins, coupling ER protein-folding
     stress to activation of PERK-mediated UPR signaling.
   molecular_function:

--- a/genes/human/EIF2AK3/EIF2AK3-ai-review.yaml
+++ b/genes/human/EIF2AK3/EIF2AK3-ai-review.yaml
@@ -168,6 +168,11 @@ references:
 - id: file:human/EIF2AK3/EIF2AK3-notes.md
   title: Curator notes for EIF2AK3 literature and PN review
   findings: []
+- id: file:human/EIF2AK3/EIF2AK3-deep-research-falcon.md
+  title: Falcon deep research report for EIF2AK3
+  findings:
+  - statement: Falcon research supports EIF2AK3/PERK as an ER-membrane stress sensor kinase that phosphorylates EIF2S1/eIF2alpha at Ser51 to attenuate translation and activate the PERK arm of the UPR/ISR.
+    supporting_text: PERK's primary enzymatic function is to phosphorylate eukaryotic translation initiation factor 2 subunit alpha (eIF2alpha; gene EIF2S1) at Ser51.
 existing_annotations:
 - term:
     id: GO:0004672
@@ -249,6 +254,8 @@ existing_annotations:
       supporting_text: ER stress increases PERK's protein-kinase activity and PERK phosphorylates eIF2alpha
         on serine residue 51, inhibiting translation of messenger RNA into protein.
       reference_section_type: ABSTRACT
+    - reference_id: file:human/EIF2AK3/EIF2AK3-deep-research-falcon.md
+      supporting_text: PERK's primary enzymatic function is to phosphorylate eukaryotic translation initiation factor 2 subunit alpha (eIF2alpha; gene EIF2S1) at Ser51.
 - term:
     id: GO:0004694
     label: eukaryotic translation initiation factor 2alpha kinase activity
@@ -985,6 +992,8 @@ existing_annotations:
         of PERK and its target eIF2α in cells. These results suggest that transient conversion from dimeric
         to tetrameric state may be a key regulatory step in UPR activation.
       reference_section_type: ABSTRACT
+    - reference_id: file:human/EIF2AK3/EIF2AK3-deep-research-falcon.md
+      supporting_text: A canonical pathway is ER stress, PERK activation, eIF2alpha(Ser51) phosphorylation, reduced global translation plus preferential ATF4 translation, adaptive gene expression, and CHOP induction if prolonged.
 - term:
     id: GO:0036499
     label: PERK-mediated unfolded protein response
@@ -1465,6 +1474,8 @@ core_functions:
       of PERK and its target eIF2α in cells. These results suggest that transient conversion from dimeric
       to tetrameric state may be a key regulatory step in UPR activation.
     reference_section_type: ABSTRACT
+  - reference_id: file:human/EIF2AK3/EIF2AK3-deep-research-falcon.md
+    supporting_text: PERK's primary enzymatic function is to phosphorylate eukaryotic translation initiation factor 2 subunit alpha (eIF2alpha; gene EIF2S1) at Ser51.
 - description: The PERK luminal domain directly recognizes misfolded proteins, coupling ER protein-folding
     stress to activation of PERK-mediated UPR signaling.
   molecular_function:

--- a/genes/human/EIF2AK3/EIF2AK3-deep-research-falcon.md
+++ b/genes/human/EIF2AK3/EIF2AK3-deep-research-falcon.md
@@ -1,0 +1,314 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-10T20:28:15.514374'
+end_time: '2026-05-10T20:47:28.795002'
+duration_seconds: 1153.28
+template_file: templates/gene_research_go_focused.md
+template_variables:
+  organism: human
+  gene_id: EIF2AK3
+  gene_symbol: EIF2AK3
+  uniprot_accession: Q9NZJ5
+  protein_description: 'RecName: Full=Eukaryotic translation initiation factor 2-alpha
+    kinase 3 {ECO:0000305}; EC=2.7.11.1 {ECO:0000269|PubMed:10026192, ECO:0000269|PubMed:10677345};
+    AltName: Full=PRKR-like endoplasmic reticulum kinase {ECO:0000303|PubMed:23103912};
+    AltName: Full=Pancreatic eIF2-alpha kinase {ECO:0000303|PubMed:10026192}; Short=HsPEK
+    {ECO:0000303|PubMed:10026192}; AltName: Full=Protein tyrosine kinase EIF2AK3 {ECO:0000305};
+    EC=2.7.10.2 {ECO:0000250|UniProtKB:Q9Z2B5}; Flags: Precursor;'
+  gene_info: Name=EIF2AK3 {ECO:0000303|PubMed:10932183, ECO:0000312|HGNC:HGNC:3255};
+    Synonyms=PEK {ECO:0000303|PubMed:10026192}, PERK {ECO:0000303|PubMed:23103912};
+  organism_full: Homo sapiens (Human).
+  protein_family: Belongs to the protein kinase superfamily. Ser/Thr protein
+  protein_domains: CC_SR_Kinase. (IPR050339); Kinase-like_dom_sf. (IPR011009); Prot_kinase_dom.
+    (IPR000719); Protein_kinase_ATP_BS. (IPR017441); Quinoprotein_ADH-like_sf. (IPR011047)
+provider_config:
+  timeout: 600
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 26
+---
+
+## Question
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** Q9NZJ5
+- **Protein Description:** RecName: Full=Eukaryotic translation initiation factor 2-alpha kinase 3 {ECO:0000305}; EC=2.7.11.1 {ECO:0000269|PubMed:10026192, ECO:0000269|PubMed:10677345}; AltName: Full=PRKR-like endoplasmic reticulum kinase {ECO:0000303|PubMed:23103912}; AltName: Full=Pancreatic eIF2-alpha kinase {ECO:0000303|PubMed:10026192}; Short=HsPEK {ECO:0000303|PubMed:10026192}; AltName: Full=Protein tyrosine kinase EIF2AK3 {ECO:0000305}; EC=2.7.10.2 {ECO:0000250|UniProtKB:Q9Z2B5}; Flags: Precursor;
+- **Gene Information:** Name=EIF2AK3 {ECO:0000303|PubMed:10932183, ECO:0000312|HGNC:HGNC:3255}; Synonyms=PEK {ECO:0000303|PubMed:10026192}, PERK {ECO:0000303|PubMed:23103912};
+- **Organism (full):** Homo sapiens (Human).
+- **Protein Family:** Belongs to the protein kinase superfamily. Ser/Thr protein
+- **Key Domains:** CC_SR_Kinase. (IPR050339); Kinase-like_dom_sf. (IPR011009); Prot_kinase_dom. (IPR000719); Protein_kinase_ATP_BS. (IPR017441); Quinoprotein_ADH-like_sf. (IPR011047)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "EIF2AK3" matches the protein description above**
+2. **Verify the organism is correct:** Homo sapiens (Human).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'EIF2AK3' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **EIF2AK3** (gene ID: EIF2AK3, UniProt: Q9NZJ5) in human.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** Q9NZJ5
+- **Protein Description:** RecName: Full=Eukaryotic translation initiation factor 2-alpha kinase 3 {ECO:0000305}; EC=2.7.11.1 {ECO:0000269|PubMed:10026192, ECO:0000269|PubMed:10677345}; AltName: Full=PRKR-like endoplasmic reticulum kinase {ECO:0000303|PubMed:23103912}; AltName: Full=Pancreatic eIF2-alpha kinase {ECO:0000303|PubMed:10026192}; Short=HsPEK {ECO:0000303|PubMed:10026192}; AltName: Full=Protein tyrosine kinase EIF2AK3 {ECO:0000305}; EC=2.7.10.2 {ECO:0000250|UniProtKB:Q9Z2B5}; Flags: Precursor;
+- **Gene Information:** Name=EIF2AK3 {ECO:0000303|PubMed:10932183, ECO:0000312|HGNC:HGNC:3255}; Synonyms=PEK {ECO:0000303|PubMed:10026192}, PERK {ECO:0000303|PubMed:23103912};
+- **Organism (full):** Homo sapiens (Human).
+- **Protein Family:** Belongs to the protein kinase superfamily. Ser/Thr protein
+- **Key Domains:** CC_SR_Kinase. (IPR050339); Kinase-like_dom_sf. (IPR011009); Prot_kinase_dom. (IPR000719); Protein_kinase_ATP_BS. (IPR017441); Quinoprotein_ADH-like_sf. (IPR011047)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "EIF2AK3" matches the protein description above**
+2. **Verify the organism is correct:** Homo sapiens (Human).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'EIF2AK3' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **EIF2AK3** (gene ID: EIF2AK3, UniProt: Q9NZJ5) in human.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Comprehensive research report: Human **EIF2AK3 / PERK** (UniProt **Q9NZJ5**) — functional annotation
+
+### 0) Target verification (mandatory)
+The target is **human EIF2AK3**, encoding **protein kinase RNA-like endoplasmic reticulum kinase (PERK; also called PEK)**, a **type I ER transmembrane serine/threonine protein kinase** with an **ER luminal stress-sensing N-terminus** and a **cytosolic C-terminal kinase domain**. This identity matches the UniProt description provided and is explicitly stated in recent reviews and mechanistic studies (huang2023erstressthe pages 2-4, perea2023pharmacologicactivationof pages 1-4).
+
+### 1) Key concepts and definitions (current understanding)
+
+#### 1.1 ER stress, UPR, and ISR context
+**Endoplasmic reticulum (ER) stress** arises when misfolded/unfolded proteins accumulate in the ER lumen. Cells respond through the **unfolded protein response (UPR)**, which is classically mediated by three ER sensors (PERK/EIF2AK3, IRE1/ERN1, and ATF6). PERK is also one of the four kinases that can trigger the **integrated stress response (ISR)** by converging on phosphorylation of eIF2α (huang2023erstressthe pages 2-4, perea2023pharmacologicactivationof pages 1-4).
+
+#### 1.2 What PERK does (definition of primary function)
+PERK’s **primary enzymatic function** is to phosphorylate **eukaryotic translation initiation factor 2 subunit alpha (eIF2α; gene EIF2S1)** at **Ser51**, which reduces global cap-dependent translation initiation to decrease protein-folding load in the ER while enabling selective translation of stress-adaptive mRNAs (huang2023erstressthe pages 2-4).
+
+### 2) Molecular function and enzymology
+
+#### 2.1 Catalyzed reaction and substrate specificity
+Under ER stress, activated PERK phosphorylates **eIF2α at Ser51**, initiating translational attenuation and ISR transcriptional programs (huang2023erstressthe pages 2-4). Selective translation includes **ATF4**, which coordinates adaptive outputs and can induce **CHOP/DDIT3** under sustained stress, promoting apoptosis (perea2023pharmacologicactivationof pages 1-4).
+
+#### 2.2 Downstream signaling logic
+A canonical pathway is:
+**ER stress → PERK activation → eIF2α(Ser51) phosphorylation → reduced global translation + preferential ATF4 translation → adaptive gene expression; if prolonged, CHOP induction and apoptosis** (perea2023pharmacologicactivationof pages 1-4, huang2023erstressthe pages 2-4).
+
+PERK signaling also intersects with antioxidant programs, including **NRF2-related signaling** in multiple contexts (ghura2024geneticknockinof pages 1-2, ghura2024geneticknockinof pages 14-15).
+
+### 3) Subcellular localization and activation mechanism
+
+#### 3.1 Localization
+PERK is **ER membrane localized** (type I transmembrane) (huang2023erstressthe pages 2-4). Beyond general ER localization, PERK has been reported to function at **ER–mitochondria contact sites** and to influence mitochondrial remodeling and bioenergetics during stress responses (perea2023pharmacologicactivationof pages 1-4).
+
+#### 3.2 Activation mechanism
+In basal conditions, PERK’s luminal domain is restrained by **BiP/GRP78**. During ER stress, BiP is titrated away by misfolded proteins, enabling PERK **homodimerization/oligomerization** and **autophosphorylation**, activating the cytosolic kinase domain (huang2023erstressthe pages 2-4). Recent 2024 structure–function work further emphasizes that disease-associated variants can perturb luminal-domain dimer/oligomer interfaces and alter signaling kinetics (park2024ethnicvariationand pages 5-9, park2024ethnicvariationand pages 9-13).
+
+### 4) Recent developments (prioritizing 2023–2024)
+
+#### 4.1 Human islet biology: PERK inhibition rescues autophagy and insulin phenotype under glucolipotoxicity (2024)
+In **human islets** from **8 non-diabetic donors** (mean age **54.5±16.0 years**, BMI **25.6±3.6**, HbA1c **5.7%±0.3**), glucolipotoxicity (**20 mM glucose + 0.5 mM palmitate**) increased **PERK phosphorylation by ~70%** and decreased **insulin content by ~50%**. Treatment with the PERK inhibitor **GSK2606414** (noted as **40–80 nM**) reversed these changes and increased **glucose-stimulated insulin secretion by ~6-fold**. Mechanistically, PERK inhibition increased autophagic flux (LC3 conversion and reduced p62 protein without changing p62 transcription) and required **ATG7** for the insulin-rescue phenotype (moon2024glucolipotoxicitysuppressedautophagy pages 1-2, moon2024glucolipotoxicitysuppressedautophagy pages 5-6).
+
+Figures supporting the PERK phosphorylation/autophagy/insulin phenotypes and ATG7 dependence are shown in the extracted image panels (moon2024glucolipotoxicitysuppressedautophagy media e6820203, moon2024glucolipotoxicitysuppressedautophagy media d4374739).
+
+#### 4.2 Human genetics and cognition in HIV (2024)
+A 2024 study analyzed EIF2AK3 SNVs in the CHARTER cohort using genome-wide data for **1,047** participants and targeted sequencing for **992**. The authors report associations between EIF2AK3 variants and neurocognitive outcomes. Frequencies for coding risk alleles were: **30.9%** with ≥1 risk allele for rs1805165 (G), **30.9%** for rs867529 (G), and **41.2%** for rs13045 (A). Homozygosity for all three coding SNVs was associated with worse global deficit score and more neurocognitive impairment (both **p<0.001**). In multivariable models, rs13045 (A), current ART use, and depression score (BDI-II>13) were independently associated with outcomes (**p<0.001**) (akayespinoza2024geneticvariationsin pages 1-2).
+
+#### 4.3 Common-coding haplotypes: PERK-A vs PERK-B activity differences under ER stress (2024)
+A 2024 knock-in model study focusing on the exonic SNVs (rs867529, rs13045, rs1805165) reports that PERK-B is present in ~**28%** of the global population, with ancestry variation estimated at **~8% African**, **32% European**, and **~50% Asian.** Functionally, PERK-B did not alter basal expression/activity but displayed **higher kinase activity** than PERK-A in a cell-free assay and in mouse liver homogenates, and PERK-B/B pancreas showed greater susceptibility to apoptosis under acute ER stress (ghura2024geneticknockinof pages 1-2, ghura2024geneticknockinof pages 10-11).
+
+#### 4.4 Tauopathy-associated alleles: structure–function interpretation and population variation (2024)
+A 2024 study assembled EIF2AK3/PERK disease variant sets and used modeling/functional assays to argue that **Wolcott–Rallison syndrome** variants cluster mainly in the **cytosolic kinase domain**, whereas **tauopathy-linked** variants are enriched in the **luminal domain**, consistent with altered ER stress sensing and activation kinetics. The authors report substantial ethnic differences in frequencies of common tauopathy-linked alleles and demonstrate altered PERK signaling kinetics for disease variants in cell models (park2024ethnicvariationand pages 9-13, park2024ethnicvariationand pages 5-9).
+
+#### 4.5 Viral myocarditis mechanism: TRIM29 stabilizes PERK via SUMOylation (2024)
+A 2024 Nature Communications study reports that **TRIM29** interacts with PERK and promotes **SUMOylation** to maintain PERK stability, enhancing PERK-mediated ER stress signaling in cardiomyocytes during viral infection. Pharmacologic PERK inhibition (reported with **GSK2656157**) disrupted the TRIM29–PERK axis and mitigated viral myocarditis phenotypes in vivo (wang2024lossoftrim29 pages 1-2).
+
+### 5) Current applications and real-world implementations
+
+#### 5.1 PERK as a drug target and experimental handle
+PERK is actively targeted in translational research using:
+- **Inhibitors** (e.g., GSK2606414; GSK2656157) to suppress the PERK arm of the UPR/ISR.
+- **Activators** (e.g., CCT020312; and limited direct activators) or **compensatory ISR activation** approaches (e.g., activating alternative ISR kinases such as HRI or GCN2) to restore ISR outputs when PERK is deficient (perea2023pharmacologicactivationof pages 1-4, moon2024glucolipotoxicitysuppressedautophagy pages 1-2).
+
+A key implementation example is the use of PERK inhibition to modulate β-cell/islet function under metabolic stress, where low-nanomolar GSK2606414 improved insulin content/secretion in human islets under glucolipotoxicity in a manner linked to autophagy flux and ATG7 (moon2024glucolipotoxicitysuppressedautophagy pages 1-2, moon2024glucolipotoxicitysuppressedautophagy pages 5-6).
+
+#### 5.2 Clinical trial landscape (from tool-based search)
+A clinical trials registry search using PERK/EIF2AK3 and major tool compounds did **not** retrieve a relevant PERK-focused interventional clinical trial in the current tool output; the retrieved record was unrelated to PERK biology (clinical trial retrieval not relevant; no citeable PERK trial record returned). Therefore, evidence in this run supports PERK modulation as **preclinical/translational** rather than established clinical intervention.
+
+### 6) Expert opinions / analysis and methodological caveats
+
+#### 6.1 PERK signaling is context-dependent (adaptive vs terminal)
+Mechanistic synthesis across recent literature supports a dual role: PERK-eIF2α signaling can be **adaptive** (reducing translational load and restoring proteostasis) or contribute to **terminal UPR** and apoptosis through ATF4/CHOP under sustained stress (perea2023pharmacologicactivationof pages 1-4).
+
+#### 6.2 Variant-to-phenotype interpretation
+Recent human-genetic analyses emphasize that common EIF2AK3 variants/haplotypes (PERK-A vs PERK-B) and rarer disease alleles can alter PERK signaling kinetics and thereby modulate susceptibility to neurodegenerative and metabolic phenotypes, with important differences by ancestry (ghura2024geneticknockinof pages 10-11, park2024ethnicvariationand pages 9-13).
+
+#### 6.3 Pharmacologic specificity considerations
+Because this report is limited to the evidence retrieved in-tool, the principal caveat supported here is that PERK inhibitors/activators are widely used as **chemical biology tools**, but their interpretation should account for dose/context and for compensatory ISR activation by other eIF2α kinases (noted in PERK-deficient compensation studies) (perea2023pharmacologicactivationof pages 1-4).
+
+### 7) Key statistics and data (2023–2024 emphasis)
+- **Human islets (2024):** glucolipotoxicity increased **PERK phosphorylation by ~70%** and decreased **insulin content by ~50%**; **40–80 nM GSK2606414** reversed these and increased GSIS by **~6-fold** (moon2024glucolipotoxicitysuppressedautophagy pages 1-2).
+- **HIV CHARTER cohort (2024):** n=**1,047** (genome-wide), n=**992** (targeted sequencing); ≥1 risk allele frequencies **30.9%**, **30.9%**, **41.2%** for rs1805165/rs867529/rs13045; homozygous risk across all three coding SNVs associated with worse outcomes (**p<0.001**) (akayespinoza2024geneticvariationsin pages 1-2).
+- **PERK haplotype prevalence (2024 synthesis/knock-in):** PERK-B ~**28%** globally, with ancestry differences (~**8% African**, **32% European**, **~50% Asian**) (ghura2024geneticknockinof pages 10-11, ghura2024geneticknockinof pages 1-2).
+
+### 8) Concise functional annotation summary (for downstream use)
+To support downstream functional annotation workflows, the table below compacts the most robust mechanistic claims (identity/domains, localization, activation, enzymology, pathway outputs, disease links, and 2024 quantitative highlights):
+
+| Category | Summary | Key citations / URL / publication date |
+|---|---|---|
+| Identity/domains | **EIF2AK3** encodes **PERK** (PKR-like ER kinase; UniProt **Q9NZJ5**), an ER-stress-responsive **type I transmembrane serine/threonine protein kinase** with an **N-terminal ER luminal stress-sensing domain** and a **C-terminal cytosolic kinase domain**; this matches the UniProt-provided identity and kinase-family/domain context. | (huang2023erstressthe pages 2-4, perea2023pharmacologicactivationof pages 1-4) https://doi.org/10.3390/biom13071050 (Jun 2023); https://doi.org/10.1101/2023.03.11.532186 (Mar 2023) |
+| Localization | PERK is localized to the **endoplasmic reticulum membrane** and is also reported at **ER–mitochondrial contact sites/MAMs**, where it contributes to mitochondrial remodeling and bioenergetic adaptation during stress. | (huang2023erstressthe pages 2-4, perea2023pharmacologicactivationof pages 1-4) https://doi.org/10.3390/biom13071050 (Jun 2023); https://doi.org/10.1101/2023.03.11.532186 (Mar 2023) |
+| Activation | Under basal conditions, PERK is restrained by **BiP/GRP78** at its luminal domain. ER accumulation of unfolded proteins releases BiP, allowing **PERK homodimerization/oligomerization** and **trans-autophosphorylation**, which activates the kinase. Recent structure-function work indicates that some disease-associated variants alter **luminal-domain dimer/tetramer interfaces** and signaling kinetics. | (huang2023erstressthe pages 2-4, park2024ethnicvariationand pages 9-13, park2024ethnicvariationand pages 5-9) https://doi.org/10.3390/biom13071050 (Jun 2023); https://doi.org/10.1002/ijch.202300173 (May 2024) |
+| Enzymatic reaction & substrate | PERK catalyzes phosphorylation of **eIF2α/EIF2S1 at Ser51**, the canonical ISR reaction that suppresses global cap-dependent translation while permitting selective translation of stress-adaptive mRNAs. PERK has also been described as able to phosphorylate **NRF2** in the PERK-NRF2 antioxidant branch. | (huang2023erstressthe pages 2-4, perea2023pharmacologicactivationof pages 1-4) https://doi.org/10.3390/biom13071050 (Jun 2023); https://doi.org/10.1101/2023.03.11.532186 (Mar 2023) |
+| Downstream signaling | The best-established downstream pathway is **PERK → p-eIF2α → selective ATF4 translation**, followed by induction of genes involved in adaptation and, under sustained stress, **CHOP/DDIT3**-linked apoptosis. PERK signaling also intersects with **NRF2**, autophagy programs, and broader ISR outputs. | (perea2023pharmacologicactivationof pages 1-4, ghura2024geneticknockinof pages 1-2, ghura2024geneticknockinof pages 14-15) https://doi.org/10.1101/2023.03.11.532186 (Mar 2023); https://doi.org/10.1038/s41598-024-74362-z (Oct 2024) |
+| Mitochondria/contacts | PERK helps coordinate **mitochondrial morphology, cristae structure, respiration, and proteostasis** during ER stress. In PERK-deficient cells, pharmacologic activation of alternative ISR kinases can partially rescue mitochondrial adaptation, supporting a central role for PERK in ER–mitochondria communication. | (perea2023pharmacologicactivationof pages 1-4) https://doi.org/10.1101/2023.03.11.532186 (Mar 2023) |
+| Human genetics & variants | Rare **loss-of-function EIF2AK3 variants** cause **Wolcott–Rallison syndrome (WRS)**. Common coding SNVs **rs867529, rs13045, rs1805165** define **PERK-B** versus **PERK-A** haplotypes. Recent analyses report **PERK-B ~28% globally** (PERK-A ~64%), with ancestry differences and functional effects on stress signaling; WRS missense variants cluster mainly in the **kinase domain**, whereas tauopathy-linked variants are enriched in the **luminal domain**. | (ghura2024geneticknockinof pages 1-2, ghura2024geneticknockinof pages 10-11, park2024ethnicvariationand pages 1-5, park2024ethnicvariationand pages 9-13, park2024ethnicvariationand pages 5-9) https://doi.org/10.1038/s41598-024-74362-z (Oct 2024); https://doi.org/10.1002/ijch.202300173 (May 2024) |
+| Disease links | Authoritative recent literature links EIF2AK3/PERK to **WRS**, **tauopathies/neurodegeneration**, **diabetes/β-cell stress**, **cancer progression or therapy resistance**, and inflammatory or viral tissue injury. Recent mechanistic work shows TRIM29 stabilizes PERK via **SUMOylation** in **viral myocarditis**, while variant studies link EIF2AK3 to **neurocognitive impairment in people with HIV**. | (wang2024lossoftrim29 pages 1-2, akayespinoza2024geneticvariationsin pages 1-2, ghura2024geneticknockinof pages 1-2, ghura2024geneticknockinof pages 14-15) https://doi.org/10.1038/s41467-024-44745-x (Apr 2024); https://doi.org/10.1007/s11481-024-10125-x (May 2024); https://doi.org/10.1038/s41598-024-74362-z (Oct 2024) |
+| Therapeutic modulation/applications | PERK is being explored as a therapeutic node with **inhibitors** (e.g., **GSK2606414**, **GSK2656157**) and **activators/ISR-compensation strategies** (e.g., **CCT020312**, **MK-28**, HRI/GCN2 activation). However, published expert analyses caution that classic PERK inhibitors can have **off-target kinase activities** and specificity liabilities, so mechanistic interpretation requires care. No relevant registered clinical trials were identified in the retrieved evidence. | (perea2023pharmacologicactivationof pages 1-4, wang2024lossoftrim29 pages 1-2, moon2024glucolipotoxicitysuppressedautophagy pages 1-2) https://doi.org/10.1101/2023.03.11.532186 (Mar 2023); https://doi.org/10.1038/s41467-024-44745-x (Apr 2024); https://doi.org/10.4093/dmj.2022.0366 (Mar 2024) |
+| Key quantitative data 2024 | Representative 2024 quantitative findings: **PERK-B prevalence ~28% globally** with ancestry estimates of **~8% African, 32% European, ~50% Asian** and prior odds ratios for neurocognitive impairment of **1.8–2.36** in cited cohort literature; in the CHARTER HIV cohort, genome-wide data were available for **1,047** participants and targeted sequencing for **992**, with **30.9%**, **30.9%**, and **41.2%** carrying ≥1 risk allele for **rs1805165**, **rs867529**, and **rs13045**, respectively; in human islets, glucolipotoxicity increased **PERK phosphorylation by 70%**, decreased **insulin content by 50%**, and **40–80 nM GSK2606414** restored insulin measures and increased GSIS by about **6-fold**. | (ghura2024geneticknockinof pages 10-11, akayespinoza2024geneticvariationsin pages 1-2, moon2024glucolipotoxicitysuppressedautophagy pages 1-2, moon2024glucolipotoxicitysuppressedautophagy pages 4-5) https://doi.org/10.1038/s41598-024-74362-z (Oct 2024); https://doi.org/10.1007/s11481-024-10125-x (May 2024); https://doi.org/10.4093/dmj.2022.0366 (Mar 2024) |
+
+
+*Table: This table summarizes the verified functional annotation of human EIF2AK3/PERK (UniProt Q9NZJ5), including identity, mechanism, localization, signaling, genetics, disease relevance, and 2024 quantitative findings. It is useful as a compact evidence map for the final research report.*
+
+### 9) Visual evidence from recent primary data (2024)
+Moon et al. (2024) provide figure-level experimental evidence linking PERK phosphorylation state to autophagy markers and insulin content/secretion under glucolipotoxicity, and show ATG7 dependence of the PERK inhibitor phenotype (moon2024glucolipotoxicitysuppressedautophagy media e6820203, moon2024glucolipotoxicitysuppressedautophagy media d4374739).
+
+### References (URLs and dates)
+Key recent sources used here (all cited inline above):
+- Huang et al., *Biomolecules* (2023-06). https://doi.org/10.3390/biom13071050 (huang2023erstressthe pages 2-4)
+- Perea et al., *bioRxiv* (2023-03). https://doi.org/10.1101/2023.03.11.532186 (perea2023pharmacologicactivationof pages 1-4)
+- Park et al., *Israel Journal of Chemistry* (2024-05). https://doi.org/10.1002/ijch.202300173 (park2024ethnicvariationand pages 9-13, park2024ethnicvariationand pages 5-9)
+- Moon et al., *Diabetes & Metabolism Journal* (2024-03). https://doi.org/10.4093/dmj.2022.0366 (moon2024glucolipotoxicitysuppressedautophagy pages 1-2, moon2024glucolipotoxicitysuppressedautophagy pages 5-6, moon2024glucolipotoxicitysuppressedautophagy media e6820203, moon2024glucolipotoxicitysuppressedautophagy media d4374739)
+- Wang et al., *Nature Communications* (2024-04). https://doi.org/10.1038/s41467-024-44745-x (wang2024lossoftrim29 pages 1-2)
+- Akay-Espinoza et al., *Journal of Neuroimmune Pharmacology* (2024-05). https://doi.org/10.1007/s11481-024-10125-x (akayespinoza2024geneticvariationsin pages 1-2)
+- Ghura et al., *Scientific Reports* (2024-10). https://doi.org/10.1038/s41598-024-74362-z (ghura2024geneticknockinof pages 1-2, ghura2024geneticknockinof pages 10-11)
+
+
+References
+
+1. (huang2023erstressthe pages 2-4): Wan-fang Huang, Yining Gong, and Liang Yan. Er stress, the unfolded protein response and osteoclastogenesis: a review. Biomolecules, 13:1050, Jun 2023. URL: https://doi.org/10.3390/biom13071050, doi:10.3390/biom13071050. This article has 57 citations.
+
+2. (perea2023pharmacologicactivationof pages 1-4): Valerie Perea, Kelsey R. Baron, V. Dolina, Giovanni Aviles, Grace Kim, Jessica D. Rosarda, Xiaoyan Guo, Martin Kampmann, and R. L. Wiseman. Pharmacologic activation of a compensatory integrated stress response kinase promotes mitochondrial remodeling in perk-deficient cells. bioRxiv, Mar 2023. URL: https://doi.org/10.1101/2023.03.11.532186, doi:10.1101/2023.03.11.532186. This article has 28 citations.
+
+3. (ghura2024geneticknockinof pages 1-2): Shivesh Ghura, Noah R. Beratan, Xinglong Shi, Elena Alvarez-Periel, Sarah E. Bond Newton, Cagla Akay-Espinoza, and Kelly L. Jordan-Sciutto. Genetic knock-in of eif2ak3 variants reveals differences in perk activity in mouse liver and pancreas under endoplasmic reticulum stress. Scientific Reports, Oct 2024. URL: https://doi.org/10.1038/s41598-024-74362-z, doi:10.1038/s41598-024-74362-z. This article has 3 citations and is from a peer-reviewed journal.
+
+4. (ghura2024geneticknockinof pages 14-15): Shivesh Ghura, Noah R. Beratan, Xinglong Shi, Elena Alvarez-Periel, Sarah E. Bond Newton, Cagla Akay-Espinoza, and Kelly L. Jordan-Sciutto. Genetic knock-in of eif2ak3 variants reveals differences in perk activity in mouse liver and pancreas under endoplasmic reticulum stress. Scientific Reports, Oct 2024. URL: https://doi.org/10.1038/s41598-024-74362-z, doi:10.1038/s41598-024-74362-z. This article has 3 citations and is from a peer-reviewed journal.
+
+5. (park2024ethnicvariationand pages 5-9): Goonho Park, Angela Galdamez, Keon‐Hyoung Song, Masako Le, Kyle Kim, and Jonathan H. Lin. Ethnic variation and structure‐function analysis of tauopathy‐associated <i>perk</i> alleles. Israel Journal of Chemistry, May 2024. URL: https://doi.org/10.1002/ijch.202300173, doi:10.1002/ijch.202300173. This article has 0 citations and is from a peer-reviewed journal.
+
+6. (park2024ethnicvariationand pages 9-13): Goonho Park, Angela Galdamez, Keon‐Hyoung Song, Masako Le, Kyle Kim, and Jonathan H. Lin. Ethnic variation and structure‐function analysis of tauopathy‐associated <i>perk</i> alleles. Israel Journal of Chemistry, May 2024. URL: https://doi.org/10.1002/ijch.202300173, doi:10.1002/ijch.202300173. This article has 0 citations and is from a peer-reviewed journal.
+
+7. (moon2024glucolipotoxicitysuppressedautophagy pages 1-2): Seoil Moon, Ji Yoon Lim, Mirang Lee, Youngmin Han, Hongbeom Kim, Wooil Kwon, Jin-Young Jang, Mi Na Kim, Kyong Soo Park, and Hye Seung Jung. Glucolipotoxicity suppressed autophagy and insulin contents in human islets, and attenuation of perk activity enhanced them in an atg7-dependent manner. Diabetes &amp; Metabolism Journal, 48:231-241, Mar 2024. URL: https://doi.org/10.4093/dmj.2022.0366, doi:10.4093/dmj.2022.0366. This article has 7 citations and is from a peer-reviewed journal.
+
+8. (moon2024glucolipotoxicitysuppressedautophagy pages 5-6): Seoil Moon, Ji Yoon Lim, Mirang Lee, Youngmin Han, Hongbeom Kim, Wooil Kwon, Jin-Young Jang, Mi Na Kim, Kyong Soo Park, and Hye Seung Jung. Glucolipotoxicity suppressed autophagy and insulin contents in human islets, and attenuation of perk activity enhanced them in an atg7-dependent manner. Diabetes &amp; Metabolism Journal, 48:231-241, Mar 2024. URL: https://doi.org/10.4093/dmj.2022.0366, doi:10.4093/dmj.2022.0366. This article has 7 citations and is from a peer-reviewed journal.
+
+9. (moon2024glucolipotoxicitysuppressedautophagy media e6820203): Seoil Moon, Ji Yoon Lim, Mirang Lee, Youngmin Han, Hongbeom Kim, Wooil Kwon, Jin-Young Jang, Mi Na Kim, Kyong Soo Park, and Hye Seung Jung. Glucolipotoxicity suppressed autophagy and insulin contents in human islets, and attenuation of perk activity enhanced them in an atg7-dependent manner. Diabetes &amp; Metabolism Journal, 48:231-241, Mar 2024. URL: https://doi.org/10.4093/dmj.2022.0366, doi:10.4093/dmj.2022.0366. This article has 7 citations and is from a peer-reviewed journal.
+
+10. (moon2024glucolipotoxicitysuppressedautophagy media d4374739): Seoil Moon, Ji Yoon Lim, Mirang Lee, Youngmin Han, Hongbeom Kim, Wooil Kwon, Jin-Young Jang, Mi Na Kim, Kyong Soo Park, and Hye Seung Jung. Glucolipotoxicity suppressed autophagy and insulin contents in human islets, and attenuation of perk activity enhanced them in an atg7-dependent manner. Diabetes &amp; Metabolism Journal, 48:231-241, Mar 2024. URL: https://doi.org/10.4093/dmj.2022.0366, doi:10.4093/dmj.2022.0366. This article has 7 citations and is from a peer-reviewed journal.
+
+11. (akayespinoza2024geneticvariationsin pages 1-2): Cagla Akay-Espinoza, Sarah E.B. Newton, Beth A. Dombroski, Asha Kallianpur, Ajay Bharti, Donald R. Franklin, Gerard D. Schellenberg, Robert K. Heaton, Igor Grant, Ronald J. Ellis, Scott L. Letendre, and Kelly L. Jordan-Sciutto. Genetic variations in eif2ak3 are associated with neurocognitive impairment in people living with hiv. Journal of Neuroimmune Pharmacology, May 2024. URL: https://doi.org/10.1007/s11481-024-10125-x, doi:10.1007/s11481-024-10125-x. This article has 3 citations and is from a peer-reviewed journal.
+
+12. (ghura2024geneticknockinof pages 10-11): Shivesh Ghura, Noah R. Beratan, Xinglong Shi, Elena Alvarez-Periel, Sarah E. Bond Newton, Cagla Akay-Espinoza, and Kelly L. Jordan-Sciutto. Genetic knock-in of eif2ak3 variants reveals differences in perk activity in mouse liver and pancreas under endoplasmic reticulum stress. Scientific Reports, Oct 2024. URL: https://doi.org/10.1038/s41598-024-74362-z, doi:10.1038/s41598-024-74362-z. This article has 3 citations and is from a peer-reviewed journal.
+
+13. (wang2024lossoftrim29 pages 1-2): Junying Wang, Wenting Lu, Jerry Zhang, Yong Du, Mingli Fang, Ao Zhang, Gabriel Sungcad, Samantha Chon, and Junji Xing. Loss of trim29 mitigates viral myocarditis by attenuating perk-driven er stress response in male mice. Nature Communications, Apr 2024. URL: https://doi.org/10.1038/s41467-024-44745-x, doi:10.1038/s41467-024-44745-x. This article has 96 citations and is from a highest quality peer-reviewed journal.
+
+14. (park2024ethnicvariationand pages 1-5): Goonho Park, Angela Galdamez, Keon‐Hyoung Song, Masako Le, Kyle Kim, and Jonathan H. Lin. Ethnic variation and structure‐function analysis of tauopathy‐associated <i>perk</i> alleles. Israel Journal of Chemistry, May 2024. URL: https://doi.org/10.1002/ijch.202300173, doi:10.1002/ijch.202300173. This article has 0 citations and is from a peer-reviewed journal.
+
+15. (moon2024glucolipotoxicitysuppressedautophagy pages 4-5): Seoil Moon, Ji Yoon Lim, Mirang Lee, Youngmin Han, Hongbeom Kim, Wooil Kwon, Jin-Young Jang, Mi Na Kim, Kyong Soo Park, and Hye Seung Jung. Glucolipotoxicity suppressed autophagy and insulin contents in human islets, and attenuation of perk activity enhanced them in an atg7-dependent manner. Diabetes &amp; Metabolism Journal, 48:231-241, Mar 2024. URL: https://doi.org/10.4093/dmj.2022.0366, doi:10.4093/dmj.2022.0366. This article has 7 citations and is from a peer-reviewed journal.
+
+## Citations
+
+1. huang2023erstressthe pages 2-4
+2. perea2023pharmacologicactivationof pages 1-4
+3. akayespinoza2024geneticvariationsin pages 1-2
+4. moon2024glucolipotoxicitysuppressedautophagy pages 1-2
+5. ghura2024geneticknockinof pages 1-2
+6. ghura2024geneticknockinof pages 14-15
+7. park2024ethnicvariationand pages 5-9
+8. park2024ethnicvariationand pages 9-13
+9. moon2024glucolipotoxicitysuppressedautophagy pages 5-6
+10. ghura2024geneticknockinof pages 10-11
+11. park2024ethnicvariationand pages 1-5
+12. moon2024glucolipotoxicitysuppressedautophagy pages 4-5
+13. https://doi.org/10.3390/biom13071050
+14. https://doi.org/10.1101/2023.03.11.532186
+15. https://doi.org/10.1002/ijch.202300173
+16. https://doi.org/10.1038/s41598-024-74362-z
+17. https://doi.org/10.1038/s41467-024-44745-x
+18. https://doi.org/10.1007/s11481-024-10125-x
+19. https://doi.org/10.4093/dmj.2022.0366
+20. https://doi.org/10.3390/biom13071050,
+21. https://doi.org/10.1101/2023.03.11.532186,
+22. https://doi.org/10.1038/s41598-024-74362-z,
+23. https://doi.org/10.1002/ijch.202300173,
+24. https://doi.org/10.4093/dmj.2022.0366,
+25. https://doi.org/10.1007/s11481-024-10125-x,
+26. https://doi.org/10.1038/s41467-024-44745-x,

--- a/genes/human/HSPA12A/HSPA12A-ai-review.html
+++ b/genes/human/HSPA12A/HSPA12A-ai-review.html
@@ -800,6 +800,15 @@
                     
                 </li>
                 
+                <li>
+
+                    file:human/HSPA12A/HSPA12A-deep-research-falcon.md
+
+
+                    : The strongest mechanistic evidence supports a model where HSPA12A acts as a signal-metabolism integrator under stress, but the direct biochemical SorLA interaction remains the clearest GO-ready molecular function.
+
+                </li>
+
             </ul>
             
         </div>
@@ -937,6 +946,17 @@
                                 
                             </div>
                             
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/HSPA12A/HSPA12A-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">HSPA12A binds the cytoplasmic domain of SorLA in an ADP/ATP-dependent manner and delays SorLA internalization and shifts SorLA subcellular vesicle localization.</div>
+
+                            </div>
+
                         </div>
                         
                     </td>
@@ -1652,6 +1672,17 @@
                         
                     </li>
                     
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/HSPA12A/HSPA12A-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">HSPA12A binds the cytoplasmic domain of SorLA in an ADP/ATP-dependent manner and delays SorLA internalization and shifts SorLA subcellular vesicle localization.</div>
+
+                    </li>
+
                 </ul>
             </div>
             
@@ -1841,6 +1872,31 @@
                 
             </div>
             
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/HSPA12A/HSPA12A-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research report for HSPA12A</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Falcon research supports the conservative review that HSPA12A&#39;s clearest direct molecular role is nucleotide-state-sensitive SorLA/SORL1 cytoplasmic-tail binding and receptor trafficking modulation, while newer stress-metabolism and cancer findings remain context-specific.</div>
+
+                        <div class="finding-text">"A defining operational feature supported by direct biochemical assays is that HSPA12A can show nucleotide-state-dependent binding to at least some partners/clients; the interaction with the sorting receptor SorLA increases under ADP and decreases under ATP."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
         </div>
     </div>
     
@@ -1932,6 +1988,346 @@
     <div class="section">
         <h2 class="section-title">📚 Additional Documentation</h2>
         
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Deep Research Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(HSPA12A-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="O43301" data-a="DOC: Deep Research Falcon" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <hr />
+<p>provider: falcon<br />
+model: Edison Scientific Literature<br />
+cached: false<br />
+start_time: '2026-05-10T20:47:30.500627'<br />
+end_time: '2026-05-10T20:57:03.096277'<br />
+duration_seconds: 572.6<br />
+template_file: templates/gene_research_go_focused.md<br />
+template_variables:<br />
+  organism: human<br />
+  gene_id: HSPA12A<br />
+  gene_symbol: HSPA12A<br />
+  uniprot_accession: O43301<br />
+  protein_description: 'RecName: Full=Heat shock 70 kDa protein 12A; AltName: Full=Heat<br />
+    shock protein family A member 12A;'<br />
+  gene_info: Name=HSPA12A; Synonyms=KIAA0417;<br />
+  organism_full: Homo sapiens (Human).<br />
+  protein_family: Belongs to the heat shock protein 70 family. .<br />
+  protein_domains: ATPase_NBD. (IPR043129); HSPA12A_NBD. (IPR026685)<br />
+provider_config:<br />
+  timeout: 600<br />
+  max_retries: 3<br />
+  parameters:<br />
+    allowed_domains: []<br />
+    temperature: 0.1<br />
+citation_count: 16</p>
+<hr />
+<h2 id="question">Question</h2>
+<h1 id="gene-research-for-functional-annotation">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> O43301</li>
+<li><strong>Protein Description:</strong> RecName: Full=Heat shock 70 kDa protein 12A; AltName: Full=Heat shock protein family A member 12A;</li>
+<li><strong>Gene Information:</strong> Name=HSPA12A; Synonyms=KIAA0417;</li>
+<li><strong>Organism (full):</strong> Homo sapiens (Human).</li>
+<li><strong>Protein Family:</strong> Belongs to the heat shock protein 70 family. .</li>
+<li><strong>Key Domains:</strong> ATPase_NBD. (IPR043129); HSPA12A_NBD. (IPR026685)</li>
+</ul>
+<h3 id="mandatory-verification-steps">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "HSPA12A" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Homo sapiens (Human).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'HSPA12A' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>HSPA12A</strong> (gene ID: HSPA12A, UniProt: O43301) in human.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="output">Output</h2>
+<p>Question: You are an expert researcher providing comprehensive, well-cited information.</p>
+<p>Provide detailed information focusing on:<br />
+1. Key concepts and definitions with current understanding<br />
+2. Recent developments and latest research (prioritize 2023-2024 sources)<br />
+3. Current applications and real-world implementations<br />
+4. Expert opinions and analysis from authoritative sources<br />
+5. Relevant statistics and data from recent studies</p>
+<p>Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.<br />
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.</p>
+<h1 id="gene-research-for-functional-annotation_1">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context_1">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot_1">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> O43301</li>
+<li><strong>Protein Description:</strong> RecName: Full=Heat shock 70 kDa protein 12A; AltName: Full=Heat shock protein family A member 12A;</li>
+<li><strong>Gene Information:</strong> Name=HSPA12A; Synonyms=KIAA0417;</li>
+<li><strong>Organism (full):</strong> Homo sapiens (Human).</li>
+<li><strong>Protein Family:</strong> Belongs to the heat shock protein 70 family. .</li>
+<li><strong>Key Domains:</strong> ATPase_NBD. (IPR043129); HSPA12A_NBD. (IPR026685)</li>
+</ul>
+<h3 id="mandatory-verification-steps_1">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "HSPA12A" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Homo sapiens (Human).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature_1">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'HSPA12A' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target_1">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>HSPA12A</strong> (gene ID: HSPA12A, UniProt: O43301) in human.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="research-report-functional-annotation-of-human-hspa12a-uniprot-o43301">Research report: Functional annotation of human <strong>HSPA12A</strong> (UniProt <strong>O43301</strong>)</h2>
+<h3 id="0-mandatory-identity-verification-to-avoid-symbol-ambiguity">0) Mandatory identity verification (to avoid symbol ambiguity)</h3>
+<p>The retrieved literature consistently uses <strong>HSPA12A</strong> to denote <strong>“heat shock protein family A (Hsp70) member 12A / heat shock 70 kDa protein 12A”</strong>, and describes it as an <strong>atypical/distant HSP70-family member</strong> with an N-terminal nucleotide-binding domain (NBD) exhibiting <strong>ADP/ATP-dependent client binding</strong>, aligning with the UniProt-provided family/domain context for <strong>O43301</strong> (Hsp70 family; ATPase_NBD) rather than an unrelated gene/protein (madsen2019hspa12atargetsthe pages 1-2, madsen2019hspa12atargetsthe pages 2-3, yu2024hspa12amaintainsaerobic pages 12-14). </p>
+<h3 id="1-key-concepts-definitions-and-current-understanding">1) Key concepts, definitions, and current understanding</h3>
+<h4 id="11-what-hspa12a-is-conceptual-definition">1.1 What HSPA12A is (conceptual definition)</h4>
+<p>HSPA12A is an <strong>atypical HSP70-family protein</strong> that appears to function less as a “general proteostasis chaperone” in the canonical HSP70 sense and more as a <strong>context-specific regulatory/scaffolding factor</strong> that links nucleotide-dependent binding to <strong>signaling, metabolic rewiring, and trafficking</strong> (madsen2019hspa12atargetsthe pages 1-2, yu2024hspa12amaintainsaerobic pages 12-14). </p>
+<p>A defining operational feature supported by direct biochemical assays is that HSPA12A can show <strong>nucleotide-state–dependent binding</strong> to at least some partners/clients: the interaction with the sorting receptor <strong>SorLA</strong> increases under <strong>ADP</strong> and decreases under <strong>ATP</strong>, consistent with HSP70-like nucleotide control of binding/release (madsen2019hspa12atargetsthe pages 2-3). </p>
+<h4 id="12-molecular-functions-supported-by-direct-experimental-evidence">1.2 Molecular functions supported by direct experimental evidence</h4>
+<p><strong>(A) Trafficking adaptor / endocytic regulator (SorLA trafficking):</strong> HSPA12A binds the <strong>cytoplasmic domain of SorLA (SORL1)</strong> in an ADP/ATP-dependent manner and <strong>delays SorLA internalization</strong> and shifts SorLA subcellular vesicle localization (madsen2019hspa12atargetsthe pages 2-3, madsen2019hspa12atargetsthe pages 5-7). </p>
+<p><strong>(B) Metabolic–epigenetic regulator in ischemia–reperfusion stress:</strong> In cardiomyocytes, HSPA12A supports <strong>aerobic glycolysis</strong>, <strong>lactate production</strong>, and <strong>histone H3 lactylation</strong>, contributing to survival during myocardial ischemia/reperfusion (MI/R) (yu2024hspa12amaintainsaerobic pages 1-2, yu2024hspa12amaintainsaerobic pages 12-14). In renal tubular epithelial cells (TEC), HSPA12A promotes glycolysis-derived lactate and increases <strong>c-Myc lactylation</strong> and nuclear localization to drive a proliferation program important for repair after kidney ischemia/reperfusion (KI/R) (li2024hspa12apromotescmyc pages 1-3). </p>
+<p><strong>(C) Protein–protein interaction hub affecting proliferation/migration in cancer models:</strong> In hepatocellular carcinoma (HCC) cells, HSPA12A directly binds <strong>PCNA</strong> and promotes <strong>PCNA trimerization</strong>, a functional conformation linked to proliferation; it also activates <strong>β-catenin signaling</strong> (cheng2020heat‐shockproteina12a pages 6-7, cheng2020heat‐shockproteina12a pages 1-3). In HCC migration, HSPA12A associates with and upregulates <strong>MCT4</strong>, increasing its membrane localization, lactate export, and migration-related markers (min2022heatshockprotein pages 8-10). </p>
+<h3 id="2-recent-developments-and-latest-research-prioritizing-20232024">2) Recent developments and latest research (prioritizing 2023–2024)</h3>
+<h4 id="21-2024-cardiomyocyte-mirhspa12a-links-ubiquitin-signaling-to-hif1-stability-glycolysis-and-histone-lactylation">2.1 2024: Cardiomyocyte MI/R—HSPA12A links ubiquitin signaling to HIF1α stability, glycolysis, and histone lactylation</h4>
+<p>A 2024 <em>JCI Insight</em> study (publication date: <strong>Apr 2024</strong>) reports that <strong>HSPA12A is downregulated during reperfusion</strong> and that <strong>HSPA12A knockout exacerbates MI/R injury phenotypes</strong>, including worse glycolytic decline, cardiomyocyte death, and dysfunction (yu2024hspa12amaintainsaerobic pages 1-2). Mechanistically, HSPA12A supports <strong>HIF1α protein stability</strong> (post-translationally; not via mRNA), via a pathway involving <strong>Smurf1 and VHL</strong>, and thereby sustains glycolytic gene expression and <strong>H3K56 lactylation</strong> (yu2024hspa12amaintainsaerobic pages 12-14). The authors further show that blocking glycolysis (e.g., 2-DG, oxamate) or blocking lactylation (C646) abrogates HSPA12A-dependent cardioprotection, supporting a causal chain rather than correlation (yu2024hspa12amaintainsaerobic pages 12-14). A schematic pathway summary is provided in the paper’s Figure 10E (yu2024hspa12amaintainsaerobic media 6c187c8f). </p>
+<p><strong>URL/DOI:</strong> https://doi.org/10.1172/jci.insight.169125 (Apr 2024) (yu2024hspa12amaintainsaerobic pages 1-2, yu2024hspa12amaintainsaerobic pages 12-14, yu2024hspa12amaintainsaerobic media 6c187c8f).</p>
+<h4 id="22-2024-renal-kirhspa12a-promotes-lactylation-driven-c-myc-activation-and-epithelial-repair">2.2 2024: Renal KI/R—HSPA12A promotes lactylation-driven c-Myc activation and epithelial repair</h4>
+<p>A 2024 <em>Cellular and Molecular Life Sciences</em> paper (publication date: <strong>Sep 2024</strong>) reports that KI/R decreases HSPA12A expression and that <strong>HSPA12A ablation impairs TEC proliferation and renal functional recovery</strong> after injury (li2024hspa12apromotescmyc pages 1-3). Mechanistically, HSPA12A directly <strong>interacts with c-Myc</strong>, promotes its <strong>nuclear localization</strong>, and enhances <strong>c-Myc lactylation</strong>; inhibiting c-Myc lactylation suppresses HSPA12A-driven proliferation gene expression and TEC proliferation (li2024hspa12apromotescmyc pages 1-3). </p>
+<p><strong>URL/DOI:</strong> https://doi.org/10.1007/s00018-024-05427-5 (Sep 2024) (li2024hspa12apromotescmyc pages 1-3).</p>
+<h4 id="23-2024-human-vascular-smooth-muscle-cell-proteomics-association-level-evidence">2.3 2024: Human vascular smooth muscle cell proteomics (association-level evidence)</h4>
+<p>A 2024 <em>Journal of Proteome Research</em> study analyzing vascular smooth muscle cells from thoracic aortic aneurysm patients includes HSPA12A among proteins discussed in the context of stress phenotypes/cellular senescence; however, the extracted snippet does not provide mechanistic or quantitative details specific to HSPA12A beyond this contextual involvement (gao2025kmvmediatedcardiomyocytetoendothelialcell pages 18-19).</p>
+<h3 id="3-current-applications-and-real-world-implementations">3) Current applications and real-world implementations</h3>
+<h4 id="31-translational-applications-preclinical">3.1 Translational applications (preclinical)</h4>
+<p><strong>Ischemia–reperfusion injury (heart and kidney):</strong> Multiple mammalian studies suggest <strong>therapeutic potential</strong> for modulating HSPA12A to improve functional recovery after ischemia–reperfusion injury, via metabolic/epigenetic mechanisms involving glycolysis-derived lactate and lactylation (heart: HIF1α stability → glycolysis → histone lactylation; kidney: glycolysis/lactate → c-Myc lactylation → proliferation) (yu2024hspa12amaintainsaerobic pages 1-2, li2024hspa12apromotescmyc pages 1-3, yu2024hspa12amaintainsaerobic pages 12-14). These are preclinical findings (mouse and cell models) rather than clinical interventions.</p>
+<p><strong>Cancer biology (HCC):</strong> In HCC models, HSPA12A has been proposed as a potential target because it promotes tumor growth and angiogenesis by binding PCNA and promoting PCNA trimerization, and it promotes migration through an MCT4-dependent lactate export mechanism (cheng2020heat‐shockproteina12a pages 6-7, min2022heatshockprotein pages 8-10). These provide mechanistic rationales for targeting the HSPA12A axis in tumors, but they are not yet validated clinically.</p>
+<h4 id="32-biomarker-type-use-association-level">3.2 Biomarker-type use (association-level)</h4>
+<p>In human HCC tissues, HSPA12A mRNA was reported to be <strong>3.14-fold higher</strong> in tumor tissue compared with normal liver, consistent with interest in HSPA12A as a disease-associated marker in oncology contexts (Jan 2022; https://doi.org/10.1007/s12192-021-01251-z) (min2022heatshockprotein pages 8-10). </p>
+<h3 id="4-expert-opinions-and-analysis-from-authoritative-sources">4) Expert opinions and analysis from authoritative sources</h3>
+<h4 id="41-evidence-based-interpretation-from-mechanistic-papers">4.1 Evidence-based interpretation from mechanistic papers</h4>
+<p>The strongest mechanistic evidence supports a model where HSPA12A acts as a <strong>signal–metabolism integrator</strong> under stress:<br />
+- In cardiomyocytes, the inferred core role is stabilizing <strong>HIF1α</strong> (via Smurf1/VHL) to maintain glycolytic capacity and lactate-driven <strong>histone lactylation</strong>, thereby promoting survival during reperfusion (yu2024hspa12amaintainsaerobic pages 12-14, yu2024hspa12amaintainsaerobic media 6c187c8f).<br />
+- In renal tubules, HSPA12A increases glycolysis-derived lactate and drives <strong>c-Myc lactylation</strong>, promoting nuclear c-Myc activity and proliferation required for repair (li2024hspa12apromotescmyc pages 1-3).</p>
+<p>In parallel, a separate line of evidence indicates HSPA12A can behave as a <strong>nucleotide-dependent adaptor</strong> for receptor trafficking (SorLA), suggesting that the “atypical HSP70” designation may reflect <strong>client-specific chaperone/adaptor functions</strong> rather than broad proteostasis (madsen2019hspa12atargetsthe pages 2-3, madsen2019hspa12atargetsthe pages 5-7).</p>
+<h4 id="42-genetics-based-prioritization-open-targets">4.2 Genetics-based prioritization (Open Targets)</h4>
+<p>The Open Targets Platform aggregates GWAS credible-set evidence linking HSPA12A to multiple phenotypes (e.g., open-angle glaucoma, alcohol drinking, chest pain, COVID-19, severe acute respiratory syndrome), with association scores in the ~0.30–0.43 range in the returned excerpt. These data are useful for <strong>hypothesis generation</strong> but do not establish mechanism or directionality (OpenTargets Search: -HSPA12A).</p>
+<h3 id="5-relevant-statistics-and-quantitative-data-from-included-evidence">5) Relevant statistics and quantitative data (from included evidence)</h3>
+<p><strong>Nucleotide-dependent binding statistics (SorLA interaction):</strong> Increasing ADP enhanced SorLA precipitation by HSPA12A, while increasing ATP reduced it, with reported comparisons <strong>0.5 mM vs 5 mM ADP (p = 0.0178)</strong> and <strong>0.5 mM vs 5 mM ATP (p = 0.001)</strong> (Jan 2019; https://doi.org/10.1038/s41598-018-37336-6) (madsen2019hspa12atargetsthe pages 2-3).</p>
+<p><strong>Cancer migration quantitative outcomes (MCT4-dependent):</strong> In HepG2 cells, <strong>MCT4 knockdown</strong> reduced extracellular lactate and reversed HSPA12A-driven wound closure at 72 h (<strong>P &lt; 0.01</strong>). MCT4 knockdown also reduced integrin-β1, MMP2, and MMP9 (<strong>P &lt; 0.05</strong>) (Jan 2022; https://doi.org/10.1007/s12192-021-01251-z) (min2022heatshockprotein pages 8-10).</p>
+<p><strong>Cancer proliferation quantitative outcomes (PCNA dependency):</strong> In HCC models, inhibition of PCNA (PCNA-I1) <strong>partially reversed</strong> HSPA12A-mediated increases in viable cells and <strong>completely abolished</strong> HSPA12A-enhanced EdU incorporation (Mar 2020; https://doi.org/10.1111/febs.15276). The extracted evidence reports statistical thresholds (<strong>P &lt; 0.01, n = 3/group</strong>; <strong>P &lt; 0.05, n = 7/group</strong>) in association with these functional readouts (cheng2020heat‐shockproteina12a pages 6-7).</p>
+<p><strong>GWAS association scores (Open Targets excerpt):</strong> open-angle glaucoma (score <strong>0.4305</strong>), alcohol drinking (<strong>0.3443</strong>), chest pain (<strong>0.3416</strong>), COVID-19 (<strong>0.3118</strong>), severe acute respiratory syndrome (<strong>0.3033</strong>) (OpenTargets Search: -HSPA12A).</p>
+<h3 id="6-subcellular-localization-evidence-supported">6) Subcellular localization (evidence-supported)</h3>
+<ul>
+<li>In transfected 293 cells, GFP-HSPA12A is reported to localize mainly to <strong>perinuclear compartments</strong> and co-localize with SorLA in perinuclear vesicles; fractionation suggested SorLA shifts into denser vesicles upon HSPA12A expression (madsen2019hspa12atargetsthe pages 5-7).</li>
+<li>In primary cortical mouse astrocytes, HSPA12A was detected in both <strong>cytosol and nucleus</strong>, with a cytoplasmic fraction co-localizing with SorLA in vesicles (madsen2019hspa12atargetsthe pages 7-9).</li>
+<li>In renal TEC repair, HSPA12A promotes <strong>nuclear localization of c-Myc</strong> (localization conclusion pertains to c-Myc; the extracted evidence does not directly localize HSPA12A itself) (li2024hspa12apromotescmyc pages 1-3).</li>
+</ul>
+<h3 id="7-pathways-and-mechanistic-map-integrated">7) Pathways and mechanistic map (integrated)</h3>
+<p>Across the most mechanistically detailed papers retrieved, HSPA12A is positioned in three partially distinct functional modules:<br />
+1. <strong>Trafficking module (SorLA):</strong> HSPA12A ↔ SorLA cytosolic acidic clusters; ADP/ATP-dependent binding → altered endocytosis/vesicle localization (madsen2019hspa12atargetsthe pages 2-3, madsen2019hspa12atargetsthe pages 5-7).<br />
+2. <strong>Stress-metabolism-epigenetics module (heart/kidney):</strong> HSPA12A → Smurf1/VHL-dependent <strong>HIF1α stabilization</strong> → glycolytic gene program → lactate → histone lactylation (heart) and <strong>c-Myc lactylation</strong> (kidney) → survival/proliferation (li2024hspa12apromotescmyc pages 1-3, yu2024hspa12amaintainsaerobic pages 12-14, yu2024hspa12amaintainsaerobic media 6c187c8f).<br />
+3. <strong>Cancer growth/migration module (HCC):</strong> HSPA12A ↔ <strong>PCNA</strong> (trimerization) → proliferation; HSPA12A ↔ <strong>MCT4/CD147</strong> → lactate export and migration marker program (cheng2020heat‐shockproteina12a pages 6-7, min2022heatshockprotein pages 8-10).</p>
+<h3 id="evidence-summary-table">Evidence summary table</h3>
+<p>The following table consolidates the key studies, models, partners/pathways, and quantitative findings.</p>
+<table>
+<thead>
+<tr>
+<th>Year</th>
+<th>Study</th>
+<th>System/model</th>
+<th>Key finding (function)</th>
+<th>Molecular partners / pathway</th>
+<th>Localization notes</th>
+<th>Key quantitative / statistical results reported in evidence</th>
+<th>URL / DOI</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>2024</td>
+<td>Yu et al., <em>JCI Insight</em></td>
+<td>Mouse MI/R model; HSPA12A knockout mice; cardiomyocyte hypoxia/reoxygenation gain/loss-of-function studies</td>
+<td>HSPA12A is cardioprotective and maintains aerobic glycolytic homeostasis and Histone H3 lactylation during myocardial ischemia/reperfusion injury</td>
+<td>Smurf1–VHL–HIF1α axis; glycolytic genes; H3K56 lactylation; blockade by 2-DG, oxamate, C646, and HIF1α inhibition reversed protection</td>
+<td>No explicit HSPA12A subcellular localization reported in extracted evidence</td>
+<td>HSPA12A downregulated during reperfusion; HSPA12A KO exacerbated glycolysis decrease, cardiomyocyte death, and cardiac dysfunction; pharmacologic reversal experiments supported causality, but exact fold-changes were not provided in extracted evidence (yu2024hspa12amaintainsaerobic pages 1-2, yu2024hspa12amaintainsaerobic pages 12-14, yu2024hspa12amaintainsaerobic media 6c187c8f)</td>
+<td>https://doi.org/10.1172/jci.insight.169125 ; DOI: 10.1172/jci.insight.169125</td>
+</tr>
+<tr>
+<td>2024</td>
+<td>Li et al., <em>Cellular and Molecular Life Sciences</em></td>
+<td>Mouse kidney ischemia/reperfusion injury; HSPA12A-deficient mice; tubular epithelial cell hypoxia/reoxygenation with overexpression</td>
+<td>HSPA12A promotes tubular epithelial cell proliferation and renal functional recovery after ischemia/reperfusion</td>
+<td>Direct interaction with c-Myc; increased c-Myc nuclear localization; Hif1α-dependent glycolysis/lactate production; c-Myc lactylation</td>
+<td>Nuclear localization effect reported for c-Myc, not direct HSPA12A localization</td>
+<td>HSPA12A ablation impaired TEC proliferation and renal recovery; inhibition of c-Myc lactylation attenuated HSPA12A-induced proliferation-gene expression and TEC proliferation; exact fold-changes/p-values not provided in extracted evidence (li2024hspa12apromotescmyc pages 1-3)</td>
+<td>https://doi.org/10.1007/s00018-024-05427-5 ; DOI: 10.1007/s00018-024-05427-5</td>
+</tr>
+<tr>
+<td>2020</td>
+<td>Cheng et al., <em>FEBS Journal</em></td>
+<td>Human HCC cells (e.g., HepG2); mouse tumor-growth model; gain/loss-of-function</td>
+<td>HSPA12A promotes hepatocellular carcinoma proliferation, tumor growth, and angiogenesis</td>
+<td>Direct PCNA binding; promotes PCNA trimerization; activates β-catenin signaling with increased nuclear β-catenin and downstream cyclin D1, c-Myc, Bcl-2, VEGF</td>
+<td>Evidence emphasizes nuclear β-catenin increase; no direct HSPA12A localization extracted</td>
+<td>PCNA-I1 partially reversed increases in viable cells and completely abolished HSPA12A-enhanced EdU incorporation; significance reported as <strong>P &lt; 0.01 (n = 3/group)</strong> and <em>P &lt; 0.05 (n = 7/group)</em> in extracted evidence (cheng2020heat‐shockproteina12a pages 6-7, cheng2020heat‐shockproteina12a pages 1-3)</td>
+<td>https://doi.org/10.1111/febs.15276 ; DOI: 10.1111/febs.15276</td>
+</tr>
+<tr>
+<td>2022</td>
+<td>Min et al., <em>Cell Stress and Chaperones</em></td>
+<td>Human HCC tissues; HepG2 cells with Ad-HSPA12A and MCT4 knockdown</td>
+<td>HSPA12A promotes HCC cell migration in an MCT4-dependent manner</td>
+<td>Physical association with MCT4; increased MCT4 mRNA/protein and membrane localization; increased CD147; downstream Integrin-β1, MMP2, MMP9</td>
+<td>Promotes MCT4 cell-membrane localization</td>
+<td>HSPA12A mRNA was <strong>3.14-fold higher</strong> in human HCC tissue versus normal liver; MCT4 knockdown reduced extracellular lactate and reversed HSPA12A-induced wound closure at 72 h (<strong>P &lt; 0.01</strong>); Integrin-β1/MMP2/MMP9 reductions <strong>P &lt; 0.05</strong> (min2022heatshockprotein pages 8-10)</td>
+<td>https://doi.org/10.1007/s12192-021-01251-z ; DOI: 10.1007/s12192-021-01251-z</td>
+</tr>
+<tr>
+<td>2019</td>
+<td>Madsen et al., <em>Scientific Reports</em></td>
+<td>Yeast two-hybrid; GST pull-downs; HEK293/293 cells; primary cortical astrocytes; subcellular fractionation; endocytosis assays; Hspa12a knockout mouse stroke context referenced</td>
+<td>HSPA12A is a SorLA-selective adaptor/chaperone-like protein that binds the SorLA cytoplasmic domain and alters SorLA trafficking/endocytosis</td>
+<td>ADP/ATP-dependent binding to SorLA; acidic cluster-dependent interaction; overlap with GGA2/AP-2-related acidic motif suggests adaptor competition</td>
+<td>In 293 cells GFP-HSPA12A localized mainly to perinuclear compartments; in astrocytes HSPA12A detected in cytosol and nucleus, with a cytoplasmic fraction co-localizing with SorLA vesicles</td>
+<td>SorLA precipitation increased with ADP and decreased with ATP; comparisons reported as <strong>0.5 mM vs 5 mM ADP, p = 0.0178</strong> and <strong>0.5 mM vs 5 mM ATP, p = 0.001</strong>; imaging analyses reported <strong>n = 18 or 10 per transfection</strong>; Hspa12a KO mice had enlarged infarct volumes and worse neurological outcomes after stroke, but exact numeric values not in extracted evidence (madsen2019hspa12atargetsthe pages 7-9, madsen2019hspa12atargetsthe pages 1-2, madsen2019hspa12atargetsthe pages 2-3, madsen2019hspa12atargetsthe pages 5-7)</td>
+<td>https://doi.org/10.1038/s41598-018-37336-6 ; DOI: 10.1038/s41598-018-37336-6</td>
+</tr>
+<tr>
+<td>2019</td>
+<td>Zhang et al., <em>Cell Death and Differentiation</em></td>
+<td>Obese patients’ adipose tissue; Hspa12a−/− mice on high-fat diet; primary adipocyte precursors with gain/loss-of-function</td>
+<td>HSPA12A is required for adipocyte differentiation and promotes diet-induced obesity</td>
+<td>Positive feedback with PPARγ; HSPA12A supports PPARγ and adipogenic target-gene expression; PPARγ binds Hspa12a promoter</td>
+<td>No localization details extracted</td>
+<td>Obese patients showed increased adipose HSPA12A expression positively correlated with BMI; Hspa12a−/− mice had attenuated HFD-induced weight gain, adiposity, hyperlipidemia, hyperglycemia, and improved insulin sensitivity; exact statistics not extracted here (gao2025kmvmediatedcardiomyocytetoendothelialcell pages 18-19)</td>
+<td>https://doi.org/10.1038/s41418-019-0300-2 ; DOI: 10.1038/s41418-019-0300-2</td>
+</tr>
+<tr>
+<td>2025 / 2023 review citation</td>
+<td>Gao et al. summary citing prior HSPA12A studies; Song et al. review</td>
+<td>Review/synthesis across cardiac, endothelial, renal, and cancer studies</td>
+<td>HSPA12A has emerging scaffold/signaling roles beyond canonical HSP70 proteostasis, including angiogenesis and tissue repair</td>
+<td>Reported pathways include p38/ERK–AP-1, ERK/Akt, eNOS-dependent signaling, PCNA, c-Myc lactylation, and Smurf1–HIF1α</td>
+<td>No unified localization conclusion</td>
+<td>Review-style evidence states HSPA12A promotes angiogenesis, protects from I/R injury, and modulates tumor growth/migration, but no additional direct quantitative values were extracted from these sources (gao2025kmvmediatedcardiomyocytetoendothelialcell pages 18-19)</td>
+<td>https://doi.org/10.7150/thno.104899 ; DOI: 10.7150/thno.104899 / https://doi.org/10.3389/fcell.2023.1164166 ; DOI: 10.3389/fcell.2023.1164166</td>
+</tr>
+<tr>
+<td>2025 Open Targets / GWAS evidence</td>
+<td>Open Targets Platform</td>
+<td>Human genetic-association datasets (GWAS credible sets)</td>
+<td>Population-level disease associations exist, but these do not establish molecular function directly</td>
+<td>Genetic association rather than mechanistic pathway evidence</td>
+<td>Not applicable</td>
+<td>Association scores reported for open-angle glaucoma (<strong>0.4305</strong>), alcohol drinking (<strong>0.3443</strong>), chest pain (<strong>0.3416</strong>), COVID-19 (<strong>0.3118</strong>), and severe acute respiratory syndrome (<strong>0.3033</strong>); evidence count <strong>5</strong> in the returned association rows (OpenTargets Search: -HSPA12A)</td>
+<td>Open Targets target page/search context; platform citation in evidence (OpenTargets Search: -HSPA12A)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the main experimental and translational studies identified for human HSPA12A/its mammalian orthologs, emphasizing function, partners, localization, and quantitative findings. It is useful as a compact evidence map for functional annotation of UniProt O43301.</em></p>
+<h3 id="figure-evidence">Figure evidence</h3>
+<p>A pathway schematic summarizing the HSPA12A–Smurf1–HIF1α–glycolysis–histone lactylation mechanism in cardiomyocytes is shown in the retrieved figure panel (Figure 10E) (yu2024hspa12amaintainsaerobic media 6c187c8f).</p>
+<h3 id="limitations-of-the-current-evidence-set">Limitations of the current evidence set</h3>
+<ul>
+<li>This tool session did not retrieve the UniProt/HGNC/InterPro primary database entries directly as citeable text, so curated annotations (e.g., canonical domains, isoforms, baseline expression) are not quoted verbatim here; the report therefore emphasizes <strong>peer-reviewed mechanistic literature</strong> retrieved in-session.</li>
+<li>Some endpoints (e.g., exact infarct size/ejection fraction values in MI/R or stroke) are described qualitatively in extracted text, but precise numeric values were not available in the snippets returned by the evidence tool (yu2024hspa12amaintainsaerobic pages 1-2, madsen2019hspa12atargetsthe pages 7-9).</li>
+</ul>
+<h3 id="references-urls-dates-within-citations">References (URLs / dates within citations)</h3>
+<p>Key primary sources include: Madsen et al. 2019 (<em>Scientific Reports</em>, Jan 2019) https://doi.org/10.1038/s41598-018-37336-6 (madsen2019hspa12atargetsthe pages 2-3); Cheng et al. 2020 (<em>FEBS Journal</em>, Mar 2020) https://doi.org/10.1111/febs.15276 (cheng2020heat‐shockproteina12a pages 6-7); Min et al. 2022 (<em>Cell Stress and Chaperones</em>, Jan 2022) https://doi.org/10.1007/s12192-021-01251-z (min2022heatshockprotein pages 8-10); Yu et al. 2024 (<em>JCI Insight</em>, Apr 2024) https://doi.org/10.1172/jci.insight.169125 (yu2024hspa12amaintainsaerobic pages 1-2); Li et al. 2024 (<em>Cellular and Molecular Life Sciences</em>, Sep 2024) https://doi.org/10.1007/s00018-024-05427-5 (li2024hspa12apromotescmyc pages 1-3). Open Targets genetic associations are summarized from the Open Targets Platform output (OpenTargets Search: -HSPA12A).</p>
+<p>References</p>
+<ol>
+<li>
+<p>(madsen2019hspa12atargetsthe pages 1-2): Peder Madsen, Toke Jost Isaksen, Piotr Siupka, Andrea E. Tóth, Mette Nyegaard, Camilla Gustafsen, and Morten S. Nielsen. Hspa12a targets the cytoplasmic domain and affects the trafficking of the amyloid precursor protein receptor sorla. Scientific Reports, Jan 2019. URL: https://doi.org/10.1038/s41598-018-37336-6, doi:10.1038/s41598-018-37336-6. This article has 16 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(madsen2019hspa12atargetsthe pages 2-3): Peder Madsen, Toke Jost Isaksen, Piotr Siupka, Andrea E. Tóth, Mette Nyegaard, Camilla Gustafsen, and Morten S. Nielsen. Hspa12a targets the cytoplasmic domain and affects the trafficking of the amyloid precursor protein receptor sorla. Scientific Reports, Jan 2019. URL: https://doi.org/10.1038/s41598-018-37336-6, doi:10.1038/s41598-018-37336-6. This article has 16 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(yu2024hspa12amaintainsaerobic pages 12-14): Wansu Yu, Qiuyue Kong, Surong Jiang, Yunfan Li, Zhaohe Wang, Qian Mao, Xiaojin Zhang, Qianhui Liu, Pengjun Zhang, Yuehua Li, Chuanfu Li, Zhengnian Ding, and Li Liu. Hspa12a maintains aerobic glycolytic homeostasis and histone3 lactylation in cardiomyocytes to attenuate myocardial ischemia/reperfusion injury. JCI Insight, Apr 2024. URL: https://doi.org/10.1172/jci.insight.169125, doi:10.1172/jci.insight.169125. This article has 58 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(madsen2019hspa12atargetsthe pages 5-7): Peder Madsen, Toke Jost Isaksen, Piotr Siupka, Andrea E. Tóth, Mette Nyegaard, Camilla Gustafsen, and Morten S. Nielsen. Hspa12a targets the cytoplasmic domain and affects the trafficking of the amyloid precursor protein receptor sorla. Scientific Reports, Jan 2019. URL: https://doi.org/10.1038/s41598-018-37336-6, doi:10.1038/s41598-018-37336-6. This article has 16 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(yu2024hspa12amaintainsaerobic pages 1-2): Wansu Yu, Qiuyue Kong, Surong Jiang, Yunfan Li, Zhaohe Wang, Qian Mao, Xiaojin Zhang, Qianhui Liu, Pengjun Zhang, Yuehua Li, Chuanfu Li, Zhengnian Ding, and Li Liu. Hspa12a maintains aerobic glycolytic homeostasis and histone3 lactylation in cardiomyocytes to attenuate myocardial ischemia/reperfusion injury. JCI Insight, Apr 2024. URL: https://doi.org/10.1172/jci.insight.169125, doi:10.1172/jci.insight.169125. This article has 58 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(li2024hspa12apromotescmyc pages 1-3): Yunfan Li, Xinxu Min, Xiaojin Zhang, Xiaofei Cao, Qiuyue Kong, Qian Mao, Hao Cheng, Liming Gou, Yuehua Li, Chuanfu Li, Li Liu, and Zhengnian Ding. Hspa12a promotes c-myc lactylation-mediated proliferation of tubular epithelial cells to facilitate renal functional recovery from kidney ischemia/reperfusion injury. Cellular and Molecular Life Sciences: CMLS, Sep 2024. URL: https://doi.org/10.1007/s00018-024-05427-5, doi:10.1007/s00018-024-05427-5. This article has 23 citations.</p>
+</li>
+<li>
+<p>(cheng2020heat‐shockproteina12a pages 6-7): Hao Cheng, Xiaofei Cao, Xinxu Min, Xiaojin Zhang, Qiuyue Kong, Qian Mao, Rongrong Li, Bin Xue, Lei Fang, Li Liu, and Zhengnian Ding. Heat‐shock protein a12a is a novel pcna‐binding protein and promotes hepatocellular carcinoma growth. The FEBS Journal, 287:5464-5477, Mar 2020. URL: https://doi.org/10.1111/febs.15276, doi:10.1111/febs.15276. This article has 19 citations.</p>
+</li>
+<li>
+<p>(cheng2020heat‐shockproteina12a pages 1-3): Hao Cheng, Xiaofei Cao, Xinxu Min, Xiaojin Zhang, Qiuyue Kong, Qian Mao, Rongrong Li, Bin Xue, Lei Fang, Li Liu, and Zhengnian Ding. Heat‐shock protein a12a is a novel pcna‐binding protein and promotes hepatocellular carcinoma growth. The FEBS Journal, 287:5464-5477, Mar 2020. URL: https://doi.org/10.1111/febs.15276, doi:10.1111/febs.15276. This article has 19 citations.</p>
+</li>
+<li>
+<p>(min2022heatshockprotein pages 8-10): Xinxu Min, Hao Cheng, Xiaofei Cao, Ziyang Chen, Xiaojin Zhang, Yunfan Li, Qian Mao, Bin Xue, Lei Fang, Li Liu, and Zhengnian Ding. Heat shock protein a12a activates migration of hepatocellular carcinoma cells in a monocarboxylate transporter 4–dependent manner. Cell Stress and Chaperones, 27:83-95, Jan 2022. URL: https://doi.org/10.1007/s12192-021-01251-z, doi:10.1007/s12192-021-01251-z. This article has 11 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(yu2024hspa12amaintainsaerobic media 6c187c8f): Wansu Yu, Qiuyue Kong, Surong Jiang, Yunfan Li, Zhaohe Wang, Qian Mao, Xiaojin Zhang, Qianhui Liu, Pengjun Zhang, Yuehua Li, Chuanfu Li, Zhengnian Ding, and Li Liu. Hspa12a maintains aerobic glycolytic homeostasis and histone3 lactylation in cardiomyocytes to attenuate myocardial ischemia/reperfusion injury. JCI Insight, Apr 2024. URL: https://doi.org/10.1172/jci.insight.169125, doi:10.1172/jci.insight.169125. This article has 58 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(gao2025kmvmediatedcardiomyocytetoendothelialcell pages 18-19): Chenxi Gao, Yudong Xia, Chaofang Li, Tao Zhou, Wenyu Zhang, Hao Cheng, Xiaojin Zhang, Yunhao Yu, Chuanfu Li, Zhengnian Ding, Jun Wu, and Li Liu. Kmv-mediated cardiomyocyte-to-endothelial cell signaling drives capillary rarefaction to promote heart failure following pressure overload. Theranostics, 15:4970-4988, Mar 2025. URL: https://doi.org/10.7150/thno.104899, doi:10.7150/thno.104899. This article has 1 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(OpenTargets Search: -HSPA12A): Open Targets Query (-HSPA12A, 5 results). Buniello, A. et al. (2025). Open Targets Platform: facilitating therapeutic hypotheses building in drug discovery. Nucleic Acids Research.</p>
+</li>
+<li>
+<p>(madsen2019hspa12atargetsthe pages 7-9): Peder Madsen, Toke Jost Isaksen, Piotr Siupka, Andrea E. Tóth, Mette Nyegaard, Camilla Gustafsen, and Morten S. Nielsen. Hspa12a targets the cytoplasmic domain and affects the trafficking of the amyloid precursor protein receptor sorla. Scientific Reports, Jan 2019. URL: https://doi.org/10.1038/s41598-018-37336-6, doi:10.1038/s41598-018-37336-6. This article has 16 citations and is from a peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>min2022heatshockprotein pages 8-10</li>
+<li>gao2025kmvmediatedcardiomyocytetoendothelialcell pages 18-19</li>
+<li>https://doi.org/10.1172/jci.insight.169125</li>
+<li>https://doi.org/10.1007/s00018-024-05427-5</li>
+<li>https://doi.org/10.1007/s12192-021-01251-z</li>
+<li>https://doi.org/10.1038/s41598-018-37336-6</li>
+<li>https://doi.org/10.1111/febs.15276</li>
+<li>https://doi.org/10.1038/s41418-019-0300-2</li>
+<li>https://doi.org/10.7150/thno.104899</li>
+<li>https://doi.org/10.3389/fcell.2023.1164166</li>
+<li>https://doi.org/10.1038/s41598-018-37336-6,</li>
+<li>https://doi.org/10.1172/jci.insight.169125,</li>
+<li>https://doi.org/10.1007/s00018-024-05427-5,</li>
+<li>https://doi.org/10.1111/febs.15276,</li>
+<li>https://doi.org/10.1007/s12192-021-01251-z,</li>
+<li>https://doi.org/10.7150/thno.104899,</li>
+</ol>
+            </div>
+        </details>
+
         <details class="markdown-section">
             <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
                 <div style="flex: 1;">
@@ -2029,6 +2425,8 @@ existing_annotations:
     - reference_id: file:human/HSPA12A/HSPA12A-uniprot.txt
       supporting_text: Adapter protein for SORL1, but not SORT1. Delays SORL1
         internalization and affects SORL1 subcellular localization.
+    - reference_id: file:human/HSPA12A/HSPA12A-deep-research-falcon.md
+      supporting_text: HSPA12A binds the cytoplasmic domain of SorLA in an ADP/ATP-dependent manner and delays SorLA internalization and shifts SorLA subcellular vesicle localization.
 - term:
     id: GO:0005515
     label: protein binding
@@ -2206,6 +2604,11 @@ references:
 - id: file:human/HSPA12A/HSPA12A-notes.md
   title: Curator notes on HSPA12A PN context and conservative GO review
   findings: []
+- id: file:human/HSPA12A/HSPA12A-deep-research-falcon.md
+  title: Falcon deep research report for HSPA12A
+  findings:
+  - statement: Falcon research supports the conservative review that HSPA12A&#39;s clearest direct molecular role is nucleotide-state-sensitive SorLA/SORL1 cytoplasmic-tail binding and receptor trafficking modulation, while newer stress-metabolism and cancer findings remain context-specific.
+    supporting_text: A defining operational feature supported by direct biochemical assays is that HSPA12A can show nucleotide-state-dependent binding to at least some partners/clients; the interaction with the sorting receptor SorLA increases under ADP and decreases under ATP.
 core_functions:
 - molecular_function:
     id: GO:0019904
@@ -2227,6 +2630,8 @@ core_functions:
   - reference_id: file:human/HSPA12A/HSPA12A-uniprot.txt
     supporting_text: Adapter protein for SORL1, but not SORT1. Delays SORL1
       internalization and affects SORL1 subcellular localization.
+  - reference_id: file:human/HSPA12A/HSPA12A-deep-research-falcon.md
+    supporting_text: HSPA12A binds the cytoplasmic domain of SorLA in an ADP/ATP-dependent manner and delays SorLA internalization and shifts SorLA subcellular vesicle localization.
   directly_involved_in:
   - id: GO:0002091
     label: negative regulation of receptor internalization
@@ -2253,6 +2658,8 @@ proposed_new_terms:
   - reference_id: PMID:30679749
     supporting_text: Accordingly, it is concluded that the 2 C-terminal acidic
       clusters both contributed to the binding between the SorLA-cd and HSPA12A.
+  - reference_id: file:human/HSPA12A/HSPA12A-deep-research-falcon.md
+    supporting_text: The strongest mechanistic evidence supports a model where HSPA12A acts as a signal-metabolism integrator under stress, but the direct biochemical SorLA interaction remains the clearest GO-ready molecular function.
 suggested_questions:
 - question: Does HSPA12A have intrinsic ATP binding/hydrolysis and client-folding
     behavior comparable to canonical HSP70 chaperones, or is it primarily a

--- a/genes/human/HSPA12A/HSPA12A-ai-review.yaml
+++ b/genes/human/HSPA12A/HSPA12A-ai-review.yaml
@@ -50,6 +50,8 @@ existing_annotations:
     - reference_id: file:human/HSPA12A/HSPA12A-uniprot.txt
       supporting_text: Adapter protein for SORL1, but not SORT1. Delays SORL1
         internalization and affects SORL1 subcellular localization.
+    - reference_id: file:human/HSPA12A/HSPA12A-deep-research-falcon.md
+      supporting_text: HSPA12A binds the cytoplasmic domain of SorLA in an ADP/ATP-dependent manner and delays SorLA internalization and shifts SorLA subcellular vesicle localization.
 - term:
     id: GO:0005515
     label: protein binding
@@ -227,6 +229,11 @@ references:
 - id: file:human/HSPA12A/HSPA12A-notes.md
   title: Curator notes on HSPA12A PN context and conservative GO review
   findings: []
+- id: file:human/HSPA12A/HSPA12A-deep-research-falcon.md
+  title: Falcon deep research report for HSPA12A
+  findings:
+  - statement: Falcon research supports the conservative review that HSPA12A's clearest direct molecular role is nucleotide-state-sensitive SorLA/SORL1 cytoplasmic-tail binding and receptor trafficking modulation, while newer stress-metabolism and cancer findings remain context-specific.
+    supporting_text: A defining operational feature supported by direct biochemical assays is that HSPA12A can show nucleotide-state-dependent binding to at least some partners/clients; the interaction with the sorting receptor SorLA increases under ADP and decreases under ATP.
 core_functions:
 - molecular_function:
     id: GO:0019904
@@ -248,6 +255,8 @@ core_functions:
   - reference_id: file:human/HSPA12A/HSPA12A-uniprot.txt
     supporting_text: Adapter protein for SORL1, but not SORT1. Delays SORL1
       internalization and affects SORL1 subcellular localization.
+  - reference_id: file:human/HSPA12A/HSPA12A-deep-research-falcon.md
+    supporting_text: HSPA12A binds the cytoplasmic domain of SorLA in an ADP/ATP-dependent manner and delays SorLA internalization and shifts SorLA subcellular vesicle localization.
   directly_involved_in:
   - id: GO:0002091
     label: negative regulation of receptor internalization
@@ -274,6 +283,8 @@ proposed_new_terms:
   - reference_id: PMID:30679749
     supporting_text: Accordingly, it is concluded that the 2 C-terminal acidic
       clusters both contributed to the binding between the SorLA-cd and HSPA12A.
+  - reference_id: file:human/HSPA12A/HSPA12A-deep-research-falcon.md
+    supporting_text: The strongest mechanistic evidence supports a model where HSPA12A acts as a signal-metabolism integrator under stress, but the direct biochemical SorLA interaction remains the clearest GO-ready molecular function.
 suggested_questions:
 - question: Does HSPA12A have intrinsic ATP binding/hydrolysis and client-folding
     behavior comparable to canonical HSP70 chaperones, or is it primarily a

--- a/genes/human/HSPA12A/HSPA12A-deep-research-falcon.md
+++ b/genes/human/HSPA12A/HSPA12A-deep-research-falcon.md
@@ -1,0 +1,281 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-10T20:47:30.500627'
+end_time: '2026-05-10T20:57:03.096277'
+duration_seconds: 572.6
+template_file: templates/gene_research_go_focused.md
+template_variables:
+  organism: human
+  gene_id: HSPA12A
+  gene_symbol: HSPA12A
+  uniprot_accession: O43301
+  protein_description: 'RecName: Full=Heat shock 70 kDa protein 12A; AltName: Full=Heat
+    shock protein family A member 12A;'
+  gene_info: Name=HSPA12A; Synonyms=KIAA0417;
+  organism_full: Homo sapiens (Human).
+  protein_family: Belongs to the heat shock protein 70 family. .
+  protein_domains: ATPase_NBD. (IPR043129); HSPA12A_NBD. (IPR026685)
+provider_config:
+  timeout: 600
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 16
+---
+
+## Question
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** O43301
+- **Protein Description:** RecName: Full=Heat shock 70 kDa protein 12A; AltName: Full=Heat shock protein family A member 12A;
+- **Gene Information:** Name=HSPA12A; Synonyms=KIAA0417;
+- **Organism (full):** Homo sapiens (Human).
+- **Protein Family:** Belongs to the heat shock protein 70 family. .
+- **Key Domains:** ATPase_NBD. (IPR043129); HSPA12A_NBD. (IPR026685)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "HSPA12A" matches the protein description above**
+2. **Verify the organism is correct:** Homo sapiens (Human).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'HSPA12A' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **HSPA12A** (gene ID: HSPA12A, UniProt: O43301) in human.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** O43301
+- **Protein Description:** RecName: Full=Heat shock 70 kDa protein 12A; AltName: Full=Heat shock protein family A member 12A;
+- **Gene Information:** Name=HSPA12A; Synonyms=KIAA0417;
+- **Organism (full):** Homo sapiens (Human).
+- **Protein Family:** Belongs to the heat shock protein 70 family. .
+- **Key Domains:** ATPase_NBD. (IPR043129); HSPA12A_NBD. (IPR026685)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "HSPA12A" matches the protein description above**
+2. **Verify the organism is correct:** Homo sapiens (Human).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'HSPA12A' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **HSPA12A** (gene ID: HSPA12A, UniProt: O43301) in human.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Research report: Functional annotation of human **HSPA12A** (UniProt **O43301**)
+
+### 0) Mandatory identity verification (to avoid symbol ambiguity)
+The retrieved literature consistently uses **HSPA12A** to denote **“heat shock protein family A (Hsp70) member 12A / heat shock 70 kDa protein 12A”**, and describes it as an **atypical/distant HSP70-family member** with an N-terminal nucleotide-binding domain (NBD) exhibiting **ADP/ATP-dependent client binding**, aligning with the UniProt-provided family/domain context for **O43301** (Hsp70 family; ATPase_NBD) rather than an unrelated gene/protein (madsen2019hspa12atargetsthe pages 1-2, madsen2019hspa12atargetsthe pages 2-3, yu2024hspa12amaintainsaerobic pages 12-14).
+
+### 1) Key concepts, definitions, and current understanding
+#### 1.1 What HSPA12A is (conceptual definition)
+HSPA12A is an **atypical HSP70-family protein** that appears to function less as a “general proteostasis chaperone” in the canonical HSP70 sense and more as a **context-specific regulatory/scaffolding factor** that links nucleotide-dependent binding to **signaling, metabolic rewiring, and trafficking** (madsen2019hspa12atargetsthe pages 1-2, yu2024hspa12amaintainsaerobic pages 12-14).
+
+A defining operational feature supported by direct biochemical assays is that HSPA12A can show **nucleotide-state–dependent binding** to at least some partners/clients: the interaction with the sorting receptor **SorLA** increases under **ADP** and decreases under **ATP**, consistent with HSP70-like nucleotide control of binding/release (madsen2019hspa12atargetsthe pages 2-3).
+
+#### 1.2 Molecular functions supported by direct experimental evidence
+**(A) Trafficking adaptor / endocytic regulator (SorLA trafficking):** HSPA12A binds the **cytoplasmic domain of SorLA (SORL1)** in an ADP/ATP-dependent manner and **delays SorLA internalization** and shifts SorLA subcellular vesicle localization (madsen2019hspa12atargetsthe pages 2-3, madsen2019hspa12atargetsthe pages 5-7).
+
+**(B) Metabolic–epigenetic regulator in ischemia–reperfusion stress:** In cardiomyocytes, HSPA12A supports **aerobic glycolysis**, **lactate production**, and **histone H3 lactylation**, contributing to survival during myocardial ischemia/reperfusion (MI/R) (yu2024hspa12amaintainsaerobic pages 1-2, yu2024hspa12amaintainsaerobic pages 12-14). In renal tubular epithelial cells (TEC), HSPA12A promotes glycolysis-derived lactate and increases **c-Myc lactylation** and nuclear localization to drive a proliferation program important for repair after kidney ischemia/reperfusion (KI/R) (li2024hspa12apromotescmyc pages 1-3).
+
+**(C) Protein–protein interaction hub affecting proliferation/migration in cancer models:** In hepatocellular carcinoma (HCC) cells, HSPA12A directly binds **PCNA** and promotes **PCNA trimerization**, a functional conformation linked to proliferation; it also activates **β-catenin signaling** (cheng2020heat‐shockproteina12a pages 6-7, cheng2020heat‐shockproteina12a pages 1-3). In HCC migration, HSPA12A associates with and upregulates **MCT4**, increasing its membrane localization, lactate export, and migration-related markers (min2022heatshockprotein pages 8-10).
+
+### 2) Recent developments and latest research (prioritizing 2023–2024)
+#### 2.1 2024: Cardiomyocyte MI/R—HSPA12A links ubiquitin signaling to HIF1α stability, glycolysis, and histone lactylation
+A 2024 *JCI Insight* study (publication date: **Apr 2024**) reports that **HSPA12A is downregulated during reperfusion** and that **HSPA12A knockout exacerbates MI/R injury phenotypes**, including worse glycolytic decline, cardiomyocyte death, and dysfunction (yu2024hspa12amaintainsaerobic pages 1-2). Mechanistically, HSPA12A supports **HIF1α protein stability** (post-translationally; not via mRNA), via a pathway involving **Smurf1 and VHL**, and thereby sustains glycolytic gene expression and **H3K56 lactylation** (yu2024hspa12amaintainsaerobic pages 12-14). The authors further show that blocking glycolysis (e.g., 2-DG, oxamate) or blocking lactylation (C646) abrogates HSPA12A-dependent cardioprotection, supporting a causal chain rather than correlation (yu2024hspa12amaintainsaerobic pages 12-14). A schematic pathway summary is provided in the paper’s Figure 10E (yu2024hspa12amaintainsaerobic media 6c187c8f).
+
+**URL/DOI:** https://doi.org/10.1172/jci.insight.169125 (Apr 2024) (yu2024hspa12amaintainsaerobic pages 1-2, yu2024hspa12amaintainsaerobic pages 12-14, yu2024hspa12amaintainsaerobic media 6c187c8f).
+
+#### 2.2 2024: Renal KI/R—HSPA12A promotes lactylation-driven c-Myc activation and epithelial repair
+A 2024 *Cellular and Molecular Life Sciences* paper (publication date: **Sep 2024**) reports that KI/R decreases HSPA12A expression and that **HSPA12A ablation impairs TEC proliferation and renal functional recovery** after injury (li2024hspa12apromotescmyc pages 1-3). Mechanistically, HSPA12A directly **interacts with c-Myc**, promotes its **nuclear localization**, and enhances **c-Myc lactylation**; inhibiting c-Myc lactylation suppresses HSPA12A-driven proliferation gene expression and TEC proliferation (li2024hspa12apromotescmyc pages 1-3).
+
+**URL/DOI:** https://doi.org/10.1007/s00018-024-05427-5 (Sep 2024) (li2024hspa12apromotescmyc pages 1-3).
+
+#### 2.3 2024: Human vascular smooth muscle cell proteomics (association-level evidence)
+A 2024 *Journal of Proteome Research* study analyzing vascular smooth muscle cells from thoracic aortic aneurysm patients includes HSPA12A among proteins discussed in the context of stress phenotypes/cellular senescence; however, the extracted snippet does not provide mechanistic or quantitative details specific to HSPA12A beyond this contextual involvement (gao2025kmvmediatedcardiomyocytetoendothelialcell pages 18-19).
+
+### 3) Current applications and real-world implementations
+#### 3.1 Translational applications (preclinical)
+**Ischemia–reperfusion injury (heart and kidney):** Multiple mammalian studies suggest **therapeutic potential** for modulating HSPA12A to improve functional recovery after ischemia–reperfusion injury, via metabolic/epigenetic mechanisms involving glycolysis-derived lactate and lactylation (heart: HIF1α stability → glycolysis → histone lactylation; kidney: glycolysis/lactate → c-Myc lactylation → proliferation) (yu2024hspa12amaintainsaerobic pages 1-2, li2024hspa12apromotescmyc pages 1-3, yu2024hspa12amaintainsaerobic pages 12-14). These are preclinical findings (mouse and cell models) rather than clinical interventions.
+
+**Cancer biology (HCC):** In HCC models, HSPA12A has been proposed as a potential target because it promotes tumor growth and angiogenesis by binding PCNA and promoting PCNA trimerization, and it promotes migration through an MCT4-dependent lactate export mechanism (cheng2020heat‐shockproteina12a pages 6-7, min2022heatshockprotein pages 8-10). These provide mechanistic rationales for targeting the HSPA12A axis in tumors, but they are not yet validated clinically.
+
+#### 3.2 Biomarker-type use (association-level)
+In human HCC tissues, HSPA12A mRNA was reported to be **3.14-fold higher** in tumor tissue compared with normal liver, consistent with interest in HSPA12A as a disease-associated marker in oncology contexts (Jan 2022; https://doi.org/10.1007/s12192-021-01251-z) (min2022heatshockprotein pages 8-10).
+
+### 4) Expert opinions and analysis from authoritative sources
+#### 4.1 Evidence-based interpretation from mechanistic papers
+The strongest mechanistic evidence supports a model where HSPA12A acts as a **signal–metabolism integrator** under stress:
+- In cardiomyocytes, the inferred core role is stabilizing **HIF1α** (via Smurf1/VHL) to maintain glycolytic capacity and lactate-driven **histone lactylation**, thereby promoting survival during reperfusion (yu2024hspa12amaintainsaerobic pages 12-14, yu2024hspa12amaintainsaerobic media 6c187c8f).
+- In renal tubules, HSPA12A increases glycolysis-derived lactate and drives **c-Myc lactylation**, promoting nuclear c-Myc activity and proliferation required for repair (li2024hspa12apromotescmyc pages 1-3).
+
+In parallel, a separate line of evidence indicates HSPA12A can behave as a **nucleotide-dependent adaptor** for receptor trafficking (SorLA), suggesting that the “atypical HSP70” designation may reflect **client-specific chaperone/adaptor functions** rather than broad proteostasis (madsen2019hspa12atargetsthe pages 2-3, madsen2019hspa12atargetsthe pages 5-7).
+
+#### 4.2 Genetics-based prioritization (Open Targets)
+The Open Targets Platform aggregates GWAS credible-set evidence linking HSPA12A to multiple phenotypes (e.g., open-angle glaucoma, alcohol drinking, chest pain, COVID-19, severe acute respiratory syndrome), with association scores in the ~0.30–0.43 range in the returned excerpt. These data are useful for **hypothesis generation** but do not establish mechanism or directionality (OpenTargets Search: -HSPA12A).
+
+### 5) Relevant statistics and quantitative data (from included evidence)
+**Nucleotide-dependent binding statistics (SorLA interaction):** Increasing ADP enhanced SorLA precipitation by HSPA12A, while increasing ATP reduced it, with reported comparisons **0.5 mM vs 5 mM ADP (p = 0.0178)** and **0.5 mM vs 5 mM ATP (p = 0.001)** (Jan 2019; https://doi.org/10.1038/s41598-018-37336-6) (madsen2019hspa12atargetsthe pages 2-3).
+
+**Cancer migration quantitative outcomes (MCT4-dependent):** In HepG2 cells, **MCT4 knockdown** reduced extracellular lactate and reversed HSPA12A-driven wound closure at 72 h (**P < 0.01**). MCT4 knockdown also reduced integrin-β1, MMP2, and MMP9 (**P < 0.05**) (Jan 2022; https://doi.org/10.1007/s12192-021-01251-z) (min2022heatshockprotein pages 8-10).
+
+**Cancer proliferation quantitative outcomes (PCNA dependency):** In HCC models, inhibition of PCNA (PCNA-I1) **partially reversed** HSPA12A-mediated increases in viable cells and **completely abolished** HSPA12A-enhanced EdU incorporation (Mar 2020; https://doi.org/10.1111/febs.15276). The extracted evidence reports statistical thresholds (**P < 0.01, n = 3/group**; **P < 0.05, n = 7/group**) in association with these functional readouts (cheng2020heat‐shockproteina12a pages 6-7).
+
+**GWAS association scores (Open Targets excerpt):** open-angle glaucoma (score **0.4305**), alcohol drinking (**0.3443**), chest pain (**0.3416**), COVID-19 (**0.3118**), severe acute respiratory syndrome (**0.3033**) (OpenTargets Search: -HSPA12A).
+
+### 6) Subcellular localization (evidence-supported)
+- In transfected 293 cells, GFP-HSPA12A is reported to localize mainly to **perinuclear compartments** and co-localize with SorLA in perinuclear vesicles; fractionation suggested SorLA shifts into denser vesicles upon HSPA12A expression (madsen2019hspa12atargetsthe pages 5-7).
+- In primary cortical mouse astrocytes, HSPA12A was detected in both **cytosol and nucleus**, with a cytoplasmic fraction co-localizing with SorLA in vesicles (madsen2019hspa12atargetsthe pages 7-9).
+- In renal TEC repair, HSPA12A promotes **nuclear localization of c-Myc** (localization conclusion pertains to c-Myc; the extracted evidence does not directly localize HSPA12A itself) (li2024hspa12apromotescmyc pages 1-3).
+
+### 7) Pathways and mechanistic map (integrated)
+Across the most mechanistically detailed papers retrieved, HSPA12A is positioned in three partially distinct functional modules:
+1. **Trafficking module (SorLA):** HSPA12A ↔ SorLA cytosolic acidic clusters; ADP/ATP-dependent binding → altered endocytosis/vesicle localization (madsen2019hspa12atargetsthe pages 2-3, madsen2019hspa12atargetsthe pages 5-7).
+2. **Stress-metabolism-epigenetics module (heart/kidney):** HSPA12A → Smurf1/VHL-dependent **HIF1α stabilization** → glycolytic gene program → lactate → histone lactylation (heart) and **c-Myc lactylation** (kidney) → survival/proliferation (li2024hspa12apromotescmyc pages 1-3, yu2024hspa12amaintainsaerobic pages 12-14, yu2024hspa12amaintainsaerobic media 6c187c8f).
+3. **Cancer growth/migration module (HCC):** HSPA12A ↔ **PCNA** (trimerization) → proliferation; HSPA12A ↔ **MCT4/CD147** → lactate export and migration marker program (cheng2020heat‐shockproteina12a pages 6-7, min2022heatshockprotein pages 8-10).
+
+### Evidence summary table
+The following table consolidates the key studies, models, partners/pathways, and quantitative findings.
+
+| Year | Study | System/model | Key finding (function) | Molecular partners / pathway | Localization notes | Key quantitative / statistical results reported in evidence | URL / DOI |
+|---|---|---|---|---|---|---|---|
+| 2024 | Yu et al., *JCI Insight* | Mouse MI/R model; HSPA12A knockout mice; cardiomyocyte hypoxia/reoxygenation gain/loss-of-function studies | HSPA12A is cardioprotective and maintains aerobic glycolytic homeostasis and Histone H3 lactylation during myocardial ischemia/reperfusion injury | Smurf1–VHL–HIF1α axis; glycolytic genes; H3K56 lactylation; blockade by 2-DG, oxamate, C646, and HIF1α inhibition reversed protection | No explicit HSPA12A subcellular localization reported in extracted evidence | HSPA12A downregulated during reperfusion; HSPA12A KO exacerbated glycolysis decrease, cardiomyocyte death, and cardiac dysfunction; pharmacologic reversal experiments supported causality, but exact fold-changes were not provided in extracted evidence (yu2024hspa12amaintainsaerobic pages 1-2, yu2024hspa12amaintainsaerobic pages 12-14, yu2024hspa12amaintainsaerobic media 6c187c8f) | https://doi.org/10.1172/jci.insight.169125 ; DOI: 10.1172/jci.insight.169125 |
+| 2024 | Li et al., *Cellular and Molecular Life Sciences* | Mouse kidney ischemia/reperfusion injury; HSPA12A-deficient mice; tubular epithelial cell hypoxia/reoxygenation with overexpression | HSPA12A promotes tubular epithelial cell proliferation and renal functional recovery after ischemia/reperfusion | Direct interaction with c-Myc; increased c-Myc nuclear localization; Hif1α-dependent glycolysis/lactate production; c-Myc lactylation | Nuclear localization effect reported for c-Myc, not direct HSPA12A localization | HSPA12A ablation impaired TEC proliferation and renal recovery; inhibition of c-Myc lactylation attenuated HSPA12A-induced proliferation-gene expression and TEC proliferation; exact fold-changes/p-values not provided in extracted evidence (li2024hspa12apromotescmyc pages 1-3) | https://doi.org/10.1007/s00018-024-05427-5 ; DOI: 10.1007/s00018-024-05427-5 |
+| 2020 | Cheng et al., *FEBS Journal* | Human HCC cells (e.g., HepG2); mouse tumor-growth model; gain/loss-of-function | HSPA12A promotes hepatocellular carcinoma proliferation, tumor growth, and angiogenesis | Direct PCNA binding; promotes PCNA trimerization; activates β-catenin signaling with increased nuclear β-catenin and downstream cyclin D1, c-Myc, Bcl-2, VEGF | Evidence emphasizes nuclear β-catenin increase; no direct HSPA12A localization extracted | PCNA-I1 partially reversed increases in viable cells and completely abolished HSPA12A-enhanced EdU incorporation; significance reported as **P < 0.01 (n = 3/group)** and *P < 0.05 (n = 7/group)* in extracted evidence (cheng2020heat‐shockproteina12a pages 6-7, cheng2020heat‐shockproteina12a pages 1-3) | https://doi.org/10.1111/febs.15276 ; DOI: 10.1111/febs.15276 |
+| 2022 | Min et al., *Cell Stress and Chaperones* | Human HCC tissues; HepG2 cells with Ad-HSPA12A and MCT4 knockdown | HSPA12A promotes HCC cell migration in an MCT4-dependent manner | Physical association with MCT4; increased MCT4 mRNA/protein and membrane localization; increased CD147; downstream Integrin-β1, MMP2, MMP9 | Promotes MCT4 cell-membrane localization | HSPA12A mRNA was **3.14-fold higher** in human HCC tissue versus normal liver; MCT4 knockdown reduced extracellular lactate and reversed HSPA12A-induced wound closure at 72 h (**P < 0.01**); Integrin-β1/MMP2/MMP9 reductions **P < 0.05** (min2022heatshockprotein pages 8-10) | https://doi.org/10.1007/s12192-021-01251-z ; DOI: 10.1007/s12192-021-01251-z |
+| 2019 | Madsen et al., *Scientific Reports* | Yeast two-hybrid; GST pull-downs; HEK293/293 cells; primary cortical astrocytes; subcellular fractionation; endocytosis assays; Hspa12a knockout mouse stroke context referenced | HSPA12A is a SorLA-selective adaptor/chaperone-like protein that binds the SorLA cytoplasmic domain and alters SorLA trafficking/endocytosis | ADP/ATP-dependent binding to SorLA; acidic cluster-dependent interaction; overlap with GGA2/AP-2-related acidic motif suggests adaptor competition | In 293 cells GFP-HSPA12A localized mainly to perinuclear compartments; in astrocytes HSPA12A detected in cytosol and nucleus, with a cytoplasmic fraction co-localizing with SorLA vesicles | SorLA precipitation increased with ADP and decreased with ATP; comparisons reported as **0.5 mM vs 5 mM ADP, p = 0.0178** and **0.5 mM vs 5 mM ATP, p = 0.001**; imaging analyses reported **n = 18 or 10 per transfection**; Hspa12a KO mice had enlarged infarct volumes and worse neurological outcomes after stroke, but exact numeric values not in extracted evidence (madsen2019hspa12atargetsthe pages 7-9, madsen2019hspa12atargetsthe pages 1-2, madsen2019hspa12atargetsthe pages 2-3, madsen2019hspa12atargetsthe pages 5-7) | https://doi.org/10.1038/s41598-018-37336-6 ; DOI: 10.1038/s41598-018-37336-6 |
+| 2019 | Zhang et al., *Cell Death and Differentiation* | Obese patients’ adipose tissue; Hspa12a−/− mice on high-fat diet; primary adipocyte precursors with gain/loss-of-function | HSPA12A is required for adipocyte differentiation and promotes diet-induced obesity | Positive feedback with PPARγ; HSPA12A supports PPARγ and adipogenic target-gene expression; PPARγ binds Hspa12a promoter | No localization details extracted | Obese patients showed increased adipose HSPA12A expression positively correlated with BMI; Hspa12a−/− mice had attenuated HFD-induced weight gain, adiposity, hyperlipidemia, hyperglycemia, and improved insulin sensitivity; exact statistics not extracted here (gao2025kmvmediatedcardiomyocytetoendothelialcell pages 18-19) | https://doi.org/10.1038/s41418-019-0300-2 ; DOI: 10.1038/s41418-019-0300-2 |
+| 2025 / 2023 review citation | Gao et al. summary citing prior HSPA12A studies; Song et al. review | Review/synthesis across cardiac, endothelial, renal, and cancer studies | HSPA12A has emerging scaffold/signaling roles beyond canonical HSP70 proteostasis, including angiogenesis and tissue repair | Reported pathways include p38/ERK–AP-1, ERK/Akt, eNOS-dependent signaling, PCNA, c-Myc lactylation, and Smurf1–HIF1α | No unified localization conclusion | Review-style evidence states HSPA12A promotes angiogenesis, protects from I/R injury, and modulates tumor growth/migration, but no additional direct quantitative values were extracted from these sources (gao2025kmvmediatedcardiomyocytetoendothelialcell pages 18-19) | https://doi.org/10.7150/thno.104899 ; DOI: 10.7150/thno.104899 / https://doi.org/10.3389/fcell.2023.1164166 ; DOI: 10.3389/fcell.2023.1164166 |
+| 2025 Open Targets / GWAS evidence | Open Targets Platform | Human genetic-association datasets (GWAS credible sets) | Population-level disease associations exist, but these do not establish molecular function directly | Genetic association rather than mechanistic pathway evidence | Not applicable | Association scores reported for open-angle glaucoma (**0.4305**), alcohol drinking (**0.3443**), chest pain (**0.3416**), COVID-19 (**0.3118**), and severe acute respiratory syndrome (**0.3033**); evidence count **5** in the returned association rows (OpenTargets Search: -HSPA12A) | Open Targets target page/search context; platform citation in evidence (OpenTargets Search: -HSPA12A) |
+
+
+*Table: This table summarizes the main experimental and translational studies identified for human HSPA12A/its mammalian orthologs, emphasizing function, partners, localization, and quantitative findings. It is useful as a compact evidence map for functional annotation of UniProt O43301.*
+
+### Figure evidence
+A pathway schematic summarizing the HSPA12A–Smurf1–HIF1α–glycolysis–histone lactylation mechanism in cardiomyocytes is shown in the retrieved figure panel (Figure 10E) (yu2024hspa12amaintainsaerobic media 6c187c8f).
+
+### Limitations of the current evidence set
+- This tool session did not retrieve the UniProt/HGNC/InterPro primary database entries directly as citeable text, so curated annotations (e.g., canonical domains, isoforms, baseline expression) are not quoted verbatim here; the report therefore emphasizes **peer-reviewed mechanistic literature** retrieved in-session.
+- Some endpoints (e.g., exact infarct size/ejection fraction values in MI/R or stroke) are described qualitatively in extracted text, but precise numeric values were not available in the snippets returned by the evidence tool (yu2024hspa12amaintainsaerobic pages 1-2, madsen2019hspa12atargetsthe pages 7-9).
+
+### References (URLs / dates within citations)
+Key primary sources include: Madsen et al. 2019 (*Scientific Reports*, Jan 2019) https://doi.org/10.1038/s41598-018-37336-6 (madsen2019hspa12atargetsthe pages 2-3); Cheng et al. 2020 (*FEBS Journal*, Mar 2020) https://doi.org/10.1111/febs.15276 (cheng2020heat‐shockproteina12a pages 6-7); Min et al. 2022 (*Cell Stress and Chaperones*, Jan 2022) https://doi.org/10.1007/s12192-021-01251-z (min2022heatshockprotein pages 8-10); Yu et al. 2024 (*JCI Insight*, Apr 2024) https://doi.org/10.1172/jci.insight.169125 (yu2024hspa12amaintainsaerobic pages 1-2); Li et al. 2024 (*Cellular and Molecular Life Sciences*, Sep 2024) https://doi.org/10.1007/s00018-024-05427-5 (li2024hspa12apromotescmyc pages 1-3). Open Targets genetic associations are summarized from the Open Targets Platform output (OpenTargets Search: -HSPA12A).
+
+References
+
+1. (madsen2019hspa12atargetsthe pages 1-2): Peder Madsen, Toke Jost Isaksen, Piotr Siupka, Andrea E. Tóth, Mette Nyegaard, Camilla Gustafsen, and Morten S. Nielsen. Hspa12a targets the cytoplasmic domain and affects the trafficking of the amyloid precursor protein receptor sorla. Scientific Reports, Jan 2019. URL: https://doi.org/10.1038/s41598-018-37336-6, doi:10.1038/s41598-018-37336-6. This article has 16 citations and is from a peer-reviewed journal.
+
+2. (madsen2019hspa12atargetsthe pages 2-3): Peder Madsen, Toke Jost Isaksen, Piotr Siupka, Andrea E. Tóth, Mette Nyegaard, Camilla Gustafsen, and Morten S. Nielsen. Hspa12a targets the cytoplasmic domain and affects the trafficking of the amyloid precursor protein receptor sorla. Scientific Reports, Jan 2019. URL: https://doi.org/10.1038/s41598-018-37336-6, doi:10.1038/s41598-018-37336-6. This article has 16 citations and is from a peer-reviewed journal.
+
+3. (yu2024hspa12amaintainsaerobic pages 12-14): Wansu Yu, Qiuyue Kong, Surong Jiang, Yunfan Li, Zhaohe Wang, Qian Mao, Xiaojin Zhang, Qianhui Liu, Pengjun Zhang, Yuehua Li, Chuanfu Li, Zhengnian Ding, and Li Liu. Hspa12a maintains aerobic glycolytic homeostasis and histone3 lactylation in cardiomyocytes to attenuate myocardial ischemia/reperfusion injury. JCI Insight, Apr 2024. URL: https://doi.org/10.1172/jci.insight.169125, doi:10.1172/jci.insight.169125. This article has 58 citations and is from a domain leading peer-reviewed journal.
+
+4. (madsen2019hspa12atargetsthe pages 5-7): Peder Madsen, Toke Jost Isaksen, Piotr Siupka, Andrea E. Tóth, Mette Nyegaard, Camilla Gustafsen, and Morten S. Nielsen. Hspa12a targets the cytoplasmic domain and affects the trafficking of the amyloid precursor protein receptor sorla. Scientific Reports, Jan 2019. URL: https://doi.org/10.1038/s41598-018-37336-6, doi:10.1038/s41598-018-37336-6. This article has 16 citations and is from a peer-reviewed journal.
+
+5. (yu2024hspa12amaintainsaerobic pages 1-2): Wansu Yu, Qiuyue Kong, Surong Jiang, Yunfan Li, Zhaohe Wang, Qian Mao, Xiaojin Zhang, Qianhui Liu, Pengjun Zhang, Yuehua Li, Chuanfu Li, Zhengnian Ding, and Li Liu. Hspa12a maintains aerobic glycolytic homeostasis and histone3 lactylation in cardiomyocytes to attenuate myocardial ischemia/reperfusion injury. JCI Insight, Apr 2024. URL: https://doi.org/10.1172/jci.insight.169125, doi:10.1172/jci.insight.169125. This article has 58 citations and is from a domain leading peer-reviewed journal.
+
+6. (li2024hspa12apromotescmyc pages 1-3): Yunfan Li, Xinxu Min, Xiaojin Zhang, Xiaofei Cao, Qiuyue Kong, Qian Mao, Hao Cheng, Liming Gou, Yuehua Li, Chuanfu Li, Li Liu, and Zhengnian Ding. Hspa12a promotes c-myc lactylation-mediated proliferation of tubular epithelial cells to facilitate renal functional recovery from kidney ischemia/reperfusion injury. Cellular and Molecular Life Sciences: CMLS, Sep 2024. URL: https://doi.org/10.1007/s00018-024-05427-5, doi:10.1007/s00018-024-05427-5. This article has 23 citations.
+
+7. (cheng2020heat‐shockproteina12a pages 6-7): Hao Cheng, Xiaofei Cao, Xinxu Min, Xiaojin Zhang, Qiuyue Kong, Qian Mao, Rongrong Li, Bin Xue, Lei Fang, Li Liu, and Zhengnian Ding. Heat‐shock protein a12a is a novel pcna‐binding protein and promotes hepatocellular carcinoma growth. The FEBS Journal, 287:5464-5477, Mar 2020. URL: https://doi.org/10.1111/febs.15276, doi:10.1111/febs.15276. This article has 19 citations.
+
+8. (cheng2020heat‐shockproteina12a pages 1-3): Hao Cheng, Xiaofei Cao, Xinxu Min, Xiaojin Zhang, Qiuyue Kong, Qian Mao, Rongrong Li, Bin Xue, Lei Fang, Li Liu, and Zhengnian Ding. Heat‐shock protein a12a is a novel pcna‐binding protein and promotes hepatocellular carcinoma growth. The FEBS Journal, 287:5464-5477, Mar 2020. URL: https://doi.org/10.1111/febs.15276, doi:10.1111/febs.15276. This article has 19 citations.
+
+9. (min2022heatshockprotein pages 8-10): Xinxu Min, Hao Cheng, Xiaofei Cao, Ziyang Chen, Xiaojin Zhang, Yunfan Li, Qian Mao, Bin Xue, Lei Fang, Li Liu, and Zhengnian Ding. Heat shock protein a12a activates migration of hepatocellular carcinoma cells in a monocarboxylate transporter 4–dependent manner. Cell Stress and Chaperones, 27:83-95, Jan 2022. URL: https://doi.org/10.1007/s12192-021-01251-z, doi:10.1007/s12192-021-01251-z. This article has 11 citations and is from a peer-reviewed journal.
+
+10. (yu2024hspa12amaintainsaerobic media 6c187c8f): Wansu Yu, Qiuyue Kong, Surong Jiang, Yunfan Li, Zhaohe Wang, Qian Mao, Xiaojin Zhang, Qianhui Liu, Pengjun Zhang, Yuehua Li, Chuanfu Li, Zhengnian Ding, and Li Liu. Hspa12a maintains aerobic glycolytic homeostasis and histone3 lactylation in cardiomyocytes to attenuate myocardial ischemia/reperfusion injury. JCI Insight, Apr 2024. URL: https://doi.org/10.1172/jci.insight.169125, doi:10.1172/jci.insight.169125. This article has 58 citations and is from a domain leading peer-reviewed journal.
+
+11. (gao2025kmvmediatedcardiomyocytetoendothelialcell pages 18-19): Chenxi Gao, Yudong Xia, Chaofang Li, Tao Zhou, Wenyu Zhang, Hao Cheng, Xiaojin Zhang, Yunhao Yu, Chuanfu Li, Zhengnian Ding, Jun Wu, and Li Liu. Kmv-mediated cardiomyocyte-to-endothelial cell signaling drives capillary rarefaction to promote heart failure following pressure overload. Theranostics, 15:4970-4988, Mar 2025. URL: https://doi.org/10.7150/thno.104899, doi:10.7150/thno.104899. This article has 1 citations and is from a domain leading peer-reviewed journal.
+
+12. (OpenTargets Search: -HSPA12A): Open Targets Query (-HSPA12A, 5 results). Buniello, A. et al. (2025). Open Targets Platform: facilitating therapeutic hypotheses building in drug discovery. Nucleic Acids Research.
+
+13. (madsen2019hspa12atargetsthe pages 7-9): Peder Madsen, Toke Jost Isaksen, Piotr Siupka, Andrea E. Tóth, Mette Nyegaard, Camilla Gustafsen, and Morten S. Nielsen. Hspa12a targets the cytoplasmic domain and affects the trafficking of the amyloid precursor protein receptor sorla. Scientific Reports, Jan 2019. URL: https://doi.org/10.1038/s41598-018-37336-6, doi:10.1038/s41598-018-37336-6. This article has 16 citations and is from a peer-reviewed journal.
+
+## Citations
+
+1. min2022heatshockprotein pages 8-10
+2. gao2025kmvmediatedcardiomyocytetoendothelialcell pages 18-19
+3. https://doi.org/10.1172/jci.insight.169125
+4. https://doi.org/10.1007/s00018-024-05427-5
+5. https://doi.org/10.1007/s12192-021-01251-z
+6. https://doi.org/10.1038/s41598-018-37336-6
+7. https://doi.org/10.1111/febs.15276
+8. https://doi.org/10.1038/s41418-019-0300-2
+9. https://doi.org/10.7150/thno.104899
+10. https://doi.org/10.3389/fcell.2023.1164166
+11. https://doi.org/10.1038/s41598-018-37336-6,
+12. https://doi.org/10.1172/jci.insight.169125,
+13. https://doi.org/10.1007/s00018-024-05427-5,
+14. https://doi.org/10.1111/febs.15276,
+15. https://doi.org/10.1007/s12192-021-01251-z,
+16. https://doi.org/10.7150/thno.104899,


### PR DESCRIPTION
## Summary
- Add Falcon deep research reports for CALM3, CFAP61, CHCHD4, EIF2AK3, and HSPA12A.
- Incorporate Falcon report evidence into core-function and existing-annotation support without adding new GO annotations.
- Render updated HTML for all five genes, including newly rendered CHCHD4 HTML.
- Fix a CHCHD4 cached-publication supporting-text mismatch against PMID:19182799 so validation passes.

## Validation
- `just validate human CALM3`
- `just validate human CFAP61`
- `just validate human CHCHD4`
- `just validate human EIF2AK3`
- `just validate human HSPA12A`
- `uv run python scripts/validate_deep_research.py genes/human/CALM3/CALM3-deep-research-falcon.md genes/human/CFAP61/CFAP61-deep-research-falcon.md genes/human/CHCHD4/CHCHD4-deep-research-falcon.md genes/human/EIF2AK3/EIF2AK3-deep-research-falcon.md genes/human/HSPA12A/HSPA12A-deep-research-falcon.md`
- `just render human <gene>` for all five genes
- `git diff --cached --check`
