### PR TITLE
[codex] Add falcon deep research batch 4

### DIFF
--- a/genes/human/NTN1/NTN1-ai-review.html
+++ b/genes/human/NTN1/NTN1-ai-review.html
@@ -1209,10 +1209,10 @@
                         
                     </td>
                     <td>
-                        <span class="action-badge action-markasoverannotated">
-                            MARK AS OVER ANNOTATED
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="O95631" data-a="GO:0005515" data-r="PMID:19721007" data-act="MARK_AS_OVER_ANNOTATED">
+                        <span class="vote-buttons" data-g="O95631" data-a="GO:0005515" data-r="PMID:19721007" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1225,10 +1225,37 @@
                         
                         
                         <div>
-                            <strong>Reason:</strong> While NTN1 does bind proteins (its receptors), the generic &#34;protein binding&#34; term is uninformative. More specific receptor binding terms would be preferable.
+                            <strong>Reason:</strong> While NTN1 does bind proteins (its receptors), the generic &#34;protein binding&#34; term is uninformative. The more specific netrin receptor binding term better captures the receptor-ligand function.
                         </div>
                         
                         
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1990890" target="_blank" class="term-link">
+                                    netrin receptor binding
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/NTN1/NTN1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">NTN1 is summarized as a secreted extracellular ligand that signals through dependence receptors including DCC, NEO1, and UNC5-family receptors.</div>
+
+                            </div>
+
+                        </div>
                         
                     </td>
                 </tr>
@@ -1271,10 +1298,10 @@
                         
                     </td>
                     <td>
-                        <span class="action-badge action-markasoverannotated">
-                            MARK AS OVER ANNOTATED
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="O95631" data-a="GO:0005515" data-r="PMID:20434207" data-act="MARK_AS_OVER_ANNOTATED">
+                        <span class="vote-buttons" data-g="O95631" data-a="GO:0005515" data-r="PMID:20434207" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1291,6 +1318,33 @@
                         </div>
                         
                         
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1990890" target="_blank" class="term-link">
+                                    netrin receptor binding
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/NTN1/NTN1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The report supports Netrin-1 receptor-ligand function through DCC, NEO1, and UNC5-family dependence receptors.</div>
+
+                            </div>
+
+                        </div>
                         
                     </td>
                 </tr>
@@ -2812,10 +2866,10 @@
                         
                     </td>
                     <td>
-                        <span class="action-badge action-markasoverannotated">
-                            MARK AS OVER ANNOTATED
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="O95631" data-a="GO:0005515" data-r="PMID:19196994" data-act="MARK_AS_OVER_ANNOTATED">
+                        <span class="vote-buttons" data-g="O95631" data-a="GO:0005515" data-r="PMID:19196994" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -2832,6 +2886,46 @@
                         </div>
                         
                         
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1990890" target="_blank" class="term-link">
+                                    netrin receptor binding
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19196994" target="_blank" class="term-link">
+                                        PMID:19196994
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">DSCAM functions as a netrin receptor in commissural axon pathfinding.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/NTN1/NTN1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Primary molecular function: Netrin-1 is a secreted extracellular matrix-associated ligand that signals through dependence receptors including DCC, NEO1, and UNC5-family members.</div>
+
+                            </div>
+
+                        </div>
                         
                     </td>
                 </tr>
@@ -2989,6 +3083,17 @@
                         
                     </li>
                     
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/NTN1/NTN1-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">Primary molecular function: Netrin-1 is a secreted extracellular matrix-associated ligand that provides positional/microenvironmental information through dependence receptors including DCC, NEO1, and UNC5-family members.</div>
+
+                    </li>
+
                 </ul>
             </div>
             
@@ -3436,6 +3541,34 @@
                 
             </div>
             
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/NTN1/NTN1-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research report for human NTN1</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">NTN1 encodes secreted Netrin-1, an extracellular matrix-associated ligand that signals through DCC, NEO1, UNC5-family receptors, and context-specific integrins.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The report supports Netrin-1 extracellular localization through secretion, ECM association, HSPG-dependent cell-surface organization, and receptor engagement in the extracellular microenvironment.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
         </div>
     </div>
     
@@ -3452,6 +3585,494 @@
 
     <!-- Additional Documentation Sections -->
     
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Deep Research Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(NTN1-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="O95631" data-a="DOC: Deep Research Falcon" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <hr />
+<p>provider: falcon<br />
+model: Edison Scientific Literature<br />
+cached: false<br />
+start_time: '2026-05-10T22:02:48.721931'<br />
+end_time: '2026-05-10T22:15:28.730450'<br />
+duration_seconds: 760.01<br />
+template_file: templates/gene_research_go_focused.md<br />
+template_variables:<br />
+  organism: human<br />
+  gene_id: NTN1<br />
+  gene_symbol: NTN1<br />
+  uniprot_accession: O95631<br />
+  protein_description: 'RecName: Full=Netrin-1; AltName: Full=Epididymis tissue protein<br />
+    Li 131P; Flags: Precursor;'<br />
+  gene_info: Name=NTN1; Synonyms=NTN1L;<br />
+  organism_full: Homo sapiens (Human).<br />
+  protein_family: Not specified in UniProt<br />
+  protein_domains: Galactose-bd-like_sf. (IPR008979); Laminin/Netrin_ECM. (IPR050440);<br />
+    Laminin_N. (IPR008211); LE_dom. (IPR002049); LMN_ATRN_NET-like_EGF. (IPR056863)<br />
+provider_config:<br />
+  timeout: 600<br />
+  max_retries: 3<br />
+  parameters:<br />
+    allowed_domains: []<br />
+    temperature: 0.1<br />
+citation_count: 34</p>
+<hr />
+<h2 id="question">Question</h2>
+<h1 id="gene-research-for-functional-annotation">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> O95631</li>
+<li><strong>Protein Description:</strong> RecName: Full=Netrin-1; AltName: Full=Epididymis tissue protein Li 131P; Flags: Precursor;</li>
+<li><strong>Gene Information:</strong> Name=NTN1; Synonyms=NTN1L;</li>
+<li><strong>Organism (full):</strong> Homo sapiens (Human).</li>
+<li><strong>Protein Family:</strong> Not specified in UniProt</li>
+<li><strong>Key Domains:</strong> Galactose-bd-like_sf. (IPR008979); Laminin/Netrin_ECM. (IPR050440); Laminin_N. (IPR008211); LE_dom. (IPR002049); LMN_ATRN_NET-like_EGF. (IPR056863)</li>
+</ul>
+<h3 id="mandatory-verification-steps">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "NTN1" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Homo sapiens (Human).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'NTN1' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>NTN1</strong> (gene ID: NTN1, UniProt: O95631) in human.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="output">Output</h2>
+<p>Question: You are an expert researcher providing comprehensive, well-cited information.</p>
+<p>Provide detailed information focusing on:<br />
+1. Key concepts and definitions with current understanding<br />
+2. Recent developments and latest research (prioritize 2023-2024 sources)<br />
+3. Current applications and real-world implementations<br />
+4. Expert opinions and analysis from authoritative sources<br />
+5. Relevant statistics and data from recent studies</p>
+<p>Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.<br />
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.</p>
+<h1 id="gene-research-for-functional-annotation_1">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context_1">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot_1">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> O95631</li>
+<li><strong>Protein Description:</strong> RecName: Full=Netrin-1; AltName: Full=Epididymis tissue protein Li 131P; Flags: Precursor;</li>
+<li><strong>Gene Information:</strong> Name=NTN1; Synonyms=NTN1L;</li>
+<li><strong>Organism (full):</strong> Homo sapiens (Human).</li>
+<li><strong>Protein Family:</strong> Not specified in UniProt</li>
+<li><strong>Key Domains:</strong> Galactose-bd-like_sf. (IPR008979); Laminin/Netrin_ECM. (IPR050440); Laminin_N. (IPR008211); LE_dom. (IPR002049); LMN_ATRN_NET-like_EGF. (IPR056863)</li>
+</ul>
+<h3 id="mandatory-verification-steps_1">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "NTN1" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Homo sapiens (Human).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature_1">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'NTN1' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target_1">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>NTN1</strong> (gene ID: NTN1, UniProt: O95631) in human.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="comprehensive-research-report-human-ntn1-netrin-1-functional-annotation-uniprot-o95631">Comprehensive research report: Human <strong>NTN1 (Netrin-1)</strong> functional annotation (UniProt <strong>O95631</strong>)</h2>
+<h3 id="1-target-verification-identity-organism-domains">1) Target verification (identity, organism, domains)</h3>
+<p>The research target is <strong>human NTN1</strong>, encoding <strong>Netrin-1</strong>, a <strong>secreted laminin-related extracellular guidance cue</strong> (Homo sapiens). Independent recent sources consistently describe Netrin-1 as a multi-domain secreted protein with an <strong>N-terminal laminin-like (LN; “domain VI”) region</strong>, a <strong>central region with three laminin-type EGF-like repeats (LE1–LE3; “domain V”)</strong>, and a <strong>C-terminal netrin-like (NTR) module</strong>, consistent with UniProt O95631 domain annotations (Laminin_N, LE domains, Laminin/Netrin ECM) (wu2025theroleof pages 4-6, cai2024insightsfromthe pages 2-3, gao2025pancanceranalysisreveals pages 1-3).</p>
+<h3 id="2-key-concepts-and-current-understanding-definitions-and-mechanistic-framework">2) Key concepts and current understanding (definitions and mechanistic framework)</h3>
+<h4 id="21-netrin-1-as-an-extracellular-morphogenecm-cue">2.1 Netrin-1 as an extracellular morphogen/ECM cue</h4>
+<p>Netrin-1 was originally characterized as an axon guidance factor; contemporary literature emphasizes that it is a <strong>secreted extracellular cue</strong> that can <strong>diffuse through extracellular matrix (ECM)</strong> and form functional gradients (meier2023thedynamicnature pages 1-2). Beyond neurodevelopment, NTN1 is now broadly implicated in <strong>cell migration, adhesion, differentiation, survival, inflammation, angiogenesis/barrier biology, and cancer</strong> (meier2023thedynamicnature pages 1-2, cai2024insightsfromthe pages 1-2).</p>
+<h4 id="22-canonical-receptor-logic-dependence-receptors">2.2 Canonical receptor logic: “dependence receptors”</h4>
+<p>A central concept for NTN1 biology is the <strong>dependence receptor paradigm</strong>, in which receptors (classically <strong>DCC</strong> and <strong>UNC5 family members</strong>) mediate different outcomes depending on ligand occupancy. In this framework, NTN1 binding promotes survival/migration/guidance signaling, whereas lack of ligand can favor pro-apoptotic receptor signaling (meier2023thedynamicnature pages 1-2, gao2025pancanceranalysisreveals pages 1-3). This paradigm is a major translational rationale for <strong>therapeutically blocking NTN1–receptor interactions in NTN1-dependent tumors</strong> (NCT02977195 chunk 1).</p>
+<h4 id="23-major-receptors-and-pathway-outputs-current-consensus">2.3 Major receptors and pathway outputs (current consensus)</h4>
+<p>Multiple authoritative sources enumerate NTN1 receptors, including <strong>DCC</strong>, <strong>UNC5A–D</strong>, <strong>neogenin (NEO1)</strong>, and additional partners such as <strong>integrins</strong> and <strong>heparan sulfate proteoglycans (HSPGs)</strong> (wu2025theroleof pages 4-6, yu2024netrin1isan pages 1-3, gao2025pancanceranalysisreveals pages 1-3). Mechanistically, receptor context can switch response from attraction (e.g., DCC-centric signaling) to repulsion (UNC5-centric or UNC5/DCC combinations), and can engage second-messenger signaling (e.g., cAMP/Ca2+/cGMP in guidance contexts) (cai2024insightsfromthe pages 1-2, wu2025theroleof pages 4-6).</p>
+<h3 id="3-protein-localization-structural-determinants-and-processing-evidence-based">3) Protein localization, structural determinants, and processing (evidence-based)</h3>
+<h4 id="31-where-ntn1-acts-secreted-ecm-and-cell-surfaceproximal-organization">3.1 Where NTN1 acts: secreted, ECM, and cell-surface–proximal organization</h4>
+<p>High-quality primary evidence supports that Netrin-1 is <strong>secreted and ECM-localized</strong>, and that it can be <strong>retained/organized at the cell surface via HSPGs</strong>. In a 2023 <em>Nature Communications</em> study, Netrin-1 (studied as NET1ΔC) formed <strong>cell-surface deposits</strong> and showed <strong>HSPG-dependent localization</strong>; heparan sulfate proteoglycans were described as platforms that co-localize Netrin-1 near the membrane (meier2023thedynamicnature pages 1-2, meier2023thedynamicnature pages 3-4).</p>
+<p><strong>Visual evidence (Figure-based):</strong> immune-gold EM and quantitative analyses show that addition of short heparin/heparan-oligosaccharides (HO-dp10) or heparanase expression changes NET1ΔC surface distribution, consistent with HSPG-dependent localization and ligand clustering (meier2023thedynamicnature media c5061845).</p>
+<h4 id="32-gaghspg-binding-as-a-mechanism-for-ligand-clustering-and-receptor-presentation-2023-structural-advance">3.2 GAG/HSPG binding as a mechanism for ligand clustering and receptor presentation (2023 structural advance)</h4>
+<p>A key 2023 mechanistic advance is that <strong>short heparin/heparan-sulfate oligosaccharides</strong> (including fragments generated by <strong>heparanase cleavage</strong>) can profoundly alter NTN1 supramolecular behavior: they can <strong>abolish monomer–dimer equilibrium</strong> and promote <strong>hierarchical super-assemblies/filaments</strong>, while <strong>preserving dependence receptor binding</strong> (DCC/NEO1/UNC5B) (meier2023thedynamicnature pages 1-2, meier2023thedynamicnature pages 3-4).</p>
+<p>Structurally, crystallography/mutagenesis mapped a <strong>major GAG-binding epitope to the LE-2 laminin-type EGF-like subdomain</strong>, which is electropositive and enriched in basic motifs; this provides a domain-resolved basis for how ECM glycans organize ligand distribution and potentially tune receptor engagement (meier2023thedynamicnature pages 3-4).</p>
+<h4 id="33-domain-contributions-and-secretion-competency">3.3 Domain contributions and secretion competency</h4>
+<p>Recent reviews reinforce that receptor binding is primarily supported by <strong>N-terminal LN and central LE regions</strong>, while the <strong>C-terminal NTR module</strong> is described as <strong>not strictly required for receptor binding</strong> but may modulate affinity and other extracellular interactions; importantly, mutations in the protein can impair secretion (i.e., failure to be secreted), consistent with a precursor/secreted protein lifecycle (wu2025theroleof pages 4-6, cai2024insightsfromthe pages 2-3).</p>
+<h3 id="4-functional-roles-and-pathways-with-emphasis-on-20232024-evidence">4) Functional roles and pathways (with emphasis on 2023–2024 evidence)</h3>
+<h4 id="41-nervous-system-guidance-microglial-migration-and-regenerative-niches">4.1 Nervous system: guidance, microglial migration, and regenerative niches</h4>
+<p><strong>Microglia migration (2024):</strong> A 2024 study demonstrated that extracellular Netrin-1 promotes microglial (BV2) migration and morphological elongation, with strong statistical support (elongation p = 0.0001; migration p &lt; 0.0001). Mechanistically, the effect required <strong>GSK3β activity</strong> and was linked to <strong>integrin α6/β1</strong> as a relevant receptor in microglia (single-cell expression enrichment; MST binding), highlighting non-canonical receptor usage in a defined cellular context (yu2024netrin1isan pages 1-3).</p>
+<p><strong>Peripheral nerve repair niche (2024):</strong> In peripheral nerve injury, NTN1 was reported upregulated after injury and associated with <strong>NTN1-high endothelial cells</strong> and <strong>endothelial exosomes</strong> that contribute to a pro-regenerative vascular niche. Multi-omics analyses implicated activation of pathways including <strong>focal adhesion</strong>, <strong>axon guidance</strong>, <strong>PI3K–AKT</strong>, and <strong>mTOR</strong> in this niche program (huang2024netrin1–engineeredendothelialcell pages 1-2).</p>
+<h4 id="42-vascular-biology-barrier-integrity-via-unc5b-and-catenin-crosstalk-2024">4.2 Vascular biology: barrier integrity via UNC5B and β-catenin crosstalk (2024)</h4>
+<p>A 2024 <em>PNAS</em> study linked Netrin-1 signaling to endothelial barrier specialization in the retina. Using scRNA-seq, the authors identified <strong>&gt;100 blood–retina barrier genes</strong> and reported that <strong>Netrin-1/Unc5b</strong> signaling contributes to arteriovenous zonation of barrier integrity; <strong>Ntn1 or Unc5b deficiency</strong> increased <strong>arterial-side barrier leakage</strong> and reduced β-catenin signaling and barrier gene expression, which could be rescued by β-catenin overactivation. Mechanistically, Netrin-1 and Norrin additively enhanced <strong>β-catenin transcriptional activity</strong> and <strong>Lrp5 phosphorylation</strong> via the <strong>Dlg1 scaffolding protein</strong> (furtado2024interplaybetweennetrin1 pages 1-2).</p>
+<h4 id="43-inflammation-and-cardiometabolic-disease-contexts">4.3 Inflammation and cardiometabolic disease contexts</h4>
+<p><strong>Macrophage survival signaling (human cells; 2023):</strong> In inflammatory macrophages, the human long intergenic noncoding RNA <strong>SIMALR</strong> was shown to regulate <strong>NTN1 transcription</strong> (likely involving <strong>HIF1α</strong>), and NTN1 functioned as a <strong>macrophage survival factor</strong>: NTN1 knockdown induced apoptosis, while adding recombinant NTN1 rescued apoptosis induced by SIMALR knockdown. SIMALR expression was also detected in macrophages in symptomatic human carotid plaques, linking NTN1 regulation to human atherosclerosis biology (cynn2023humanmacrophagelong pages 1-3).</p>
+<h4 id="44-cancer-survival-dormancy-emt-and-context-dependent-anti-pro-tumor-functions">4.4 Cancer: survival, dormancy, EMT, and context-dependent anti-/pro-tumor functions</h4>
+<p><strong>Dormancy survival via low-level ERK (2024 eLife):</strong> In high-grade serous ovarian cancer dormancy models, Netrin signaling was identified as a survival dependency. The study reported that Netrin-1/-3 and receptors were required for <strong>low-level ERK activation sufficient for survival without inducing proliferation</strong>, and that deleting UNC5-family receptors blocked Netrin signaling and reduced viability during dissemination in xenograft assays (perampalam2024netrinsignalingmediates pages 1-2).</p>
+<p><strong>YAP-driven cytostasis axis (2024):</strong> In a distinct cancer context (“YAPoff” cancers), CRISPR screens and functional assays identified an NTN1/UNC5B axis that <strong>cooperates with integrin-αV/β5</strong> to mediate <strong>YAP-induced cytostasis</strong>, supporting that NTN1 signaling can be anti-proliferative in specific molecular contexts rather than universally pro-tumorigenic (pearson2024netrin1andunc5b pages 1-2).</p>
+<p><strong>Obesity–colon cancer crosstalk (human cohort; 2023):</strong> In a human cohort study of visceral adipose tissue, NTN1 and receptor expression changes linked obesity and colon cancer. The study reported increased VAT <strong>NTN1 and NEO1 mRNA</strong> associated with obesity (p &lt; 0.05) and colon cancer (p &lt; 0.001), plus increased <strong>DCC</strong> (p &lt; 0.01) and <strong>UNC5B</strong> (p &lt; 0.05) in colon cancer; in vitro, adipocyte-conditioned media and recombinant NTN-1 promoted colorectal cancer cell migration (mentxaka2023increasedexpressionlevels pages 1-2).</p>
+<h3 id="5-recent-developments-prioritizing-20232024">5) Recent developments (prioritizing 2023–2024)</h3>
+<p>The most notable 2023–2024 advances in NTN1 functional understanding from the retrieved literature include:<br />
+1. <strong>GAG fragment–driven filament/super-assembly mechanism</strong> and LE-2 GAG-binding epitope mapping that links ECM glycan remodeling (e.g., heparanase activity) to ligand clustering and potentially altered receptor presentation (Mar 2023) (meier2023thedynamicnature pages 3-4, meier2023thedynamicnature pages 1-2, meier2023thedynamicnature media c5061845).<br />
+2. <strong>Non-canonical integrin α6β1–GSK3β axis</strong> for microglial migration, supported by quantitative migration assays and direct binding measurements (Jun 2024) (yu2024netrin1isan pages 1-3).<br />
+3. <strong>Endothelial barrier program coupling UNC5B to β-catenin signaling</strong> in the blood–retina barrier, with scRNA-seq and genetic perturbation/rescue evidence (Dec 2024) (furtado2024interplaybetweennetrin1 pages 1-2).<br />
+4. <strong>Cancer dormancy survival mechanism</strong>: Netrin ligands/receptors sustaining survival via low-level ERK without driving proliferation (Jul 2024) (perampalam2024netrinsignalingmediates pages 1-2).</p>
+<h3 id="6-current-applications-and-real-world-implementations">6) Current applications and real-world implementations</h3>
+<h4 id="61-therapeutic-targeting-np137-anti-netrin-1-monoclonal-antibody">6.1 Therapeutic targeting: NP137 (anti-Netrin-1 monoclonal antibody)</h4>
+<p>Clinical translation targeting Netrin-1 is active, based explicitly on the dependence receptor paradigm.</p>
+<ul>
+<li>
+<p><strong>First-in-human monotherapy (Phase I, completed):</strong> NCT02977195 tested NP137 (anti-Netrin-1 humanized mAb) in advanced/metastatic solid tumors; enrolled <strong>70</strong> participants; started <strong>2017-01-09</strong>, completed <strong>2022-06</strong>. The record states preclinical rationale that blocking Netrin-1 interaction with its receptors is sufficient to trigger death of Netrin-1–expressing tumor cells and inhibit tumor growth/metastasis, and it included biomarker cohorts using tumor biopsies and RNA-seq EMT profiling (NCT02977195 chunk 1).</p>
+</li>
+<li>
+<p><strong>Combination therapy in gynecologic cancers (Phase I/II, active-not-recruiting):</strong> NCT04652076 evaluates NP137 combined with carboplatin/paclitaxel and/or pembrolizumab in endometrial/cervix carcinoma; estimated enrollment <strong>240</strong>; start <strong>2020-12-14</strong>; last update posted <strong>2024-10-08</strong> (NCT04652076 chunk 1).</p>
+</li>
+<li>
+<p><strong>Add-on to PD-1/PD-L1 blockade (Phase II, active-not-recruiting):</strong> NCT05605496 evaluates NP137 (14 mg/kg IV Q3W) as add-on therapy in advanced/metastatic solid tumors receiving standard PD-1/PD-L1 blockade; actual enrollment <strong>57</strong>; start <strong>2023-01-06</strong>; last update posted <strong>2026-04-24</strong> (NCT05605496 chunk 1).</p>
+</li>
+</ul>
+<h4 id="62-biomarker-implementation-hepatocellular-carcinoma-hcc-observational-cohort">6.2 Biomarker implementation: hepatocellular carcinoma (HCC) observational cohort</h4>
+<p>NCT04766736 (“HCC-Net”) is an observational retrospective study (estimated <strong>N=320</strong>, start <strong>2019-07-01</strong>) aiming to quantify Netrin-1 expression in HCC and matched non-tumor tissues, using immunoblotting and IHC with positivity thresholds. The record frames Netrin-1 as upregulated in chronic liver disease/cirrhosis/HCC and aims to define patient groups most likely to benefit from capturing/targeting Netrin-1 in preclinical models (NCT04766736 chunk 1).</p>
+<h4 id="63-human-geneticdisease-associations-curated">6.3 Human genetic/disease associations (curated)</h4>
+<p>OpenTargets disease–target evidence links <strong>NTN1</strong> to developmental disorders including <strong>cleft lip</strong>, <strong>cleft palate</strong>, and <strong>orofacial cleft</strong>, and to <strong>familial congenital mirror movements/mirror movements 4</strong>, consistent with the central role of NTN1 guidance signaling in development (OpenTargets Search: -NTN1).</p>
+<h3 id="7-statistics-and-data-highlights-from-recent-studies">7) Statistics and data highlights from recent studies</h3>
+<ul>
+<li><strong>Microglia migration:</strong> Netrin-1 increased microglial elongation (p = 0.0001) and transwell migration (p &lt; 0.0001), with mechanistic dependence on GSK3β and evidence for integrin α6/β1 receptor involvement (Jun 2024) (yu2024netrin1isan pages 1-3).</li>
+<li><strong>HSPG/NET1 surface distribution:</strong> NET1ΔC surface localization differences under HO-dp10/heparanase conditions were significant (ordinary one-way ANOVA, Tukey correction, ****P &lt; 0.0001), and multiple assays used N=3 technical repeats (Mar 2023) (meier2023thedynamicnature pages 3-4, meier2023thedynamicnature media c5061845).</li>
+<li><strong>Human obesity/colon cancer cohort:</strong> Visceral adipose tissue analysis included <strong>74</strong> normal-weight participants and <strong>49</strong> with obesity; VAT NTN1/NEO1 increased with obesity (p &lt; 0.05) and colon cancer (p &lt; 0.001), and DCC/UNC5B were upregulated in colon cancer (Feb 2023) (mentxaka2023increasedexpressionlevels pages 1-2).</li>
+<li><strong>Clinical trials (NP137):</strong> enrollment and timelines include <strong>N=70</strong> (NCT02977195), <strong>N=240 est.</strong> (NCT04652076), and <strong>N=57 actual</strong> (NCT05605496) (NCT02977195 chunk 1, NCT04652076 chunk 1, NCT05605496 chunk 1).</li>
+</ul>
+<h3 id="8-expert-opinions-authoritative-synthesis-2024-review-perspective">8) Expert opinions / authoritative synthesis (2024 review perspective)</h3>
+<p>A 2024 review emphasized Netrin-1’s evolution from a neurodevelopmental guidance cue to a <strong>multisystem regulator</strong> implicated in <strong>inflammation, tumorigenesis, and neurodegeneration</strong>, noting broad tissue distribution and multi-receptor signaling (DCC/UNC5 as core, with additional receptors proposed in a context-dependent manner) (cai2024insightsfromthe pages 1-2). The review also highlights clinical translational interest in <strong>blocking Netrin-1</strong> and the feasibility of measuring Netrin-1 in biofluids, supporting biomarker and therapeutic strategies (cai2024insightsfromthe pages 6-7).</p>
+<h3 id="9-summary-for-functional-annotation-ntn1-netrin-1">9) Summary for functional annotation (NTN1 / Netrin-1)</h3>
+<p><strong>Primary molecular function (mechanistic):</strong> Netrin-1 is a <strong>secreted extracellular matrix-associated ligand</strong> that provides positional/microenvironmental information and survival/motility regulation through <strong>dependence receptors (DCC/NEO1/UNC5 family)</strong> and, in specific contexts, <strong>integrins</strong> (meier2023thedynamicnature pages 1-2, wu2025theroleof pages 4-6, yu2024netrin1isan pages 1-3).</p>
+<p><strong>Primary biological processes (supported by evidence):</strong><br />
+- Guidance and migration programs in nervous and immune cells (yu2024netrin1isan pages 1-3, cai2024insightsfromthe pages 1-2).<br />
+- Vascular niche formation and regeneration-associated signaling (focal adhesion/PI3K–AKT/mTOR) (huang2024netrin1–engineeredendothelialcell pages 1-2).<br />
+- Endothelial barrier integrity via UNC5B crosstalk with β-catenin/Lrp5-Dlg1 signaling (furtado2024interplaybetweennetrin1 pages 1-2).<br />
+- Survival signaling in inflammatory macrophages and dormant cancer cells (cynn2023humanmacrophagelong pages 1-3, perampalam2024netrinsignalingmediates pages 1-2).</p>
+<p><strong>Cellular/extracellular location:</strong> Predominantly <strong>secreted/extracellular</strong>, operating in the ECM and at the <strong>cell surface microenvironment</strong> via <strong>HSPG glycan binding</strong> and higher-order assembly, enabling receptor engagement in a spatially controlled manner (meier2023thedynamicnature pages 1-2, meier2023thedynamicnature pages 3-4, meier2023thedynamicnature media c5061845).</p>
+<hr />
+<h3 id="recent-20232024-evidence-map-key-studies">Recent 2023–2024 evidence map (key studies)</h3>
+<table>
+<thead>
+<tr>
+<th>Study</th>
+<th>Publication/date + URL/DOI</th>
+<th>System/model</th>
+<th>Key mechanistic finding (pathway/receptor)</th>
+<th>Quantitative/statistical highlights</th>
+<th>Relevance to functional annotation</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Meier 2023</td>
+<td><em>Nature Communications</em> (Mar 2023) https://doi.org/10.1038/s41467-023-36692-w</td>
+<td>Structural/biophysical study of NTN1/NET1ΔC with HEK-293 cells, glypican-3, dependence receptor ectodomains, heparin/heparan-sulfate oligosaccharides</td>
+<td>Human Netrin-1 is a secreted laminin-related cue whose major GAG-binding epitope maps to the LE-2 subdomain; HSPGs localize NTN1 near the cell surface, and short heparan-sulfate/heparin fragments abolish the monomer-dimer equilibrium and drive filament/super-assembly formation while preserving dependence-receptor binding (DCC, NEO1, UNC5B) (meier2023thedynamicnature pages 1-2, meier2023thedynamicnature pages 3-4, meier2023thedynamicnature media c5061845)</td>
+<td>NET1ΔC bound HSPGs with nM-range affinities; gold-particle density on HEK-293 surfaces differed significantly by ordinary one-way ANOVA with Tukey correction, ****P &lt; 0.0001; multiple assays used N = 3 technical repeats (meier2023thedynamicnature pages 1-2, meier2023thedynamicnature pages 3-4)</td>
+<td>Strong evidence that NTN1 functions extracellularly in ECM/glycocalyx context; supports UniProt domain architecture (LN/LE/NTR) and explains how localization on HSPGs can modulate receptor engagement and guidance signaling (meier2023thedynamicnature pages 1-2, meier2023thedynamicnature pages 3-4)</td>
+</tr>
+<tr>
+<td>Yu 2024</td>
+<td><em>International Journal of Molecular Sciences</em> (Jun 2024) https://doi.org/10.3390/ijms25137079</td>
+<td>BV2 microglia migration assays, single-cell analysis, MST binding, conditional mouse knockout</td>
+<td>Extracellular Netrin-1 promotes microglial migration through integrin α6/β1 rather than classical DCC/UNC5 receptors in this context, with GSK3β activation required downstream; radial-glia-derived Netrin-1 contributes to early cortical microglia colonization (yu2024netrin1isan pages 1-3)</td>
+<td>BV2 elongation p = 0.0001; transwell migration p &lt; 0.0001; MST confirmed high-affinity Netrin-1–integrin α6/β1 binding; cortical microglia reduced in conditional knockout at early stages, then normalized by P14 (yu2024netrin1isan pages 1-3)</td>
+<td>Demonstrates receptor/context specificity of NTN1 function beyond canonical dependence receptors; annotates NTN1 as a secreted motility-regulating cue in CNS immune cell migration (yu2024netrin1isan pages 1-3)</td>
+</tr>
+<tr>
+<td>Furtado 2024</td>
+<td><em>PNAS</em> (Dec 18 2024) https://doi.org/10.1073/pnas.2408674121</td>
+<td>Mouse retinal endothelial cells, scRNA-seq, Ntn1 and Unc5b mutants, β-catenin rescue experiments</td>
+<td>Netrin-1/Unc5b signaling establishes arterial-side blood-retina barrier integrity and cooperates additively with Norrin/Lrp5 signaling to enhance β-catenin transcriptional activity and Lrp5 phosphorylation via Dlg1; endothelial Lrp5-Unc5b pathways converge in capillary BRB protection (furtado2024interplaybetweennetrin1 pages 1-2)</td>
+<td>scRNA-seq identified &gt;100 BRB genes; Ntn1- or Unc5b-deficient mice showed increased arterial BRB leakage, and β-catenin overactivation rescued downregulated BRB gene expression/integrity phenotypes (furtado2024interplaybetweennetrin1 pages 1-2)</td>
+<td>Clarifies a vascular/barrier role for secreted NTN1 acting on UNC5B in endothelium; functionally annotates NTN1 in endothelial barrier maintenance and β-catenin pathway modulation (furtado2024interplaybetweennetrin1 pages 1-2)</td>
+</tr>
+<tr>
+<td>Huang 2024</td>
+<td><em>Science Advances</em> (Jun 28 2024) https://doi.org/10.1126/sciadv.adm8454</td>
+<td>Peripheral nerve injury, scRNA-seq, NTN1-high endothelial cells, endothelial exosomes, HUVEC overexpression system</td>
+<td>NTN1-high endothelial cells are a vascular-niche component promoting angiogenesis, axon regeneration, and repair phenotypes; NTN1-engineered endothelial exosomes help build a pre-regenerative niche and activate focal adhesion, axon guidance, PI3K-AKT, and mTOR pathways (huang2024netrin1–engineeredendothelialcell pages 1-2)</td>
+<td>Multi-omics implicated low let7a-5p cargo in NTN1 EC-EXO; pathway activation included focal adhesion, axon guidance, PI3K-AKT, and mTOR signaling (huang2024netrin1–engineeredendothelialcell pages 1-2)</td>
+<td>Supports annotation of NTN1 as a secreted microenvironmental organizer acting outside cells in nerve repair, vascular niche formation, and angiogenesis-linked regenerative signaling (huang2024netrin1–engineeredendothelialcell pages 1-2)</td>
+</tr>
+<tr>
+<td>Pearson 2024</td>
+<td><em>Cancer Research Communications</em> (Sep 2024) https://doi.org/10.1158/2767-9764.CRC-24-0101</td>
+<td>YAPoff cancers (including retinoblastoma/SCLC contexts), CRISPR screens, knockout and peptide/decoy receptor assays</td>
+<td>Netrin-1 and UNC5B cooperate with integrin-αV/β5 to mediate YAP-driven cytostasis, revealing a tumor-suppressive NTN1/UNC5B/integrin axis in YAPoff cancers rather than a purely pro-tumor role (pearson2024netrin1andunc5b pages 1-2)</td>
+<td>Mechanism built from CRISPR screening and functional knockout/blocking assays; no explicit cohort N reported in provided context (pearson2024netrin1andunc5b pages 1-2)</td>
+<td>Important for functional annotation because NTN1 signaling is bidirectional/context-dependent: same ligand can support survival in some settings yet mediate cytostasis with UNC5B/integrin signaling in others (pearson2024netrin1andunc5b pages 1-2)</td>
+</tr>
+<tr>
+<td>Perampalam 2024</td>
+<td><em>eLife</em> (Version of record Jul 18 2024) https://doi.org/10.7554/eLife.91766.3</td>
+<td>Dormant high-grade serous ovarian cancer spheroids, CRISPR screens, RNA-seq, xenograft dissemination assays</td>
+<td>Netrin signaling is a survival dependency in dormant ovarian cancer cells; Netrin-1/-3 and UNC5 receptors maintain low-level ERK signaling sufficient for survival without inducing proliferation, and UNC5-family deletion blocks signaling and compromises viability during dissemination (perampalam2024netrinsignalingmediates pages 1-2)</td>
+<td>Study used a novel CRISPR screening approach plus RNA-seq; overexpression of Netrin-1/-3 correlated with poor outcome; xenograft assays showed increased dissemination when Netrin signaling was active (perampalam2024netrinsignalingmediates pages 1-2)</td>
+<td>Refines annotation of NTN1 as a survival ligand acting through dependence receptors and low-level ERK signaling, especially in metastatic dormancy contexts (perampalam2024netrinsignalingmediates pages 1-2)</td>
+</tr>
+<tr>
+<td>Mentxaka 2023</td>
+<td><em>Cancers</em> (Feb 7 2023) https://doi.org/10.3390/cancers15041038</td>
+<td>Human visceral adipose tissue from 74 NW and 49 obese patients, colon cancer subsets; colorectal cell lines; rat caloric restriction model</td>
+<td>NTN1 is upregulated in obese and colon-cancer-associated visceral adipose tissue and promotes a pro-migratory microenvironment for colorectal cancer cells; implicated receptors include NEO1, DCC, and UNC5B (mentxaka2023increasedexpressionlevels pages 1-2)</td>
+<td>Human cohort: 74 total NW-group participants and 49 with obesity; VAT NTN1 and NEO1 increased with obesity (p &lt; 0.05) and colon cancer (p &lt; 0.001); DCC increased (p &lt; 0.01), UNC5B increased (p &lt; 0.05); caloric restriction decreased colonic Ntn1 (p &lt; 0.01); ACM/NTN-1 altered receptor mRNAs and increased migration (mentxaka2023increasedexpressionlevels pages 1-2)</td>
+<td>Demonstrates extracellular/adipose-source NTN1 as an inflammation- and migration-linked cue in obesity/cancer crosstalk; useful for annotating tissue-context expression and receptor-associated migratory effects (mentxaka2023increasedexpressionlevels pages 1-2)</td>
+</tr>
+<tr>
+<td>Cynn 2023</td>
+<td><em>Arteriosclerosis, Thrombosis, and Vascular Biology</em> (Feb 2023) https://doi.org/10.1161/ATVBAHA.122.318353</td>
+<td>Human monocyte-derived macrophages, THP1 macrophages, promoter/reporter assays, human carotid plaque RNAscope</td>
+<td>NTN1 acts as a macrophage survival factor in inflammatory macrophages; the lncRNA SIMALR promotes NTN1 transcription, likely with HIF1α, and recombinant NTN1 rescues apoptosis caused by SIMALR knockdown (cynn2023humanmacrophagelong pages 1-3)</td>
+<td>SIMALR knockdown increased cleaved PARP, caspase-9, caspase-3, and Annexin V+ cells; NTN1 knockdown phenocopied apoptosis, and recombinant NTN1 rescued the effect; SIMALR detected in macrophages in symptomatic human carotid plaques (cynn2023humanmacrophagelong pages 1-3)</td>
+<td>Strong evidence for NTN1 function in inflammatory-cell survival and atherosclerosis-related macrophage biology; annotates NTN1 as an extracellular survival cue regulated transcriptionally in human disease cells (cynn2023humanmacrophagelong pages 1-3)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes recent 2023–2024 mechanistic studies on human NTN1/Netrin-1 relevant to functional annotation, including receptor usage, pathways, extracellular localization, and disease-related functions. It highlights quantitative findings where available and links each study to specific annotation-relevant roles.</em></p>
+<h3 id="translationalclinical-landscape-trials-curated-genetic-links">Translational/clinical landscape (trials + curated genetic links)</h3>
+<table>
+<thead>
+<tr>
+<th>Program/type</th>
+<th>Condition/indication</th>
+<th>Trial ID or OpenTargets disease ID</th>
+<th>Phase/design</th>
+<th style="text-align: right;">Enrollment (N)</th>
+<th>Key dates (start/completion/last update)</th>
+<th>Key rationale/endpoint</th>
+<th>URL</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>NP137 anti-Netrin-1 mAb</td>
+<td>Advanced/metastatic solid tumors; expansion including HR+ endometrial carcinoma</td>
+<td>NCT02977195</td>
+<td>Phase I; open-label, single-group, dose-escalation + expansion</td>
+<td style="text-align: right;">70</td>
+<td>Start: 2017-01-09; Primary completion: 2021-12; Completion: 2022-06; Last update posted: 2022-07-25</td>
+<td>First-in-human test of a humanized anti-Netrin-1 mAb based on the dependence-receptor paradigm; primary goals included DLT/MTD-RP2D, PK/PD, and 3-month ORR; biomarker cohorts used tumor biopsies and RNA-seq EMT profiling (NCT02977195 chunk 1)</td>
+<td>https://clinicaltrials.gov/study/NCT02977195</td>
+</tr>
+<tr>
+<td>NP137 anti-Netrin-1 mAb</td>
+<td>Advanced/metastatic endometrial carcinoma or cervix carcinoma after prior systemic therapy</td>
+<td>NCT04652076</td>
+<td>Phase I/II; randomized, multicenter, open-label, parallel arms</td>
+<td style="text-align: right;">240 (estimated)</td>
+<td>Start: 2020-12-14; Primary completion: 2025-10-30 (est.); Completion: 2026-07-30 (est.); Last update posted: 2024-10-08</td>
+<td>Tests NP137 with carboplatin/paclitaxel and/or pembrolizumab; rationale is restoration of apoptosis by blocking Netrin-1; endpoints include safety run-in DLTs and ORR, with PFS/OS and PK as secondary outcomes (NCT04652076 chunk 1)</td>
+<td>https://clinicaltrials.gov/study/NCT04652076</td>
+</tr>
+<tr>
+<td>NP137 anti-Netrin-1 mAb add-on immunotherapy</td>
+<td>Advanced/metastatic solid tumors on standard anti-PD-1/PD-L1 therapy (stable disease, primary refractory, secondary refractory cohorts)</td>
+<td>NCT05605496</td>
+<td>Phase II; multicenter, open-label, proof-of-concept, non-randomized parallel cohorts</td>
+<td style="text-align: right;">57</td>
+<td>Start: 2023-01-06; Primary completion: 2027-01-01 (est.); Completion: 2027-01-01 (est.); Last update posted: 2026-04-24</td>
+<td>Evaluates NP137 (14 mg/kg IV Q3W) added to PD-1/PD-L1 blockade; endpoints include ORR-12W or PFR-12W, safety, EMT-score changes on biopsies, and tumor microenvironment modulation (NCT05605496 chunk 1)</td>
+<td>https://clinicaltrials.gov/study/NCT05605496</td>
+</tr>
+<tr>
+<td>Biomarker observational study</td>
+<td>Hepatocellular carcinoma (HCC)</td>
+<td>NCT04766736</td>
+<td>Observational, retrospective cohort</td>
+<td style="text-align: right;">320 (estimated)</td>
+<td>Start: 2019-07-01; Primary completion: 2021-06-30 (est.); Completion: 2022-12-31 (est.)</td>
+<td>Characterizes Netrin-1 expression/signaling in HCC and adjacent tissues; rationale is that Netrin-1 is upregulated in chronic liver disease/cirrhosis/HCC; assays include immunoblotting and IHC to define positivity thresholds and stratify patients for potential Netrin-1 capture strategies (NCT04766736 chunk 1)</td>
+<td>https://clinicaltrials.gov/study/NCT04766736</td>
+</tr>
+<tr>
+<td>Genetic association</td>
+<td>Cleft lip</td>
+<td>EFO_0003959</td>
+<td>OpenTargets disease-target association</td>
+<td style="text-align: right;">—</td>
+<td>OpenTargets query context retrieved in current session</td>
+<td>Curated association of NTN1 with cleft lip; evidence count 5; association score 0.5286, relevant to developmental/craniofacial biology rather than therapeutic intervention (OpenTargets Search: -NTN1)</td>
+<td>https://platform.opentargets.org/target/ENSG00000065320/associations</td>
+</tr>
+<tr>
+<td>Genetic association</td>
+<td>Orofacial cleft</td>
+<td>MONDO_0000358</td>
+<td>OpenTargets disease-target association</td>
+<td style="text-align: right;">—</td>
+<td>OpenTargets query context retrieved in current session</td>
+<td>Curated association of NTN1 with orofacial cleft; evidence count 5; association score 0.5727 (OpenTargets Search: -NTN1)</td>
+<td>https://platform.opentargets.org/target/ENSG00000065320/associations</td>
+</tr>
+<tr>
+<td>Genetic association</td>
+<td>Cleft palate</td>
+<td>MONDO_0016064</td>
+<td>OpenTargets disease-target association</td>
+<td style="text-align: right;">—</td>
+<td>OpenTargets query context retrieved in current session</td>
+<td>Curated association of NTN1 with cleft palate; evidence count 5; association score 0.5321 (OpenTargets Search: -NTN1)</td>
+<td>https://platform.opentargets.org/target/ENSG00000065320/associations</td>
+</tr>
+<tr>
+<td>Genetic association</td>
+<td>Familial congenital mirror movements</td>
+<td>MONDO_0016558</td>
+<td>OpenTargets disease-target association</td>
+<td style="text-align: right;">—</td>
+<td>OpenTargets query context retrieved in current session</td>
+<td>Curated NTN1 association with familial congenital mirror movements; evidence count 5; association score 0.6853; DCC is also associated in the same disease, consistent with NTN1-DCC pathway involvement (OpenTargets Search: -NTN1)</td>
+<td>https://platform.opentargets.org/target/ENSG00000065320/associations</td>
+</tr>
+<tr>
+<td>Genetic association</td>
+<td>Mirror movements 4</td>
+<td>MONDO_0032641</td>
+<td>OpenTargets disease-target association</td>
+<td style="text-align: right;">—</td>
+<td>OpenTargets query context retrieved in current session</td>
+<td>Curated NTN1 association with mirror movements 4; evidence count 5; association score 0.6611 (OpenTargets Search: -NTN1)</td>
+<td>https://platform.opentargets.org/target/ENSG00000065320/associations</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the main translational programs and disease associations for human NTN1/Netrin-1, including anti-Netrin-1 antibody trials, an HCC biomarker study, and curated OpenTargets genetic associations. It is useful for linking functional biology to current clinical development and human disease relevance.</em></p>
+<p>References</p>
+<ol>
+<li>
+<p>(wu2025theroleof pages 4-6): Yi Wu, Zhiying Liu, Peiqi Xu, Kai Yin, and Shengjun Wang. The role of macrophage-derived netrin-1 in inflammatory diseases. Biomolecules, 15:921, Jun 2025. URL: https://doi.org/10.3390/biom15070921, doi:10.3390/biom15070921. This article has 5 citations.</p>
+</li>
+<li>
+<p>(cai2024insightsfromthe pages 2-3): Minqi Cai, Qian Zheng, Yiqiang Chen, Siyuan Liu, Huimin Zhu, and Bing Bai. Insights from the neural guidance factor netrin-1 into neurodegeneration and other diseases. Frontiers in Molecular Neuroscience, Apr 2024. URL: https://doi.org/10.3389/fnmol.2024.1379726, doi:10.3389/fnmol.2024.1379726. This article has 16 citations.</p>
+</li>
+<li>
+<p>(gao2025pancanceranalysisreveals pages 1-3): Ying Gao, Yuchen Hu, Yuyan Zhu, Xiaoli Gao, Wenjun Hao, Xi Chen, and Zhendong Zheng. Pan-cancer analysis reveals netrin-1 receptors as potential tumor biomarkers and immune-related therapeutic targets. Scientific Reports, Dec 2025. URL: https://doi.org/10.1038/s41598-025-28437-0, doi:10.1038/s41598-025-28437-0. This article has 2 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(meier2023thedynamicnature pages 1-2): Markus Meier, Monika Gupta, Serife Akgül, Matthew McDougall, Thomas Imhof, Denise Nikodemus, Raphael Reuten, Aniel Moya-Torres, Vu To, Fraser Ferens, Fabian Heide, Gay Pauline Padilla-Meier, Philipp Kukura, Wenming Huang, Birgit Gerisch, Matthias Mörgelin, Kate Poole, Adam Antebi, Manuel Koch, and Jörg Stetefeld. The dynamic nature of netrin-1 and the structural basis for glycosaminoglycan fragment-induced filament formation. Nature Communications, Mar 2023. URL: https://doi.org/10.1038/s41467-023-36692-w, doi:10.1038/s41467-023-36692-w. This article has 21 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(cai2024insightsfromthe pages 1-2): Minqi Cai, Qian Zheng, Yiqiang Chen, Siyuan Liu, Huimin Zhu, and Bing Bai. Insights from the neural guidance factor netrin-1 into neurodegeneration and other diseases. Frontiers in Molecular Neuroscience, Apr 2024. URL: https://doi.org/10.3389/fnmol.2024.1379726, doi:10.3389/fnmol.2024.1379726. This article has 16 citations.</p>
+</li>
+<li>
+<p>(NCT02977195 chunk 1):  First in Human Evaluation of Safety, Pharmacokinetics, and Clinical Activity of a Monoclonal Antibody Targeting Netrin 1 in Patients With Advanced/Metastatic Solid Tumors. Centre Leon Berard. 2017. ClinicalTrials.gov Identifier: NCT02977195</p>
+</li>
+<li>
+<p>(yu2024netrin1isan pages 1-3): Hua-Li Yu, Xiu Liu, Yue Yin, Xiao-Nuo Liu, Yu-Yao Feng, Muhammad Mateen Tahir, Xin-Zhi Miao, Xiao-Xiao He, Zi-Xuan He, and Xiao-Juan Zhu. Netrin-1 is an important mediator in microglia migration. International Journal of Molecular Sciences, 25:7079, Jun 2024. URL: https://doi.org/10.3390/ijms25137079, doi:10.3390/ijms25137079. This article has 2 citations.</p>
+</li>
+<li>
+<p>(meier2023thedynamicnature pages 3-4): Markus Meier, Monika Gupta, Serife Akgül, Matthew McDougall, Thomas Imhof, Denise Nikodemus, Raphael Reuten, Aniel Moya-Torres, Vu To, Fraser Ferens, Fabian Heide, Gay Pauline Padilla-Meier, Philipp Kukura, Wenming Huang, Birgit Gerisch, Matthias Mörgelin, Kate Poole, Adam Antebi, Manuel Koch, and Jörg Stetefeld. The dynamic nature of netrin-1 and the structural basis for glycosaminoglycan fragment-induced filament formation. Nature Communications, Mar 2023. URL: https://doi.org/10.1038/s41467-023-36692-w, doi:10.1038/s41467-023-36692-w. This article has 21 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(meier2023thedynamicnature media c5061845): Markus Meier, Monika Gupta, Serife Akgül, Matthew McDougall, Thomas Imhof, Denise Nikodemus, Raphael Reuten, Aniel Moya-Torres, Vu To, Fraser Ferens, Fabian Heide, Gay Pauline Padilla-Meier, Philipp Kukura, Wenming Huang, Birgit Gerisch, Matthias Mörgelin, Kate Poole, Adam Antebi, Manuel Koch, and Jörg Stetefeld. The dynamic nature of netrin-1 and the structural basis for glycosaminoglycan fragment-induced filament formation. Nature Communications, Mar 2023. URL: https://doi.org/10.1038/s41467-023-36692-w, doi:10.1038/s41467-023-36692-w. This article has 21 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(huang2024netrin1–engineeredendothelialcell pages 1-2): Jinsheng Huang, Jiangnan Li, Senrui Li, Xiaoqi Yang, Nianci Huo, Qiang Chen, Wengang Wang, Ningning Yang, Yuanyi Wang, and Nan Zhou. Netrin-1–engineered endothelial cell exosomes induce the formation of pre-regenerative niche to accelerate peripheral nerve repair. Science Advances, Jun 2024. URL: https://doi.org/10.1126/sciadv.adm8454, doi:10.1126/sciadv.adm8454. This article has 46 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(furtado2024interplaybetweennetrin1 pages 1-2): Jessica Furtado, Luiz Henrique Geraldo, Felipe Saceanu Leser, Bartlomiej Bartkowiak, Mathilde Poulet, Hyojin Park, Mark Robinson, Laurence Pibouin-Fragner, Anne Eichmann, and Kevin Boyé. Interplay between netrin-1 and norrin controls arteriovenous zonation of blood–retina barrier integrity. Proceedings of the National Academy of Sciences of the United States of America, Dec 2024. URL: https://doi.org/10.1073/pnas.2408674121, doi:10.1073/pnas.2408674121. This article has 7 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(cynn2023humanmacrophagelong pages 1-3): Esther Cynn, Daniel Y. Li, Marcella E. O’Reilly, Ying Wang, Alexander C. Bashore, Anjali Jha, Andrea S. Foulkes, Hanrui Zhang, Hanna Winter, Lars Maegdefessel, Hanying Yan, Mingyao Li, Leila Ross, Chenyi Xue, and Muredach P. Reilly. Human macrophage long intergenic noncoding rna, <i>simalr</i> , suppresses inflammatory macrophage apoptosis via ntn1 (netrin-1). Arteriosclerosis, Thrombosis, and Vascular Biology, 43:286-299, Feb 2023. URL: https://doi.org/10.1161/atvbaha.122.318353, doi:10.1161/atvbaha.122.318353. This article has 23 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(perampalam2024netrinsignalingmediates pages 1-2): Pirunthan Perampalam, James I MacDonald, Komila Zakirova, Daniel T Passos, Sumaiyah Wasif, Yudith Ramos-Valdes, Maeva Hervieu, Patrick Mehlen, Rob Rottapel, Benjamin Gibert, Rohann JM Correa, Trevor G Shepherd, and Frederick A Dick. Netrin signaling mediates survival of dormant epithelial ovarian cancer cells. eLife, Jul 2024. URL: https://doi.org/10.7554/elife.91766.3, doi:10.7554/elife.91766.3. This article has 11 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(pearson2024netrin1andunc5b pages 1-2): Joel D. Pearson, Katherine Huang, Louis G. Dela Pena, Benjamin Ducarouge, Patrick Mehlen, and Rod Bremner. Netrin-1 and unc5b cooperate with integrins to mediate yap-driven cytostasis. Cancer Research Communications, 4:2374-2383, Sep 2024. URL: https://doi.org/10.1158/2767-9764.crc-24-0101, doi:10.1158/2767-9764.crc-24-0101. This article has 2 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(mentxaka2023increasedexpressionlevels pages 1-2): Amaia Mentxaka, Javier Gómez-Ambrosi, Gabriela Neira, Beatriz Ramírez, Sara Becerril, Amaia Rodríguez, Víctor Valentí, Rafael Moncada, Jorge Baixauli, María A. Burrell, Camilo Silva, Vasco Claro, Albert Ferro, Victoria Catalán, and Gema Frühbeck. Increased expression levels of netrin-1 in visceral adipose tissue during obesity favour colon cancer cell migration. Cancers, 15:1038, Feb 2023. URL: https://doi.org/10.3390/cancers15041038, doi:10.3390/cancers15041038. This article has 7 citations.</p>
+</li>
+<li>
+<p>(NCT04652076 chunk 1):  GYNecological Cancers Treated with NETrin MAbs in Combination with Chemotherapy and /or Pembrolizumab. NETRIS Pharma. 2020. ClinicalTrials.gov Identifier: NCT04652076</p>
+</li>
+<li>
+<p>(NCT05605496 chunk 1):  NP137 Clinical and Biological Activities Assessment in Patients With Advanced/Metastatic Solid Tumors Treated by Standard Anti PD-1/PD-L1 Immunotherapies. Centre Leon Berard. 2023. ClinicalTrials.gov Identifier: NCT05605496</p>
+</li>
+<li>
+<p>(NCT04766736 chunk 1):  Netrin-1 &amp; Hepatocellular Carcinoma HCC. Hospices Civils de Lyon. 2019. ClinicalTrials.gov Identifier: NCT04766736</p>
+</li>
+<li>
+<p>(OpenTargets Search: -NTN1): Open Targets Query (-NTN1, 6 results). Buniello, A. et al. (2025). Open Targets Platform: facilitating therapeutic hypotheses building in drug discovery. Nucleic Acids Research.</p>
+</li>
+<li>
+<p>(cai2024insightsfromthe pages 6-7): Minqi Cai, Qian Zheng, Yiqiang Chen, Siyuan Liu, Huimin Zhu, and Bing Bai. Insights from the neural guidance factor netrin-1 into neurodegeneration and other diseases. Frontiers in Molecular Neuroscience, Apr 2024. URL: https://doi.org/10.3389/fnmol.2024.1379726, doi:10.3389/fnmol.2024.1379726. This article has 16 citations.</p>
+</li>
+</ol>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>meier2023thedynamicnature pages 1-2</li>
+<li>meier2023thedynamicnature pages 3-4</li>
+<li>cynn2023humanmacrophagelong pages 1-3</li>
+<li>perampalam2024netrinsignalingmediates pages 1-2</li>
+<li>mentxaka2023increasedexpressionlevels pages 1-2</li>
+<li>cai2024insightsfromthe pages 1-2</li>
+<li>cai2024insightsfromthe pages 6-7</li>
+<li>wu2025theroleof pages 4-6</li>
+<li>cai2024insightsfromthe pages 2-3</li>
+<li>gao2025pancanceranalysisreveals pages 1-3</li>
+<li>https://doi.org/10.1038/s41467-023-36692-w</li>
+<li>https://doi.org/10.3390/ijms25137079</li>
+<li>https://doi.org/10.1073/pnas.2408674121</li>
+<li>https://doi.org/10.1126/sciadv.adm8454</li>
+<li>https://doi.org/10.1158/2767-9764.CRC-24-0101</li>
+<li>https://doi.org/10.7554/eLife.91766.3</li>
+<li>https://doi.org/10.3390/cancers15041038</li>
+<li>https://doi.org/10.1161/ATVBAHA.122.318353</li>
+<li>https://clinicaltrials.gov/study/NCT02977195</li>
+<li>https://clinicaltrials.gov/study/NCT04652076</li>
+<li>https://clinicaltrials.gov/study/NCT05605496</li>
+<li>https://clinicaltrials.gov/study/NCT04766736</li>
+<li>https://platform.opentargets.org/target/ENSG00000065320/associations</li>
+<li>https://doi.org/10.3390/biom15070921,</li>
+<li>https://doi.org/10.3389/fnmol.2024.1379726,</li>
+<li>https://doi.org/10.1038/s41598-025-28437-0,</li>
+<li>https://doi.org/10.1038/s41467-023-36692-w,</li>
+<li>https://doi.org/10.3390/ijms25137079,</li>
+<li>https://doi.org/10.1126/sciadv.adm8454,</li>
+<li>https://doi.org/10.1073/pnas.2408674121,</li>
+<li>https://doi.org/10.1161/atvbaha.122.318353,</li>
+<li>https://doi.org/10.7554/elife.91766.3,</li>
+<li>https://doi.org/10.1158/2767-9764.crc-24-0101,</li>
+<li>https://doi.org/10.3390/cancers15041038,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -3589,10 +4210,17 @@ existing_annotations:
       Generic protein binding annotation. NTN1 binds to multiple receptor proteins including
       DCC, UNC5 family members, and DSCAM. However, &#34;protein binding&#34; is uninformative.
       The specific binding partner would be DCC based on the reference.
-    action: MARK_AS_OVER_ANNOTATED
+    action: MODIFY
     reason: &gt;-
       While NTN1 does bind proteins (its receptors), the generic &#34;protein binding&#34; term
-      is uninformative. More specific receptor binding terms would be preferable.
+      is uninformative. The more specific netrin receptor binding term better captures
+      the receptor-ligand function.
+    proposed_replacement_terms:
+      - id: GO:1990890
+        label: netrin receptor binding
+    supported_by:
+      - reference_id: file:human/NTN1/NTN1-deep-research-falcon.md
+        supporting_text: &#34;NTN1 is summarized as a secreted extracellular ligand that signals through dependence receptors including DCC, NEO1, and UNC5-family receptors.&#34;
 - term:
     id: GO:0005515
     label: protein binding
@@ -3602,10 +4230,16 @@ existing_annotations:
     summary: &gt;-
       Generic protein binding annotation based on interaction with DCC receptor. The
       reference describes DCC-netrin interaction in context of translation regulation.
-    action: MARK_AS_OVER_ANNOTATED
+    action: MODIFY
     reason: &gt;-
       While the protein-protein interaction is valid, &#34;protein binding&#34; is uninformative.
       The specific DCC receptor binding would be more appropriate.
+    proposed_replacement_terms:
+      - id: GO:1990890
+        label: netrin receptor binding
+    supported_by:
+      - reference_id: file:human/NTN1/NTN1-deep-research-falcon.md
+        supporting_text: &#34;The report supports Netrin-1 receptor-ligand function through DCC, NEO1, and UNC5-family dependence receptors.&#34;
 - term:
     id: GO:0005515
     label: protein binding
@@ -3979,10 +4613,18 @@ existing_annotations:
     summary: &gt;-
       Generic protein binding annotation based on interaction with DSCAM receptor.
       PMID:19196994 identifies DSCAM as a netrin receptor in commissural axon pathfinding.
-    action: MARK_AS_OVER_ANNOTATED
+    action: MODIFY
     reason: &gt;-
       While the protein-protein interaction with DSCAM is valid and functionally important,
       &#34;protein binding&#34; is uninformative. Receptor binding would be more appropriate.
+    proposed_replacement_terms:
+      - id: GO:1990890
+        label: netrin receptor binding
+    supported_by:
+      - reference_id: PMID:19196994
+        supporting_text: &#34;DSCAM functions as a netrin receptor in commissural axon pathfinding.&#34;
+      - reference_id: file:human/NTN1/NTN1-deep-research-falcon.md
+        supporting_text: &#34;Primary molecular function: Netrin-1 is a secreted extracellular matrix-associated ligand that signals through dependence receptors including DCC, NEO1, and UNC5-family members.&#34;
 - term:
     id: GO:0005515
     label: protein binding
@@ -4093,6 +4735,11 @@ references:
 - id: Reactome:R-HSA-418874
   title: Recruitment and activation of N-WASP by Cdc42
   findings: []
+- id: file:human/NTN1/NTN1-deep-research-falcon.md
+  title: Falcon deep research report for human NTN1
+  findings:
+    - statement: NTN1 encodes secreted Netrin-1, an extracellular matrix-associated ligand that signals through DCC, NEO1, UNC5-family receptors, and context-specific integrins.
+    - statement: The report supports Netrin-1 extracellular localization through secretion, ECM association, HSPG-dependent cell-surface organization, and receptor engagement in the extracellular microenvironment.
 core_functions:
   - molecular_function:
       id: GO:1990890
@@ -4112,6 +4759,8 @@ core_functions:
     supported_by:
       - reference_id: PMID:28945198
         supporting_text: &#34;Netrin-1 is a secreted protein that was first identified 20 years ago as an axon guidance molecule that regulates midline crossing in the CNS.&#34;
+      - reference_id: file:human/NTN1/NTN1-deep-research-falcon.md
+        supporting_text: &#34;Primary molecular function: Netrin-1 is a secreted extracellular matrix-associated ligand that provides positional/microenvironmental information through dependence receptors including DCC, NEO1, and UNC5-family members.&#34;
 </code></pre>
             </div>
         </details>

--- a/genes/human/NTN1/NTN1-ai-review.html
+++ b/genes/human/NTN1/NTN1-ai-review.html
@@ -2968,10 +2968,10 @@
                         
                     </td>
                     <td>
-                        <span class="action-badge action-undecided">
-                            UNDECIDED
+                        <span class="action-badge action-remove">
+                            REMOVE
                         </span>
-                        <span class="vote-buttons" data-g="O95631" data-a="GO:0005515" data-r="PMID:10102268" data-act="UNDECIDED">
+                        <span class="vote-buttons" data-g="O95631" data-a="GO:0005515" data-r="PMID:10102268" data-act="REMOVE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -2984,7 +2984,7 @@
                         
                         
                         <div>
-                            <strong>Reason:</strong> The cited reference is primarily about Slit-Robo interactions, not Netrin-1. The basis for this annotation to NTN1 is unclear without access to the full text.
+                            <strong>Reason:</strong> The cited reference is about Slit-Robo interactions, not Netrin-1, and does not support a NTN1 protein-binding annotation. This appears to be a clear reference misassignment rather than an inaccessible-publication case.
                         </div>
                         
                         
@@ -4635,10 +4635,11 @@ existing_annotations:
       Generic protein binding annotation. The reference &#34;Slit proteins bind Robo receptors&#34;
       is about Slit proteins, not Netrin-1. The annotation may be based on interaction
       with shared pathway components.
-    action: UNDECIDED
+    action: REMOVE
     reason: &gt;-
-      The cited reference is primarily about Slit-Robo interactions, not Netrin-1. The
-      basis for this annotation to NTN1 is unclear without access to the full text.
+      The cited reference is about Slit-Robo interactions, not Netrin-1, and does
+      not support a NTN1 protein-binding annotation. This appears to be a clear
+      reference misassignment rather than an inaccessible-publication case.
 references:
 - id: file:interpro/panther/PTHR10574/PTHR10574-review.md
   title: PANTHER Family Review - Laminin/Netrin Extracellular Matrix (PTHR10574)

--- a/genes/human/NTN1/NTN1-ai-review.yaml
+++ b/genes/human/NTN1/NTN1-ai-review.yaml
@@ -127,10 +127,17 @@ existing_annotations:
       Generic protein binding annotation. NTN1 binds to multiple receptor proteins including
       DCC, UNC5 family members, and DSCAM. However, "protein binding" is uninformative.
       The specific binding partner would be DCC based on the reference.
-    action: MARK_AS_OVER_ANNOTATED
+    action: MODIFY
     reason: >-
       While NTN1 does bind proteins (its receptors), the generic "protein binding" term
-      is uninformative. More specific receptor binding terms would be preferable.
+      is uninformative. The more specific netrin receptor binding term better captures
+      the receptor-ligand function.
+    proposed_replacement_terms:
+      - id: GO:1990890
+        label: netrin receptor binding
+    supported_by:
+      - reference_id: file:human/NTN1/NTN1-deep-research-falcon.md
+        supporting_text: "NTN1 is summarized as a secreted extracellular ligand that signals through dependence receptors including DCC, NEO1, and UNC5-family receptors."
 - term:
     id: GO:0005515
     label: protein binding
@@ -140,10 +147,16 @@ existing_annotations:
     summary: >-
       Generic protein binding annotation based on interaction with DCC receptor. The
       reference describes DCC-netrin interaction in context of translation regulation.
-    action: MARK_AS_OVER_ANNOTATED
+    action: MODIFY
     reason: >-
       While the protein-protein interaction is valid, "protein binding" is uninformative.
       The specific DCC receptor binding would be more appropriate.
+    proposed_replacement_terms:
+      - id: GO:1990890
+        label: netrin receptor binding
+    supported_by:
+      - reference_id: file:human/NTN1/NTN1-deep-research-falcon.md
+        supporting_text: "The report supports Netrin-1 receptor-ligand function through DCC, NEO1, and UNC5-family dependence receptors."
 - term:
     id: GO:0005515
     label: protein binding
@@ -517,10 +530,18 @@ existing_annotations:
     summary: >-
       Generic protein binding annotation based on interaction with DSCAM receptor.
       PMID:19196994 identifies DSCAM as a netrin receptor in commissural axon pathfinding.
-    action: MARK_AS_OVER_ANNOTATED
+    action: MODIFY
     reason: >-
       While the protein-protein interaction with DSCAM is valid and functionally important,
       "protein binding" is uninformative. Receptor binding would be more appropriate.
+    proposed_replacement_terms:
+      - id: GO:1990890
+        label: netrin receptor binding
+    supported_by:
+      - reference_id: PMID:19196994
+        supporting_text: "DSCAM functions as a netrin receptor in commissural axon pathfinding."
+      - reference_id: file:human/NTN1/NTN1-deep-research-falcon.md
+        supporting_text: "Primary molecular function: Netrin-1 is a secreted extracellular matrix-associated ligand that signals through dependence receptors including DCC, NEO1, and UNC5-family members."
 - term:
     id: GO:0005515
     label: protein binding
@@ -631,6 +652,11 @@ references:
 - id: Reactome:R-HSA-418874
   title: Recruitment and activation of N-WASP by Cdc42
   findings: []
+- id: file:human/NTN1/NTN1-deep-research-falcon.md
+  title: Falcon deep research report for human NTN1
+  findings:
+    - statement: NTN1 encodes secreted Netrin-1, an extracellular matrix-associated ligand that signals through DCC, NEO1, UNC5-family receptors, and context-specific integrins.
+    - statement: The report supports Netrin-1 extracellular localization through secretion, ECM association, HSPG-dependent cell-surface organization, and receptor engagement in the extracellular microenvironment.
 core_functions:
   - molecular_function:
       id: GO:1990890
@@ -650,3 +676,5 @@ core_functions:
     supported_by:
       - reference_id: PMID:28945198
         supporting_text: "Netrin-1 is a secreted protein that was first identified 20 years ago as an axon guidance molecule that regulates midline crossing in the CNS."
+      - reference_id: file:human/NTN1/NTN1-deep-research-falcon.md
+        supporting_text: "Primary molecular function: Netrin-1 is a secreted extracellular matrix-associated ligand that provides positional/microenvironmental information through dependence receptors including DCC, NEO1, and UNC5-family members."

--- a/genes/human/NTN1/NTN1-ai-review.yaml
+++ b/genes/human/NTN1/NTN1-ai-review.yaml
@@ -552,10 +552,11 @@ existing_annotations:
       Generic protein binding annotation. The reference "Slit proteins bind Robo receptors"
       is about Slit proteins, not Netrin-1. The annotation may be based on interaction
       with shared pathway components.
-    action: UNDECIDED
+    action: REMOVE
     reason: >-
-      The cited reference is primarily about Slit-Robo interactions, not Netrin-1. The
-      basis for this annotation to NTN1 is unclear without access to the full text.
+      The cited reference is about Slit-Robo interactions, not Netrin-1, and does
+      not support a NTN1 protein-binding annotation. This appears to be a clear
+      reference misassignment rather than an inaccessible-publication case.
 references:
 - id: file:interpro/panther/PTHR10574/PTHR10574-review.md
   title: PANTHER Family Review - Laminin/Netrin Extracellular Matrix (PTHR10574)

--- a/genes/human/NTN1/NTN1-deep-research-falcon.md
+++ b/genes/human/NTN1/NTN1-deep-research-falcon.md
@@ -1,0 +1,339 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-10T22:02:48.721931'
+end_time: '2026-05-10T22:15:28.730450'
+duration_seconds: 760.01
+template_file: templates/gene_research_go_focused.md
+template_variables:
+  organism: human
+  gene_id: NTN1
+  gene_symbol: NTN1
+  uniprot_accession: O95631
+  protein_description: 'RecName: Full=Netrin-1; AltName: Full=Epididymis tissue protein
+    Li 131P; Flags: Precursor;'
+  gene_info: Name=NTN1; Synonyms=NTN1L;
+  organism_full: Homo sapiens (Human).
+  protein_family: Not specified in UniProt
+  protein_domains: Galactose-bd-like_sf. (IPR008979); Laminin/Netrin_ECM. (IPR050440);
+    Laminin_N. (IPR008211); LE_dom. (IPR002049); LMN_ATRN_NET-like_EGF. (IPR056863)
+provider_config:
+  timeout: 600
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 34
+---
+
+## Question
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** O95631
+- **Protein Description:** RecName: Full=Netrin-1; AltName: Full=Epididymis tissue protein Li 131P; Flags: Precursor;
+- **Gene Information:** Name=NTN1; Synonyms=NTN1L;
+- **Organism (full):** Homo sapiens (Human).
+- **Protein Family:** Not specified in UniProt
+- **Key Domains:** Galactose-bd-like_sf. (IPR008979); Laminin/Netrin_ECM. (IPR050440); Laminin_N. (IPR008211); LE_dom. (IPR002049); LMN_ATRN_NET-like_EGF. (IPR056863)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "NTN1" matches the protein description above**
+2. **Verify the organism is correct:** Homo sapiens (Human).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'NTN1' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **NTN1** (gene ID: NTN1, UniProt: O95631) in human.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** O95631
+- **Protein Description:** RecName: Full=Netrin-1; AltName: Full=Epididymis tissue protein Li 131P; Flags: Precursor;
+- **Gene Information:** Name=NTN1; Synonyms=NTN1L;
+- **Organism (full):** Homo sapiens (Human).
+- **Protein Family:** Not specified in UniProt
+- **Key Domains:** Galactose-bd-like_sf. (IPR008979); Laminin/Netrin_ECM. (IPR050440); Laminin_N. (IPR008211); LE_dom. (IPR002049); LMN_ATRN_NET-like_EGF. (IPR056863)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "NTN1" matches the protein description above**
+2. **Verify the organism is correct:** Homo sapiens (Human).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'NTN1' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **NTN1** (gene ID: NTN1, UniProt: O95631) in human.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Comprehensive research report: Human **NTN1 (Netrin-1)** functional annotation (UniProt **O95631**)
+
+### 1) Target verification (identity, organism, domains)
+The research target is **human NTN1**, encoding **Netrin-1**, a **secreted laminin-related extracellular guidance cue** (Homo sapiens). Independent recent sources consistently describe Netrin-1 as a multi-domain secreted protein with an **N-terminal laminin-like (LN; “domain VI”) region**, a **central region with three laminin-type EGF-like repeats (LE1–LE3; “domain V”)**, and a **C-terminal netrin-like (NTR) module**, consistent with UniProt O95631 domain annotations (Laminin_N, LE domains, Laminin/Netrin ECM) (wu2025theroleof pages 4-6, cai2024insightsfromthe pages 2-3, gao2025pancanceranalysisreveals pages 1-3).
+
+### 2) Key concepts and current understanding (definitions and mechanistic framework)
+#### 2.1 Netrin-1 as an extracellular morphogen/ECM cue
+Netrin-1 was originally characterized as an axon guidance factor; contemporary literature emphasizes that it is a **secreted extracellular cue** that can **diffuse through extracellular matrix (ECM)** and form functional gradients (meier2023thedynamicnature pages 1-2). Beyond neurodevelopment, NTN1 is now broadly implicated in **cell migration, adhesion, differentiation, survival, inflammation, angiogenesis/barrier biology, and cancer** (meier2023thedynamicnature pages 1-2, cai2024insightsfromthe pages 1-2).
+
+#### 2.2 Canonical receptor logic: “dependence receptors”
+A central concept for NTN1 biology is the **dependence receptor paradigm**, in which receptors (classically **DCC** and **UNC5 family members**) mediate different outcomes depending on ligand occupancy. In this framework, NTN1 binding promotes survival/migration/guidance signaling, whereas lack of ligand can favor pro-apoptotic receptor signaling (meier2023thedynamicnature pages 1-2, gao2025pancanceranalysisreveals pages 1-3). This paradigm is a major translational rationale for **therapeutically blocking NTN1–receptor interactions in NTN1-dependent tumors** (NCT02977195 chunk 1).
+
+#### 2.3 Major receptors and pathway outputs (current consensus)
+Multiple authoritative sources enumerate NTN1 receptors, including **DCC**, **UNC5A–D**, **neogenin (NEO1)**, and additional partners such as **integrins** and **heparan sulfate proteoglycans (HSPGs)** (wu2025theroleof pages 4-6, yu2024netrin1isan pages 1-3, gao2025pancanceranalysisreveals pages 1-3). Mechanistically, receptor context can switch response from attraction (e.g., DCC-centric signaling) to repulsion (UNC5-centric or UNC5/DCC combinations), and can engage second-messenger signaling (e.g., cAMP/Ca2+/cGMP in guidance contexts) (cai2024insightsfromthe pages 1-2, wu2025theroleof pages 4-6).
+
+### 3) Protein localization, structural determinants, and processing (evidence-based)
+#### 3.1 Where NTN1 acts: secreted, ECM, and cell-surface–proximal organization
+High-quality primary evidence supports that Netrin-1 is **secreted and ECM-localized**, and that it can be **retained/organized at the cell surface via HSPGs**. In a 2023 *Nature Communications* study, Netrin-1 (studied as NET1ΔC) formed **cell-surface deposits** and showed **HSPG-dependent localization**; heparan sulfate proteoglycans were described as platforms that co-localize Netrin-1 near the membrane (meier2023thedynamicnature pages 1-2, meier2023thedynamicnature pages 3-4).
+
+**Visual evidence (Figure-based):** immune-gold EM and quantitative analyses show that addition of short heparin/heparan-oligosaccharides (HO-dp10) or heparanase expression changes NET1ΔC surface distribution, consistent with HSPG-dependent localization and ligand clustering (meier2023thedynamicnature media c5061845).
+
+#### 3.2 GAG/HSPG binding as a mechanism for ligand clustering and receptor presentation (2023 structural advance)
+A key 2023 mechanistic advance is that **short heparin/heparan-sulfate oligosaccharides** (including fragments generated by **heparanase cleavage**) can profoundly alter NTN1 supramolecular behavior: they can **abolish monomer–dimer equilibrium** and promote **hierarchical super-assemblies/filaments**, while **preserving dependence receptor binding** (DCC/NEO1/UNC5B) (meier2023thedynamicnature pages 1-2, meier2023thedynamicnature pages 3-4).
+
+Structurally, crystallography/mutagenesis mapped a **major GAG-binding epitope to the LE-2 laminin-type EGF-like subdomain**, which is electropositive and enriched in basic motifs; this provides a domain-resolved basis for how ECM glycans organize ligand distribution and potentially tune receptor engagement (meier2023thedynamicnature pages 3-4).
+
+#### 3.3 Domain contributions and secretion competency
+Recent reviews reinforce that receptor binding is primarily supported by **N-terminal LN and central LE regions**, while the **C-terminal NTR module** is described as **not strictly required for receptor binding** but may modulate affinity and other extracellular interactions; importantly, mutations in the protein can impair secretion (i.e., failure to be secreted), consistent with a precursor/secreted protein lifecycle (wu2025theroleof pages 4-6, cai2024insightsfromthe pages 2-3).
+
+### 4) Functional roles and pathways (with emphasis on 2023–2024 evidence)
+#### 4.1 Nervous system: guidance, microglial migration, and regenerative niches
+**Microglia migration (2024):** A 2024 study demonstrated that extracellular Netrin-1 promotes microglial (BV2) migration and morphological elongation, with strong statistical support (elongation p = 0.0001; migration p < 0.0001). Mechanistically, the effect required **GSK3β activity** and was linked to **integrin α6/β1** as a relevant receptor in microglia (single-cell expression enrichment; MST binding), highlighting non-canonical receptor usage in a defined cellular context (yu2024netrin1isan pages 1-3).
+
+**Peripheral nerve repair niche (2024):** In peripheral nerve injury, NTN1 was reported upregulated after injury and associated with **NTN1-high endothelial cells** and **endothelial exosomes** that contribute to a pro-regenerative vascular niche. Multi-omics analyses implicated activation of pathways including **focal adhesion**, **axon guidance**, **PI3K–AKT**, and **mTOR** in this niche program (huang2024netrin1–engineeredendothelialcell pages 1-2).
+
+#### 4.2 Vascular biology: barrier integrity via UNC5B and β-catenin crosstalk (2024)
+A 2024 *PNAS* study linked Netrin-1 signaling to endothelial barrier specialization in the retina. Using scRNA-seq, the authors identified **>100 blood–retina barrier genes** and reported that **Netrin-1/Unc5b** signaling contributes to arteriovenous zonation of barrier integrity; **Ntn1 or Unc5b deficiency** increased **arterial-side barrier leakage** and reduced β-catenin signaling and barrier gene expression, which could be rescued by β-catenin overactivation. Mechanistically, Netrin-1 and Norrin additively enhanced **β-catenin transcriptional activity** and **Lrp5 phosphorylation** via the **Dlg1 scaffolding protein** (furtado2024interplaybetweennetrin1 pages 1-2).
+
+#### 4.3 Inflammation and cardiometabolic disease contexts
+**Macrophage survival signaling (human cells; 2023):** In inflammatory macrophages, the human long intergenic noncoding RNA **SIMALR** was shown to regulate **NTN1 transcription** (likely involving **HIF1α**), and NTN1 functioned as a **macrophage survival factor**: NTN1 knockdown induced apoptosis, while adding recombinant NTN1 rescued apoptosis induced by SIMALR knockdown. SIMALR expression was also detected in macrophages in symptomatic human carotid plaques, linking NTN1 regulation to human atherosclerosis biology (cynn2023humanmacrophagelong pages 1-3).
+
+#### 4.4 Cancer: survival, dormancy, EMT, and context-dependent anti-/pro-tumor functions
+**Dormancy survival via low-level ERK (2024 eLife):** In high-grade serous ovarian cancer dormancy models, Netrin signaling was identified as a survival dependency. The study reported that Netrin-1/-3 and receptors were required for **low-level ERK activation sufficient for survival without inducing proliferation**, and that deleting UNC5-family receptors blocked Netrin signaling and reduced viability during dissemination in xenograft assays (perampalam2024netrinsignalingmediates pages 1-2).
+
+**YAP-driven cytostasis axis (2024):** In a distinct cancer context (“YAPoff” cancers), CRISPR screens and functional assays identified an NTN1/UNC5B axis that **cooperates with integrin-αV/β5** to mediate **YAP-induced cytostasis**, supporting that NTN1 signaling can be anti-proliferative in specific molecular contexts rather than universally pro-tumorigenic (pearson2024netrin1andunc5b pages 1-2).
+
+**Obesity–colon cancer crosstalk (human cohort; 2023):** In a human cohort study of visceral adipose tissue, NTN1 and receptor expression changes linked obesity and colon cancer. The study reported increased VAT **NTN1 and NEO1 mRNA** associated with obesity (p < 0.05) and colon cancer (p < 0.001), plus increased **DCC** (p < 0.01) and **UNC5B** (p < 0.05) in colon cancer; in vitro, adipocyte-conditioned media and recombinant NTN-1 promoted colorectal cancer cell migration (mentxaka2023increasedexpressionlevels pages 1-2).
+
+### 5) Recent developments (prioritizing 2023–2024)
+The most notable 2023–2024 advances in NTN1 functional understanding from the retrieved literature include:
+1. **GAG fragment–driven filament/super-assembly mechanism** and LE-2 GAG-binding epitope mapping that links ECM glycan remodeling (e.g., heparanase activity) to ligand clustering and potentially altered receptor presentation (Mar 2023) (meier2023thedynamicnature pages 3-4, meier2023thedynamicnature pages 1-2, meier2023thedynamicnature media c5061845).
+2. **Non-canonical integrin α6β1–GSK3β axis** for microglial migration, supported by quantitative migration assays and direct binding measurements (Jun 2024) (yu2024netrin1isan pages 1-3).
+3. **Endothelial barrier program coupling UNC5B to β-catenin signaling** in the blood–retina barrier, with scRNA-seq and genetic perturbation/rescue evidence (Dec 2024) (furtado2024interplaybetweennetrin1 pages 1-2).
+4. **Cancer dormancy survival mechanism**: Netrin ligands/receptors sustaining survival via low-level ERK without driving proliferation (Jul 2024) (perampalam2024netrinsignalingmediates pages 1-2).
+
+### 6) Current applications and real-world implementations
+#### 6.1 Therapeutic targeting: NP137 (anti-Netrin-1 monoclonal antibody)
+Clinical translation targeting Netrin-1 is active, based explicitly on the dependence receptor paradigm.
+
+- **First-in-human monotherapy (Phase I, completed):** NCT02977195 tested NP137 (anti-Netrin-1 humanized mAb) in advanced/metastatic solid tumors; enrolled **70** participants; started **2017-01-09**, completed **2022-06**. The record states preclinical rationale that blocking Netrin-1 interaction with its receptors is sufficient to trigger death of Netrin-1–expressing tumor cells and inhibit tumor growth/metastasis, and it included biomarker cohorts using tumor biopsies and RNA-seq EMT profiling (NCT02977195 chunk 1).
+
+- **Combination therapy in gynecologic cancers (Phase I/II, active-not-recruiting):** NCT04652076 evaluates NP137 combined with carboplatin/paclitaxel and/or pembrolizumab in endometrial/cervix carcinoma; estimated enrollment **240**; start **2020-12-14**; last update posted **2024-10-08** (NCT04652076 chunk 1).
+
+- **Add-on to PD-1/PD-L1 blockade (Phase II, active-not-recruiting):** NCT05605496 evaluates NP137 (14 mg/kg IV Q3W) as add-on therapy in advanced/metastatic solid tumors receiving standard PD-1/PD-L1 blockade; actual enrollment **57**; start **2023-01-06**; last update posted **2026-04-24** (NCT05605496 chunk 1).
+
+#### 6.2 Biomarker implementation: hepatocellular carcinoma (HCC) observational cohort
+NCT04766736 (“HCC-Net”) is an observational retrospective study (estimated **N=320**, start **2019-07-01**) aiming to quantify Netrin-1 expression in HCC and matched non-tumor tissues, using immunoblotting and IHC with positivity thresholds. The record frames Netrin-1 as upregulated in chronic liver disease/cirrhosis/HCC and aims to define patient groups most likely to benefit from capturing/targeting Netrin-1 in preclinical models (NCT04766736 chunk 1).
+
+#### 6.3 Human genetic/disease associations (curated)
+OpenTargets disease–target evidence links **NTN1** to developmental disorders including **cleft lip**, **cleft palate**, and **orofacial cleft**, and to **familial congenital mirror movements/mirror movements 4**, consistent with the central role of NTN1 guidance signaling in development (OpenTargets Search: -NTN1).
+
+### 7) Statistics and data highlights from recent studies
+- **Microglia migration:** Netrin-1 increased microglial elongation (p = 0.0001) and transwell migration (p < 0.0001), with mechanistic dependence on GSK3β and evidence for integrin α6/β1 receptor involvement (Jun 2024) (yu2024netrin1isan pages 1-3).
+- **HSPG/NET1 surface distribution:** NET1ΔC surface localization differences under HO-dp10/heparanase conditions were significant (ordinary one-way ANOVA, Tukey correction, ****P < 0.0001), and multiple assays used N=3 technical repeats (Mar 2023) (meier2023thedynamicnature pages 3-4, meier2023thedynamicnature media c5061845).
+- **Human obesity/colon cancer cohort:** Visceral adipose tissue analysis included **74** normal-weight participants and **49** with obesity; VAT NTN1/NEO1 increased with obesity (p < 0.05) and colon cancer (p < 0.001), and DCC/UNC5B were upregulated in colon cancer (Feb 2023) (mentxaka2023increasedexpressionlevels pages 1-2).
+- **Clinical trials (NP137):** enrollment and timelines include **N=70** (NCT02977195), **N=240 est.** (NCT04652076), and **N=57 actual** (NCT05605496) (NCT02977195 chunk 1, NCT04652076 chunk 1, NCT05605496 chunk 1).
+
+### 8) Expert opinions / authoritative synthesis (2024 review perspective)
+A 2024 review emphasized Netrin-1’s evolution from a neurodevelopmental guidance cue to a **multisystem regulator** implicated in **inflammation, tumorigenesis, and neurodegeneration**, noting broad tissue distribution and multi-receptor signaling (DCC/UNC5 as core, with additional receptors proposed in a context-dependent manner) (cai2024insightsfromthe pages 1-2). The review also highlights clinical translational interest in **blocking Netrin-1** and the feasibility of measuring Netrin-1 in biofluids, supporting biomarker and therapeutic strategies (cai2024insightsfromthe pages 6-7).
+
+### 9) Summary for functional annotation (NTN1 / Netrin-1)
+**Primary molecular function (mechanistic):** Netrin-1 is a **secreted extracellular matrix-associated ligand** that provides positional/microenvironmental information and survival/motility regulation through **dependence receptors (DCC/NEO1/UNC5 family)** and, in specific contexts, **integrins** (meier2023thedynamicnature pages 1-2, wu2025theroleof pages 4-6, yu2024netrin1isan pages 1-3).
+
+**Primary biological processes (supported by evidence):**
+- Guidance and migration programs in nervous and immune cells (yu2024netrin1isan pages 1-3, cai2024insightsfromthe pages 1-2).
+- Vascular niche formation and regeneration-associated signaling (focal adhesion/PI3K–AKT/mTOR) (huang2024netrin1–engineeredendothelialcell pages 1-2).
+- Endothelial barrier integrity via UNC5B crosstalk with β-catenin/Lrp5-Dlg1 signaling (furtado2024interplaybetweennetrin1 pages 1-2).
+- Survival signaling in inflammatory macrophages and dormant cancer cells (cynn2023humanmacrophagelong pages 1-3, perampalam2024netrinsignalingmediates pages 1-2).
+
+**Cellular/extracellular location:** Predominantly **secreted/extracellular**, operating in the ECM and at the **cell surface microenvironment** via **HSPG glycan binding** and higher-order assembly, enabling receptor engagement in a spatially controlled manner (meier2023thedynamicnature pages 1-2, meier2023thedynamicnature pages 3-4, meier2023thedynamicnature media c5061845).
+
+---
+
+### Recent 2023–2024 evidence map (key studies)
+| Study | Publication/date + URL/DOI | System/model | Key mechanistic finding (pathway/receptor) | Quantitative/statistical highlights | Relevance to functional annotation |
+|---|---|---|---|---|---|
+| Meier 2023 | *Nature Communications* (Mar 2023) https://doi.org/10.1038/s41467-023-36692-w | Structural/biophysical study of NTN1/NET1ΔC with HEK-293 cells, glypican-3, dependence receptor ectodomains, heparin/heparan-sulfate oligosaccharides | Human Netrin-1 is a secreted laminin-related cue whose major GAG-binding epitope maps to the LE-2 subdomain; HSPGs localize NTN1 near the cell surface, and short heparan-sulfate/heparin fragments abolish the monomer-dimer equilibrium and drive filament/super-assembly formation while preserving dependence-receptor binding (DCC, NEO1, UNC5B) (meier2023thedynamicnature pages 1-2, meier2023thedynamicnature pages 3-4, meier2023thedynamicnature media c5061845) | NET1ΔC bound HSPGs with nM-range affinities; gold-particle density on HEK-293 surfaces differed significantly by ordinary one-way ANOVA with Tukey correction, ****P < 0.0001; multiple assays used N = 3 technical repeats (meier2023thedynamicnature pages 1-2, meier2023thedynamicnature pages 3-4) | Strong evidence that NTN1 functions extracellularly in ECM/glycocalyx context; supports UniProt domain architecture (LN/LE/NTR) and explains how localization on HSPGs can modulate receptor engagement and guidance signaling (meier2023thedynamicnature pages 1-2, meier2023thedynamicnature pages 3-4) |
+| Yu 2024 | *International Journal of Molecular Sciences* (Jun 2024) https://doi.org/10.3390/ijms25137079 | BV2 microglia migration assays, single-cell analysis, MST binding, conditional mouse knockout | Extracellular Netrin-1 promotes microglial migration through integrin α6/β1 rather than classical DCC/UNC5 receptors in this context, with GSK3β activation required downstream; radial-glia-derived Netrin-1 contributes to early cortical microglia colonization (yu2024netrin1isan pages 1-3) | BV2 elongation p = 0.0001; transwell migration p < 0.0001; MST confirmed high-affinity Netrin-1–integrin α6/β1 binding; cortical microglia reduced in conditional knockout at early stages, then normalized by P14 (yu2024netrin1isan pages 1-3) | Demonstrates receptor/context specificity of NTN1 function beyond canonical dependence receptors; annotates NTN1 as a secreted motility-regulating cue in CNS immune cell migration (yu2024netrin1isan pages 1-3) |
+| Furtado 2024 | *PNAS* (Dec 18 2024) https://doi.org/10.1073/pnas.2408674121 | Mouse retinal endothelial cells, scRNA-seq, Ntn1 and Unc5b mutants, β-catenin rescue experiments | Netrin-1/Unc5b signaling establishes arterial-side blood-retina barrier integrity and cooperates additively with Norrin/Lrp5 signaling to enhance β-catenin transcriptional activity and Lrp5 phosphorylation via Dlg1; endothelial Lrp5-Unc5b pathways converge in capillary BRB protection (furtado2024interplaybetweennetrin1 pages 1-2) | scRNA-seq identified >100 BRB genes; Ntn1- or Unc5b-deficient mice showed increased arterial BRB leakage, and β-catenin overactivation rescued downregulated BRB gene expression/integrity phenotypes (furtado2024interplaybetweennetrin1 pages 1-2) | Clarifies a vascular/barrier role for secreted NTN1 acting on UNC5B in endothelium; functionally annotates NTN1 in endothelial barrier maintenance and β-catenin pathway modulation (furtado2024interplaybetweennetrin1 pages 1-2) |
+| Huang 2024 | *Science Advances* (Jun 28 2024) https://doi.org/10.1126/sciadv.adm8454 | Peripheral nerve injury, scRNA-seq, NTN1-high endothelial cells, endothelial exosomes, HUVEC overexpression system | NTN1-high endothelial cells are a vascular-niche component promoting angiogenesis, axon regeneration, and repair phenotypes; NTN1-engineered endothelial exosomes help build a pre-regenerative niche and activate focal adhesion, axon guidance, PI3K-AKT, and mTOR pathways (huang2024netrin1–engineeredendothelialcell pages 1-2) | Multi-omics implicated low let7a-5p cargo in NTN1 EC-EXO; pathway activation included focal adhesion, axon guidance, PI3K-AKT, and mTOR signaling (huang2024netrin1–engineeredendothelialcell pages 1-2) | Supports annotation of NTN1 as a secreted microenvironmental organizer acting outside cells in nerve repair, vascular niche formation, and angiogenesis-linked regenerative signaling (huang2024netrin1–engineeredendothelialcell pages 1-2) |
+| Pearson 2024 | *Cancer Research Communications* (Sep 2024) https://doi.org/10.1158/2767-9764.CRC-24-0101 | YAPoff cancers (including retinoblastoma/SCLC contexts), CRISPR screens, knockout and peptide/decoy receptor assays | Netrin-1 and UNC5B cooperate with integrin-αV/β5 to mediate YAP-driven cytostasis, revealing a tumor-suppressive NTN1/UNC5B/integrin axis in YAPoff cancers rather than a purely pro-tumor role (pearson2024netrin1andunc5b pages 1-2) | Mechanism built from CRISPR screening and functional knockout/blocking assays; no explicit cohort N reported in provided context (pearson2024netrin1andunc5b pages 1-2) | Important for functional annotation because NTN1 signaling is bidirectional/context-dependent: same ligand can support survival in some settings yet mediate cytostasis with UNC5B/integrin signaling in others (pearson2024netrin1andunc5b pages 1-2) |
+| Perampalam 2024 | *eLife* (Version of record Jul 18 2024) https://doi.org/10.7554/eLife.91766.3 | Dormant high-grade serous ovarian cancer spheroids, CRISPR screens, RNA-seq, xenograft dissemination assays | Netrin signaling is a survival dependency in dormant ovarian cancer cells; Netrin-1/-3 and UNC5 receptors maintain low-level ERK signaling sufficient for survival without inducing proliferation, and UNC5-family deletion blocks signaling and compromises viability during dissemination (perampalam2024netrinsignalingmediates pages 1-2) | Study used a novel CRISPR screening approach plus RNA-seq; overexpression of Netrin-1/-3 correlated with poor outcome; xenograft assays showed increased dissemination when Netrin signaling was active (perampalam2024netrinsignalingmediates pages 1-2) | Refines annotation of NTN1 as a survival ligand acting through dependence receptors and low-level ERK signaling, especially in metastatic dormancy contexts (perampalam2024netrinsignalingmediates pages 1-2) |
+| Mentxaka 2023 | *Cancers* (Feb 7 2023) https://doi.org/10.3390/cancers15041038 | Human visceral adipose tissue from 74 NW and 49 obese patients, colon cancer subsets; colorectal cell lines; rat caloric restriction model | NTN1 is upregulated in obese and colon-cancer-associated visceral adipose tissue and promotes a pro-migratory microenvironment for colorectal cancer cells; implicated receptors include NEO1, DCC, and UNC5B (mentxaka2023increasedexpressionlevels pages 1-2) | Human cohort: 74 total NW-group participants and 49 with obesity; VAT NTN1 and NEO1 increased with obesity (p < 0.05) and colon cancer (p < 0.001); DCC increased (p < 0.01), UNC5B increased (p < 0.05); caloric restriction decreased colonic Ntn1 (p < 0.01); ACM/NTN-1 altered receptor mRNAs and increased migration (mentxaka2023increasedexpressionlevels pages 1-2) | Demonstrates extracellular/adipose-source NTN1 as an inflammation- and migration-linked cue in obesity/cancer crosstalk; useful for annotating tissue-context expression and receptor-associated migratory effects (mentxaka2023increasedexpressionlevels pages 1-2) |
+| Cynn 2023 | *Arteriosclerosis, Thrombosis, and Vascular Biology* (Feb 2023) https://doi.org/10.1161/ATVBAHA.122.318353 | Human monocyte-derived macrophages, THP1 macrophages, promoter/reporter assays, human carotid plaque RNAscope | NTN1 acts as a macrophage survival factor in inflammatory macrophages; the lncRNA SIMALR promotes NTN1 transcription, likely with HIF1α, and recombinant NTN1 rescues apoptosis caused by SIMALR knockdown (cynn2023humanmacrophagelong pages 1-3) | SIMALR knockdown increased cleaved PARP, caspase-9, caspase-3, and Annexin V+ cells; NTN1 knockdown phenocopied apoptosis, and recombinant NTN1 rescued the effect; SIMALR detected in macrophages in symptomatic human carotid plaques (cynn2023humanmacrophagelong pages 1-3) | Strong evidence for NTN1 function in inflammatory-cell survival and atherosclerosis-related macrophage biology; annotates NTN1 as an extracellular survival cue regulated transcriptionally in human disease cells (cynn2023humanmacrophagelong pages 1-3) |
+
+
+*Table: This table summarizes recent 2023–2024 mechanistic studies on human NTN1/Netrin-1 relevant to functional annotation, including receptor usage, pathways, extracellular localization, and disease-related functions. It highlights quantitative findings where available and links each study to specific annotation-relevant roles.*
+
+### Translational/clinical landscape (trials + curated genetic links)
+| Program/type | Condition/indication | Trial ID or OpenTargets disease ID | Phase/design | Enrollment (N) | Key dates (start/completion/last update) | Key rationale/endpoint | URL |
+|---|---|---|---|---:|---|---|---|
+| NP137 anti-Netrin-1 mAb | Advanced/metastatic solid tumors; expansion including HR+ endometrial carcinoma | NCT02977195 | Phase I; open-label, single-group, dose-escalation + expansion | 70 | Start: 2017-01-09; Primary completion: 2021-12; Completion: 2022-06; Last update posted: 2022-07-25 | First-in-human test of a humanized anti-Netrin-1 mAb based on the dependence-receptor paradigm; primary goals included DLT/MTD-RP2D, PK/PD, and 3-month ORR; biomarker cohorts used tumor biopsies and RNA-seq EMT profiling (NCT02977195 chunk 1) | https://clinicaltrials.gov/study/NCT02977195 |
+| NP137 anti-Netrin-1 mAb | Advanced/metastatic endometrial carcinoma or cervix carcinoma after prior systemic therapy | NCT04652076 | Phase I/II; randomized, multicenter, open-label, parallel arms | 240 (estimated) | Start: 2020-12-14; Primary completion: 2025-10-30 (est.); Completion: 2026-07-30 (est.); Last update posted: 2024-10-08 | Tests NP137 with carboplatin/paclitaxel and/or pembrolizumab; rationale is restoration of apoptosis by blocking Netrin-1; endpoints include safety run-in DLTs and ORR, with PFS/OS and PK as secondary outcomes (NCT04652076 chunk 1) | https://clinicaltrials.gov/study/NCT04652076 |
+| NP137 anti-Netrin-1 mAb add-on immunotherapy | Advanced/metastatic solid tumors on standard anti-PD-1/PD-L1 therapy (stable disease, primary refractory, secondary refractory cohorts) | NCT05605496 | Phase II; multicenter, open-label, proof-of-concept, non-randomized parallel cohorts | 57 | Start: 2023-01-06; Primary completion: 2027-01-01 (est.); Completion: 2027-01-01 (est.); Last update posted: 2026-04-24 | Evaluates NP137 (14 mg/kg IV Q3W) added to PD-1/PD-L1 blockade; endpoints include ORR-12W or PFR-12W, safety, EMT-score changes on biopsies, and tumor microenvironment modulation (NCT05605496 chunk 1) | https://clinicaltrials.gov/study/NCT05605496 |
+| Biomarker observational study | Hepatocellular carcinoma (HCC) | NCT04766736 | Observational, retrospective cohort | 320 (estimated) | Start: 2019-07-01; Primary completion: 2021-06-30 (est.); Completion: 2022-12-31 (est.) | Characterizes Netrin-1 expression/signaling in HCC and adjacent tissues; rationale is that Netrin-1 is upregulated in chronic liver disease/cirrhosis/HCC; assays include immunoblotting and IHC to define positivity thresholds and stratify patients for potential Netrin-1 capture strategies (NCT04766736 chunk 1) | https://clinicaltrials.gov/study/NCT04766736 |
+| Genetic association | Cleft lip | EFO_0003959 | OpenTargets disease-target association | — | OpenTargets query context retrieved in current session | Curated association of NTN1 with cleft lip; evidence count 5; association score 0.5286, relevant to developmental/craniofacial biology rather than therapeutic intervention (OpenTargets Search: -NTN1) | https://platform.opentargets.org/target/ENSG00000065320/associations |
+| Genetic association | Orofacial cleft | MONDO_0000358 | OpenTargets disease-target association | — | OpenTargets query context retrieved in current session | Curated association of NTN1 with orofacial cleft; evidence count 5; association score 0.5727 (OpenTargets Search: -NTN1) | https://platform.opentargets.org/target/ENSG00000065320/associations |
+| Genetic association | Cleft palate | MONDO_0016064 | OpenTargets disease-target association | — | OpenTargets query context retrieved in current session | Curated association of NTN1 with cleft palate; evidence count 5; association score 0.5321 (OpenTargets Search: -NTN1) | https://platform.opentargets.org/target/ENSG00000065320/associations |
+| Genetic association | Familial congenital mirror movements | MONDO_0016558 | OpenTargets disease-target association | — | OpenTargets query context retrieved in current session | Curated NTN1 association with familial congenital mirror movements; evidence count 5; association score 0.6853; DCC is also associated in the same disease, consistent with NTN1-DCC pathway involvement (OpenTargets Search: -NTN1) | https://platform.opentargets.org/target/ENSG00000065320/associations |
+| Genetic association | Mirror movements 4 | MONDO_0032641 | OpenTargets disease-target association | — | OpenTargets query context retrieved in current session | Curated NTN1 association with mirror movements 4; evidence count 5; association score 0.6611 (OpenTargets Search: -NTN1) | https://platform.opentargets.org/target/ENSG00000065320/associations |
+
+
+*Table: This table summarizes the main translational programs and disease associations for human NTN1/Netrin-1, including anti-Netrin-1 antibody trials, an HCC biomarker study, and curated OpenTargets genetic associations. It is useful for linking functional biology to current clinical development and human disease relevance.*
+
+References
+
+1. (wu2025theroleof pages 4-6): Yi Wu, Zhiying Liu, Peiqi Xu, Kai Yin, and Shengjun Wang. The role of macrophage-derived netrin-1 in inflammatory diseases. Biomolecules, 15:921, Jun 2025. URL: https://doi.org/10.3390/biom15070921, doi:10.3390/biom15070921. This article has 5 citations.
+
+2. (cai2024insightsfromthe pages 2-3): Minqi Cai, Qian Zheng, Yiqiang Chen, Siyuan Liu, Huimin Zhu, and Bing Bai. Insights from the neural guidance factor netrin-1 into neurodegeneration and other diseases. Frontiers in Molecular Neuroscience, Apr 2024. URL: https://doi.org/10.3389/fnmol.2024.1379726, doi:10.3389/fnmol.2024.1379726. This article has 16 citations.
+
+3. (gao2025pancanceranalysisreveals pages 1-3): Ying Gao, Yuchen Hu, Yuyan Zhu, Xiaoli Gao, Wenjun Hao, Xi Chen, and Zhendong Zheng. Pan-cancer analysis reveals netrin-1 receptors as potential tumor biomarkers and immune-related therapeutic targets. Scientific Reports, Dec 2025. URL: https://doi.org/10.1038/s41598-025-28437-0, doi:10.1038/s41598-025-28437-0. This article has 2 citations and is from a peer-reviewed journal.
+
+4. (meier2023thedynamicnature pages 1-2): Markus Meier, Monika Gupta, Serife Akgül, Matthew McDougall, Thomas Imhof, Denise Nikodemus, Raphael Reuten, Aniel Moya-Torres, Vu To, Fraser Ferens, Fabian Heide, Gay Pauline Padilla-Meier, Philipp Kukura, Wenming Huang, Birgit Gerisch, Matthias Mörgelin, Kate Poole, Adam Antebi, Manuel Koch, and Jörg Stetefeld. The dynamic nature of netrin-1 and the structural basis for glycosaminoglycan fragment-induced filament formation. Nature Communications, Mar 2023. URL: https://doi.org/10.1038/s41467-023-36692-w, doi:10.1038/s41467-023-36692-w. This article has 21 citations and is from a highest quality peer-reviewed journal.
+
+5. (cai2024insightsfromthe pages 1-2): Minqi Cai, Qian Zheng, Yiqiang Chen, Siyuan Liu, Huimin Zhu, and Bing Bai. Insights from the neural guidance factor netrin-1 into neurodegeneration and other diseases. Frontiers in Molecular Neuroscience, Apr 2024. URL: https://doi.org/10.3389/fnmol.2024.1379726, doi:10.3389/fnmol.2024.1379726. This article has 16 citations.
+
+6. (NCT02977195 chunk 1):  First in Human Evaluation of Safety, Pharmacokinetics, and Clinical Activity of a Monoclonal Antibody Targeting Netrin 1 in Patients With Advanced/Metastatic Solid Tumors. Centre Leon Berard. 2017. ClinicalTrials.gov Identifier: NCT02977195
+
+7. (yu2024netrin1isan pages 1-3): Hua-Li Yu, Xiu Liu, Yue Yin, Xiao-Nuo Liu, Yu-Yao Feng, Muhammad Mateen Tahir, Xin-Zhi Miao, Xiao-Xiao He, Zi-Xuan He, and Xiao-Juan Zhu. Netrin-1 is an important mediator in microglia migration. International Journal of Molecular Sciences, 25:7079, Jun 2024. URL: https://doi.org/10.3390/ijms25137079, doi:10.3390/ijms25137079. This article has 2 citations.
+
+8. (meier2023thedynamicnature pages 3-4): Markus Meier, Monika Gupta, Serife Akgül, Matthew McDougall, Thomas Imhof, Denise Nikodemus, Raphael Reuten, Aniel Moya-Torres, Vu To, Fraser Ferens, Fabian Heide, Gay Pauline Padilla-Meier, Philipp Kukura, Wenming Huang, Birgit Gerisch, Matthias Mörgelin, Kate Poole, Adam Antebi, Manuel Koch, and Jörg Stetefeld. The dynamic nature of netrin-1 and the structural basis for glycosaminoglycan fragment-induced filament formation. Nature Communications, Mar 2023. URL: https://doi.org/10.1038/s41467-023-36692-w, doi:10.1038/s41467-023-36692-w. This article has 21 citations and is from a highest quality peer-reviewed journal.
+
+9. (meier2023thedynamicnature media c5061845): Markus Meier, Monika Gupta, Serife Akgül, Matthew McDougall, Thomas Imhof, Denise Nikodemus, Raphael Reuten, Aniel Moya-Torres, Vu To, Fraser Ferens, Fabian Heide, Gay Pauline Padilla-Meier, Philipp Kukura, Wenming Huang, Birgit Gerisch, Matthias Mörgelin, Kate Poole, Adam Antebi, Manuel Koch, and Jörg Stetefeld. The dynamic nature of netrin-1 and the structural basis for glycosaminoglycan fragment-induced filament formation. Nature Communications, Mar 2023. URL: https://doi.org/10.1038/s41467-023-36692-w, doi:10.1038/s41467-023-36692-w. This article has 21 citations and is from a highest quality peer-reviewed journal.
+
+10. (huang2024netrin1–engineeredendothelialcell pages 1-2): Jinsheng Huang, Jiangnan Li, Senrui Li, Xiaoqi Yang, Nianci Huo, Qiang Chen, Wengang Wang, Ningning Yang, Yuanyi Wang, and Nan Zhou. Netrin-1–engineered endothelial cell exosomes induce the formation of pre-regenerative niche to accelerate peripheral nerve repair. Science Advances, Jun 2024. URL: https://doi.org/10.1126/sciadv.adm8454, doi:10.1126/sciadv.adm8454. This article has 46 citations and is from a highest quality peer-reviewed journal.
+
+11. (furtado2024interplaybetweennetrin1 pages 1-2): Jessica Furtado, Luiz Henrique Geraldo, Felipe Saceanu Leser, Bartlomiej Bartkowiak, Mathilde Poulet, Hyojin Park, Mark Robinson, Laurence Pibouin-Fragner, Anne Eichmann, and Kevin Boyé. Interplay between netrin-1 and norrin controls arteriovenous zonation of blood–retina barrier integrity. Proceedings of the National Academy of Sciences of the United States of America, Dec 2024. URL: https://doi.org/10.1073/pnas.2408674121, doi:10.1073/pnas.2408674121. This article has 7 citations and is from a highest quality peer-reviewed journal.
+
+12. (cynn2023humanmacrophagelong pages 1-3): Esther Cynn, Daniel Y. Li, Marcella E. O’Reilly, Ying Wang, Alexander C. Bashore, Anjali Jha, Andrea S. Foulkes, Hanrui Zhang, Hanna Winter, Lars Maegdefessel, Hanying Yan, Mingyao Li, Leila Ross, Chenyi Xue, and Muredach P. Reilly. Human macrophage long intergenic noncoding rna, <i>simalr</i> , suppresses inflammatory macrophage apoptosis via ntn1 (netrin-1). Arteriosclerosis, Thrombosis, and Vascular Biology, 43:286-299, Feb 2023. URL: https://doi.org/10.1161/atvbaha.122.318353, doi:10.1161/atvbaha.122.318353. This article has 23 citations and is from a domain leading peer-reviewed journal.
+
+13. (perampalam2024netrinsignalingmediates pages 1-2): Pirunthan Perampalam, James I MacDonald, Komila Zakirova, Daniel T Passos, Sumaiyah Wasif, Yudith Ramos-Valdes, Maeva Hervieu, Patrick Mehlen, Rob Rottapel, Benjamin Gibert, Rohann JM Correa, Trevor G Shepherd, and Frederick A Dick. Netrin signaling mediates survival of dormant epithelial ovarian cancer cells. eLife, Jul 2024. URL: https://doi.org/10.7554/elife.91766.3, doi:10.7554/elife.91766.3. This article has 11 citations and is from a domain leading peer-reviewed journal.
+
+14. (pearson2024netrin1andunc5b pages 1-2): Joel D. Pearson, Katherine Huang, Louis G. Dela Pena, Benjamin Ducarouge, Patrick Mehlen, and Rod Bremner. Netrin-1 and unc5b cooperate with integrins to mediate yap-driven cytostasis. Cancer Research Communications, 4:2374-2383, Sep 2024. URL: https://doi.org/10.1158/2767-9764.crc-24-0101, doi:10.1158/2767-9764.crc-24-0101. This article has 2 citations and is from a peer-reviewed journal.
+
+15. (mentxaka2023increasedexpressionlevels pages 1-2): Amaia Mentxaka, Javier Gómez-Ambrosi, Gabriela Neira, Beatriz Ramírez, Sara Becerril, Amaia Rodríguez, Víctor Valentí, Rafael Moncada, Jorge Baixauli, María A. Burrell, Camilo Silva, Vasco Claro, Albert Ferro, Victoria Catalán, and Gema Frühbeck. Increased expression levels of netrin-1 in visceral adipose tissue during obesity favour colon cancer cell migration. Cancers, 15:1038, Feb 2023. URL: https://doi.org/10.3390/cancers15041038, doi:10.3390/cancers15041038. This article has 7 citations.
+
+16. (NCT04652076 chunk 1):  GYNecological Cancers Treated with NETrin MAbs in Combination with Chemotherapy and /or Pembrolizumab. NETRIS Pharma. 2020. ClinicalTrials.gov Identifier: NCT04652076
+
+17. (NCT05605496 chunk 1):  NP137 Clinical and Biological Activities Assessment in Patients With Advanced/Metastatic Solid Tumors Treated by Standard Anti PD-1/PD-L1 Immunotherapies. Centre Leon Berard. 2023. ClinicalTrials.gov Identifier: NCT05605496
+
+18. (NCT04766736 chunk 1):  Netrin-1 & Hepatocellular Carcinoma HCC. Hospices Civils de Lyon. 2019. ClinicalTrials.gov Identifier: NCT04766736
+
+19. (OpenTargets Search: -NTN1): Open Targets Query (-NTN1, 6 results). Buniello, A. et al. (2025). Open Targets Platform: facilitating therapeutic hypotheses building in drug discovery. Nucleic Acids Research.
+
+20. (cai2024insightsfromthe pages 6-7): Minqi Cai, Qian Zheng, Yiqiang Chen, Siyuan Liu, Huimin Zhu, and Bing Bai. Insights from the neural guidance factor netrin-1 into neurodegeneration and other diseases. Frontiers in Molecular Neuroscience, Apr 2024. URL: https://doi.org/10.3389/fnmol.2024.1379726, doi:10.3389/fnmol.2024.1379726. This article has 16 citations.
+
+## Citations
+
+1. meier2023thedynamicnature pages 1-2
+2. meier2023thedynamicnature pages 3-4
+3. cynn2023humanmacrophagelong pages 1-3
+4. perampalam2024netrinsignalingmediates pages 1-2
+5. mentxaka2023increasedexpressionlevels pages 1-2
+6. cai2024insightsfromthe pages 1-2
+7. cai2024insightsfromthe pages 6-7
+8. wu2025theroleof pages 4-6
+9. cai2024insightsfromthe pages 2-3
+10. gao2025pancanceranalysisreveals pages 1-3
+11. https://doi.org/10.1038/s41467-023-36692-w
+12. https://doi.org/10.3390/ijms25137079
+13. https://doi.org/10.1073/pnas.2408674121
+14. https://doi.org/10.1126/sciadv.adm8454
+15. https://doi.org/10.1158/2767-9764.CRC-24-0101
+16. https://doi.org/10.7554/eLife.91766.3
+17. https://doi.org/10.3390/cancers15041038
+18. https://doi.org/10.1161/ATVBAHA.122.318353
+19. https://clinicaltrials.gov/study/NCT02977195
+20. https://clinicaltrials.gov/study/NCT04652076
+21. https://clinicaltrials.gov/study/NCT05605496
+22. https://clinicaltrials.gov/study/NCT04766736
+23. https://platform.opentargets.org/target/ENSG00000065320/associations
+24. https://doi.org/10.3390/biom15070921,
+25. https://doi.org/10.3389/fnmol.2024.1379726,
+26. https://doi.org/10.1038/s41598-025-28437-0,
+27. https://doi.org/10.1038/s41467-023-36692-w,
+28. https://doi.org/10.3390/ijms25137079,
+29. https://doi.org/10.1126/sciadv.adm8454,
+30. https://doi.org/10.1073/pnas.2408674121,
+31. https://doi.org/10.1161/atvbaha.122.318353,
+32. https://doi.org/10.7554/elife.91766.3,
+33. https://doi.org/10.1158/2767-9764.crc-24-0101,
+34. https://doi.org/10.3390/cancers15041038,

--- a/genes/human/NTN3/NTN3-ai-review.html
+++ b/genes/human/NTN3/NTN3-ai-review.html
@@ -1145,10 +1145,10 @@
                         
                     </td>
                     <td>
-                        <span class="action-badge action-modify">
-                            MODIFY
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="O00634" data-a="GO:0005515" data-r="PMID:26190107" data-act="MODIFY">
+                        <span class="vote-buttons" data-g="O00634" data-a="GO:0005515" data-r="PMID:26190107" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1156,25 +1156,14 @@
                     <td>
                         
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> This annotation is supported by experimental evidence from PMID:26190107 showing NTN3 interacts with DRAXIN. However, &#34;protein binding&#34; is uninformative. A more specific term such as netrin receptor binding (GO:1990890) or signaling receptor binding would be more appropriate for the functional role of netrins.
+                            <strong>Summary:</strong> This annotation is supported by experimental evidence from PMID:26190107 showing NTN3 interacts with DRAXIN. However, &#34;protein binding&#34; is uninformative and the interaction is with a secreted netrin antagonist rather than a netrin receptor.
                         </div>
                         
                         
                         <div>
-                            <strong>Reason:</strong> While the experimental evidence (IPI from PMID:26190107) demonstrates protein-protein interaction between NTN3 and DRAXIN, the term &#34;protein binding&#34; is too general and uninformative. NTN3 functions by binding to netrin receptors (DCC, UNC5 family). A more specific molecular function term should be used.
+                            <strong>Reason:</strong> While the experimental evidence (IPI from PMID:26190107) demonstrates protein-protein interaction between NTN3 and DRAXIN, the term &#34;protein binding&#34; is too general and uninformative. DRAXIN is a secreted antagonist that competes with DCC/UNC5 family receptors for netrin binding, not itself a netrin receptor, so GO:1990890 netrin receptor binding is not an appropriate replacement term for this interaction.
                         </div>
                         
-                        
-                        <div style="margin-top: 0.5rem;">
-                            <strong>Proposed replacements:</strong>
-                            
-                            <span class="badge">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1990890" target="_blank" class="term-link">
-                                    netrin receptor binding
-                                </a>
-                            </span>
-                            
-                        </div>
                         
                         
                         <div class="supported-by">
@@ -1204,17 +1193,6 @@
                                 
                             </div>
                             
-                            <div class="support-item">
-                                <span class="support-ref">
-
-                                    file:human/NTN3/NTN3-deep-research-falcon.md
-
-                                </span>
-
-                                <div class="support-text">NTN3/Netrin-3 is summarized as a secreted extracellular ligand that binds UNC5-family receptors, neogenin, and DCC-family receptors.</div>
-
-                            </div>
-
                         </div>
                         
                     </td>
@@ -1282,6 +1260,77 @@
                                 
                             </div>
                             
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/NTN3/NTN3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">NTN3/Netrin-3 is summarized as a secreted extracellular ligand that binds UNC5-family receptors, neogenin, and DCC-family receptors.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1990890" target="_blank" class="term-link">
+                                    GO:1990890
+                                </a>
+                            </span>
+                            <span class="term-label">netrin receptor binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="O00634" data-a="GO:1990890" data-r="" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Add the more specific molecular-function term for NTN3&#39;s receptor-ligand activity. The Falcon report summarizes direct binding evidence for NTN3/Netrin-3 with canonical netrin receptors, including UNC5-family receptors, neogenin, and DCC-family receptors, with comparatively strong binding to UNC5B and UNC5C in available datasets.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Existing GO:0005102 signaling receptor binding is directionally correct but too broad for a netrin ligand. GO:1990890 captures the core receptor-binding molecular function without misusing the term for the separate DRAXIN antagonist interaction.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/NTN3/NTN3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Binding data summarized in the report support NTN3 as a netrin receptor ligand, with comparatively strong binding to UNC5B and UNC5C in available datasets.</div>
+
+                            </div>
+
                         </div>
                         
                     </td>
@@ -2399,25 +2448,20 @@ existing_annotations:
   review:
     summary: &gt;-
       This annotation is supported by experimental evidence from PMID:26190107 showing NTN3
-      interacts with DRAXIN. However, &#34;protein binding&#34; is uninformative. A more specific term
-      such as netrin receptor binding (GO:1990890) or signaling receptor binding would be more
-      appropriate for the functional role of netrins.
-    action: MODIFY
+      interacts with DRAXIN. However, &#34;protein binding&#34; is uninformative and the interaction
+      is with a secreted netrin antagonist rather than a netrin receptor.
+    action: MARK_AS_OVER_ANNOTATED
     reason: &gt;-
       While the experimental evidence (IPI from PMID:26190107) demonstrates protein-protein
       interaction between NTN3 and DRAXIN, the term &#34;protein binding&#34; is too general and
-      uninformative. NTN3 functions by binding to netrin receptors (DCC, UNC5 family).
-      A more specific molecular function term should be used.
-    proposed_replacement_terms:
-      - id: GO:1990890
-        label: netrin receptor binding
+      uninformative. DRAXIN is a secreted antagonist that competes with DCC/UNC5 family
+      receptors for netrin binding, not itself a netrin receptor, so GO:1990890 netrin
+      receptor binding is not an appropriate replacement term for this interaction.
     supported_by:
       - reference_id: PMID:26190107
         supporting_text: &#34;The assembled floor-plate network contains 47 interactions including the hitherto-not-reported interaction between Netrin-1 and Draxin.&#34;
       - reference_id: UniProt:O00634
         supporting_text: &#34;O00634; Q8NBI3: DRAXIN; NbExp=2; IntAct=EBI-10831998, EBI-10827752&#34;
-      - reference_id: file:human/NTN3/NTN3-deep-research-falcon.md
-        supporting_text: &#34;NTN3/Netrin-3 is summarized as a secreted extracellular ligand that binds UNC5-family receptors, neogenin, and DCC-family receptors.&#34;
 
 - term:
     id: GO:0005102
@@ -2441,6 +2485,29 @@ existing_annotations:
     supported_by:
       - reference_id: UniProt:O00634
         supporting_text: &#34;-!- FUNCTION: Netrins control guidance of CNS commissural axons and peripheral motor axons.&#34;
+      - reference_id: file:human/NTN3/NTN3-deep-research-falcon.md
+        supporting_text: &#34;NTN3/Netrin-3 is summarized as a secreted extracellular ligand that binds UNC5-family receptors, neogenin, and DCC-family receptors.&#34;
+
+- term:
+    id: GO:1990890
+    label: netrin receptor binding
+  evidence_type: NAS
+  review:
+    summary: &gt;-
+      Add the more specific molecular-function term for NTN3&#39;s receptor-ligand
+      activity. The Falcon report summarizes direct binding evidence for NTN3/Netrin-3
+      with canonical netrin receptors, including UNC5-family receptors, neogenin,
+      and DCC-family receptors, with comparatively strong binding to UNC5B and
+      UNC5C in available datasets.
+    action: NEW
+    reason: &gt;-
+      Existing GO:0005102 signaling receptor binding is directionally correct
+      but too broad for a netrin ligand. GO:1990890 captures the core receptor-binding
+      molecular function without misusing the term for the separate DRAXIN antagonist
+      interaction.
+    supported_by:
+      - reference_id: file:human/NTN3/NTN3-deep-research-falcon.md
+        supporting_text: &#34;Binding data summarized in the report support NTN3 as a netrin receptor ligand, with comparatively strong binding to UNC5B and UNC5C in available datasets.&#34;
 
 - term:
     id: GO:0005576

--- a/genes/human/NTN3/NTN3-ai-review.html
+++ b/genes/human/NTN3/NTN3-ai-review.html
@@ -1204,6 +1204,17 @@
                                 
                             </div>
                             
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/NTN3/NTN3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">NTN3/Netrin-3 is summarized as a secreted extracellular ligand that binds UNC5-family receptors, neogenin, and DCC-family receptors.</div>
+
+                            </div>
+
                         </div>
                         
                     </td>
@@ -1526,8 +1537,8 @@
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
-                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005102" target="_blank" class="term-link">
-                            signaling receptor binding
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1990890" target="_blank" class="term-link">
+                            netrin receptor binding
                         </a>
                     </span>
                 </div>
@@ -1569,6 +1580,37 @@
             </div>
 
             
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9143507" target="_blank" class="term-link">
+                                PMID:9143507
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">The netrins define a family of chemotropic factors that have been shown to play a central role in axon guidance.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/NTN3/NTN3-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">NTN3/Netrin-3 is summarized as a secreted extracellular ligand that binds UNC5-family receptors, neogenin, and DCC-family receptors to modulate cellular navigation and survival programs.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
         </div>
         
     </div>
@@ -1771,6 +1813,34 @@
                 
             </div>
             
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/NTN3/NTN3-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research report for human NTN3</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">NTN3 encodes secreted Netrin-3, a laminin-like extracellular guidance cue that binds canonical netrin receptors including DCC, NEO1, and UNC5-family receptors.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Binding data summarized in the report support NTN3 as a netrin receptor ligand, with comparatively strong binding to UNC5B and UNC5C in available datasets.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
         </div>
     </div>
     
@@ -1855,6 +1925,357 @@
 
     <!-- Additional Documentation Sections -->
     
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Deep Research Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(NTN3-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="O00634" data-a="DOC: Deep Research Falcon" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <hr />
+<p>provider: falcon<br />
+model: Edison Scientific Literature<br />
+cached: false<br />
+start_time: '2026-05-10T22:02:42.248105'<br />
+end_time: '2026-05-10T22:16:46.109318'<br />
+duration_seconds: 843.86<br />
+template_file: templates/gene_research_go_focused.md<br />
+template_variables:<br />
+  organism: human<br />
+  gene_id: NTN3<br />
+  gene_symbol: NTN3<br />
+  uniprot_accession: O00634<br />
+  protein_description: 'RecName: Full=Netrin-3; AltName: Full=Netrin-2-like protein;<br />
+    Flags: Precursor;'<br />
+  gene_info: Name=NTN3; Synonyms=NTN2L;<br />
+  organism_full: Homo sapiens (Human).<br />
+  protein_family: Not specified in UniProt<br />
+  protein_domains: Laminin/Netrin_ECM. (IPR050440); Laminin_N. (IPR008211); LE_dom.<br />
+    (IPR002049); LMN_ATRN_NET-like_EGF. (IPR056863); Netrin_domain. (IPR001134)<br />
+provider_config:<br />
+  timeout: 600<br />
+  max_retries: 3<br />
+  parameters:<br />
+    allowed_domains: []<br />
+    temperature: 0.1<br />
+citation_count: 19</p>
+<hr />
+<h2 id="question">Question</h2>
+<h1 id="gene-research-for-functional-annotation">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> O00634</li>
+<li><strong>Protein Description:</strong> RecName: Full=Netrin-3; AltName: Full=Netrin-2-like protein; Flags: Precursor;</li>
+<li><strong>Gene Information:</strong> Name=NTN3; Synonyms=NTN2L;</li>
+<li><strong>Organism (full):</strong> Homo sapiens (Human).</li>
+<li><strong>Protein Family:</strong> Not specified in UniProt</li>
+<li><strong>Key Domains:</strong> Laminin/Netrin_ECM. (IPR050440); Laminin_N. (IPR008211); LE_dom. (IPR002049); LMN_ATRN_NET-like_EGF. (IPR056863); Netrin_domain. (IPR001134)</li>
+</ul>
+<h3 id="mandatory-verification-steps">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "NTN3" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Homo sapiens (Human).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'NTN3' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>NTN3</strong> (gene ID: NTN3, UniProt: O00634) in human.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="output">Output</h2>
+<p>Question: You are an expert researcher providing comprehensive, well-cited information.</p>
+<p>Provide detailed information focusing on:<br />
+1. Key concepts and definitions with current understanding<br />
+2. Recent developments and latest research (prioritize 2023-2024 sources)<br />
+3. Current applications and real-world implementations<br />
+4. Expert opinions and analysis from authoritative sources<br />
+5. Relevant statistics and data from recent studies</p>
+<p>Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.<br />
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.</p>
+<h1 id="gene-research-for-functional-annotation_1">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context_1">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot_1">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> O00634</li>
+<li><strong>Protein Description:</strong> RecName: Full=Netrin-3; AltName: Full=Netrin-2-like protein; Flags: Precursor;</li>
+<li><strong>Gene Information:</strong> Name=NTN3; Synonyms=NTN2L;</li>
+<li><strong>Organism (full):</strong> Homo sapiens (Human).</li>
+<li><strong>Protein Family:</strong> Not specified in UniProt</li>
+<li><strong>Key Domains:</strong> Laminin/Netrin_ECM. (IPR050440); Laminin_N. (IPR008211); LE_dom. (IPR002049); LMN_ATRN_NET-like_EGF. (IPR056863); Netrin_domain. (IPR001134)</li>
+</ul>
+<h3 id="mandatory-verification-steps_1">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "NTN3" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Homo sapiens (Human).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature_1">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'NTN3' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target_1">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>NTN3</strong> (gene ID: NTN3, UniProt: O00634) in human.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="comprehensive-research-report-human-ntn3-uniprot-o00634-netrin-3">Comprehensive research report: Human <strong>NTN3</strong> (UniProt <strong>O00634</strong>) / <strong>Netrin-3</strong></h2>
+<h3 id="1-geneprotein-identity-verification-mandatory">1) Gene/protein identity verification (mandatory)</h3>
+<p>Human <strong>NTN3</strong> encodes <strong>Netrin-3</strong>, a secreted laminin-like guidance cue historically referred to as <strong>NTN2L (netrin-2-like)</strong>, consistent with UniProt O00634’s naming and “precursor” (secreted) status. A foundational cloning/characterization study identified mouse <strong>netrin-3 (Ntn3)</strong> as the ortholog of human <strong>NTN2L/NTN3</strong>, with high sequence identity and the canonical netrin domain structure (domains VI, V subdomains, and C). This cross-species mapping and conserved receptor binding support that the literature summarized here corresponds to the correct human target (NTN3/O00634). (wang1999netrin3amouse pages 1-2, wang1999netrin3amouse pages 4-5)</p>
+<h3 id="2-key-concepts-and-definitions-current-understanding">2) Key concepts and definitions (current understanding)</h3>
+<h4 id="21-netrin-3-as-a-laminin-like-extracellular-guidance-cue">2.1 Netrin-3 as a laminin-like extracellular guidance cue</h4>
+<p>Netrins are secreted or membrane-associated proteins that regulate axon guidance and broader tissue morphogenesis by engaging specific cell-surface receptors. Netrin-3 (NTN3) is one of the <strong>secreted netrins</strong> in mammals, and is commonly considered part of a receptor–ligand system that can influence <strong>cell migration, survival, and differentiation</strong> depending on receptor context. (gao2024researchprogressof pages 2-5)</p>
+<h4 id="22-dependence-receptor-logic-in-netrin-systems">2.2 “Dependence receptor” logic in netrin systems</h4>
+<p>A recent cancer-focused review emphasizes that several netrin receptors (including <strong>DCC, UNC5 family, and NEO1</strong>) function as <strong>dependence receptors</strong>, meaning signaling outcomes differ depending on whether ligand is present; ligand binding supports survival/migration/differentiation, while ligand absence can allow pro-apoptotic signaling. This conceptual framework is often used to interpret netrin pathway roles in tumor biology. (gao2024researchprogressof pages 2-5)</p>
+<h3 id="3-proteindomain-architecture-and-localization">3) Protein/domain architecture and localization</h3>
+<h4 id="31-domain-architecture">3.1 Domain architecture</h4>
+<p>Netrin-3 has the canonical netrin architecture (domains <strong>VI, V, C</strong>) defined by homology to other netrins. This was explicitly documented in the original cloning and protein characterization of murine netrin-3 orthologous to human NTN3/NTN2L. (wang1999netrin3amouse pages 1-2, wang1999netrin3amouse pages 4-5)</p>
+<h4 id="32-subcellularextracellular-localization">3.2 Subcellular/extracellular localization</h4>
+<p>Netrin-3 is a <strong>secreted extracellular</strong> protein. Developmental expression studies in mouse indicated netrin-3 is produced in specific tissues and acts extracellularly to bind netrin receptors on responding cells. (wang1999netrin3amouse pages 1-2, wang1999netrin3amouse pages 7-8)</p>
+<h3 id="4-receptors-binding-specificity-and-quantitative-affinity-data">4) Receptors, binding specificity, and quantitative affinity data</h3>
+<h4 id="41-canonical-receptors-for-netrin-3">4.1 Canonical receptors for netrin-3</h4>
+<p>Mouse netrin-3 was shown to bind receptors from the <strong>DCC family</strong> (DCC and <strong>neogenin/NEO1</strong>) and the <strong>UNC5 family</strong>, but with comparatively weaker binding to DCC than to several other receptors tested. (wang1999netrin3amouse pages 1-2, wang1999netrin3amouse pages 7-8)</p>
+<h4 id="42-quantitative-binding-affinities-kd">4.2 Quantitative binding affinities (Kd)</h4>
+<p>Two independent quantitative datasets illustrate netrin-3’s receptor preference pattern:</p>
+<p><strong>(A) Equilibrium binding (mouse netrin-3; 1999):</strong><br />
+- UNC5H1: <strong>Kd 6.2 nM</strong><br />
+- UNC5H2: <strong>Kd 3.3 nM</strong><br />
+- UNC5H3: <strong>Kd 4.5 nM</strong><br />
+- Neogenin: <strong>Kd 3.0 nM</strong><br />
+- DCC: <strong>Kd 11.5 nM</strong><br />
+These results support the conclusion that netrin-3 binds multiple canonical netrin receptors, with lower affinity for DCC than for UNC5 receptors/neogenin in that assay system. (wang1999netrin3amouse pages 7-8)</p>
+<p><strong>(B) Bio-layer interferometry (BLI; netrin-3 ortholog surrogate used for biophysics; 2021 figure):</strong><br />
+- DCC: <strong>Kd 31.0 ± 0.1 nM</strong><br />
+- UNC5A: <strong>Kd 106.0 ± 4.3 nM</strong><br />
+- UNC5B: <strong>Kd 8.8 ± 0.2 nM</strong><br />
+- UNC5C: <strong>Kd 4.3 ± 0.2 nM</strong><br />
+- Neogenin (Neo1): <strong>Kd 51.7 ± 0.1 nM</strong><br />
+This dataset again highlights relatively strong binding to <strong>UNC5B/UNC5C</strong> compared with DCC and UNC5A. (jiang2021targetingnetrin‐3in media f2f71bc0, jiang2021targetingnetrin‐3in media 4186dfe0)</p>
+<h3 id="5-biological-functions-and-pathways-evidence-based">5) Biological functions and pathways (evidence-based)</h3>
+<h4 id="51-axon-guidance-and-peripheral-nervous-system-development-foundational-experimental-evidence">5.1 Axon guidance and peripheral nervous system development (foundational experimental evidence)</h4>
+<p>Mouse netrin-3 is strongly expressed in <strong>sensory ganglia</strong> during peripheral nerve development, as well as in mesenchymal cells and muscles at relevant developmental stages, and is described as largely excluded from the CNS at early stages. Functionally, netrin-3 can mimic netrin-1’s outgrowth-promoting activity on commissural axons and chemorepulsive activity in a motor axon assay, but it has lower specific outgrowth activity than netrin-1. (wang1999netrin3amouse pages 1-2, wang1999netrin3amouse pages 7-8)</p>
+<p>A quantitative comparison in explant outgrowth assays reported that optimal commissural outgrowth required about <strong>120 µg/mL netrin-3</strong>, approximately <strong>fourfold higher</strong> than netrin-1 under the conditions described, consistent with lower specific activity. (wang1999netrin3amouse pages 7-8)</p>
+<h4 id="52-lung-branching-morphogenesis-ntn3-expression-context">5.2 Lung branching morphogenesis: NTN3 expression context</h4>
+<p>In embryonic lung development, netrin gene expression analysis showed that <strong>netrin-3 (Ntn3) is transcribed diffusely at low levels throughout lung endoderm and mesoderm</strong> (E11.5 in the study). In the same work, the authors emphasized that DCC and Unc5b are expressed in lung epithelial cells and could transduce netrin signals during branching morphogenesis; mechanistic in vitro morphogenesis experiments mainly focused on netrin-1/netrin-4 effects, so NTN3’s direct functional role in branching morphogenesis remains less directly established in the provided evidence. (liu2004novelrolefor pages 1-2)</p>
+<h4 id="53-kidney-vascular-patterning-receptors-relevant-to-netrin-signaling-context">5.3 Kidney vascular patterning: receptors relevant to netrin signaling (context)</h4>
+<p>A kidney development preprint discussing netrin signaling reports that vascular smooth muscle cells in vitro express receptors including <strong>NEO1</strong> and <strong>UNC5B</strong>, and that signaling through these receptors supports endothelial vascular smooth muscle coverage. While this section focuses on netrin-1, it reinforces that UNC5B/NEO1 are plausible transducers for netrin ligands in vascular contexts, consistent with netrin-3’s demonstrated ability to bind these receptor families. (honeycutt2023netrin1directs pages 14-17, wang1999netrin3amouse pages 7-8)</p>
+<h4 id="54-diabetic-neuropathic-pain-mouse-limited-access-evidence-from-supplementary-materials">5.4 Diabetic neuropathic pain (mouse): limited-access evidence from supplementary materials</h4>
+<p>A 2023 study titled “Netrin-3 suppresses diabetic neuropathic pain…” was retrieved only as <strong>supplementary materials</strong> in the current tool context. From these supplement pages:<br />
+- Adult mouse <strong>Ntn-3 is expressed in multiple neural tissues</strong> (qPCR; n=5–6). (pan2023netrin3suppressesdiabetic pages 1-9)<br />
+- <strong>Ntn-3 knockout</strong> mice showed <strong>no significant baseline developmental/behavioral defects</strong>, including no significant differences in baseline sensory assays (mechanical allodynia, cold allodynia, thermal hyperalgesia; n=6–17 depending on assay). (pan2023netrin3suppressesdiabetic pages 1-9)<br />
+- AAV-driven Ntn-3 overexpression in DRG was predominantly in <strong>CGRP+ neurons</strong> (n=3). (pan2023netrin3suppressesdiabetic pages 1-9)<br />
+Because the main article text and primary experimental figures were not available in the retrieved text chunk, mechanistic conclusions about pain suppression and receptor pathways cannot be reliably summarized here beyond these supporting data. (pan2023netrin3suppressesdiabetic pages 1-9)</p>
+<h3 id="6-recent-developments-prioritizing-20232024-and-cancer-biology-strongest-human-evidence">6) Recent developments (prioritizing 2023–2024) and cancer biology (strongest human evidence)</h3>
+<h4 id="61-ntn3-as-a-lineage-associated-dependency-in-neuroblastoma-and-small-cell-lung-cancer">6.1 NTN3 as a lineage-associated dependency in neuroblastoma and small cell lung cancer</h4>
+<p>A key translational paper reported that NTN3 is selectively expressed in <strong>neuroblastoma (NB)</strong> and <strong>small cell lung cancer (SCLC)</strong> (neuroectodermal/neuroendocrine lineages), with netrin-3 and netrin-1 expression described as <strong>mutually exclusive</strong> in these contexts. Mechanistically, NTN3 expression was linked to:<br />
+- <strong>MYCN</strong> regulation in neuroblastoma (ChIP-seq enhancer/promoter occupancy; MYCN pathway enrichment in high-NTN3 patients <strong>P=0.039</strong>, FDR q=0.025). (jiang2021targetingnetrin‐3in pages 5-7, jiang2021targetingnetrin‐3in pages 5-5)<br />
+- <strong>ASCL1 or NeuroD1</strong> regulation in SCLC. (jiang2021targetingnetrin‐3in pages 1-2, jiang2021targetingnetrin‐3in pages 5-7)</p>
+<h4 id="62-patient-outcome-statistics-neuroblastoma">6.2 Patient outcome statistics (neuroblastoma)</h4>
+<p>NTN3 expression was reported to correlate with neuroblastoma stage/aggressiveness and overall survival. Specifically, one analysis reported <strong>150-month overall survival</strong> of <strong>72.5%</strong> (low NTN3) vs <strong>46.6%</strong> (high NTN3), <strong>P=0.029</strong>; a subgroup with <strong>≥2× NTN3</strong> expression had <strong>28.5%</strong> overall survival (<strong>P=0.002</strong>). (jiang2021targetingnetrin‐3in pages 1-2)</p>
+<p>A figure-based dataset from the same work shows Kaplan–Meier curves where <strong>high NTN3</strong> is associated with worse overall survival in a cohort of <strong>181 patients (P=0.0294)</strong> and a larger cohort of <strong>498 patients (P ≤ 0.0001)</strong>, with a stage-4 trend <strong>P=0.0514</strong>. (jiang2021targetingnetrin‐3in media f2f71bc0, jiang2021targetingnetrin‐3in media 4186dfe0)</p>
+<h4 id="63-functional-perturbation-and-in-vivo-evidence-sclc-and-nb">6.3 Functional perturbation and in vivo evidence (SCLC and NB)</h4>
+<p>Functional experiments support a causal role for NTN3 in tumor growth/engraftment:<br />
+- In SCLC xenograft/engraftment assays, CRISPR targeting of NTN3 delayed or inhibited engraftment; reported guide-level p-values include <strong>H82</strong> (sG1 <strong>P=0.0022</strong>; sG2,sG3 <strong>≤0.001</strong>) and <strong>H69</strong> (sG1 <strong>P=0.017</strong>; sG2 <strong>P=0.028</strong>; sG3 <strong>P=0.001</strong>). (jiang2021targetingnetrin‐3in pages 8-9)<br />
+- In chick CAM tumor assays for NB lines, NTN3 silencing reduced tumor size (reported <strong>p=0.0011</strong> and <strong>p=0.0025</strong> in two lines/experiments as excerpted). (jiang2021targetingnetrin‐3in pages 5-5)</p>
+<h4 id="64-ovarian-cancer-dormancy-and-dissemination-2024-elife">6.4 Ovarian cancer dormancy and dissemination (2024 eLife)</h4>
+<p>A 2024 eLife paper identifies netrin pathway components as essential for survival of dormant high-grade serous ovarian cancer (HGSOC) spheroids. The authors state that Netrin-1 and <strong>Netrin-3</strong> and their receptors are required for low-level ERK activation supporting survival in dormancy conditions. They further report that sorting TCGA cases by high expression of Netrin-1 and -3 reveals <strong>significantly shorter overall survival</strong>, and that this trend is evident even in cases that only overexpress Netrin-3. (perampalam2024netrinsignalingmediates pages 10-13)</p>
+<h3 id="7-current-applications-and-real-world-implementations">7) Current applications and real-world implementations</h3>
+<h4 id="71-therapeutic-targeting-np137-cross-reactivity-and-ntn3-as-a-druggable-ligand">7.1 Therapeutic targeting: NP137 cross-reactivity and NTN3 as a druggable ligand</h4>
+<p>The anti-netrin-1 humanized monoclonal antibody <strong>NP137</strong> (developed against netrin-1) was discussed as relevant to NTN3 because the NP137 epitope in netrin-1 shares ~<strong>90% homology</strong> with the corresponding region in netrin-3, supporting cross-reactivity and enabling <strong>functional interference</strong> with netrin-3 in relevant tumor models. (jiang2021targetingnetrin‐3in pages 1-2, jiang2021targetingnetrin‐3in pages 5-7)</p>
+<h4 id="72-biomarker-potential">7.2 Biomarker potential</h4>
+<p>Because NTN3 is secreted, the NB/SCLC study suggests it “could thus emerge as a diagnostic marker” potentially measurable in blood, though it also reports difficulties validating commercial antibodies for immunohistochemistry, indicating practical assay-development limitations. (jiang2021targetingnetrin‐3in pages 8-9)</p>
+<h4 id="73-database-driven-disease-associations-supporting-context-limited-evidence-size">7.3 Database-driven disease associations (supporting context, limited evidence size)</h4>
+<p>Open Targets lists small evidence sets connecting NTN3 to neurological pain-related conditions (trigeminal nerve disease/neuralgia) and cancer-related phenotypes (including cancer, nonpapillary renal cell carcinoma, prostate cancer), but with only <strong>2 evidence items</strong> per association in the retrieved output, so these associations should be treated as hypothesis-supporting rather than definitive. (OpenTargets Search: -NTN3)</p>
+<h3 id="8-human-tissue-expression-and-localization-database-supported">8) Human tissue expression and localization (database-supported)</h3>
+<p>A 2023 ccRCC-focused paper that mined GTEx and Human Protein Atlas datasets reports:<br />
+- <strong>NTN3 mRNA</strong> tends to be <strong>low across tissues</strong>, with relatively higher expression in <strong>testes, liver, and endometrium</strong>. (ke2023netrinfamilygenes pages 6-9)<br />
+- HPA immunohistochemistry summary described NTN3 protein detection more broadly in <strong>cavity-containing tissues</strong>, including <strong>esophagus, bronchus, nasal cavity, and kidney</strong>. (ke2023netrinfamilygenes pages 6-9)</p>
+<p>In ccRCC TCGA analyses, NTN3 was described as downregulated in tumors but not significantly different in paired tumor/adjacent samples (n=72 pairs) and was the exception to netrin-family genes showing strong ROC performance (AUC&gt;0.8). (ke2023netrinfamilygenes pages 6-9)</p>
+<h3 id="9-expert-synthesis-and-interpretation-evidence-grounded">9) Expert synthesis and interpretation (evidence-grounded)</h3>
+<p>Across foundational developmental neurobiology and modern cancer biology, the most evidence-supported “primary function” for NTN3/Netrin-3 is as a <strong>secreted extracellular ligand</strong> that binds <strong>UNC5 family receptors, neogenin, and DCC-family receptors</strong> to modulate cellular navigation and survival programs, with a consistent pattern of <strong>stronger binding to UNC5B/UNC5C</strong> than to DCC in multiple binding datasets. (wang1999netrin3amouse pages 7-8, jiang2021targetingnetrin‐3in media f2f71bc0, jiang2021targetingnetrin‐3in media 4186dfe0)</p>
+<p>The strongest human disease evidence to date (in the retrieved corpus) places NTN3 as a <strong>lineage-associated dependency factor</strong> in <strong>neuroblastoma</strong> and <strong>small cell lung cancer</strong>, and as part of a broader netrin signaling module supporting survival of <strong>dormant ovarian cancer spheroids</strong>, making ligand–receptor interference a plausible therapeutic strategy in specific contexts (with NP137 cross-reactivity as a concrete implementation path). (jiang2021targetingnetrin‐3in pages 1-2, jiang2021targetingnetrin‐3in pages 8-9, jiang2021targetingnetrin‐3in pages 5-5, perampalam2024netrinsignalingmediates pages 10-13)</p>
+<h3 id="10-summary-of-key-evidence-table">10) Summary of key evidence (table)</h3>
+<p>The following table consolidates the main functional-annotation claims and quantitative data for NTN3.</p>
+<table>
+<thead>
+<tr>
+<th>Category</th>
+<th>Key findings</th>
+<th>Primary supporting citation context IDs</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>identity/domains</td>
+<td>Human <strong>NTN3</strong> corresponds to <strong>Netrin-3</strong> (historically <strong>NTN2L; netrin-2-like</strong>), a <strong>secreted netrin family</strong> protein. Foundational cloning work on the orthologous mouse protein showed the canonical netrin architecture with <strong>VI, V, and C domains</strong> and high identity to human NTN2L/NTN3, supporting the UniProt O00634 assignment. A recent review lists human <strong>NTN3 at 16p13.3</strong>, <strong>580 aa</strong>, ~<strong>61 kDa</strong>.</td>
+<td>(wang1999netrin3amouse pages 1-2, wang1999netrin3amouse pages 4-5, gao2024researchprogressof pages 2-5)</td>
+</tr>
+<tr>
+<td>localization</td>
+<td>NTN3/Netrin-3 is a <strong>secreted extracellular guidance cue</strong>. During embryogenesis in mouse, netrin-3 is highly expressed in <strong>sensory ganglia</strong>, mesenchymal cells, and muscle, with relative exclusion from early CNS ventral spinal cord; in lung development, <strong>netrin-3 transcripts are diffuse at low levels throughout endoderm and mesoderm</strong> rather than restricted to basal lamina-enriched proximal buds like netrin-4.</td>
+<td>(wang1999netrin3amouse pages 1-2, wang1999netrin3amouse pages 7-8, liu2004novelrolefor pages 1-2)</td>
+</tr>
+<tr>
+<td>receptors/binding</td>
+<td>Mouse netrin-3 binds canonical netrin receptors with reported equilibrium <strong>Kd</strong> values: <strong>UNC5H1 6.2 nM</strong>, <strong>UNC5H2 3.3 nM</strong>, <strong>UNC5H3 4.5 nM</strong>, <strong>neogenin 3.0 nM</strong>, <strong>DCC 11.5 nM</strong>, indicating weaker DCC binding than other receptors. Jiang et al. used a netrin-3 ortholog surrogate and reported <strong>Kd</strong> values by BLI: <strong>DCC 31.0 ± 0.1 nM</strong>, <strong>UNC5A 106.0 ± 4.3 nM</strong>, <strong>UNC5B 8.8 ± 0.2 nM</strong>, <strong>UNC5C 4.3 ± 0.2 nM</strong>, <strong>Neogenin 51.7 ± 0.1 nM</strong>; strongest binding was to <strong>UNC5B/UNC5C</strong>.</td>
+<td>(wang1999netrin3amouse pages 7-8, jiang2021targetingnetrin‐3in pages 5-7, jiang2021targetingnetrin‐3in media f2f71bc0, jiang2021targetingnetrin‐3in media 4186dfe0)</td>
+</tr>
+<tr>
+<td>developmental roles</td>
+<td>Foundational evidence supports a <strong>developmental axon-guidance role</strong>, especially in the <strong>peripheral nervous system</strong>: murine netrin-3 promotes commissural axon outgrowth and repels trochlear motor axons, but with lower specific activity than netrin-1; optimal commissural outgrowth required about <strong>120 µg/mL</strong> netrin-3, ~<strong>4-fold higher</strong> than netrin-1. In embryonic lung, NTN3 is present transcriptionally but the morphogenetic inhibition data were strongest for netrin-1/netrin-4, so NTN3’s lung role remains less directly established.</td>
+<td>(wang1999netrin3amouse pages 1-2, wang1999netrin3amouse pages 7-8, liu2004novelrolefor pages 1-2, liu2004novelrolefor pages 2-5)</td>
+</tr>
+<tr>
+<td>pain/neuronal</td>
+<td>In adult mouse, <strong>Ntn-3 is expressed in multiple neural tissues</strong>. In the diabetic neuropathic pain study’s supplementary data, <strong>Ntn-3 knockout mice</strong> showed <strong>normal development and baseline sensory behavior</strong> (mechanical, cold, thermal assays; no significant differences), and <strong>AAV-Ntn-3 overexpression</strong> in DRG was predominantly in <strong>CGRP+ neurons</strong>. Supplementary analyses also showed no significant effect of Ntn-3 deficiency on diabetes-associated peripheral axon loss or spinal cord gliosis.</td>
+<td>(pan2023netrin3suppressesdiabetic pages 1-9)</td>
+</tr>
+<tr>
+<td>cancer roles</td>
+<td><strong>Neuroblastoma (NB) and small cell lung cancer (SCLC)</strong> are the clearest human cancer contexts for NTN3. NTN3 is selectively/highly expressed in NB and SCLC, apparently <strong>mutually exclusive with NTN1</strong>; expression is driven by <strong>MYCN</strong> in NB and <strong>ASCL1/NeuroD1</strong> in SCLC. In NB, high NTN3 correlated with poorer overall survival: <strong>72.5% vs 46.6% OS at 150 months</strong> for low vs high NTN3 (<strong>P = 0.029</strong>); a subgroup with <strong>≥2× NTN3</strong> had <strong>28.5% OS</strong> (<strong>P = 0.002</strong>). In another cohort, Kaplan–Meier associations were significant in <strong>181 patients (P = 0.0294)</strong> and <strong>498 patients (P ≤ 0.0001)</strong>, with stage-4 trend <strong>P = 0.0514</strong>. MYCN-pathway enrichment in high-NTN3 NB was <strong>P = 0.039, FDR q = 0.025</strong>. CRISPR/knockdown reduced tumor growth/engraftment: CAM assays <strong>p = 0.0011</strong> and <strong>p = 0.0025</strong> after NTN3 silencing in NB lines; SCLC engraftment delays/inhibition with CRISPR had <strong>H82</strong> guide p-values <strong>0.0022, ≤0.001, ≤0.001</strong> and <strong>H69</strong> guide p-values <strong>0.017, 0.028, 0.001</strong>. In ovarian cancer dormancy, Netrin signaling involving <strong>Netrin-1/-3</strong> supports survival of dormant spheroids, and high <strong>Netrin-1/-3</strong> expression associated with shorter overall survival.</td>
+<td>(jiang2021targetingnetrin‐3in pages 1-2, jiang2021targetingnetrin‐3in pages 8-9, jiang2021targetingnetrin‐3in pages 5-7, jiang2021targetingnetrin‐3in pages 5-5, perampalam2024netrinsignalingmediates pages 10-13, jiang2021targetingnetrin‐3in media f2f71bc0, jiang2021targetingnetrin‐3in media 4186dfe0)</td>
+</tr>
+<tr>
+<td>therapeutics/biomarkers</td>
+<td>The anti-netrin-1 antibody <strong>NP137</strong> recognizes a V2-domain epitope with about <strong>90% sequence homology</strong> in netrin-3, supporting <strong>cross-reactivity</strong> and providing proof-of-concept for NTN3 targeting. Jiang et al. showed <strong>genetic silencing or antibody interference</strong> delayed tumor engraftment and reduced tumor growth in NB/SCLC models. The authors also noted secreted NTN3 <strong>could emerge as a diagnostic marker</strong>, potentially blood-detectable, although they <strong>could not validate available anti-NTN3 antibodies for IHC</strong>.</td>
+<td>(jiang2021targetingnetrin‐3in pages 1-2, jiang2021targetingnetrin‐3in pages 8-9, jiang2021targetingnetrin‐3in pages 5-7)</td>
+</tr>
+<tr>
+<td>expression in human tissues</td>
+<td>In GTEx/HPA-based analyses, <strong>NTN3 mRNA is generally low across human tissues</strong>, with relatively higher expression in <strong>testis, liver, and endometrium</strong>. Human Protein Atlas immunohistochemistry data summarized in ccRCC work indicated broader protein detection in <strong>cavity-containing tissues</strong> including <strong>esophagus, bronchus, nasal cavity, and kidney</strong>.</td>
+<td>(ke2023netrinfamilygenes pages 6-9)</td>
+</tr>
+<tr>
+<td>databases</td>
+<td>Open Targets currently shows limited disease-target evidence for <strong>NTN3</strong>, including associations to <strong>trigeminal nerve disease</strong>, <strong>trigeminal neuralgia</strong>, <strong>cancer</strong>, <strong>nonpapillary renal cell carcinoma</strong>, and <strong>prostate cancer</strong>, but evidence size is small (<strong>2 evidence items</strong> for listed associations). In ccRCC TCGA analyses, <strong>NTN3 was downregulated</strong> but not significantly different in <strong>72 paired</strong> tumor-adjacent samples and did <strong>not</strong> show strong diagnostic performance (<strong>exception to AUC &gt; 0.8</strong> genes). In single-gene Cox analysis, NTN3 behaved as a <strong>DFS risk factor (HR &gt; 1)</strong> but was not highlighted as an independent prognostic factor.</td>
+<td>(OpenTargets Search: -NTN3, ke2023netrinfamilygenes pages 6-9)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the main experimentally supported functional annotation points for human NTN3/Netrin-3, including identity, receptor binding, developmental roles, cancer relevance, and tissue expression. It also highlights the strongest quantitative findings and the context IDs that support each row.</em></p>
+<h3 id="11-key-references-publication-date-url">11) Key references (publication date + URL)</h3>
+<ul>
+<li>Wang H et al. <strong>Jun 1999</strong>. <em>Netrin-3, a mouse homolog of human NTN2L, is highly expressed in sensory ganglia and shows differential binding to netrin receptors.</em> <strong>J Neurosci</strong>. https://doi.org/10.1523/jneurosci.19-12-04938.1999 (wang1999netrin3amouse pages 1-2, wang1999netrin3amouse pages 7-8)</li>
+<li>Liu Y et al. <strong>May 25, 2004</strong>. <em>Novel Role for Netrins in Regulating Epithelial Behavior during Lung Branching Morphogenesis.</em> <strong>Current Biology</strong>. https://doi.org/10.1016/j.cub.2004.05.020 (liu2004novelrolefor pages 1-2, liu2004novelrolefor pages 2-5)</li>
+<li>Jiang S et al. <strong>Mar 2021</strong>. <em>Targeting netrin-3 in small cell lung cancer and neuroblastoma.</em> <strong>EMBO Molecular Medicine</strong>. https://doi.org/10.15252/emmm.202012878 (jiang2021targetingnetrin‐3in pages 1-2, jiang2021targetingnetrin‐3in pages 8-9, jiang2021targetingnetrin‐3in pages 5-5, jiang2021targetingnetrin‐3in media f2f71bc0, jiang2021targetingnetrin‐3in media 4186dfe0)</li>
+<li>Ke S et al. <strong>May 2023</strong>. <em>Netrin family genes as prognostic markers and therapeutic targets for ccRCC…</em> <strong>Cancers (Basel)</strong>. https://doi.org/10.3390/cancers15102816 (ke2023netrinfamilygenes pages 6-9)</li>
+<li>Gao X et al. <strong>Mar 2024</strong>. <em>Research progress of the netrins and their receptors in cancer.</em> <strong>J Cell Mol Med</strong>. https://doi.org/10.1111/jcmm.18241 (gao2024researchprogressof pages 2-5)</li>
+<li>Perampalam P et al. <strong>Jul 2024</strong> (eLife version; article describes dormancy model). <em>Netrin signaling mediates survival of dormant epithelial ovarian cancer cells.</em> <strong>eLife</strong>. https://doi.org/10.7554/elife.91766.3 (perampalam2024netrinsignalingmediates pages 10-13)</li>
+</ul>
+<h3 id="12-limitations-of-the-current-evidence-package">12) Limitations of the current evidence package</h3>
+<ul>
+<li>The diabetic neuropathic pain paper was only accessible here as <strong>supplementary material</strong>; core mechanistic claims from the main text could not be verified in the retrieved text. (pan2023netrin3suppressesdiabetic pages 1-9)</li>
+<li>Several recent (2023–2024) axon-guidance structural papers were marked unobtainable in the retrieval logs; therefore, the report relies on available primary data plus a 2024 cancer review for receptor family framing. (gao2024researchprogressof pages 2-5)</li>
+</ul>
+<p>References</p>
+<ol>
+<li>
+<p>(wang1999netrin3amouse pages 1-2): Hao Wang, Neal G. Copeland, Debra J. Gilbert, Nancy A. Jenkins, and Marc Tessier-Lavigne. Netrin-3, a mouse homolog of human ntn2l, is highly expressed in sensory ganglia and shows differential binding to netrin receptors. The Journal of Neuroscience, 19:4938-4947, Jun 1999. URL: https://doi.org/10.1523/jneurosci.19-12-04938.1999, doi:10.1523/jneurosci.19-12-04938.1999. This article has 202 citations.</p>
+</li>
+<li>
+<p>(wang1999netrin3amouse pages 4-5): Hao Wang, Neal G. Copeland, Debra J. Gilbert, Nancy A. Jenkins, and Marc Tessier-Lavigne. Netrin-3, a mouse homolog of human ntn2l, is highly expressed in sensory ganglia and shows differential binding to netrin receptors. The Journal of Neuroscience, 19:4938-4947, Jun 1999. URL: https://doi.org/10.1523/jneurosci.19-12-04938.1999, doi:10.1523/jneurosci.19-12-04938.1999. This article has 202 citations.</p>
+</li>
+<li>
+<p>(gao2024researchprogressof pages 2-5): Xing Gao, Jiazhou Ye, Xi Huang, Shilin Huang, Wenfeng Luo, Dandan Zeng, Shizhou Li, Minchao Tang, Rongyun Mai, Yongqiang Li, Yan Lin, and Rong Liang. Research progress of the netrins and their receptors in cancer. Journal of Cellular and Molecular Medicine, Mar 2024. URL: https://doi.org/10.1111/jcmm.18241, doi:10.1111/jcmm.18241. This article has 6 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(wang1999netrin3amouse pages 7-8): Hao Wang, Neal G. Copeland, Debra J. Gilbert, Nancy A. Jenkins, and Marc Tessier-Lavigne. Netrin-3, a mouse homolog of human ntn2l, is highly expressed in sensory ganglia and shows differential binding to netrin receptors. The Journal of Neuroscience, 19:4938-4947, Jun 1999. URL: https://doi.org/10.1523/jneurosci.19-12-04938.1999, doi:10.1523/jneurosci.19-12-04938.1999. This article has 202 citations.</p>
+</li>
+<li>
+<p>(jiang2021targetingnetrin‐3in media f2f71bc0): Shan Jiang, Mathieu Richaud, Pauline Vieugué, Nicolas Rama, Jean‐Guy Delcros, Maha Siouda, Mitsuaki Sanada, Anna‐Rita Redavid, Benjamin Ducarouge, Maëva Hervieu, Silvia Breusa, Ambroise Manceau, Charles‐Henry Gattolliat, Nicolas Gadot, Valérie Combaret, David Neves, Sandra Ortiz‐Cuaran, Pierre Saintigny, Olivier Meurette, Thomas Walter, Isabelle Janoueix‐Lerosey, Paul Hofman, Peter Mulligan, David Goldshneider, Patrick Mehlen, and Benjamin Gibert. Targeting netrin‐3 in small cell lung cancer and neuroblastoma. EMBO Molecular Medicine, Mar 2021. URL: https://doi.org/10.15252/emmm.202012878, doi:10.15252/emmm.202012878. This article has 25 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(jiang2021targetingnetrin‐3in media 4186dfe0): Shan Jiang, Mathieu Richaud, Pauline Vieugué, Nicolas Rama, Jean‐Guy Delcros, Maha Siouda, Mitsuaki Sanada, Anna‐Rita Redavid, Benjamin Ducarouge, Maëva Hervieu, Silvia Breusa, Ambroise Manceau, Charles‐Henry Gattolliat, Nicolas Gadot, Valérie Combaret, David Neves, Sandra Ortiz‐Cuaran, Pierre Saintigny, Olivier Meurette, Thomas Walter, Isabelle Janoueix‐Lerosey, Paul Hofman, Peter Mulligan, David Goldshneider, Patrick Mehlen, and Benjamin Gibert. Targeting netrin‐3 in small cell lung cancer and neuroblastoma. EMBO Molecular Medicine, Mar 2021. URL: https://doi.org/10.15252/emmm.202012878, doi:10.15252/emmm.202012878. This article has 25 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(liu2004novelrolefor pages 1-2): Yuru Liu, Elke Stein, Timothy Oliver, Yong Li, William J Brunken, Manuel Koch, Marc Tessier-Lavigne, and Brigid L.M Hogan. Novel role for netrins in regulating epithelial behavior during lung branching morphogenesis. Current Biology, 14:897-905, May 2004. URL: https://doi.org/10.1016/j.cub.2004.05.020, doi:10.1016/j.cub.2004.05.020. This article has 229 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(honeycutt2023netrin1directs pages 14-17): Samuel E. Honeycutt, Pierre-Emmanuel Y. N'Guetta, Deanna M. Hardesty, Yubin Xiong, Shamus L. Cooper, Matthew J. Stevenson, and Lori L. O'Brien. Netrin 1 directs vascular patterning and maturity in the developing kidney. Development, Nov 2023. URL: https://doi.org/10.1242/dev.201886, doi:10.1242/dev.201886. This article has 29 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(pan2023netrin3suppressesdiabetic pages 1-9): Weiping Pan, Xueyin N. Huang, Zikai Yu, Qiong-Qiong Ding, Li-Ping Xia, Jianfeng Hua, Bokai Gu, Qisong Xiong, Hualin Yu, Junbo Wang, Zhenzhong Xu, Linghui Zeng, Ge Bai, and Huaqing Liu. Netrin-3 suppresses diabetic neuropathic pain by gating the intra-epidermal sprouting of sensory axons. Neuroscience Bulletin, 39:745-758, Jan 2023. URL: https://doi.org/10.1007/s12264-022-01011-8, doi:10.1007/s12264-022-01011-8. This article has 4 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(jiang2021targetingnetrin‐3in pages 5-7): Shan Jiang, Mathieu Richaud, Pauline Vieugué, Nicolas Rama, Jean‐Guy Delcros, Maha Siouda, Mitsuaki Sanada, Anna‐Rita Redavid, Benjamin Ducarouge, Maëva Hervieu, Silvia Breusa, Ambroise Manceau, Charles‐Henry Gattolliat, Nicolas Gadot, Valérie Combaret, David Neves, Sandra Ortiz‐Cuaran, Pierre Saintigny, Olivier Meurette, Thomas Walter, Isabelle Janoueix‐Lerosey, Paul Hofman, Peter Mulligan, David Goldshneider, Patrick Mehlen, and Benjamin Gibert. Targeting netrin‐3 in small cell lung cancer and neuroblastoma. EMBO Molecular Medicine, Mar 2021. URL: https://doi.org/10.15252/emmm.202012878, doi:10.15252/emmm.202012878. This article has 25 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(jiang2021targetingnetrin‐3in pages 5-5): Shan Jiang, Mathieu Richaud, Pauline Vieugué, Nicolas Rama, Jean‐Guy Delcros, Maha Siouda, Mitsuaki Sanada, Anna‐Rita Redavid, Benjamin Ducarouge, Maëva Hervieu, Silvia Breusa, Ambroise Manceau, Charles‐Henry Gattolliat, Nicolas Gadot, Valérie Combaret, David Neves, Sandra Ortiz‐Cuaran, Pierre Saintigny, Olivier Meurette, Thomas Walter, Isabelle Janoueix‐Lerosey, Paul Hofman, Peter Mulligan, David Goldshneider, Patrick Mehlen, and Benjamin Gibert. Targeting netrin‐3 in small cell lung cancer and neuroblastoma. EMBO Molecular Medicine, Mar 2021. URL: https://doi.org/10.15252/emmm.202012878, doi:10.15252/emmm.202012878. This article has 25 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(jiang2021targetingnetrin‐3in pages 1-2): Shan Jiang, Mathieu Richaud, Pauline Vieugué, Nicolas Rama, Jean‐Guy Delcros, Maha Siouda, Mitsuaki Sanada, Anna‐Rita Redavid, Benjamin Ducarouge, Maëva Hervieu, Silvia Breusa, Ambroise Manceau, Charles‐Henry Gattolliat, Nicolas Gadot, Valérie Combaret, David Neves, Sandra Ortiz‐Cuaran, Pierre Saintigny, Olivier Meurette, Thomas Walter, Isabelle Janoueix‐Lerosey, Paul Hofman, Peter Mulligan, David Goldshneider, Patrick Mehlen, and Benjamin Gibert. Targeting netrin‐3 in small cell lung cancer and neuroblastoma. EMBO Molecular Medicine, Mar 2021. URL: https://doi.org/10.15252/emmm.202012878, doi:10.15252/emmm.202012878. This article has 25 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(jiang2021targetingnetrin‐3in pages 8-9): Shan Jiang, Mathieu Richaud, Pauline Vieugué, Nicolas Rama, Jean‐Guy Delcros, Maha Siouda, Mitsuaki Sanada, Anna‐Rita Redavid, Benjamin Ducarouge, Maëva Hervieu, Silvia Breusa, Ambroise Manceau, Charles‐Henry Gattolliat, Nicolas Gadot, Valérie Combaret, David Neves, Sandra Ortiz‐Cuaran, Pierre Saintigny, Olivier Meurette, Thomas Walter, Isabelle Janoueix‐Lerosey, Paul Hofman, Peter Mulligan, David Goldshneider, Patrick Mehlen, and Benjamin Gibert. Targeting netrin‐3 in small cell lung cancer and neuroblastoma. EMBO Molecular Medicine, Mar 2021. URL: https://doi.org/10.15252/emmm.202012878, doi:10.15252/emmm.202012878. This article has 25 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(perampalam2024netrinsignalingmediates pages 10-13): Pirunthan Perampalam, James I MacDonald, Komila Zakirova, Daniel T Passos, Sumaiyah Wasif, Yudith Ramos-Valdes, Maeva Hervieu, Patrick Mehlen, Rob Rottapel, Benjamin Gibert, Rohann JM Correa, Trevor G Shepherd, and Frederick A Dick. Netrin signaling mediates survival of dormant epithelial ovarian cancer cells. eLife, Jul 2024. URL: https://doi.org/10.7554/elife.91766.3, doi:10.7554/elife.91766.3. This article has 11 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(OpenTargets Search: -NTN3): Open Targets Query (-NTN3, 5 results). Buniello, A. et al. (2025). Open Targets Platform: facilitating therapeutic hypotheses building in drug discovery. Nucleic Acids Research.</p>
+</li>
+<li>
+<p>(ke2023netrinfamilygenes pages 6-9): Shuai Ke, Jiayu Guo, Qinghua Wang, Haoren Shao, Mu He, Tao Li, T. Qiu, and Jiayu Guo. Netrin family genes as prognostic markers and therapeutic targets for clear cell renal cell carcinoma: netrin-4 acts through the wnt/β-catenin signaling pathway. Cancers, 15:2816, May 2023. URL: https://doi.org/10.3390/cancers15102816, doi:10.3390/cancers15102816. This article has 11 citations.</p>
+</li>
+<li>
+<p>(liu2004novelrolefor pages 2-5): Yuru Liu, Elke Stein, Timothy Oliver, Yong Li, William J Brunken, Manuel Koch, Marc Tessier-Lavigne, and Brigid L.M Hogan. Novel role for netrins in regulating epithelial behavior during lung branching morphogenesis. Current Biology, 14:897-905, May 2004. URL: https://doi.org/10.1016/j.cub.2004.05.020, doi:10.1016/j.cub.2004.05.020. This article has 229 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>gao2024researchprogressof pages 2-5</li>
+<li>liu2004novelrolefor pages 1-2</li>
+<li>perampalam2024netrinsignalingmediates pages 10-13</li>
+<li>ke2023netrinfamilygenes pages 6-9</li>
+<li>liu2004novelrolefor pages 2-5</li>
+<li>https://doi.org/10.1523/jneurosci.19-12-04938.1999</li>
+<li>https://doi.org/10.1016/j.cub.2004.05.020</li>
+<li>https://doi.org/10.15252/emmm.202012878</li>
+<li>https://doi.org/10.3390/cancers15102816</li>
+<li>https://doi.org/10.1111/jcmm.18241</li>
+<li>https://doi.org/10.7554/elife.91766.3</li>
+<li>https://doi.org/10.1523/jneurosci.19-12-04938.1999,</li>
+<li>https://doi.org/10.1111/jcmm.18241,</li>
+<li>https://doi.org/10.15252/emmm.202012878,</li>
+<li>https://doi.org/10.1016/j.cub.2004.05.020,</li>
+<li>https://doi.org/10.1242/dev.201886,</li>
+<li>https://doi.org/10.1007/s12264-022-01011-8,</li>
+<li>https://doi.org/10.7554/elife.91766.3,</li>
+<li>https://doi.org/10.3390/cancers15102816,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -1995,6 +2416,8 @@ existing_annotations:
         supporting_text: &#34;The assembled floor-plate network contains 47 interactions including the hitherto-not-reported interaction between Netrin-1 and Draxin.&#34;
       - reference_id: UniProt:O00634
         supporting_text: &#34;O00634; Q8NBI3: DRAXIN; NbExp=2; IntAct=EBI-10831998, EBI-10827752&#34;
+      - reference_id: file:human/NTN3/NTN3-deep-research-falcon.md
+        supporting_text: &#34;NTN3/Netrin-3 is summarized as a secreted extracellular ligand that binds UNC5-family receptors, neogenin, and DCC-family receptors.&#34;
 
 - term:
     id: GO:0005102
@@ -2123,19 +2546,30 @@ references:
     - statement: Predicted 580-amino-acid protein with homology to chicken, Drosophila netrins and C. elegans UNC-6
       supporting_text: &#34;The NTN2L gene is predicted to encode a 580-amino-acid protein having homology to the chicken and Drosophila netrins and to Caenorhabditis elegans UNC-6.&#34;
 
+- id: file:human/NTN3/NTN3-deep-research-falcon.md
+  title: Falcon deep research report for human NTN3
+  findings:
+    - statement: NTN3 encodes secreted Netrin-3, a laminin-like extracellular guidance cue that binds canonical netrin receptors including DCC, NEO1, and UNC5-family receptors.
+    - statement: Binding data summarized in the report support NTN3 as a netrin receptor ligand, with comparatively strong binding to UNC5B and UNC5C in available datasets.
+
 core_functions:
   - description: &gt;-
       NTN3 functions as a secreted axon guidance cue that binds netrin receptors (DCC, UNC5 family)
       to mediate chemotropic guidance of CNS commissural axons and peripheral motor axons.
     molecular_function:
-      id: GO:0005102
-      label: signaling receptor binding
+      id: GO:1990890
+      label: netrin receptor binding
     directly_involved_in:
       - id: GO:0007411
         label: axon guidance
     locations:
       - id: GO:0005576
         label: extracellular region
+    supported_by:
+      - reference_id: PMID:9143507
+        supporting_text: &#34;The netrins define a family of chemotropic factors that have been shown to play a central role in axon guidance.&#34;
+      - reference_id: file:human/NTN3/NTN3-deep-research-falcon.md
+        supporting_text: &#34;NTN3/Netrin-3 is summarized as a secreted extracellular ligand that binds UNC5-family receptors, neogenin, and DCC-family receptors to modulate cellular navigation and survival programs.&#34;
 
 suggested_questions:
   - question: &gt;-

--- a/genes/human/NTN3/NTN3-ai-review.yaml
+++ b/genes/human/NTN3/NTN3-ai-review.yaml
@@ -113,25 +113,20 @@ existing_annotations:
   review:
     summary: >-
       This annotation is supported by experimental evidence from PMID:26190107 showing NTN3
-      interacts with DRAXIN. However, "protein binding" is uninformative. A more specific term
-      such as netrin receptor binding (GO:1990890) or signaling receptor binding would be more
-      appropriate for the functional role of netrins.
-    action: MODIFY
+      interacts with DRAXIN. However, "protein binding" is uninformative and the interaction
+      is with a secreted netrin antagonist rather than a netrin receptor.
+    action: MARK_AS_OVER_ANNOTATED
     reason: >-
       While the experimental evidence (IPI from PMID:26190107) demonstrates protein-protein
       interaction between NTN3 and DRAXIN, the term "protein binding" is too general and
-      uninformative. NTN3 functions by binding to netrin receptors (DCC, UNC5 family).
-      A more specific molecular function term should be used.
-    proposed_replacement_terms:
-      - id: GO:1990890
-        label: netrin receptor binding
+      uninformative. DRAXIN is a secreted antagonist that competes with DCC/UNC5 family
+      receptors for netrin binding, not itself a netrin receptor, so GO:1990890 netrin
+      receptor binding is not an appropriate replacement term for this interaction.
     supported_by:
       - reference_id: PMID:26190107
         supporting_text: "The assembled floor-plate network contains 47 interactions including the hitherto-not-reported interaction between Netrin-1 and Draxin."
       - reference_id: UniProt:O00634
         supporting_text: "O00634; Q8NBI3: DRAXIN; NbExp=2; IntAct=EBI-10831998, EBI-10827752"
-      - reference_id: file:human/NTN3/NTN3-deep-research-falcon.md
-        supporting_text: "NTN3/Netrin-3 is summarized as a secreted extracellular ligand that binds UNC5-family receptors, neogenin, and DCC-family receptors."
 
 - term:
     id: GO:0005102
@@ -155,6 +150,29 @@ existing_annotations:
     supported_by:
       - reference_id: UniProt:O00634
         supporting_text: "-!- FUNCTION: Netrins control guidance of CNS commissural axons and peripheral motor axons."
+      - reference_id: file:human/NTN3/NTN3-deep-research-falcon.md
+        supporting_text: "NTN3/Netrin-3 is summarized as a secreted extracellular ligand that binds UNC5-family receptors, neogenin, and DCC-family receptors."
+
+- term:
+    id: GO:1990890
+    label: netrin receptor binding
+  evidence_type: NAS
+  review:
+    summary: >-
+      Add the more specific molecular-function term for NTN3's receptor-ligand
+      activity. The Falcon report summarizes direct binding evidence for NTN3/Netrin-3
+      with canonical netrin receptors, including UNC5-family receptors, neogenin,
+      and DCC-family receptors, with comparatively strong binding to UNC5B and
+      UNC5C in available datasets.
+    action: NEW
+    reason: >-
+      Existing GO:0005102 signaling receptor binding is directionally correct
+      but too broad for a netrin ligand. GO:1990890 captures the core receptor-binding
+      molecular function without misusing the term for the separate DRAXIN antagonist
+      interaction.
+    supported_by:
+      - reference_id: file:human/NTN3/NTN3-deep-research-falcon.md
+        supporting_text: "Binding data summarized in the report support NTN3 as a netrin receptor ligand, with comparatively strong binding to UNC5B and UNC5C in available datasets."
 
 - term:
     id: GO:0005576

--- a/genes/human/NTN3/NTN3-ai-review.yaml
+++ b/genes/human/NTN3/NTN3-ai-review.yaml
@@ -130,6 +130,8 @@ existing_annotations:
         supporting_text: "The assembled floor-plate network contains 47 interactions including the hitherto-not-reported interaction between Netrin-1 and Draxin."
       - reference_id: UniProt:O00634
         supporting_text: "O00634; Q8NBI3: DRAXIN; NbExp=2; IntAct=EBI-10831998, EBI-10827752"
+      - reference_id: file:human/NTN3/NTN3-deep-research-falcon.md
+        supporting_text: "NTN3/Netrin-3 is summarized as a secreted extracellular ligand that binds UNC5-family receptors, neogenin, and DCC-family receptors."
 
 - term:
     id: GO:0005102
@@ -258,19 +260,30 @@ references:
     - statement: Predicted 580-amino-acid protein with homology to chicken, Drosophila netrins and C. elegans UNC-6
       supporting_text: "The NTN2L gene is predicted to encode a 580-amino-acid protein having homology to the chicken and Drosophila netrins and to Caenorhabditis elegans UNC-6."
 
+- id: file:human/NTN3/NTN3-deep-research-falcon.md
+  title: Falcon deep research report for human NTN3
+  findings:
+    - statement: NTN3 encodes secreted Netrin-3, a laminin-like extracellular guidance cue that binds canonical netrin receptors including DCC, NEO1, and UNC5-family receptors.
+    - statement: Binding data summarized in the report support NTN3 as a netrin receptor ligand, with comparatively strong binding to UNC5B and UNC5C in available datasets.
+
 core_functions:
   - description: >-
       NTN3 functions as a secreted axon guidance cue that binds netrin receptors (DCC, UNC5 family)
       to mediate chemotropic guidance of CNS commissural axons and peripheral motor axons.
     molecular_function:
-      id: GO:0005102
-      label: signaling receptor binding
+      id: GO:1990890
+      label: netrin receptor binding
     directly_involved_in:
       - id: GO:0007411
         label: axon guidance
     locations:
       - id: GO:0005576
         label: extracellular region
+    supported_by:
+      - reference_id: PMID:9143507
+        supporting_text: "The netrins define a family of chemotropic factors that have been shown to play a central role in axon guidance."
+      - reference_id: file:human/NTN3/NTN3-deep-research-falcon.md
+        supporting_text: "NTN3/Netrin-3 is summarized as a secreted extracellular ligand that binds UNC5-family receptors, neogenin, and DCC-family receptors to modulate cellular navigation and survival programs."
 
 suggested_questions:
   - question: >-

--- a/genes/human/NTN3/NTN3-deep-research-falcon.md
+++ b/genes/human/NTN3/NTN3-deep-research-falcon.md
@@ -1,0 +1,327 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-10T22:02:42.248105'
+end_time: '2026-05-10T22:16:46.109318'
+duration_seconds: 843.86
+template_file: templates/gene_research_go_focused.md
+template_variables:
+  organism: human
+  gene_id: NTN3
+  gene_symbol: NTN3
+  uniprot_accession: O00634
+  protein_description: 'RecName: Full=Netrin-3; AltName: Full=Netrin-2-like protein;
+    Flags: Precursor;'
+  gene_info: Name=NTN3; Synonyms=NTN2L;
+  organism_full: Homo sapiens (Human).
+  protein_family: Not specified in UniProt
+  protein_domains: Laminin/Netrin_ECM. (IPR050440); Laminin_N. (IPR008211); LE_dom.
+    (IPR002049); LMN_ATRN_NET-like_EGF. (IPR056863); Netrin_domain. (IPR001134)
+provider_config:
+  timeout: 600
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 19
+---
+
+## Question
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** O00634
+- **Protein Description:** RecName: Full=Netrin-3; AltName: Full=Netrin-2-like protein; Flags: Precursor;
+- **Gene Information:** Name=NTN3; Synonyms=NTN2L;
+- **Organism (full):** Homo sapiens (Human).
+- **Protein Family:** Not specified in UniProt
+- **Key Domains:** Laminin/Netrin_ECM. (IPR050440); Laminin_N. (IPR008211); LE_dom. (IPR002049); LMN_ATRN_NET-like_EGF. (IPR056863); Netrin_domain. (IPR001134)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "NTN3" matches the protein description above**
+2. **Verify the organism is correct:** Homo sapiens (Human).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'NTN3' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **NTN3** (gene ID: NTN3, UniProt: O00634) in human.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** O00634
+- **Protein Description:** RecName: Full=Netrin-3; AltName: Full=Netrin-2-like protein; Flags: Precursor;
+- **Gene Information:** Name=NTN3; Synonyms=NTN2L;
+- **Organism (full):** Homo sapiens (Human).
+- **Protein Family:** Not specified in UniProt
+- **Key Domains:** Laminin/Netrin_ECM. (IPR050440); Laminin_N. (IPR008211); LE_dom. (IPR002049); LMN_ATRN_NET-like_EGF. (IPR056863); Netrin_domain. (IPR001134)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "NTN3" matches the protein description above**
+2. **Verify the organism is correct:** Homo sapiens (Human).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'NTN3' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **NTN3** (gene ID: NTN3, UniProt: O00634) in human.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Comprehensive research report: Human **NTN3** (UniProt **O00634**) / **Netrin-3**
+
+### 1) Gene/protein identity verification (mandatory)
+Human **NTN3** encodes **Netrin-3**, a secreted laminin-like guidance cue historically referred to as **NTN2L (netrin-2-like)**, consistent with UniProt O00634’s naming and “precursor” (secreted) status. A foundational cloning/characterization study identified mouse **netrin-3 (Ntn3)** as the ortholog of human **NTN2L/NTN3**, with high sequence identity and the canonical netrin domain structure (domains VI, V subdomains, and C). This cross-species mapping and conserved receptor binding support that the literature summarized here corresponds to the correct human target (NTN3/O00634). (wang1999netrin3amouse pages 1-2, wang1999netrin3amouse pages 4-5)
+
+### 2) Key concepts and definitions (current understanding)
+#### 2.1 Netrin-3 as a laminin-like extracellular guidance cue
+Netrins are secreted or membrane-associated proteins that regulate axon guidance and broader tissue morphogenesis by engaging specific cell-surface receptors. Netrin-3 (NTN3) is one of the **secreted netrins** in mammals, and is commonly considered part of a receptor–ligand system that can influence **cell migration, survival, and differentiation** depending on receptor context. (gao2024researchprogressof pages 2-5)
+
+#### 2.2 “Dependence receptor” logic in netrin systems
+A recent cancer-focused review emphasizes that several netrin receptors (including **DCC, UNC5 family, and NEO1**) function as **dependence receptors**, meaning signaling outcomes differ depending on whether ligand is present; ligand binding supports survival/migration/differentiation, while ligand absence can allow pro-apoptotic signaling. This conceptual framework is often used to interpret netrin pathway roles in tumor biology. (gao2024researchprogressof pages 2-5)
+
+### 3) Protein/domain architecture and localization
+#### 3.1 Domain architecture
+Netrin-3 has the canonical netrin architecture (domains **VI, V, C**) defined by homology to other netrins. This was explicitly documented in the original cloning and protein characterization of murine netrin-3 orthologous to human NTN3/NTN2L. (wang1999netrin3amouse pages 1-2, wang1999netrin3amouse pages 4-5)
+
+#### 3.2 Subcellular/extracellular localization
+Netrin-3 is a **secreted extracellular** protein. Developmental expression studies in mouse indicated netrin-3 is produced in specific tissues and acts extracellularly to bind netrin receptors on responding cells. (wang1999netrin3amouse pages 1-2, wang1999netrin3amouse pages 7-8)
+
+### 4) Receptors, binding specificity, and quantitative affinity data
+#### 4.1 Canonical receptors for netrin-3
+Mouse netrin-3 was shown to bind receptors from the **DCC family** (DCC and **neogenin/NEO1**) and the **UNC5 family**, but with comparatively weaker binding to DCC than to several other receptors tested. (wang1999netrin3amouse pages 1-2, wang1999netrin3amouse pages 7-8)
+
+#### 4.2 Quantitative binding affinities (Kd)
+Two independent quantitative datasets illustrate netrin-3’s receptor preference pattern:
+
+**(A) Equilibrium binding (mouse netrin-3; 1999):**
+- UNC5H1: **Kd 6.2 nM**
+- UNC5H2: **Kd 3.3 nM**
+- UNC5H3: **Kd 4.5 nM**
+- Neogenin: **Kd 3.0 nM**
+- DCC: **Kd 11.5 nM**
+These results support the conclusion that netrin-3 binds multiple canonical netrin receptors, with lower affinity for DCC than for UNC5 receptors/neogenin in that assay system. (wang1999netrin3amouse pages 7-8)
+
+**(B) Bio-layer interferometry (BLI; netrin-3 ortholog surrogate used for biophysics; 2021 figure):**
+- DCC: **Kd 31.0 ± 0.1 nM**
+- UNC5A: **Kd 106.0 ± 4.3 nM**
+- UNC5B: **Kd 8.8 ± 0.2 nM**
+- UNC5C: **Kd 4.3 ± 0.2 nM**
+- Neogenin (Neo1): **Kd 51.7 ± 0.1 nM**
+This dataset again highlights relatively strong binding to **UNC5B/UNC5C** compared with DCC and UNC5A. (jiang2021targetingnetrin‐3in media f2f71bc0, jiang2021targetingnetrin‐3in media 4186dfe0)
+
+### 5) Biological functions and pathways (evidence-based)
+#### 5.1 Axon guidance and peripheral nervous system development (foundational experimental evidence)
+Mouse netrin-3 is strongly expressed in **sensory ganglia** during peripheral nerve development, as well as in mesenchymal cells and muscles at relevant developmental stages, and is described as largely excluded from the CNS at early stages. Functionally, netrin-3 can mimic netrin-1’s outgrowth-promoting activity on commissural axons and chemorepulsive activity in a motor axon assay, but it has lower specific outgrowth activity than netrin-1. (wang1999netrin3amouse pages 1-2, wang1999netrin3amouse pages 7-8)
+
+A quantitative comparison in explant outgrowth assays reported that optimal commissural outgrowth required about **120 µg/mL netrin-3**, approximately **fourfold higher** than netrin-1 under the conditions described, consistent with lower specific activity. (wang1999netrin3amouse pages 7-8)
+
+#### 5.2 Lung branching morphogenesis: NTN3 expression context
+In embryonic lung development, netrin gene expression analysis showed that **netrin-3 (Ntn3) is transcribed diffusely at low levels throughout lung endoderm and mesoderm** (E11.5 in the study). In the same work, the authors emphasized that DCC and Unc5b are expressed in lung epithelial cells and could transduce netrin signals during branching morphogenesis; mechanistic in vitro morphogenesis experiments mainly focused on netrin-1/netrin-4 effects, so NTN3’s direct functional role in branching morphogenesis remains less directly established in the provided evidence. (liu2004novelrolefor pages 1-2)
+
+#### 5.3 Kidney vascular patterning: receptors relevant to netrin signaling (context)
+A kidney development preprint discussing netrin signaling reports that vascular smooth muscle cells in vitro express receptors including **NEO1** and **UNC5B**, and that signaling through these receptors supports endothelial vascular smooth muscle coverage. While this section focuses on netrin-1, it reinforces that UNC5B/NEO1 are plausible transducers for netrin ligands in vascular contexts, consistent with netrin-3’s demonstrated ability to bind these receptor families. (honeycutt2023netrin1directs pages 14-17, wang1999netrin3amouse pages 7-8)
+
+#### 5.4 Diabetic neuropathic pain (mouse): limited-access evidence from supplementary materials
+A 2023 study titled “Netrin-3 suppresses diabetic neuropathic pain…” was retrieved only as **supplementary materials** in the current tool context. From these supplement pages:
+- Adult mouse **Ntn-3 is expressed in multiple neural tissues** (qPCR; n=5–6). (pan2023netrin3suppressesdiabetic pages 1-9)
+- **Ntn-3 knockout** mice showed **no significant baseline developmental/behavioral defects**, including no significant differences in baseline sensory assays (mechanical allodynia, cold allodynia, thermal hyperalgesia; n=6–17 depending on assay). (pan2023netrin3suppressesdiabetic pages 1-9)
+- AAV-driven Ntn-3 overexpression in DRG was predominantly in **CGRP+ neurons** (n=3). (pan2023netrin3suppressesdiabetic pages 1-9)
+Because the main article text and primary experimental figures were not available in the retrieved text chunk, mechanistic conclusions about pain suppression and receptor pathways cannot be reliably summarized here beyond these supporting data. (pan2023netrin3suppressesdiabetic pages 1-9)
+
+### 6) Recent developments (prioritizing 2023–2024) and cancer biology (strongest human evidence)
+#### 6.1 NTN3 as a lineage-associated dependency in neuroblastoma and small cell lung cancer
+A key translational paper reported that NTN3 is selectively expressed in **neuroblastoma (NB)** and **small cell lung cancer (SCLC)** (neuroectodermal/neuroendocrine lineages), with netrin-3 and netrin-1 expression described as **mutually exclusive** in these contexts. Mechanistically, NTN3 expression was linked to:
+- **MYCN** regulation in neuroblastoma (ChIP-seq enhancer/promoter occupancy; MYCN pathway enrichment in high-NTN3 patients **P=0.039**, FDR q=0.025). (jiang2021targetingnetrin‐3in pages 5-7, jiang2021targetingnetrin‐3in pages 5-5)
+- **ASCL1 or NeuroD1** regulation in SCLC. (jiang2021targetingnetrin‐3in pages 1-2, jiang2021targetingnetrin‐3in pages 5-7)
+
+#### 6.2 Patient outcome statistics (neuroblastoma)
+NTN3 expression was reported to correlate with neuroblastoma stage/aggressiveness and overall survival. Specifically, one analysis reported **150-month overall survival** of **72.5%** (low NTN3) vs **46.6%** (high NTN3), **P=0.029**; a subgroup with **≥2× NTN3** expression had **28.5%** overall survival (**P=0.002**). (jiang2021targetingnetrin‐3in pages 1-2)
+
+A figure-based dataset from the same work shows Kaplan–Meier curves where **high NTN3** is associated with worse overall survival in a cohort of **181 patients (P=0.0294)** and a larger cohort of **498 patients (P ≤ 0.0001)**, with a stage-4 trend **P=0.0514**. (jiang2021targetingnetrin‐3in media f2f71bc0, jiang2021targetingnetrin‐3in media 4186dfe0)
+
+#### 6.3 Functional perturbation and in vivo evidence (SCLC and NB)
+Functional experiments support a causal role for NTN3 in tumor growth/engraftment:
+- In SCLC xenograft/engraftment assays, CRISPR targeting of NTN3 delayed or inhibited engraftment; reported guide-level p-values include **H82** (sG1 **P=0.0022**; sG2,sG3 **≤0.001**) and **H69** (sG1 **P=0.017**; sG2 **P=0.028**; sG3 **P=0.001**). (jiang2021targetingnetrin‐3in pages 8-9)
+- In chick CAM tumor assays for NB lines, NTN3 silencing reduced tumor size (reported **p=0.0011** and **p=0.0025** in two lines/experiments as excerpted). (jiang2021targetingnetrin‐3in pages 5-5)
+
+#### 6.4 Ovarian cancer dormancy and dissemination (2024 eLife)
+A 2024 eLife paper identifies netrin pathway components as essential for survival of dormant high-grade serous ovarian cancer (HGSOC) spheroids. The authors state that Netrin-1 and **Netrin-3** and their receptors are required for low-level ERK activation supporting survival in dormancy conditions. They further report that sorting TCGA cases by high expression of Netrin-1 and -3 reveals **significantly shorter overall survival**, and that this trend is evident even in cases that only overexpress Netrin-3. (perampalam2024netrinsignalingmediates pages 10-13)
+
+### 7) Current applications and real-world implementations
+#### 7.1 Therapeutic targeting: NP137 cross-reactivity and NTN3 as a druggable ligand
+The anti-netrin-1 humanized monoclonal antibody **NP137** (developed against netrin-1) was discussed as relevant to NTN3 because the NP137 epitope in netrin-1 shares ~**90% homology** with the corresponding region in netrin-3, supporting cross-reactivity and enabling **functional interference** with netrin-3 in relevant tumor models. (jiang2021targetingnetrin‐3in pages 1-2, jiang2021targetingnetrin‐3in pages 5-7)
+
+#### 7.2 Biomarker potential
+Because NTN3 is secreted, the NB/SCLC study suggests it “could thus emerge as a diagnostic marker” potentially measurable in blood, though it also reports difficulties validating commercial antibodies for immunohistochemistry, indicating practical assay-development limitations. (jiang2021targetingnetrin‐3in pages 8-9)
+
+#### 7.3 Database-driven disease associations (supporting context, limited evidence size)
+Open Targets lists small evidence sets connecting NTN3 to neurological pain-related conditions (trigeminal nerve disease/neuralgia) and cancer-related phenotypes (including cancer, nonpapillary renal cell carcinoma, prostate cancer), but with only **2 evidence items** per association in the retrieved output, so these associations should be treated as hypothesis-supporting rather than definitive. (OpenTargets Search: -NTN3)
+
+### 8) Human tissue expression and localization (database-supported)
+A 2023 ccRCC-focused paper that mined GTEx and Human Protein Atlas datasets reports:
+- **NTN3 mRNA** tends to be **low across tissues**, with relatively higher expression in **testes, liver, and endometrium**. (ke2023netrinfamilygenes pages 6-9)
+- HPA immunohistochemistry summary described NTN3 protein detection more broadly in **cavity-containing tissues**, including **esophagus, bronchus, nasal cavity, and kidney**. (ke2023netrinfamilygenes pages 6-9)
+
+In ccRCC TCGA analyses, NTN3 was described as downregulated in tumors but not significantly different in paired tumor/adjacent samples (n=72 pairs) and was the exception to netrin-family genes showing strong ROC performance (AUC>0.8). (ke2023netrinfamilygenes pages 6-9)
+
+### 9) Expert synthesis and interpretation (evidence-grounded)
+Across foundational developmental neurobiology and modern cancer biology, the most evidence-supported “primary function” for NTN3/Netrin-3 is as a **secreted extracellular ligand** that binds **UNC5 family receptors, neogenin, and DCC-family receptors** to modulate cellular navigation and survival programs, with a consistent pattern of **stronger binding to UNC5B/UNC5C** than to DCC in multiple binding datasets. (wang1999netrin3amouse pages 7-8, jiang2021targetingnetrin‐3in media f2f71bc0, jiang2021targetingnetrin‐3in media 4186dfe0)
+
+The strongest human disease evidence to date (in the retrieved corpus) places NTN3 as a **lineage-associated dependency factor** in **neuroblastoma** and **small cell lung cancer**, and as part of a broader netrin signaling module supporting survival of **dormant ovarian cancer spheroids**, making ligand–receptor interference a plausible therapeutic strategy in specific contexts (with NP137 cross-reactivity as a concrete implementation path). (jiang2021targetingnetrin‐3in pages 1-2, jiang2021targetingnetrin‐3in pages 8-9, jiang2021targetingnetrin‐3in pages 5-5, perampalam2024netrinsignalingmediates pages 10-13)
+
+### 10) Summary of key evidence (table)
+The following table consolidates the main functional-annotation claims and quantitative data for NTN3.
+
+| Category | Key findings | Primary supporting citation context IDs |
+|---|---|---|
+| identity/domains | Human **NTN3** corresponds to **Netrin-3** (historically **NTN2L; netrin-2-like**), a **secreted netrin family** protein. Foundational cloning work on the orthologous mouse protein showed the canonical netrin architecture with **VI, V, and C domains** and high identity to human NTN2L/NTN3, supporting the UniProt O00634 assignment. A recent review lists human **NTN3 at 16p13.3**, **580 aa**, ~**61 kDa**. | (wang1999netrin3amouse pages 1-2, wang1999netrin3amouse pages 4-5, gao2024researchprogressof pages 2-5) |
+| localization | NTN3/Netrin-3 is a **secreted extracellular guidance cue**. During embryogenesis in mouse, netrin-3 is highly expressed in **sensory ganglia**, mesenchymal cells, and muscle, with relative exclusion from early CNS ventral spinal cord; in lung development, **netrin-3 transcripts are diffuse at low levels throughout endoderm and mesoderm** rather than restricted to basal lamina-enriched proximal buds like netrin-4. | (wang1999netrin3amouse pages 1-2, wang1999netrin3amouse pages 7-8, liu2004novelrolefor pages 1-2) |
+| receptors/binding | Mouse netrin-3 binds canonical netrin receptors with reported equilibrium **Kd** values: **UNC5H1 6.2 nM**, **UNC5H2 3.3 nM**, **UNC5H3 4.5 nM**, **neogenin 3.0 nM**, **DCC 11.5 nM**, indicating weaker DCC binding than other receptors. Jiang et al. used a netrin-3 ortholog surrogate and reported **Kd** values by BLI: **DCC 31.0 ± 0.1 nM**, **UNC5A 106.0 ± 4.3 nM**, **UNC5B 8.8 ± 0.2 nM**, **UNC5C 4.3 ± 0.2 nM**, **Neogenin 51.7 ± 0.1 nM**; strongest binding was to **UNC5B/UNC5C**. | (wang1999netrin3amouse pages 7-8, jiang2021targetingnetrin‐3in pages 5-7, jiang2021targetingnetrin‐3in media f2f71bc0, jiang2021targetingnetrin‐3in media 4186dfe0) |
+| developmental roles | Foundational evidence supports a **developmental axon-guidance role**, especially in the **peripheral nervous system**: murine netrin-3 promotes commissural axon outgrowth and repels trochlear motor axons, but with lower specific activity than netrin-1; optimal commissural outgrowth required about **120 µg/mL** netrin-3, ~**4-fold higher** than netrin-1. In embryonic lung, NTN3 is present transcriptionally but the morphogenetic inhibition data were strongest for netrin-1/netrin-4, so NTN3’s lung role remains less directly established. | (wang1999netrin3amouse pages 1-2, wang1999netrin3amouse pages 7-8, liu2004novelrolefor pages 1-2, liu2004novelrolefor pages 2-5) |
+| pain/neuronal | In adult mouse, **Ntn-3 is expressed in multiple neural tissues**. In the diabetic neuropathic pain study’s supplementary data, **Ntn-3 knockout mice** showed **normal development and baseline sensory behavior** (mechanical, cold, thermal assays; no significant differences), and **AAV-Ntn-3 overexpression** in DRG was predominantly in **CGRP+ neurons**. Supplementary analyses also showed no significant effect of Ntn-3 deficiency on diabetes-associated peripheral axon loss or spinal cord gliosis. | (pan2023netrin3suppressesdiabetic pages 1-9) |
+| cancer roles | **Neuroblastoma (NB) and small cell lung cancer (SCLC)** are the clearest human cancer contexts for NTN3. NTN3 is selectively/highly expressed in NB and SCLC, apparently **mutually exclusive with NTN1**; expression is driven by **MYCN** in NB and **ASCL1/NeuroD1** in SCLC. In NB, high NTN3 correlated with poorer overall survival: **72.5% vs 46.6% OS at 150 months** for low vs high NTN3 (**P = 0.029**); a subgroup with **≥2× NTN3** had **28.5% OS** (**P = 0.002**). In another cohort, Kaplan–Meier associations were significant in **181 patients (P = 0.0294)** and **498 patients (P ≤ 0.0001)**, with stage-4 trend **P = 0.0514**. MYCN-pathway enrichment in high-NTN3 NB was **P = 0.039, FDR q = 0.025**. CRISPR/knockdown reduced tumor growth/engraftment: CAM assays **p = 0.0011** and **p = 0.0025** after NTN3 silencing in NB lines; SCLC engraftment delays/inhibition with CRISPR had **H82** guide p-values **0.0022, ≤0.001, ≤0.001** and **H69** guide p-values **0.017, 0.028, 0.001**. In ovarian cancer dormancy, Netrin signaling involving **Netrin-1/-3** supports survival of dormant spheroids, and high **Netrin-1/-3** expression associated with shorter overall survival. | (jiang2021targetingnetrin‐3in pages 1-2, jiang2021targetingnetrin‐3in pages 8-9, jiang2021targetingnetrin‐3in pages 5-7, jiang2021targetingnetrin‐3in pages 5-5, perampalam2024netrinsignalingmediates pages 10-13, jiang2021targetingnetrin‐3in media f2f71bc0, jiang2021targetingnetrin‐3in media 4186dfe0) |
+| therapeutics/biomarkers | The anti-netrin-1 antibody **NP137** recognizes a V2-domain epitope with about **90% sequence homology** in netrin-3, supporting **cross-reactivity** and providing proof-of-concept for NTN3 targeting. Jiang et al. showed **genetic silencing or antibody interference** delayed tumor engraftment and reduced tumor growth in NB/SCLC models. The authors also noted secreted NTN3 **could emerge as a diagnostic marker**, potentially blood-detectable, although they **could not validate available anti-NTN3 antibodies for IHC**. | (jiang2021targetingnetrin‐3in pages 1-2, jiang2021targetingnetrin‐3in pages 8-9, jiang2021targetingnetrin‐3in pages 5-7) |
+| expression in human tissues | In GTEx/HPA-based analyses, **NTN3 mRNA is generally low across human tissues**, with relatively higher expression in **testis, liver, and endometrium**. Human Protein Atlas immunohistochemistry data summarized in ccRCC work indicated broader protein detection in **cavity-containing tissues** including **esophagus, bronchus, nasal cavity, and kidney**. | (ke2023netrinfamilygenes pages 6-9) |
+| databases | Open Targets currently shows limited disease-target evidence for **NTN3**, including associations to **trigeminal nerve disease**, **trigeminal neuralgia**, **cancer**, **nonpapillary renal cell carcinoma**, and **prostate cancer**, but evidence size is small (**2 evidence items** for listed associations). In ccRCC TCGA analyses, **NTN3 was downregulated** but not significantly different in **72 paired** tumor-adjacent samples and did **not** show strong diagnostic performance (**exception to AUC > 0.8** genes). In single-gene Cox analysis, NTN3 behaved as a **DFS risk factor (HR > 1)** but was not highlighted as an independent prognostic factor. | (OpenTargets Search: -NTN3, ke2023netrinfamilygenes pages 6-9) |
+
+
+*Table: This table summarizes the main experimentally supported functional annotation points for human NTN3/Netrin-3, including identity, receptor binding, developmental roles, cancer relevance, and tissue expression. It also highlights the strongest quantitative findings and the context IDs that support each row.*
+
+### 11) Key references (publication date + URL)
+- Wang H et al. **Jun 1999**. *Netrin-3, a mouse homolog of human NTN2L, is highly expressed in sensory ganglia and shows differential binding to netrin receptors.* **J Neurosci**. https://doi.org/10.1523/jneurosci.19-12-04938.1999 (wang1999netrin3amouse pages 1-2, wang1999netrin3amouse pages 7-8)
+- Liu Y et al. **May 25, 2004**. *Novel Role for Netrins in Regulating Epithelial Behavior during Lung Branching Morphogenesis.* **Current Biology**. https://doi.org/10.1016/j.cub.2004.05.020 (liu2004novelrolefor pages 1-2, liu2004novelrolefor pages 2-5)
+- Jiang S et al. **Mar 2021**. *Targeting netrin-3 in small cell lung cancer and neuroblastoma.* **EMBO Molecular Medicine**. https://doi.org/10.15252/emmm.202012878 (jiang2021targetingnetrin‐3in pages 1-2, jiang2021targetingnetrin‐3in pages 8-9, jiang2021targetingnetrin‐3in pages 5-5, jiang2021targetingnetrin‐3in media f2f71bc0, jiang2021targetingnetrin‐3in media 4186dfe0)
+- Ke S et al. **May 2023**. *Netrin family genes as prognostic markers and therapeutic targets for ccRCC…* **Cancers (Basel)**. https://doi.org/10.3390/cancers15102816 (ke2023netrinfamilygenes pages 6-9)
+- Gao X et al. **Mar 2024**. *Research progress of the netrins and their receptors in cancer.* **J Cell Mol Med**. https://doi.org/10.1111/jcmm.18241 (gao2024researchprogressof pages 2-5)
+- Perampalam P et al. **Jul 2024** (eLife version; article describes dormancy model). *Netrin signaling mediates survival of dormant epithelial ovarian cancer cells.* **eLife**. https://doi.org/10.7554/elife.91766.3 (perampalam2024netrinsignalingmediates pages 10-13)
+
+### 12) Limitations of the current evidence package
+- The diabetic neuropathic pain paper was only accessible here as **supplementary material**; core mechanistic claims from the main text could not be verified in the retrieved text. (pan2023netrin3suppressesdiabetic pages 1-9)
+- Several recent (2023–2024) axon-guidance structural papers were marked unobtainable in the retrieval logs; therefore, the report relies on available primary data plus a 2024 cancer review for receptor family framing. (gao2024researchprogressof pages 2-5)
+
+
+References
+
+1. (wang1999netrin3amouse pages 1-2): Hao Wang, Neal G. Copeland, Debra J. Gilbert, Nancy A. Jenkins, and Marc Tessier-Lavigne. Netrin-3, a mouse homolog of human ntn2l, is highly expressed in sensory ganglia and shows differential binding to netrin receptors. The Journal of Neuroscience, 19:4938-4947, Jun 1999. URL: https://doi.org/10.1523/jneurosci.19-12-04938.1999, doi:10.1523/jneurosci.19-12-04938.1999. This article has 202 citations.
+
+2. (wang1999netrin3amouse pages 4-5): Hao Wang, Neal G. Copeland, Debra J. Gilbert, Nancy A. Jenkins, and Marc Tessier-Lavigne. Netrin-3, a mouse homolog of human ntn2l, is highly expressed in sensory ganglia and shows differential binding to netrin receptors. The Journal of Neuroscience, 19:4938-4947, Jun 1999. URL: https://doi.org/10.1523/jneurosci.19-12-04938.1999, doi:10.1523/jneurosci.19-12-04938.1999. This article has 202 citations.
+
+3. (gao2024researchprogressof pages 2-5): Xing Gao, Jiazhou Ye, Xi Huang, Shilin Huang, Wenfeng Luo, Dandan Zeng, Shizhou Li, Minchao Tang, Rongyun Mai, Yongqiang Li, Yan Lin, and Rong Liang. Research progress of the netrins and their receptors in cancer. Journal of Cellular and Molecular Medicine, Mar 2024. URL: https://doi.org/10.1111/jcmm.18241, doi:10.1111/jcmm.18241. This article has 6 citations and is from a peer-reviewed journal.
+
+4. (wang1999netrin3amouse pages 7-8): Hao Wang, Neal G. Copeland, Debra J. Gilbert, Nancy A. Jenkins, and Marc Tessier-Lavigne. Netrin-3, a mouse homolog of human ntn2l, is highly expressed in sensory ganglia and shows differential binding to netrin receptors. The Journal of Neuroscience, 19:4938-4947, Jun 1999. URL: https://doi.org/10.1523/jneurosci.19-12-04938.1999, doi:10.1523/jneurosci.19-12-04938.1999. This article has 202 citations.
+
+5. (jiang2021targetingnetrin‐3in media f2f71bc0): Shan Jiang, Mathieu Richaud, Pauline Vieugué, Nicolas Rama, Jean‐Guy Delcros, Maha Siouda, Mitsuaki Sanada, Anna‐Rita Redavid, Benjamin Ducarouge, Maëva Hervieu, Silvia Breusa, Ambroise Manceau, Charles‐Henry Gattolliat, Nicolas Gadot, Valérie Combaret, David Neves, Sandra Ortiz‐Cuaran, Pierre Saintigny, Olivier Meurette, Thomas Walter, Isabelle Janoueix‐Lerosey, Paul Hofman, Peter Mulligan, David Goldshneider, Patrick Mehlen, and Benjamin Gibert. Targeting netrin‐3 in small cell lung cancer and neuroblastoma. EMBO Molecular Medicine, Mar 2021. URL: https://doi.org/10.15252/emmm.202012878, doi:10.15252/emmm.202012878. This article has 25 citations and is from a highest quality peer-reviewed journal.
+
+6. (jiang2021targetingnetrin‐3in media 4186dfe0): Shan Jiang, Mathieu Richaud, Pauline Vieugué, Nicolas Rama, Jean‐Guy Delcros, Maha Siouda, Mitsuaki Sanada, Anna‐Rita Redavid, Benjamin Ducarouge, Maëva Hervieu, Silvia Breusa, Ambroise Manceau, Charles‐Henry Gattolliat, Nicolas Gadot, Valérie Combaret, David Neves, Sandra Ortiz‐Cuaran, Pierre Saintigny, Olivier Meurette, Thomas Walter, Isabelle Janoueix‐Lerosey, Paul Hofman, Peter Mulligan, David Goldshneider, Patrick Mehlen, and Benjamin Gibert. Targeting netrin‐3 in small cell lung cancer and neuroblastoma. EMBO Molecular Medicine, Mar 2021. URL: https://doi.org/10.15252/emmm.202012878, doi:10.15252/emmm.202012878. This article has 25 citations and is from a highest quality peer-reviewed journal.
+
+7. (liu2004novelrolefor pages 1-2): Yuru Liu, Elke Stein, Timothy Oliver, Yong Li, William J Brunken, Manuel Koch, Marc Tessier-Lavigne, and Brigid L.M Hogan. Novel role for netrins in regulating epithelial behavior during lung branching morphogenesis. Current Biology, 14:897-905, May 2004. URL: https://doi.org/10.1016/j.cub.2004.05.020, doi:10.1016/j.cub.2004.05.020. This article has 229 citations and is from a highest quality peer-reviewed journal.
+
+8. (honeycutt2023netrin1directs pages 14-17): Samuel E. Honeycutt, Pierre-Emmanuel Y. N'Guetta, Deanna M. Hardesty, Yubin Xiong, Shamus L. Cooper, Matthew J. Stevenson, and Lori L. O'Brien. Netrin 1 directs vascular patterning and maturity in the developing kidney. Development, Nov 2023. URL: https://doi.org/10.1242/dev.201886, doi:10.1242/dev.201886. This article has 29 citations and is from a domain leading peer-reviewed journal.
+
+9. (pan2023netrin3suppressesdiabetic pages 1-9): Weiping Pan, Xueyin N. Huang, Zikai Yu, Qiong-Qiong Ding, Li-Ping Xia, Jianfeng Hua, Bokai Gu, Qisong Xiong, Hualin Yu, Junbo Wang, Zhenzhong Xu, Linghui Zeng, Ge Bai, and Huaqing Liu. Netrin-3 suppresses diabetic neuropathic pain by gating the intra-epidermal sprouting of sensory axons. Neuroscience Bulletin, 39:745-758, Jan 2023. URL: https://doi.org/10.1007/s12264-022-01011-8, doi:10.1007/s12264-022-01011-8. This article has 4 citations and is from a peer-reviewed journal.
+
+10. (jiang2021targetingnetrin‐3in pages 5-7): Shan Jiang, Mathieu Richaud, Pauline Vieugué, Nicolas Rama, Jean‐Guy Delcros, Maha Siouda, Mitsuaki Sanada, Anna‐Rita Redavid, Benjamin Ducarouge, Maëva Hervieu, Silvia Breusa, Ambroise Manceau, Charles‐Henry Gattolliat, Nicolas Gadot, Valérie Combaret, David Neves, Sandra Ortiz‐Cuaran, Pierre Saintigny, Olivier Meurette, Thomas Walter, Isabelle Janoueix‐Lerosey, Paul Hofman, Peter Mulligan, David Goldshneider, Patrick Mehlen, and Benjamin Gibert. Targeting netrin‐3 in small cell lung cancer and neuroblastoma. EMBO Molecular Medicine, Mar 2021. URL: https://doi.org/10.15252/emmm.202012878, doi:10.15252/emmm.202012878. This article has 25 citations and is from a highest quality peer-reviewed journal.
+
+11. (jiang2021targetingnetrin‐3in pages 5-5): Shan Jiang, Mathieu Richaud, Pauline Vieugué, Nicolas Rama, Jean‐Guy Delcros, Maha Siouda, Mitsuaki Sanada, Anna‐Rita Redavid, Benjamin Ducarouge, Maëva Hervieu, Silvia Breusa, Ambroise Manceau, Charles‐Henry Gattolliat, Nicolas Gadot, Valérie Combaret, David Neves, Sandra Ortiz‐Cuaran, Pierre Saintigny, Olivier Meurette, Thomas Walter, Isabelle Janoueix‐Lerosey, Paul Hofman, Peter Mulligan, David Goldshneider, Patrick Mehlen, and Benjamin Gibert. Targeting netrin‐3 in small cell lung cancer and neuroblastoma. EMBO Molecular Medicine, Mar 2021. URL: https://doi.org/10.15252/emmm.202012878, doi:10.15252/emmm.202012878. This article has 25 citations and is from a highest quality peer-reviewed journal.
+
+12. (jiang2021targetingnetrin‐3in pages 1-2): Shan Jiang, Mathieu Richaud, Pauline Vieugué, Nicolas Rama, Jean‐Guy Delcros, Maha Siouda, Mitsuaki Sanada, Anna‐Rita Redavid, Benjamin Ducarouge, Maëva Hervieu, Silvia Breusa, Ambroise Manceau, Charles‐Henry Gattolliat, Nicolas Gadot, Valérie Combaret, David Neves, Sandra Ortiz‐Cuaran, Pierre Saintigny, Olivier Meurette, Thomas Walter, Isabelle Janoueix‐Lerosey, Paul Hofman, Peter Mulligan, David Goldshneider, Patrick Mehlen, and Benjamin Gibert. Targeting netrin‐3 in small cell lung cancer and neuroblastoma. EMBO Molecular Medicine, Mar 2021. URL: https://doi.org/10.15252/emmm.202012878, doi:10.15252/emmm.202012878. This article has 25 citations and is from a highest quality peer-reviewed journal.
+
+13. (jiang2021targetingnetrin‐3in pages 8-9): Shan Jiang, Mathieu Richaud, Pauline Vieugué, Nicolas Rama, Jean‐Guy Delcros, Maha Siouda, Mitsuaki Sanada, Anna‐Rita Redavid, Benjamin Ducarouge, Maëva Hervieu, Silvia Breusa, Ambroise Manceau, Charles‐Henry Gattolliat, Nicolas Gadot, Valérie Combaret, David Neves, Sandra Ortiz‐Cuaran, Pierre Saintigny, Olivier Meurette, Thomas Walter, Isabelle Janoueix‐Lerosey, Paul Hofman, Peter Mulligan, David Goldshneider, Patrick Mehlen, and Benjamin Gibert. Targeting netrin‐3 in small cell lung cancer and neuroblastoma. EMBO Molecular Medicine, Mar 2021. URL: https://doi.org/10.15252/emmm.202012878, doi:10.15252/emmm.202012878. This article has 25 citations and is from a highest quality peer-reviewed journal.
+
+14. (perampalam2024netrinsignalingmediates pages 10-13): Pirunthan Perampalam, James I MacDonald, Komila Zakirova, Daniel T Passos, Sumaiyah Wasif, Yudith Ramos-Valdes, Maeva Hervieu, Patrick Mehlen, Rob Rottapel, Benjamin Gibert, Rohann JM Correa, Trevor G Shepherd, and Frederick A Dick. Netrin signaling mediates survival of dormant epithelial ovarian cancer cells. eLife, Jul 2024. URL: https://doi.org/10.7554/elife.91766.3, doi:10.7554/elife.91766.3. This article has 11 citations and is from a domain leading peer-reviewed journal.
+
+15. (OpenTargets Search: -NTN3): Open Targets Query (-NTN3, 5 results). Buniello, A. et al. (2025). Open Targets Platform: facilitating therapeutic hypotheses building in drug discovery. Nucleic Acids Research.
+
+16. (ke2023netrinfamilygenes pages 6-9): Shuai Ke, Jiayu Guo, Qinghua Wang, Haoren Shao, Mu He, Tao Li, T. Qiu, and Jiayu Guo. Netrin family genes as prognostic markers and therapeutic targets for clear cell renal cell carcinoma: netrin-4 acts through the wnt/β-catenin signaling pathway. Cancers, 15:2816, May 2023. URL: https://doi.org/10.3390/cancers15102816, doi:10.3390/cancers15102816. This article has 11 citations.
+
+17. (liu2004novelrolefor pages 2-5): Yuru Liu, Elke Stein, Timothy Oliver, Yong Li, William J Brunken, Manuel Koch, Marc Tessier-Lavigne, and Brigid L.M Hogan. Novel role for netrins in regulating epithelial behavior during lung branching morphogenesis. Current Biology, 14:897-905, May 2004. URL: https://doi.org/10.1016/j.cub.2004.05.020, doi:10.1016/j.cub.2004.05.020. This article has 229 citations and is from a highest quality peer-reviewed journal.
+
+## Citations
+
+1. gao2024researchprogressof pages 2-5
+2. liu2004novelrolefor pages 1-2
+3. perampalam2024netrinsignalingmediates pages 10-13
+4. ke2023netrinfamilygenes pages 6-9
+5. liu2004novelrolefor pages 2-5
+6. https://doi.org/10.1523/jneurosci.19-12-04938.1999
+7. https://doi.org/10.1016/j.cub.2004.05.020
+8. https://doi.org/10.15252/emmm.202012878
+9. https://doi.org/10.3390/cancers15102816
+10. https://doi.org/10.1111/jcmm.18241
+11. https://doi.org/10.7554/elife.91766.3
+12. https://doi.org/10.1523/jneurosci.19-12-04938.1999,
+13. https://doi.org/10.1111/jcmm.18241,
+14. https://doi.org/10.15252/emmm.202012878,
+15. https://doi.org/10.1016/j.cub.2004.05.020,
+16. https://doi.org/10.1242/dev.201886,
+17. https://doi.org/10.1007/s12264-022-01011-8,
+18. https://doi.org/10.7554/elife.91766.3,
+19. https://doi.org/10.3390/cancers15102816,

--- a/genes/human/PCSK1N/PCSK1N-ai-review.html
+++ b/genes/human/PCSK1N/PCSK1N-ai-review.html
@@ -1112,6 +1112,17 @@
                                 
                             </div>
                             
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PCSK1N/PCSK1N-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The report summarizes proSAAS as an endogenous PC1/3 inhibitor that modulates prohormone-processing protease activity in the regulated secretory pathway.</div>
+
+                            </div>
+
                         </div>
                         
                     </td>
@@ -1652,6 +1663,17 @@
                                 
                             </div>
                             
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PCSK1N/PCSK1N-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The report summarizes proSAAS as a secretory chaperone/anti-aggregant that can limit fibrillation or aggregation of amyloid-beta, alpha-synuclein, and islet amyloid polypeptide.</div>
+
+                            </div>
+
                         </div>
                         
                     </td>
@@ -2318,6 +2340,17 @@
                         
                     </li>
                     
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/PCSK1N/PCSK1N-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">Canonical function: PCSK1N/proSAAS is a potent inhibitor of PC1/3 in the regulated secretory pathway, modulating prohormone processing in endocrine cells and islets.</div>
+
+                    </li>
+
                 </ul>
             </div>
             
@@ -2489,6 +2522,17 @@
                         
                     </li>
                     
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/PCSK1N/PCSK1N-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">Emerging function: proSAAS also acts as a secretory chaperone/anti-aggregant, blocking fibrillation or aggregation of amyloid-beta, alpha-synuclein, and islet amyloid polypeptide in vitro and protecting cells from toxic oligomers.</div>
+
+                    </li>
+
                 </ul>
             </div>
             
@@ -2602,6 +2646,34 @@
                 <div class="reference-header">
                     <span class="reference-id">
                         
+                        file:human/PCSK1N/PCSK1N-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research report for human PCSK1N</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">PCSK1N encodes proSAAS, a regulated-secretory-pathway precursor and endogenous PC1/3 inhibitor that modulates prohormone processing in secretory granules.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The report also supports proSAAS as a secretory chaperone or anti-aggregant with activity against amyloidogenic clients including amyloid-beta and alpha-synuclein.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/10632593" target="_blank" class="term-link">
                             PMID:10632593
                         </a>
@@ -3018,6 +3090,334 @@
     <div class="section">
         <h2 class="section-title">📚 Additional Documentation</h2>
         
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Deep Research Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(PCSK1N-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q9UHG2" data-a="DOC: Deep Research Falcon" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <hr />
+<p>provider: falcon<br />
+model: Edison Scientific Literature<br />
+cached: false<br />
+start_time: '2026-05-10T22:23:34.233199'<br />
+end_time: '2026-05-10T22:32:04.062923'<br />
+duration_seconds: 509.83<br />
+template_file: templates/gene_research_go_focused.md<br />
+template_variables:<br />
+  organism: human<br />
+  gene_id: PCSK1N<br />
+  gene_symbol: PCSK1N<br />
+  uniprot_accession: Q9UHG2<br />
+  protein_description: 'RecName: Full=ProSAAS; AltName: Full=Proprotein convertase<br />
+    subtilisin/kexin type 1 inhibitor; Short=Proprotein convertase 1 inhibitor; AltName:<br />
+    Full=pro-SAAS; Contains: RecName: Full=KEP; Contains: RecName: Full=Big SAAS;<br />
+    Short=b-SAAS; Contains: RecName: Full=Little SAAS; Short=l-SAAS; AltName: Full=N-proSAAS;<br />
+    Contains: RecName: Full=Big PEN-LEN; Short=b-PEN-LEN; AltName: Full=SAAS CT(1-49);<br />
+    Contains: RecName: Full=PEN; Contains: RecName: Full=Little LEN; Short=l-LEN;<br />
+    Contains: RecName: Full=Big LEN; Short=b-LEN; AltName: Full=SAAS CT(25-40); Flags:<br />
+    Precursor;'<br />
+  gene_info: Name=PCSK1N;<br />
+  organism_full: Homo sapiens (Human).<br />
+  protein_family: Not specified in UniProt<br />
+  protein_domains: ProSAAS. (IPR010832); ProSAAS (PF07259)<br />
+provider_config:<br />
+  timeout: 600<br />
+  max_retries: 3<br />
+  parameters:<br />
+    allowed_domains: []<br />
+    temperature: 0.1<br />
+citation_count: 21</p>
+<hr />
+<h2 id="question">Question</h2>
+<h1 id="gene-research-for-functional-annotation">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> Q9UHG2</li>
+<li><strong>Protein Description:</strong> RecName: Full=ProSAAS; AltName: Full=Proprotein convertase subtilisin/kexin type 1 inhibitor; Short=Proprotein convertase 1 inhibitor; AltName: Full=pro-SAAS; Contains: RecName: Full=KEP; Contains: RecName: Full=Big SAAS; Short=b-SAAS; Contains: RecName: Full=Little SAAS; Short=l-SAAS; AltName: Full=N-proSAAS; Contains: RecName: Full=Big PEN-LEN; Short=b-PEN-LEN; AltName: Full=SAAS CT(1-49); Contains: RecName: Full=PEN; Contains: RecName: Full=Little LEN; Short=l-LEN; Contains: RecName: Full=Big LEN; Short=b-LEN; AltName: Full=SAAS CT(25-40); Flags: Precursor;</li>
+<li><strong>Gene Information:</strong> Name=PCSK1N;</li>
+<li><strong>Organism (full):</strong> Homo sapiens (Human).</li>
+<li><strong>Protein Family:</strong> Not specified in UniProt</li>
+<li><strong>Key Domains:</strong> ProSAAS. (IPR010832); ProSAAS (PF07259)</li>
+</ul>
+<h3 id="mandatory-verification-steps">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "PCSK1N" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Homo sapiens (Human).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'PCSK1N' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>PCSK1N</strong> (gene ID: PCSK1N, UniProt: Q9UHG2) in human.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="output">Output</h2>
+<p>Question: You are an expert researcher providing comprehensive, well-cited information.</p>
+<p>Provide detailed information focusing on:<br />
+1. Key concepts and definitions with current understanding<br />
+2. Recent developments and latest research (prioritize 2023-2024 sources)<br />
+3. Current applications and real-world implementations<br />
+4. Expert opinions and analysis from authoritative sources<br />
+5. Relevant statistics and data from recent studies</p>
+<p>Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.<br />
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.</p>
+<h1 id="gene-research-for-functional-annotation_1">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context_1">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot_1">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> Q9UHG2</li>
+<li><strong>Protein Description:</strong> RecName: Full=ProSAAS; AltName: Full=Proprotein convertase subtilisin/kexin type 1 inhibitor; Short=Proprotein convertase 1 inhibitor; AltName: Full=pro-SAAS; Contains: RecName: Full=KEP; Contains: RecName: Full=Big SAAS; Short=b-SAAS; Contains: RecName: Full=Little SAAS; Short=l-SAAS; AltName: Full=N-proSAAS; Contains: RecName: Full=Big PEN-LEN; Short=b-PEN-LEN; AltName: Full=SAAS CT(1-49); Contains: RecName: Full=PEN; Contains: RecName: Full=Little LEN; Short=l-LEN; Contains: RecName: Full=Big LEN; Short=b-LEN; AltName: Full=SAAS CT(25-40); Flags: Precursor;</li>
+<li><strong>Gene Information:</strong> Name=PCSK1N;</li>
+<li><strong>Organism (full):</strong> Homo sapiens (Human).</li>
+<li><strong>Protein Family:</strong> Not specified in UniProt</li>
+<li><strong>Key Domains:</strong> ProSAAS. (IPR010832); ProSAAS (PF07259)</li>
+</ul>
+<h3 id="mandatory-verification-steps_1">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "PCSK1N" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Homo sapiens (Human).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature_1">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'PCSK1N' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target_1">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>PCSK1N</strong> (gene ID: PCSK1N, UniProt: Q9UHG2) in human.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="research-report-functional-annotation-of-human-pcsk1n-prosaas-uniprot-q9uhg2">Research Report: Functional Annotation of Human <strong>PCSK1N</strong> (proSAAS) — UniProt <strong>Q9UHG2</strong></h2>
+<h3 id="1-target-verification-geneprotein-identity">1) Target verification (gene/protein identity)</h3>
+<p>The UniProt accession <strong>Q9UHG2</strong> corresponds to the human gene <strong>PCSK1N</strong>, whose product is commonly called <strong>proSAAS</strong> and is also described as a <strong>proprotein convertase subtilisin/kexin type 1 inhibitor</strong> (i.e., an inhibitor of PC1/3/PCSK1). This identity mapping (PCSK1N ↔ proSAAS; human) is explicitly stated in experimental literature and is consistent with authoritative target resources. (schaffer2025theneuronalchaperone pages 1-2, shakya2020increasedexpressionand pages 1-2, OpenTargets Search: -PCSK1N)</p>
+<h3 id="2-key-concepts-definitions-and-current-understanding">2) Key concepts, definitions, and current understanding</h3>
+<h4 id="21-prosaas-is-a-regulated-secretory-pathway-precursor-protein">2.1 ProSAAS is a regulated-secretory-pathway precursor protein</h4>
+<p>ProSAAS is described as a <strong>granin-like neuroendocrine peptide precursor</strong> enriched in neural and endocrine tissues, with sequence features (e.g., proline-rich regions and at least one furin/proprotein convertase cleavage site) consistent with proteolytic processing in the secretory pathway. (shakya2020increasedexpressionand pages 1-2)</p>
+<p>A key concept in PCSK1N biology is that proSAAS is synthesized as a precursor and then <strong>processed into smaller fragments</strong> in secretory compartments; in retinal extracts, immunoblotting evidence supports the existence of at least two processed forms (approximately <strong>21 kDa</strong> and <strong>13 kDa</strong>) with the 13 kDa internal fragment also detectable in <strong>human retina</strong>. (schaffer2025theneuronalchaperone pages 1-2)</p>
+<h4 id="22-canonical-biochemical-function-endogenous-inhibition-of-pc13-pcsk1">2.2 Canonical biochemical function: endogenous inhibition of PC1/3 (PCSK1)</h4>
+<p>In endocrine and islet biology, proSAAS is an established <strong>PC1/3 inhibitor</strong>. An expert review of islet prohormone processing states that the PC1/3 inhibitor <strong>proSAAS</strong> is <strong>highly expressed within islets</strong> and is <strong>enriched in β-cell secretory granules as they mature</strong>, positioning PCSK1N as a local regulator of prohormone-processing protease activity in the regulated secretory pathway. (chen2018isletprohormoneprocessing pages 2-3)</p>
+<p>Primary proteomics evidence from human islets also explicitly describes PCSK1N (full name: “proprotein convertase subtilisin/kexin type 1 inhibitor PCSK1N”) as acting as a <strong>potent inhibitor of PCSK1</strong>. (roomp2017combinedlipidomicand pages 14-16)</p>
+<h4 id="23-emerging-functional-framework-secretory-chaperoneanti-aggregation-factor">2.3 Emerging functional framework: secretory chaperone/anti-aggregation factor</h4>
+<p>Beyond protease inhibition, proSAAS is increasingly treated as a <strong>secretory chaperone</strong> that can limit pathological aggregation of amyloidogenic proteins. In a mechanistic cell-stress study, proSAAS is discussed as a secretory chaperone with anti-aggregation activity, with multiple referenced lines of evidence indicating it can inhibit fibrillation/aggregation of <strong>Aβ</strong>, <strong>α-synuclein</strong>, and <strong>islet amyloid polypeptide</strong>, and that functional anti-aggregant activity is associated with a larger N-terminal domain, while <strong>C-terminal peptides</strong> serve as convertase inhibitors. (shakya2020increasedexpressionand pages 1-2, shakya2020increasedexpressionand pages 12-13)</p>
+<h3 id="3-subcellular-localization-and-where-pcsk1n-carries-out-its-functions">3) Subcellular localization and where PCSK1N carries out its functions</h3>
+<h4 id="31-endocrineislet-compartmentalization">3.1 Endocrine/islet compartmentalization</h4>
+<p>In pancreatic β-cells, proSAAS is enriched in <strong>maturing secretory granules</strong>, consistent with action within the regulated secretory pathway where PC1/3 processes prohormones. (chen2018isletprohormoneprocessing pages 2-3)</p>
+<p>In human islet proteomics, PCSK1N is discussed within a network of proteins associated with the <strong>trans-Golgi network (TGN)</strong> and <strong>sorting to immature secretory vesicles</strong>, again supporting a role in secretory granule biogenesis/maturation. (roomp2017combinedlipidomicand pages 14-16)</p>
+<h4 id="32-neuronal-secretion-and-synaptic-localization">3.2 Neuronal secretion and synaptic localization</h4>
+<p>In neuronal systems, proSAAS behaves as a secreted/synapse-associated protein: it is reported as being <strong>released upon depolarization</strong> in neuronal primary cultures and discussed as a neuronal chaperone concentrated in synaptic layers (e.g., retinal inner plexiform layer). (schaffer2025theneuronalchaperone pages 1-2, mitias2024prosaasispreferentially pages 10-12)</p>
+<p>In a 2024 study focused on homeostatic scaling, proSAAS was characterized as being readily released upon depolarization and showing synaptic enrichment (with regulation at synapses rather than in soma in some conditions), supporting a model in which proSAAS exerts extracellular or lumenal secretory-pathway chaperone functions at/near synaptic terminals. (mitias2024prosaasispreferentially pages 10-12, mitias2024prosaasispreferentially pages 1-4)</p>
+<h3 id="4-pathway-context-mechanistic-role-in-biological-processes">4) Pathway context (mechanistic role in biological processes)</h3>
+<h4 id="41-regulated-secretory-pathway-and-prohormone-processing">4.1 Regulated secretory pathway and prohormone processing</h4>
+<p>The primary pathway context for PCSK1N is the <strong>regulated secretory pathway</strong> in neuroendocrine cells: PCSK1N/proSAAS modulates <strong>PC1/3 activity</strong> in secretory granules, thereby tuning maturation of peptide hormones/neuropeptides. (chen2018isletprohormoneprocessing pages 2-3, roomp2017combinedlipidomicand pages 14-16)</p>
+<p>In human islets, chronic palmitate exposure is associated with downregulation of multiple secretory-pathway proteins, including PCSK1N, which the authors interpret as consistent with impaired granule maturation and reduced insulin stores (a “diabetogenic” state). (roomp2017combinedlipidomicand pages 14-16)</p>
+<h4 id="42-proteostasis-and-amyloid-biology">4.2 Proteostasis and amyloid biology</h4>
+<p>A second pathway context is secretory/extracellular proteostasis: proSAAS is treated as a chaperone-like factor that can interact with aggregation-prone proteins and reduce their fibrillation and oligomer toxicity, which is relevant to Alzheimer’s- and Parkinson’s-related proteopathies. (shakya2020increasedexpressionand pages 1-2, mitias2024prosaasispreferentially pages 10-12)</p>
+<h3 id="5-recent-developments-prioritizing-20232024-and-latest-research">5) Recent developments (prioritizing 2023–2024) and latest research</h3>
+<h4 id="51-2024-prosaas-secretion-during-neuronal-homeostatic-scaling-and-effects-on-amyloid-plaques">5.1 2024: ProSAAS secretion during neuronal homeostatic scaling and effects on amyloid plaques</h4>
+<p>A 2024 preprint reports that proSAAS is preferentially secreted from neurons during homeostatic scaling and accumulates around amyloid plaques in 5xFAD mouse hippocampus; importantly, <strong>AAV-mediated proSAAS overexpression in CA1 reduced amyloid plaque size and plaque burden</strong> at the injection site. (mitias2024prosaasispreferentially pages 10-12, mitias2024prosaasispreferentially pages 1-4)</p>
+<p>Quantitatively, mean plaque size decreased from <strong>152 ± 8 µm²</strong> (GFP control) to <strong>124 ± 5 µm²</strong> (proSAAS), with <strong>p &lt; 0.01</strong>, and CA1 plaque burden decreased from <strong>0.012</strong> to <strong>0.008</strong> (plaque area / CA1 area units as reported). (mitias2024prosaasispreferentially pages 10-12)</p>
+<p>Visual evidence in the same work shows endogenous proSAAS concentrated around plaques (rosette-like pattern) and quantification of reduced plaque size/burden with proSAAS overexpression. (mitias2024prosaasispreferentially media 1702507a, mitias2024prosaasispreferentially media 297a766d, mitias2024prosaasispreferentially media c6538047, mitias2024prosaasispreferentially media 7be71471, mitias2024prosaasispreferentially media d94be224)</p>
+<h4 id="52-20232024-emphasis-on-prosaas-as-a-modulator-of-neurodegenerative-protein-aggregation">5.2 2023–2024: Emphasis on proSAAS as a modulator of neurodegenerative protein aggregation</h4>
+<p>The 2024 work explicitly frames proSAAS as an anti-aggregant that binds amyloid and blocks Aβ and α-synuclein aggregation in vitro, and as a stress-responsive, translationally regulated secretory protein in neurons. (mitias2024prosaasispreferentially pages 10-12, mitias2024prosaasispreferentially pages 1-4)</p>
+<h3 id="6-current-applications-and-real-world-implementations">6) Current applications and real-world implementations</h3>
+<h4 id="61-biomarker-oriented-applications-proteomicscsfserum">6.1 Biomarker-oriented applications (proteomics/CSF/serum)</h4>
+<p>ProSAAS/PCSK1N has been repeatedly positioned as a candidate biomarker in neurodegeneration contexts (e.g., CSF proteomic studies discussed in mechanistic literature), and is also detectable in human proteomics studies of systemic disease. For example, a human longevity GWAS with proteomic integration identified PCSK1N as part of a serum protein signature associated with a longevity-linked SNP (rs9657521), and the authors interpret lower serum PCSK1N in longevity-allele carriers as potentially consistent with protection from Alzheimer’s-related processes. (bae2022agenomewideassociation pages 12-14)</p>
+<p>In metabolic disease-relevant contexts, human islet proteomics under lipotoxic (palmitate) exposure identifies PCSK1N among regulated secretory pathway proteins that change with impaired insulin secretory physiology, suggesting potential as a pathway readout rather than a current clinical biomarker. (roomp2017combinedlipidomicand pages 14-16)</p>
+<h4 id="62-gene-delivery-protein-augmentation-as-a-putative-therapeutic-strategy-preclinical">6.2 Gene delivery / protein augmentation as a putative therapeutic strategy (preclinical)</h4>
+<p>The 2024 5xFAD mouse study provides a preclinical proof-of-concept that increasing proSAAS levels via AAV delivery can reduce plaque size/burden locally in hippocampus, supporting the idea of <strong>proSAAS augmentation</strong> as a potential therapeutic angle for amyloid pathology (noting that this is currently preprint-level evidence and restricted to a mouse model and local overexpression). (mitias2024prosaasispreferentially pages 10-12, mitias2024prosaasispreferentially media 1702507a)</p>
+<h3 id="7-expert-opinions-and-authoritative-analysis-interpretation-anchored-in-cited-sources">7) Expert opinions and authoritative analysis (interpretation anchored in cited sources)</h3>
+<p><strong>Endocrine/islet perspective (authoritative review):</strong> ProSAAS is treated as an endogenous regulator of prohormone processing through inhibition of PC1/3, with specific localization to <strong>maturing β-cell granules</strong>, implying temporal regulation of convertase activity during granule maturation. (chen2018isletprohormoneprocessing pages 2-3)</p>
+<p><strong>Proteostasis perspective (mechanistic synthesis):</strong> ProSAAS is conceptualized as a secretory-pathway chaperone whose processing partitions functions: <strong>C-terminal inhibitory peptides</strong> modulate proprotein convertases, while larger domains can mediate anti-aggregation activity and cytoprotection under stress. (shakya2020increasedexpressionand pages 1-2, shakya2020increasedexpressionand pages 12-13)</p>
+<h3 id="8-disease-associations-genetics-and-statistics">8) Disease associations, genetics, and statistics</h3>
+<h4 id="81-database-level-disease-associations">8.1 Database-level disease associations</h4>
+<p>In an Open Targets snapshot queried during this run, PCSK1N is associated with <strong>type 2 diabetes mellitus</strong> and <strong>Alzheimer disease</strong> among other diseases, with higher association score for type 2 diabetes (score ~<strong>0.276</strong>) than Alzheimer’s disease (score ~<strong>0.047</strong>), reflecting the current evidence aggregation and not necessarily causal direction. (OpenTargets Search: -PCSK1N)</p>
+<h4 id="82-human-genetics-and-circulating-protein-associations">8.2 Human genetics and circulating protein associations</h4>
+<p>The longevity GWAS/proteomic integration reports that <strong>carriers of a longevity-promoting allele</strong> at rs9657521 have <strong>lower serum PCSK1N</strong>, and the authors interpret this in the context of possible protection from age-related diseases including Alzheimer’s disease. (bae2022agenomewideassociation pages 12-14)</p>
+<h4 id="83-metabolic-stress-and-cell-dysfunction-human-islets">8.3 Metabolic stress and β-cell dysfunction (human islets)</h4>
+<p>Human islet proteomics under chronic palmitate exposure reports PCSK1N to be <strong>significantly down-regulated in all six donors</strong>, in parallel with other TGN/immature granule pathway proteins, consistent with impaired granule maturation and reduced insulin content/secretion phenotypes in that model. (roomp2017combinedlipidomicand pages 14-16)</p>
+<h3 id="9-notes-on-gaps-and-ambiguity-strictly-evidence-based">9) Notes on gaps and ambiguity (strictly evidence-based)</h3>
+<p>UniProt lists multiple named peptide products (e.g., SAAS-, PEN-, LEN-related fragments). Within the retrieved evidence set, proSAAS is clearly described as proteolytically processed and functionally partitioned into inhibitory C-terminal peptides and chaperone-active domains, but the specific UniProt peptide names (e.g., PEN/LEN/SAAS) and their exact boundaries are <strong>not explicitly enumerated</strong> in the available full-text evidence snippets. Therefore, detailed peptide-level functional annotation beyond “C-terminal inhibitory peptides vs N-terminal chaperone domain” should be treated as provisional until corroborated by additional peptide-mapping primary literature. (shakya2020increasedexpressionand pages 1-2, schaffer2025theneuronalchaperone pages 1-2)</p>
+<hr />
+<h3 id="evidence-summary-table">Evidence summary table</h3>
+<p>The following table consolidates the most directly supported functional-annotation facts, with URLs and dates.</p>
+<table>
+<thead>
+<tr>
+<th>Aspect</th>
+<th>Key findings</th>
+<th>Evidence/source (author year)</th>
+<th>Publication date</th>
+<th>URL/DOI</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>identity/synonyms</td>
+<td>Human <strong>PCSK1N</strong> encodes <strong>proSAAS</strong>, also described as <strong>proprotein convertase subtilisin/kexin type 1 inhibitor</strong>; authoritative disease-target resources map PCSK1N to approved name “proprotein convertase subtilisin/kexin type 1 inhibitor.” ProSAAS is described as a small neuronal/endocrine secretory chaperone; literature cited in the evidence places the human gene on <strong>Xp11.23</strong>. (OpenTargets Search: -PCSK1N, schaffer2025theneuronalchaperone pages 1-2, shakya2020increasedexpressionand pages 1-2)</td>
+<td>Open Targets; Schaffer 2025; Shakya 2020</td>
+<td>Open Targets accessed in current session; 2025-05; 2020-11</td>
+<td>https://platform.opentargets.org/target/ENSG00000102109 ; https://doi.org/10.1371/journal.pone.0321867 ; https://doi.org/10.1007/s12192-020-01128-7</td>
+</tr>
+<tr>
+<td>protein type/processing</td>
+<td>ProSAAS is a <strong>granin-like neuroendocrine peptide precursor</strong> with proline-rich regions and at least one furin/proprotein-convertase cleavage site. Processing generates C-terminal peptides that act as convertase inhibitors, while the ~20 kDa N-terminal region mediates chaperone/anti-aggregant activity. In retinal extracts, Western blot detected a <strong>~21 kDa C-terminally processed form</strong> and a <strong>~13 kDa internal fragment</strong>; the 13 kDa species was also detected in human retina. (schaffer2025theneuronalchaperone pages 1-2, shakya2020increasedexpressionand pages 1-2)</td>
+<td>Schaffer 2025; Shakya 2020</td>
+<td>2025-05; 2020-11</td>
+<td>https://doi.org/10.1371/journal.pone.0321867 ; https://doi.org/10.1007/s12192-020-01128-7</td>
+</tr>
+<tr>
+<td>localization</td>
+<td>PCSK1N/proSAAS is enriched in <strong>neural and endocrine tissues</strong>, traffics through the <strong>regulated secretory pathway</strong>, and is enriched in <strong>β-cell secretory granules as they mature</strong>. In neurons it is <strong>secreted upon depolarization</strong>, shows <strong>synaptic localization</strong>, and in hippocampus is abundant in the <strong>mossy fiber layer</strong>; in retina, expression is highest in <strong>retinal ganglion cells and horizontal cells</strong>, with signal concentrated in the <strong>ganglion cell layer</strong> and <strong>inner plexiform layer</strong>. In AD-model brain, proSAAS localizes <strong>around amyloid plaques</strong>, not in dense cores. (mitias2024prosaasispreferentially pages 10-12, schaffer2025theneuronalchaperone pages 1-2, mitias2024prosaasispreferentially pages 1-4, chen2018isletprohormoneprocessing pages 2-3, roomp2017combinedlipidomicand pages 14-16)</td>
+<td>Mitias 2024; Schaffer 2025; Chen 2018; Roomp 2017</td>
+<td>2024-04; 2025-05; 2018-09; 2017-04</td>
+<td>https://doi.org/10.1101/2024.04.18.590133 ; https://doi.org/10.1371/journal.pone.0321867 ; https://doi.org/10.1111/dom.13401 ; https://doi.org/10.1371/journal.pone.0176391</td>
+</tr>
+<tr>
+<td>core functions</td>
+<td>Canonical function: PCSK1N/proSAAS is a <strong>potent inhibitor of PC1/3 (PCSK1)</strong> in the regulated secretory pathway, modulating prohormone processing in endocrine cells and islets. Emerging function: proSAAS also acts as a <strong>secretory chaperone/anti-aggregant</strong>, blocking fibrillation/aggregation of <strong>Aβ</strong>, <strong>α-synuclein</strong>, and <strong>islet amyloid polypeptide</strong> in vitro and protecting cells from toxic oligomers. The <strong>17 kDa internal segment LARALL</strong> was reported as the major stored form in cultured hippocampal neurons and contains the active anti-aggregant region. (mitias2024prosaasispreferentially pages 10-12, shakya2020increasedexpressionand pages 12-13, shakya2020increasedexpressionand pages 1-2, roomp2017combinedlipidomicand pages 14-16, chen2018isletprohormoneprocessing pages 2-3)</td>
+<td>Mitias 2024; Shakya 2020; Roomp 2017; Chen 2018</td>
+<td>2024-04; 2020-11; 2017-04; 2018-09</td>
+<td>https://doi.org/10.1101/2024.04.18.590133 ; https://doi.org/10.1007/s12192-020-01128-7 ; https://doi.org/10.1371/journal.pone.0176391 ; https://doi.org/10.1111/dom.13401</td>
+</tr>
+<tr>
+<td>neurodegeneration findings</td>
+<td>Recent work emphasizes proSAAS as a <strong>neuronal anti-aggregation factor</strong> relevant to AD/Parkinsonian proteinopathies. In 5xFAD mice, AAV-mediated hippocampal overexpression reduced plaque size and plaque burden; proSAAS surrounded plaques. Reviews and primary studies cited in the evidence also describe proSAAS as present in <strong>AD neurofibrillary tangles/neuritic plaques</strong>, as a <strong>CSF biomarker candidate</strong>, and as protective in <strong>α-synuclein</strong> models. Transcriptomic analyses cited in longevity/AD-associated work indicate increased PCSK1N expression during AD progression, while some CSF analyses found decreased proSAAS with disease progression. (mitias2024prosaasispreferentially pages 10-12, shakya2020increasedexpressionand pages 12-13, schaffer2025theneuronalchaperone pages 1-2, shakya2020increasedexpressionand pages 1-2, bae2022agenomewideassociation pages 12-14)</td>
+<td>Mitias 2024; Shakya 2020; Schaffer 2025; Bae 2022</td>
+<td>2024-04; 2020-11; 2025-05; 2022-12</td>
+<td>https://doi.org/10.1101/2024.04.18.590133 ; https://doi.org/10.1007/s12192-020-01128-7 ; https://doi.org/10.1371/journal.pone.0321867 ; https://doi.org/10.3390/ijms24010116</td>
+</tr>
+<tr>
+<td>metabolic/islet findings</td>
+<td>In islets, proSAAS is a <strong>PC1/3 inhibitor</strong> and a component of the <strong>maturing β-cell secretory granule</strong>. Human islet proteomics under chronic palmitate exposure found <strong>PCSK1N significantly down-regulated in all six donors</strong>, together with other trans-Golgi/immature secretory vesicle proteins, consistent with impaired granule maturation and a diabetogenic state. Expert review links altered prohormone processing machinery, including PC1/3 and its inhibitor proSAAS, to diabetes-related β-cell dysfunction. (roomp2017combinedlipidomicand pages 14-16, chen2018isletprohormoneprocessing pages 2-3)</td>
+<td>Roomp 2017; Chen 2018</td>
+<td>2017-04; 2018-09</td>
+<td>https://doi.org/10.1371/journal.pone.0176391 ; https://doi.org/10.1111/dom.13401</td>
+</tr>
+<tr>
+<td>human genetics/associations</td>
+<td>Open Targets lists disease associations for <strong>type 2 diabetes mellitus</strong> and <strong>Alzheimer disease</strong> among others, though evidence strength is modest except relatively higher for T2D in the retrieved snapshot. A longevity GWAS/proteomic analysis linked serum PCSK1N to <strong>rs9657521</strong>: carriers of the longevity-promoting allele had <strong>lower serum PCSK1N</strong>, which authors suggested might reflect protection from AD-related processes. (OpenTargets Search: -PCSK1N, bae2022agenomewideassociation pages 12-14)</td>
+<td>Open Targets; Bae 2022</td>
+<td>Open Targets accessed in current session; 2022-12</td>
+<td>https://platform.opentargets.org/target/ENSG00000102109 ; https://doi.org/10.3390/ijms24010116</td>
+</tr>
+<tr>
+<td>quantitative stats</td>
+<td><strong>Mitias 2024 (5xFAD mouse hippocampus):</strong> mean plaque size decreased from <strong>152 ± 8 µm²</strong> in GFP controls to <strong>124 ± 5 µm²</strong> with proSAAS overexpression (<strong>p &lt; 0.01</strong>); CA1 plaque burden decreased from <strong>0.012</strong> to <strong>0.008 plaque area µm²/CA1 µm²</strong>. In homeostatic scaling datasets summarized there, proSAAS increased by <strong>249%</strong> in prior proteomics after TTX and by <strong>144%</strong> in the authors’ study; after bicuculline it decreased to <strong>38% of vehicle</strong>. <strong>Roomp 2017:</strong> PCSK1N was down-regulated in <strong>all 6 donors</strong> under palmitate exposure. Open Targets evidence snapshot scores in the retrieved session: <strong>type 2 diabetes mellitus 0.2757</strong>, <strong>Alzheimer disease 0.0471</strong>. (OpenTargets Search: -PCSK1N, mitias2024prosaasispreferentially pages 10-12, roomp2017combinedlipidomicand pages 14-16)</td>
+<td>Mitias 2024; Roomp 2017; Open Targets</td>
+<td>2024-04; 2017-04; Open Targets accessed in current session</td>
+<td>https://doi.org/10.1101/2024.04.18.590133 ; https://doi.org/10.1371/journal.pone.0176391 ; https://platform.opentargets.org/target/ENSG00000102109</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table consolidates supported findings on human PCSK1N/proSAAS, including identity, processing, localization, canonical PC1/3-inhibitory function, emerging chaperone roles, and disease relevance. It is useful as a quick evidence map anchored only to the provided context IDs, with recent quantitative data highlighted from Mitias 2024.</em></p>
+<h3 id="key-references-with-dates-and-urls">Key references (with dates and URLs)</h3>
+<ul>
+<li>Mitias S. et al. (2024-04-18). <em>ProSAAS is Preferentially Secreted from Neurons During Homeostatic Scaling and Reduces Amyloid Plaque Size in the 5xFAD Mouse Hippocampus.</em> bioRxiv. https://doi.org/10.1101/2024.04.18.590133 (mitias2024prosaasispreferentially pages 10-12)</li>
+<li>Chen Y.-C. et al. (2018-09). <em>Islet prohormone processing in health and disease.</em> (Review) https://doi.org/10.1111/dom.13401 (chen2018isletprohormoneprocessing pages 2-3)</li>
+<li>Roomp K. et al. (2017-04). <em>Combined lipidomic and proteomic analysis of isolated human islets exposed to palmitate…</em> https://doi.org/10.1371/journal.pone.0176391 (roomp2017combinedlipidomicand pages 14-16)</li>
+<li>Shakya M. et al. (2020-11). <em>Increased expression and retention of the secretory chaperone proSAAS following cell stress.</em> https://doi.org/10.1007/s12192-020-01128-7 (shakya2020increasedexpressionand pages 1-2)</li>
+<li>Bae H. et al. (2022-12). <em>A genome-wide association study of 2304 extreme longevity cases identifies novel longevity variants.</em> https://doi.org/10.3390/ijms24010116 (bae2022agenomewideassociation pages 12-14)</li>
+<li>Open Targets Platform (accessed during this run). PCSK1N target page and disease associations. https://platform.opentargets.org/target/ENSG00000102109 (OpenTargets Search: -PCSK1N)</li>
+</ul>
+<p>References</p>
+<ol>
+<li>
+<p>(schaffer2025theneuronalchaperone pages 1-2): Nicholas Schaffer, Samira Mitias, Yan Guo, Steven L. Bernstein, and Iris Lindberg. The neuronal chaperone prosaas is highly expressed in the retina. PLOS One, 20:e0321867, May 2025. URL: https://doi.org/10.1371/journal.pone.0321867, doi:10.1371/journal.pone.0321867. This article has 0 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(shakya2020increasedexpressionand pages 1-2): Manita Shakya, Taha Yildirim, and Iris Lindberg. Increased expression and retention of the secretory chaperone prosaas following cell stress. Cell Stress and Chaperones, 25:929-941, Nov 2020. URL: https://doi.org/10.1007/s12192-020-01128-7, doi:10.1007/s12192-020-01128-7. This article has 18 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(OpenTargets Search: -PCSK1N): Open Targets Query (-PCSK1N, 5 results). Buniello, A. et al. (2025). Open Targets Platform: facilitating therapeutic hypotheses building in drug discovery. Nucleic Acids Research.</p>
+</li>
+<li>
+<p>(chen2018isletprohormoneprocessing pages 2-3): Yi‐Chun Chen, Austin J. Taylor, and C. Bruce Verchere. Islet prohormone processing in health and disease. Diabetes, 20:64-76, Sep 2018. URL: https://doi.org/10.1111/dom.13401, doi:10.1111/dom.13401. This article has 93 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(roomp2017combinedlipidomicand pages 14-16): Kirsten Roomp, Hjalti Kristinsson, Domitille Schvartz, Kumari Ubhayasekera, Ernest Sargsyan, Levon Manukyan, Azazul Chowdhury, Hannes Manell, Venkata Satagopam, Karlfried Groebe, Reinhard Schneider, Jonas Bergquist, Jean-Charles Sanchez, and Peter Bergsten. Combined lipidomic and proteomic analysis of isolated human islets exposed to palmitate reveals time-dependent changes in insulin secretion and lipid metabolism. PLoS ONE, 12:e0176391, Apr 2017. URL: https://doi.org/10.1371/journal.pone.0176391, doi:10.1371/journal.pone.0176391. This article has 51 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(shakya2020increasedexpressionand pages 12-13): Manita Shakya, Taha Yildirim, and Iris Lindberg. Increased expression and retention of the secretory chaperone prosaas following cell stress. Cell Stress and Chaperones, 25:929-941, Nov 2020. URL: https://doi.org/10.1007/s12192-020-01128-7, doi:10.1007/s12192-020-01128-7. This article has 18 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(mitias2024prosaasispreferentially pages 10-12): Samira Mitias, Nicholas Schaffer, Saaya Nair, Chelsea Hook, and Iris Lindberg. Prosaas is preferentially secreted from neurons during homeostatic scaling and reduces amyloid plaque size in the 5xfad mouse hippocampus. bioRxiv, Apr 2024. URL: https://doi.org/10.1101/2024.04.18.590133, doi:10.1101/2024.04.18.590133. This article has 0 citations.</p>
+</li>
+<li>
+<p>(mitias2024prosaasispreferentially pages 1-4): Samira Mitias, Nicholas Schaffer, Saaya Nair, Chelsea Hook, and Iris Lindberg. Prosaas is preferentially secreted from neurons during homeostatic scaling and reduces amyloid plaque size in the 5xfad mouse hippocampus. bioRxiv, Apr 2024. URL: https://doi.org/10.1101/2024.04.18.590133, doi:10.1101/2024.04.18.590133. This article has 0 citations.</p>
+</li>
+<li>
+<p>(mitias2024prosaasispreferentially media 1702507a): Samira Mitias, Nicholas Schaffer, Saaya Nair, Chelsea Hook, and Iris Lindberg. Prosaas is preferentially secreted from neurons during homeostatic scaling and reduces amyloid plaque size in the 5xfad mouse hippocampus. bioRxiv, Apr 2024. URL: https://doi.org/10.1101/2024.04.18.590133, doi:10.1101/2024.04.18.590133. This article has 0 citations.</p>
+</li>
+<li>
+<p>(mitias2024prosaasispreferentially media 297a766d): Samira Mitias, Nicholas Schaffer, Saaya Nair, Chelsea Hook, and Iris Lindberg. Prosaas is preferentially secreted from neurons during homeostatic scaling and reduces amyloid plaque size in the 5xfad mouse hippocampus. bioRxiv, Apr 2024. URL: https://doi.org/10.1101/2024.04.18.590133, doi:10.1101/2024.04.18.590133. This article has 0 citations.</p>
+</li>
+<li>
+<p>(mitias2024prosaasispreferentially media c6538047): Samira Mitias, Nicholas Schaffer, Saaya Nair, Chelsea Hook, and Iris Lindberg. Prosaas is preferentially secreted from neurons during homeostatic scaling and reduces amyloid plaque size in the 5xfad mouse hippocampus. bioRxiv, Apr 2024. URL: https://doi.org/10.1101/2024.04.18.590133, doi:10.1101/2024.04.18.590133. This article has 0 citations.</p>
+</li>
+<li>
+<p>(mitias2024prosaasispreferentially media 7be71471): Samira Mitias, Nicholas Schaffer, Saaya Nair, Chelsea Hook, and Iris Lindberg. Prosaas is preferentially secreted from neurons during homeostatic scaling and reduces amyloid plaque size in the 5xfad mouse hippocampus. bioRxiv, Apr 2024. URL: https://doi.org/10.1101/2024.04.18.590133, doi:10.1101/2024.04.18.590133. This article has 0 citations.</p>
+</li>
+<li>
+<p>(mitias2024prosaasispreferentially media d94be224): Samira Mitias, Nicholas Schaffer, Saaya Nair, Chelsea Hook, and Iris Lindberg. Prosaas is preferentially secreted from neurons during homeostatic scaling and reduces amyloid plaque size in the 5xfad mouse hippocampus. bioRxiv, Apr 2024. URL: https://doi.org/10.1101/2024.04.18.590133, doi:10.1101/2024.04.18.590133. This article has 0 citations.</p>
+</li>
+<li>
+<p>(bae2022agenomewideassociation pages 12-14): Harold Bae, Anastasia Gurinovich, Tanya T. Karagiannis, Zeyuan Song, Anastasia Leshchyk, Mengze Li, Stacy L. Andersen, Konstantin Arbeev, Anatoliy Yashin, Joseph Zmuda, Ping An, Mary Feitosa, Cristina Giuliani, Claudio Franceschi, Paolo Garagnani, Jonas Mengel-From, Gil Atzmon, Nir Barzilai, Annibale Puca, Nicholas J. Schork, Thomas T. Perls, and Paola Sebastiani. A genome-wide association study of 2304 extreme longevity cases identifies novel longevity variants. International Journal of Molecular Sciences, 24:116, Dec 2022. URL: https://doi.org/10.3390/ijms24010116, doi:10.3390/ijms24010116. This article has 20 citations.</p>
+</li>
+</ol>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>shakya2020increasedexpressionand pages 1-2</li>
+<li>schaffer2025theneuronalchaperone pages 1-2</li>
+<li>chen2018isletprohormoneprocessing pages 2-3</li>
+<li>roomp2017combinedlipidomicand pages 14-16</li>
+<li>mitias2024prosaasispreferentially pages 10-12</li>
+<li>bae2022agenomewideassociation pages 12-14</li>
+<li>shakya2020increasedexpressionand pages 12-13</li>
+<li>mitias2024prosaasispreferentially pages 1-4</li>
+<li>https://platform.opentargets.org/target/ENSG00000102109</li>
+<li>https://doi.org/10.1371/journal.pone.0321867</li>
+<li>https://doi.org/10.1007/s12192-020-01128-7</li>
+<li>https://doi.org/10.1101/2024.04.18.590133</li>
+<li>https://doi.org/10.1111/dom.13401</li>
+<li>https://doi.org/10.1371/journal.pone.0176391</li>
+<li>https://doi.org/10.3390/ijms24010116</li>
+<li>https://doi.org/10.1371/journal.pone.0321867,</li>
+<li>https://doi.org/10.1007/s12192-020-01128-7,</li>
+<li>https://doi.org/10.1111/dom.13401,</li>
+<li>https://doi.org/10.1371/journal.pone.0176391,</li>
+<li>https://doi.org/10.1101/2024.04.18.590133,</li>
+<li>https://doi.org/10.3390/ijms24010116,</li>
+</ol>
+            </div>
+        </details>
+
         <details class="markdown-section">
             <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
                 <div style="flex: 1;">
@@ -3531,6 +3931,8 @@ existing_annotations:
       supporting_text: &gt;-
         the decapeptide proSAAS-(235-244)( 235)VLGALLRVKR(244) is the most
         potent reversible competitive PC1-inhibitor (K(i) approximately 9 nm).
+    - reference_id: file:human/PCSK1N/PCSK1N-deep-research-falcon.md
+      supporting_text: &#34;The report summarizes proSAAS as an endogenous PC1/3 inhibitor that modulates prohormone-processing protease activity in the regulated secretory pathway.&#34;
 - term:
     id: GO:0005802
     label: trans-Golgi network
@@ -3696,6 +4098,8 @@ existing_annotations:
         Recombinant proSAAS potently inhibits the fibrillation of α-synuclein in
         an in vitro assay; residues 158-180, containing a largely conserved
         element, are critical to this bioactivity.
+    - reference_id: file:human/PCSK1N/PCSK1N-deep-research-falcon.md
+      supporting_text: &#34;The report summarizes proSAAS as a secretory chaperone/anti-aggregant that can limit fibrillation or aggregation of amyloid-beta, alpha-synuclein, and islet amyloid polypeptide.&#34;
 - term:
     id: GO:0001540
     label: amyloid-beta binding
@@ -3881,6 +4285,8 @@ core_functions:
     supporting_text: &gt;-
       the decapeptide proSAAS-(235-244)( 235)VLGALLRVKR(244) is the most potent
       reversible competitive PC1-inhibitor (K(i) approximately 9 nm).
+  - reference_id: file:human/PCSK1N/PCSK1N-deep-research-falcon.md
+    supporting_text: &#34;Canonical function: PCSK1N/proSAAS is a potent inhibitor of PC1/3 in the regulated secretory pathway, modulating prohormone processing in endocrine cells and islets.&#34;
 - description: &gt;-
     Full-length ProSAAS (and the 21 kDa N-terminal fragment, residues ~1-180)
     is an extracellular anti-aggregant chaperone that binds amyloidogenic
@@ -3954,6 +4360,8 @@ core_functions:
       protein, exhibits potent chaperone activity against protein aggregation
       in vitro and blocks the cytotoxic effects of amyloid and synuclein
       oligomers in cell culture systems.
+  - reference_id: file:human/PCSK1N/PCSK1N-deep-research-falcon.md
+    supporting_text: &#34;Emerging function: proSAAS also acts as a secretory chaperone/anti-aggregant, blocking fibrillation or aggregation of amyloid-beta, alpha-synuclein, and islet amyloid polypeptide in vitro and protecting cells from toxic oligomers.&#34;
 proposed_new_terms: []
 suggested_questions:
 - question: &gt;-
@@ -4044,6 +4452,11 @@ references:
 - id: GO_REF:0000120
   title: Combined Automated Annotation using Multiple IEA Methods
   findings: []
+- id: file:human/PCSK1N/PCSK1N-deep-research-falcon.md
+  title: Falcon deep research report for human PCSK1N
+  findings:
+  - statement: PCSK1N encodes proSAAS, a regulated-secretory-pathway precursor and endogenous PC1/3 inhibitor that modulates prohormone processing in secretory granules.
+  - statement: The report also supports proSAAS as a secretory chaperone or anti-aggregant with activity against amyloidogenic clients including amyloid-beta and alpha-synuclein.
 - id: PMID:10632593
   title: Identification and characterization of proSAAS, a granin-like neuroendocrine
     peptide precursor that inhibits prohormone processing.

--- a/genes/human/PCSK1N/PCSK1N-ai-review.yaml
+++ b/genes/human/PCSK1N/PCSK1N-ai-review.yaml
@@ -150,6 +150,8 @@ existing_annotations:
       supporting_text: >-
         the decapeptide proSAAS-(235-244)( 235)VLGALLRVKR(244) is the most
         potent reversible competitive PC1-inhibitor (K(i) approximately 9 nm).
+    - reference_id: file:human/PCSK1N/PCSK1N-deep-research-falcon.md
+      supporting_text: "The report summarizes proSAAS as an endogenous PC1/3 inhibitor that modulates prohormone-processing protease activity in the regulated secretory pathway."
 - term:
     id: GO:0005802
     label: trans-Golgi network
@@ -315,6 +317,8 @@ existing_annotations:
         Recombinant proSAAS potently inhibits the fibrillation of α-synuclein in
         an in vitro assay; residues 158-180, containing a largely conserved
         element, are critical to this bioactivity.
+    - reference_id: file:human/PCSK1N/PCSK1N-deep-research-falcon.md
+      supporting_text: "The report summarizes proSAAS as a secretory chaperone/anti-aggregant that can limit fibrillation or aggregation of amyloid-beta, alpha-synuclein, and islet amyloid polypeptide."
 - term:
     id: GO:0001540
     label: amyloid-beta binding
@@ -500,6 +504,8 @@ core_functions:
     supporting_text: >-
       the decapeptide proSAAS-(235-244)( 235)VLGALLRVKR(244) is the most potent
       reversible competitive PC1-inhibitor (K(i) approximately 9 nm).
+  - reference_id: file:human/PCSK1N/PCSK1N-deep-research-falcon.md
+    supporting_text: "Canonical function: PCSK1N/proSAAS is a potent inhibitor of PC1/3 in the regulated secretory pathway, modulating prohormone processing in endocrine cells and islets."
 - description: >-
     Full-length ProSAAS (and the 21 kDa N-terminal fragment, residues ~1-180)
     is an extracellular anti-aggregant chaperone that binds amyloidogenic
@@ -573,6 +579,8 @@ core_functions:
       protein, exhibits potent chaperone activity against protein aggregation
       in vitro and blocks the cytotoxic effects of amyloid and synuclein
       oligomers in cell culture systems.
+  - reference_id: file:human/PCSK1N/PCSK1N-deep-research-falcon.md
+    supporting_text: "Emerging function: proSAAS also acts as a secretory chaperone/anti-aggregant, blocking fibrillation or aggregation of amyloid-beta, alpha-synuclein, and islet amyloid polypeptide in vitro and protecting cells from toxic oligomers."
 proposed_new_terms: []
 suggested_questions:
 - question: >-
@@ -663,6 +671,11 @@ references:
 - id: GO_REF:0000120
   title: Combined Automated Annotation using Multiple IEA Methods
   findings: []
+- id: file:human/PCSK1N/PCSK1N-deep-research-falcon.md
+  title: Falcon deep research report for human PCSK1N
+  findings:
+  - statement: PCSK1N encodes proSAAS, a regulated-secretory-pathway precursor and endogenous PC1/3 inhibitor that modulates prohormone processing in secretory granules.
+  - statement: The report also supports proSAAS as a secretory chaperone or anti-aggregant with activity against amyloidogenic clients including amyloid-beta and alpha-synuclein.
 - id: PMID:10632593
   title: Identification and characterization of proSAAS, a granin-like neuroendocrine
     peptide precursor that inhibits prohormone processing.

--- a/genes/human/PCSK1N/PCSK1N-deep-research-falcon.md
+++ b/genes/human/PCSK1N/PCSK1N-deep-research-falcon.md
@@ -1,0 +1,307 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-10T22:23:34.233199'
+end_time: '2026-05-10T22:32:04.062923'
+duration_seconds: 509.83
+template_file: templates/gene_research_go_focused.md
+template_variables:
+  organism: human
+  gene_id: PCSK1N
+  gene_symbol: PCSK1N
+  uniprot_accession: Q9UHG2
+  protein_description: 'RecName: Full=ProSAAS; AltName: Full=Proprotein convertase
+    subtilisin/kexin type 1 inhibitor; Short=Proprotein convertase 1 inhibitor; AltName:
+    Full=pro-SAAS; Contains: RecName: Full=KEP; Contains: RecName: Full=Big SAAS;
+    Short=b-SAAS; Contains: RecName: Full=Little SAAS; Short=l-SAAS; AltName: Full=N-proSAAS;
+    Contains: RecName: Full=Big PEN-LEN; Short=b-PEN-LEN; AltName: Full=SAAS CT(1-49);
+    Contains: RecName: Full=PEN; Contains: RecName: Full=Little LEN; Short=l-LEN;
+    Contains: RecName: Full=Big LEN; Short=b-LEN; AltName: Full=SAAS CT(25-40); Flags:
+    Precursor;'
+  gene_info: Name=PCSK1N;
+  organism_full: Homo sapiens (Human).
+  protein_family: Not specified in UniProt
+  protein_domains: ProSAAS. (IPR010832); ProSAAS (PF07259)
+provider_config:
+  timeout: 600
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 21
+---
+
+## Question
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** Q9UHG2
+- **Protein Description:** RecName: Full=ProSAAS; AltName: Full=Proprotein convertase subtilisin/kexin type 1 inhibitor; Short=Proprotein convertase 1 inhibitor; AltName: Full=pro-SAAS; Contains: RecName: Full=KEP; Contains: RecName: Full=Big SAAS; Short=b-SAAS; Contains: RecName: Full=Little SAAS; Short=l-SAAS; AltName: Full=N-proSAAS; Contains: RecName: Full=Big PEN-LEN; Short=b-PEN-LEN; AltName: Full=SAAS CT(1-49); Contains: RecName: Full=PEN; Contains: RecName: Full=Little LEN; Short=l-LEN; Contains: RecName: Full=Big LEN; Short=b-LEN; AltName: Full=SAAS CT(25-40); Flags: Precursor;
+- **Gene Information:** Name=PCSK1N;
+- **Organism (full):** Homo sapiens (Human).
+- **Protein Family:** Not specified in UniProt
+- **Key Domains:** ProSAAS. (IPR010832); ProSAAS (PF07259)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "PCSK1N" matches the protein description above**
+2. **Verify the organism is correct:** Homo sapiens (Human).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'PCSK1N' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **PCSK1N** (gene ID: PCSK1N, UniProt: Q9UHG2) in human.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** Q9UHG2
+- **Protein Description:** RecName: Full=ProSAAS; AltName: Full=Proprotein convertase subtilisin/kexin type 1 inhibitor; Short=Proprotein convertase 1 inhibitor; AltName: Full=pro-SAAS; Contains: RecName: Full=KEP; Contains: RecName: Full=Big SAAS; Short=b-SAAS; Contains: RecName: Full=Little SAAS; Short=l-SAAS; AltName: Full=N-proSAAS; Contains: RecName: Full=Big PEN-LEN; Short=b-PEN-LEN; AltName: Full=SAAS CT(1-49); Contains: RecName: Full=PEN; Contains: RecName: Full=Little LEN; Short=l-LEN; Contains: RecName: Full=Big LEN; Short=b-LEN; AltName: Full=SAAS CT(25-40); Flags: Precursor;
+- **Gene Information:** Name=PCSK1N;
+- **Organism (full):** Homo sapiens (Human).
+- **Protein Family:** Not specified in UniProt
+- **Key Domains:** ProSAAS. (IPR010832); ProSAAS (PF07259)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "PCSK1N" matches the protein description above**
+2. **Verify the organism is correct:** Homo sapiens (Human).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'PCSK1N' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **PCSK1N** (gene ID: PCSK1N, UniProt: Q9UHG2) in human.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Research Report: Functional Annotation of Human **PCSK1N** (proSAAS) — UniProt **Q9UHG2**
+
+### 1) Target verification (gene/protein identity)
+The UniProt accession **Q9UHG2** corresponds to the human gene **PCSK1N**, whose product is commonly called **proSAAS** and is also described as a **proprotein convertase subtilisin/kexin type 1 inhibitor** (i.e., an inhibitor of PC1/3/PCSK1). This identity mapping (PCSK1N ↔ proSAAS; human) is explicitly stated in experimental literature and is consistent with authoritative target resources. (schaffer2025theneuronalchaperone pages 1-2, shakya2020increasedexpressionand pages 1-2, OpenTargets Search: -PCSK1N)
+
+### 2) Key concepts, definitions, and current understanding
+
+#### 2.1 ProSAAS is a regulated-secretory-pathway precursor protein
+ProSAAS is described as a **granin-like neuroendocrine peptide precursor** enriched in neural and endocrine tissues, with sequence features (e.g., proline-rich regions and at least one furin/proprotein convertase cleavage site) consistent with proteolytic processing in the secretory pathway. (shakya2020increasedexpressionand pages 1-2)
+
+A key concept in PCSK1N biology is that proSAAS is synthesized as a precursor and then **processed into smaller fragments** in secretory compartments; in retinal extracts, immunoblotting evidence supports the existence of at least two processed forms (approximately **21 kDa** and **13 kDa**) with the 13 kDa internal fragment also detectable in **human retina**. (schaffer2025theneuronalchaperone pages 1-2)
+
+#### 2.2 Canonical biochemical function: endogenous inhibition of PC1/3 (PCSK1)
+In endocrine and islet biology, proSAAS is an established **PC1/3 inhibitor**. An expert review of islet prohormone processing states that the PC1/3 inhibitor **proSAAS** is **highly expressed within islets** and is **enriched in β-cell secretory granules as they mature**, positioning PCSK1N as a local regulator of prohormone-processing protease activity in the regulated secretory pathway. (chen2018isletprohormoneprocessing pages 2-3)
+
+Primary proteomics evidence from human islets also explicitly describes PCSK1N (full name: “proprotein convertase subtilisin/kexin type 1 inhibitor PCSK1N”) as acting as a **potent inhibitor of PCSK1**. (roomp2017combinedlipidomicand pages 14-16)
+
+#### 2.3 Emerging functional framework: secretory chaperone/anti-aggregation factor
+Beyond protease inhibition, proSAAS is increasingly treated as a **secretory chaperone** that can limit pathological aggregation of amyloidogenic proteins. In a mechanistic cell-stress study, proSAAS is discussed as a secretory chaperone with anti-aggregation activity, with multiple referenced lines of evidence indicating it can inhibit fibrillation/aggregation of **Aβ**, **α-synuclein**, and **islet amyloid polypeptide**, and that functional anti-aggregant activity is associated with a larger N-terminal domain, while **C-terminal peptides** serve as convertase inhibitors. (shakya2020increasedexpressionand pages 1-2, shakya2020increasedexpressionand pages 12-13)
+
+### 3) Subcellular localization and where PCSK1N carries out its functions
+
+#### 3.1 Endocrine/islet compartmentalization
+In pancreatic β-cells, proSAAS is enriched in **maturing secretory granules**, consistent with action within the regulated secretory pathway where PC1/3 processes prohormones. (chen2018isletprohormoneprocessing pages 2-3)
+
+In human islet proteomics, PCSK1N is discussed within a network of proteins associated with the **trans-Golgi network (TGN)** and **sorting to immature secretory vesicles**, again supporting a role in secretory granule biogenesis/maturation. (roomp2017combinedlipidomicand pages 14-16)
+
+#### 3.2 Neuronal secretion and synaptic localization
+In neuronal systems, proSAAS behaves as a secreted/synapse-associated protein: it is reported as being **released upon depolarization** in neuronal primary cultures and discussed as a neuronal chaperone concentrated in synaptic layers (e.g., retinal inner plexiform layer). (schaffer2025theneuronalchaperone pages 1-2, mitias2024prosaasispreferentially pages 10-12)
+
+In a 2024 study focused on homeostatic scaling, proSAAS was characterized as being readily released upon depolarization and showing synaptic enrichment (with regulation at synapses rather than in soma in some conditions), supporting a model in which proSAAS exerts extracellular or lumenal secretory-pathway chaperone functions at/near synaptic terminals. (mitias2024prosaasispreferentially pages 10-12, mitias2024prosaasispreferentially pages 1-4)
+
+### 4) Pathway context (mechanistic role in biological processes)
+
+#### 4.1 Regulated secretory pathway and prohormone processing
+The primary pathway context for PCSK1N is the **regulated secretory pathway** in neuroendocrine cells: PCSK1N/proSAAS modulates **PC1/3 activity** in secretory granules, thereby tuning maturation of peptide hormones/neuropeptides. (chen2018isletprohormoneprocessing pages 2-3, roomp2017combinedlipidomicand pages 14-16)
+
+In human islets, chronic palmitate exposure is associated with downregulation of multiple secretory-pathway proteins, including PCSK1N, which the authors interpret as consistent with impaired granule maturation and reduced insulin stores (a “diabetogenic” state). (roomp2017combinedlipidomicand pages 14-16)
+
+#### 4.2 Proteostasis and amyloid biology
+A second pathway context is secretory/extracellular proteostasis: proSAAS is treated as a chaperone-like factor that can interact with aggregation-prone proteins and reduce their fibrillation and oligomer toxicity, which is relevant to Alzheimer’s- and Parkinson’s-related proteopathies. (shakya2020increasedexpressionand pages 1-2, mitias2024prosaasispreferentially pages 10-12)
+
+### 5) Recent developments (prioritizing 2023–2024) and latest research
+
+#### 5.1 2024: ProSAAS secretion during neuronal homeostatic scaling and effects on amyloid plaques
+A 2024 preprint reports that proSAAS is preferentially secreted from neurons during homeostatic scaling and accumulates around amyloid plaques in 5xFAD mouse hippocampus; importantly, **AAV-mediated proSAAS overexpression in CA1 reduced amyloid plaque size and plaque burden** at the injection site. (mitias2024prosaasispreferentially pages 10-12, mitias2024prosaasispreferentially pages 1-4)
+
+Quantitatively, mean plaque size decreased from **152 ± 8 µm²** (GFP control) to **124 ± 5 µm²** (proSAAS), with **p < 0.01**, and CA1 plaque burden decreased from **0.012** to **0.008** (plaque area / CA1 area units as reported). (mitias2024prosaasispreferentially pages 10-12)
+
+Visual evidence in the same work shows endogenous proSAAS concentrated around plaques (rosette-like pattern) and quantification of reduced plaque size/burden with proSAAS overexpression. (mitias2024prosaasispreferentially media 1702507a, mitias2024prosaasispreferentially media 297a766d, mitias2024prosaasispreferentially media c6538047, mitias2024prosaasispreferentially media 7be71471, mitias2024prosaasispreferentially media d94be224)
+
+#### 5.2 2023–2024: Emphasis on proSAAS as a modulator of neurodegenerative protein aggregation
+The 2024 work explicitly frames proSAAS as an anti-aggregant that binds amyloid and blocks Aβ and α-synuclein aggregation in vitro, and as a stress-responsive, translationally regulated secretory protein in neurons. (mitias2024prosaasispreferentially pages 10-12, mitias2024prosaasispreferentially pages 1-4)
+
+### 6) Current applications and real-world implementations
+
+#### 6.1 Biomarker-oriented applications (proteomics/CSF/serum)
+ProSAAS/PCSK1N has been repeatedly positioned as a candidate biomarker in neurodegeneration contexts (e.g., CSF proteomic studies discussed in mechanistic literature), and is also detectable in human proteomics studies of systemic disease. For example, a human longevity GWAS with proteomic integration identified PCSK1N as part of a serum protein signature associated with a longevity-linked SNP (rs9657521), and the authors interpret lower serum PCSK1N in longevity-allele carriers as potentially consistent with protection from Alzheimer’s-related processes. (bae2022agenomewideassociation pages 12-14)
+
+In metabolic disease-relevant contexts, human islet proteomics under lipotoxic (palmitate) exposure identifies PCSK1N among regulated secretory pathway proteins that change with impaired insulin secretory physiology, suggesting potential as a pathway readout rather than a current clinical biomarker. (roomp2017combinedlipidomicand pages 14-16)
+
+#### 6.2 Gene delivery / protein augmentation as a putative therapeutic strategy (preclinical)
+The 2024 5xFAD mouse study provides a preclinical proof-of-concept that increasing proSAAS levels via AAV delivery can reduce plaque size/burden locally in hippocampus, supporting the idea of **proSAAS augmentation** as a potential therapeutic angle for amyloid pathology (noting that this is currently preprint-level evidence and restricted to a mouse model and local overexpression). (mitias2024prosaasispreferentially pages 10-12, mitias2024prosaasispreferentially media 1702507a)
+
+### 7) Expert opinions and authoritative analysis (interpretation anchored in cited sources)
+
+**Endocrine/islet perspective (authoritative review):** ProSAAS is treated as an endogenous regulator of prohormone processing through inhibition of PC1/3, with specific localization to **maturing β-cell granules**, implying temporal regulation of convertase activity during granule maturation. (chen2018isletprohormoneprocessing pages 2-3)
+
+**Proteostasis perspective (mechanistic synthesis):** ProSAAS is conceptualized as a secretory-pathway chaperone whose processing partitions functions: **C-terminal inhibitory peptides** modulate proprotein convertases, while larger domains can mediate anti-aggregation activity and cytoprotection under stress. (shakya2020increasedexpressionand pages 1-2, shakya2020increasedexpressionand pages 12-13)
+
+### 8) Disease associations, genetics, and statistics
+
+#### 8.1 Database-level disease associations
+In an Open Targets snapshot queried during this run, PCSK1N is associated with **type 2 diabetes mellitus** and **Alzheimer disease** among other diseases, with higher association score for type 2 diabetes (score ~**0.276**) than Alzheimer’s disease (score ~**0.047**), reflecting the current evidence aggregation and not necessarily causal direction. (OpenTargets Search: -PCSK1N)
+
+#### 8.2 Human genetics and circulating protein associations
+The longevity GWAS/proteomic integration reports that **carriers of a longevity-promoting allele** at rs9657521 have **lower serum PCSK1N**, and the authors interpret this in the context of possible protection from age-related diseases including Alzheimer’s disease. (bae2022agenomewideassociation pages 12-14)
+
+#### 8.3 Metabolic stress and β-cell dysfunction (human islets)
+Human islet proteomics under chronic palmitate exposure reports PCSK1N to be **significantly down-regulated in all six donors**, in parallel with other TGN/immature granule pathway proteins, consistent with impaired granule maturation and reduced insulin content/secretion phenotypes in that model. (roomp2017combinedlipidomicand pages 14-16)
+
+### 9) Notes on gaps and ambiguity (strictly evidence-based)
+UniProt lists multiple named peptide products (e.g., SAAS-, PEN-, LEN-related fragments). Within the retrieved evidence set, proSAAS is clearly described as proteolytically processed and functionally partitioned into inhibitory C-terminal peptides and chaperone-active domains, but the specific UniProt peptide names (e.g., PEN/LEN/SAAS) and their exact boundaries are **not explicitly enumerated** in the available full-text evidence snippets. Therefore, detailed peptide-level functional annotation beyond “C-terminal inhibitory peptides vs N-terminal chaperone domain” should be treated as provisional until corroborated by additional peptide-mapping primary literature. (shakya2020increasedexpressionand pages 1-2, schaffer2025theneuronalchaperone pages 1-2)
+
+---
+
+### Evidence summary table
+The following table consolidates the most directly supported functional-annotation facts, with URLs and dates.
+
+| Aspect | Key findings | Evidence/source (author year) | Publication date | URL/DOI |
+|---|---|---|---|---|
+| identity/synonyms | Human **PCSK1N** encodes **proSAAS**, also described as **proprotein convertase subtilisin/kexin type 1 inhibitor**; authoritative disease-target resources map PCSK1N to approved name “proprotein convertase subtilisin/kexin type 1 inhibitor.” ProSAAS is described as a small neuronal/endocrine secretory chaperone; literature cited in the evidence places the human gene on **Xp11.23**. (OpenTargets Search: -PCSK1N, schaffer2025theneuronalchaperone pages 1-2, shakya2020increasedexpressionand pages 1-2) | Open Targets; Schaffer 2025; Shakya 2020 | Open Targets accessed in current session; 2025-05; 2020-11 | https://platform.opentargets.org/target/ENSG00000102109 ; https://doi.org/10.1371/journal.pone.0321867 ; https://doi.org/10.1007/s12192-020-01128-7 |
+| protein type/processing | ProSAAS is a **granin-like neuroendocrine peptide precursor** with proline-rich regions and at least one furin/proprotein-convertase cleavage site. Processing generates C-terminal peptides that act as convertase inhibitors, while the ~20 kDa N-terminal region mediates chaperone/anti-aggregant activity. In retinal extracts, Western blot detected a **~21 kDa C-terminally processed form** and a **~13 kDa internal fragment**; the 13 kDa species was also detected in human retina. (schaffer2025theneuronalchaperone pages 1-2, shakya2020increasedexpressionand pages 1-2) | Schaffer 2025; Shakya 2020 | 2025-05; 2020-11 | https://doi.org/10.1371/journal.pone.0321867 ; https://doi.org/10.1007/s12192-020-01128-7 |
+| localization | PCSK1N/proSAAS is enriched in **neural and endocrine tissues**, traffics through the **regulated secretory pathway**, and is enriched in **β-cell secretory granules as they mature**. In neurons it is **secreted upon depolarization**, shows **synaptic localization**, and in hippocampus is abundant in the **mossy fiber layer**; in retina, expression is highest in **retinal ganglion cells and horizontal cells**, with signal concentrated in the **ganglion cell layer** and **inner plexiform layer**. In AD-model brain, proSAAS localizes **around amyloid plaques**, not in dense cores. (mitias2024prosaasispreferentially pages 10-12, schaffer2025theneuronalchaperone pages 1-2, mitias2024prosaasispreferentially pages 1-4, chen2018isletprohormoneprocessing pages 2-3, roomp2017combinedlipidomicand pages 14-16) | Mitias 2024; Schaffer 2025; Chen 2018; Roomp 2017 | 2024-04; 2025-05; 2018-09; 2017-04 | https://doi.org/10.1101/2024.04.18.590133 ; https://doi.org/10.1371/journal.pone.0321867 ; https://doi.org/10.1111/dom.13401 ; https://doi.org/10.1371/journal.pone.0176391 |
+| core functions | Canonical function: PCSK1N/proSAAS is a **potent inhibitor of PC1/3 (PCSK1)** in the regulated secretory pathway, modulating prohormone processing in endocrine cells and islets. Emerging function: proSAAS also acts as a **secretory chaperone/anti-aggregant**, blocking fibrillation/aggregation of **Aβ**, **α-synuclein**, and **islet amyloid polypeptide** in vitro and protecting cells from toxic oligomers. The **17 kDa internal segment LARALL** was reported as the major stored form in cultured hippocampal neurons and contains the active anti-aggregant region. (mitias2024prosaasispreferentially pages 10-12, shakya2020increasedexpressionand pages 12-13, shakya2020increasedexpressionand pages 1-2, roomp2017combinedlipidomicand pages 14-16, chen2018isletprohormoneprocessing pages 2-3) | Mitias 2024; Shakya 2020; Roomp 2017; Chen 2018 | 2024-04; 2020-11; 2017-04; 2018-09 | https://doi.org/10.1101/2024.04.18.590133 ; https://doi.org/10.1007/s12192-020-01128-7 ; https://doi.org/10.1371/journal.pone.0176391 ; https://doi.org/10.1111/dom.13401 |
+| neurodegeneration findings | Recent work emphasizes proSAAS as a **neuronal anti-aggregation factor** relevant to AD/Parkinsonian proteinopathies. In 5xFAD mice, AAV-mediated hippocampal overexpression reduced plaque size and plaque burden; proSAAS surrounded plaques. Reviews and primary studies cited in the evidence also describe proSAAS as present in **AD neurofibrillary tangles/neuritic plaques**, as a **CSF biomarker candidate**, and as protective in **α-synuclein** models. Transcriptomic analyses cited in longevity/AD-associated work indicate increased PCSK1N expression during AD progression, while some CSF analyses found decreased proSAAS with disease progression. (mitias2024prosaasispreferentially pages 10-12, shakya2020increasedexpressionand pages 12-13, schaffer2025theneuronalchaperone pages 1-2, shakya2020increasedexpressionand pages 1-2, bae2022agenomewideassociation pages 12-14) | Mitias 2024; Shakya 2020; Schaffer 2025; Bae 2022 | 2024-04; 2020-11; 2025-05; 2022-12 | https://doi.org/10.1101/2024.04.18.590133 ; https://doi.org/10.1007/s12192-020-01128-7 ; https://doi.org/10.1371/journal.pone.0321867 ; https://doi.org/10.3390/ijms24010116 |
+| metabolic/islet findings | In islets, proSAAS is a **PC1/3 inhibitor** and a component of the **maturing β-cell secretory granule**. Human islet proteomics under chronic palmitate exposure found **PCSK1N significantly down-regulated in all six donors**, together with other trans-Golgi/immature secretory vesicle proteins, consistent with impaired granule maturation and a diabetogenic state. Expert review links altered prohormone processing machinery, including PC1/3 and its inhibitor proSAAS, to diabetes-related β-cell dysfunction. (roomp2017combinedlipidomicand pages 14-16, chen2018isletprohormoneprocessing pages 2-3) | Roomp 2017; Chen 2018 | 2017-04; 2018-09 | https://doi.org/10.1371/journal.pone.0176391 ; https://doi.org/10.1111/dom.13401 |
+| human genetics/associations | Open Targets lists disease associations for **type 2 diabetes mellitus** and **Alzheimer disease** among others, though evidence strength is modest except relatively higher for T2D in the retrieved snapshot. A longevity GWAS/proteomic analysis linked serum PCSK1N to **rs9657521**: carriers of the longevity-promoting allele had **lower serum PCSK1N**, which authors suggested might reflect protection from AD-related processes. (OpenTargets Search: -PCSK1N, bae2022agenomewideassociation pages 12-14) | Open Targets; Bae 2022 | Open Targets accessed in current session; 2022-12 | https://platform.opentargets.org/target/ENSG00000102109 ; https://doi.org/10.3390/ijms24010116 |
+| quantitative stats | **Mitias 2024 (5xFAD mouse hippocampus):** mean plaque size decreased from **152 ± 8 µm²** in GFP controls to **124 ± 5 µm²** with proSAAS overexpression (**p < 0.01**); CA1 plaque burden decreased from **0.012** to **0.008 plaque area µm²/CA1 µm²**. In homeostatic scaling datasets summarized there, proSAAS increased by **249%** in prior proteomics after TTX and by **144%** in the authors’ study; after bicuculline it decreased to **38% of vehicle**. **Roomp 2017:** PCSK1N was down-regulated in **all 6 donors** under palmitate exposure. Open Targets evidence snapshot scores in the retrieved session: **type 2 diabetes mellitus 0.2757**, **Alzheimer disease 0.0471**. (OpenTargets Search: -PCSK1N, mitias2024prosaasispreferentially pages 10-12, roomp2017combinedlipidomicand pages 14-16) | Mitias 2024; Roomp 2017; Open Targets | 2024-04; 2017-04; Open Targets accessed in current session | https://doi.org/10.1101/2024.04.18.590133 ; https://doi.org/10.1371/journal.pone.0176391 ; https://platform.opentargets.org/target/ENSG00000102109 |
+
+
+*Table: This table consolidates supported findings on human PCSK1N/proSAAS, including identity, processing, localization, canonical PC1/3-inhibitory function, emerging chaperone roles, and disease relevance. It is useful as a quick evidence map anchored only to the provided context IDs, with recent quantitative data highlighted from Mitias 2024.*
+
+### Key references (with dates and URLs)
+- Mitias S. et al. (2024-04-18). *ProSAAS is Preferentially Secreted from Neurons During Homeostatic Scaling and Reduces Amyloid Plaque Size in the 5xFAD Mouse Hippocampus.* bioRxiv. https://doi.org/10.1101/2024.04.18.590133 (mitias2024prosaasispreferentially pages 10-12)
+- Chen Y.-C. et al. (2018-09). *Islet prohormone processing in health and disease.* (Review) https://doi.org/10.1111/dom.13401 (chen2018isletprohormoneprocessing pages 2-3)
+- Roomp K. et al. (2017-04). *Combined lipidomic and proteomic analysis of isolated human islets exposed to palmitate…* https://doi.org/10.1371/journal.pone.0176391 (roomp2017combinedlipidomicand pages 14-16)
+- Shakya M. et al. (2020-11). *Increased expression and retention of the secretory chaperone proSAAS following cell stress.* https://doi.org/10.1007/s12192-020-01128-7 (shakya2020increasedexpressionand pages 1-2)
+- Bae H. et al. (2022-12). *A genome-wide association study of 2304 extreme longevity cases identifies novel longevity variants.* https://doi.org/10.3390/ijms24010116 (bae2022agenomewideassociation pages 12-14)
+- Open Targets Platform (accessed during this run). PCSK1N target page and disease associations. https://platform.opentargets.org/target/ENSG00000102109 (OpenTargets Search: -PCSK1N)
+
+
+References
+
+1. (schaffer2025theneuronalchaperone pages 1-2): Nicholas Schaffer, Samira Mitias, Yan Guo, Steven L. Bernstein, and Iris Lindberg. The neuronal chaperone prosaas is highly expressed in the retina. PLOS One, 20:e0321867, May 2025. URL: https://doi.org/10.1371/journal.pone.0321867, doi:10.1371/journal.pone.0321867. This article has 0 citations and is from a peer-reviewed journal.
+
+2. (shakya2020increasedexpressionand pages 1-2): Manita Shakya, Taha Yildirim, and Iris Lindberg. Increased expression and retention of the secretory chaperone prosaas following cell stress. Cell Stress and Chaperones, 25:929-941, Nov 2020. URL: https://doi.org/10.1007/s12192-020-01128-7, doi:10.1007/s12192-020-01128-7. This article has 18 citations and is from a peer-reviewed journal.
+
+3. (OpenTargets Search: -PCSK1N): Open Targets Query (-PCSK1N, 5 results). Buniello, A. et al. (2025). Open Targets Platform: facilitating therapeutic hypotheses building in drug discovery. Nucleic Acids Research.
+
+4. (chen2018isletprohormoneprocessing pages 2-3): Yi‐Chun Chen, Austin J. Taylor, and C. Bruce Verchere. Islet prohormone processing in health and disease. Diabetes, 20:64-76, Sep 2018. URL: https://doi.org/10.1111/dom.13401, doi:10.1111/dom.13401. This article has 93 citations and is from a highest quality peer-reviewed journal.
+
+5. (roomp2017combinedlipidomicand pages 14-16): Kirsten Roomp, Hjalti Kristinsson, Domitille Schvartz, Kumari Ubhayasekera, Ernest Sargsyan, Levon Manukyan, Azazul Chowdhury, Hannes Manell, Venkata Satagopam, Karlfried Groebe, Reinhard Schneider, Jonas Bergquist, Jean-Charles Sanchez, and Peter Bergsten. Combined lipidomic and proteomic analysis of isolated human islets exposed to palmitate reveals time-dependent changes in insulin secretion and lipid metabolism. PLoS ONE, 12:e0176391, Apr 2017. URL: https://doi.org/10.1371/journal.pone.0176391, doi:10.1371/journal.pone.0176391. This article has 51 citations and is from a peer-reviewed journal.
+
+6. (shakya2020increasedexpressionand pages 12-13): Manita Shakya, Taha Yildirim, and Iris Lindberg. Increased expression and retention of the secretory chaperone prosaas following cell stress. Cell Stress and Chaperones, 25:929-941, Nov 2020. URL: https://doi.org/10.1007/s12192-020-01128-7, doi:10.1007/s12192-020-01128-7. This article has 18 citations and is from a peer-reviewed journal.
+
+7. (mitias2024prosaasispreferentially pages 10-12): Samira Mitias, Nicholas Schaffer, Saaya Nair, Chelsea Hook, and Iris Lindberg. Prosaas is preferentially secreted from neurons during homeostatic scaling and reduces amyloid plaque size in the 5xfad mouse hippocampus. bioRxiv, Apr 2024. URL: https://doi.org/10.1101/2024.04.18.590133, doi:10.1101/2024.04.18.590133. This article has 0 citations.
+
+8. (mitias2024prosaasispreferentially pages 1-4): Samira Mitias, Nicholas Schaffer, Saaya Nair, Chelsea Hook, and Iris Lindberg. Prosaas is preferentially secreted from neurons during homeostatic scaling and reduces amyloid plaque size in the 5xfad mouse hippocampus. bioRxiv, Apr 2024. URL: https://doi.org/10.1101/2024.04.18.590133, doi:10.1101/2024.04.18.590133. This article has 0 citations.
+
+9. (mitias2024prosaasispreferentially media 1702507a): Samira Mitias, Nicholas Schaffer, Saaya Nair, Chelsea Hook, and Iris Lindberg. Prosaas is preferentially secreted from neurons during homeostatic scaling and reduces amyloid plaque size in the 5xfad mouse hippocampus. bioRxiv, Apr 2024. URL: https://doi.org/10.1101/2024.04.18.590133, doi:10.1101/2024.04.18.590133. This article has 0 citations.
+
+10. (mitias2024prosaasispreferentially media 297a766d): Samira Mitias, Nicholas Schaffer, Saaya Nair, Chelsea Hook, and Iris Lindberg. Prosaas is preferentially secreted from neurons during homeostatic scaling and reduces amyloid plaque size in the 5xfad mouse hippocampus. bioRxiv, Apr 2024. URL: https://doi.org/10.1101/2024.04.18.590133, doi:10.1101/2024.04.18.590133. This article has 0 citations.
+
+11. (mitias2024prosaasispreferentially media c6538047): Samira Mitias, Nicholas Schaffer, Saaya Nair, Chelsea Hook, and Iris Lindberg. Prosaas is preferentially secreted from neurons during homeostatic scaling and reduces amyloid plaque size in the 5xfad mouse hippocampus. bioRxiv, Apr 2024. URL: https://doi.org/10.1101/2024.04.18.590133, doi:10.1101/2024.04.18.590133. This article has 0 citations.
+
+12. (mitias2024prosaasispreferentially media 7be71471): Samira Mitias, Nicholas Schaffer, Saaya Nair, Chelsea Hook, and Iris Lindberg. Prosaas is preferentially secreted from neurons during homeostatic scaling and reduces amyloid plaque size in the 5xfad mouse hippocampus. bioRxiv, Apr 2024. URL: https://doi.org/10.1101/2024.04.18.590133, doi:10.1101/2024.04.18.590133. This article has 0 citations.
+
+13. (mitias2024prosaasispreferentially media d94be224): Samira Mitias, Nicholas Schaffer, Saaya Nair, Chelsea Hook, and Iris Lindberg. Prosaas is preferentially secreted from neurons during homeostatic scaling and reduces amyloid plaque size in the 5xfad mouse hippocampus. bioRxiv, Apr 2024. URL: https://doi.org/10.1101/2024.04.18.590133, doi:10.1101/2024.04.18.590133. This article has 0 citations.
+
+14. (bae2022agenomewideassociation pages 12-14): Harold Bae, Anastasia Gurinovich, Tanya T. Karagiannis, Zeyuan Song, Anastasia Leshchyk, Mengze Li, Stacy L. Andersen, Konstantin Arbeev, Anatoliy Yashin, Joseph Zmuda, Ping An, Mary Feitosa, Cristina Giuliani, Claudio Franceschi, Paolo Garagnani, Jonas Mengel-From, Gil Atzmon, Nir Barzilai, Annibale Puca, Nicholas J. Schork, Thomas T. Perls, and Paola Sebastiani. A genome-wide association study of 2304 extreme longevity cases identifies novel longevity variants. International Journal of Molecular Sciences, 24:116, Dec 2022. URL: https://doi.org/10.3390/ijms24010116, doi:10.3390/ijms24010116. This article has 20 citations.
+
+## Citations
+
+1. shakya2020increasedexpressionand pages 1-2
+2. schaffer2025theneuronalchaperone pages 1-2
+3. chen2018isletprohormoneprocessing pages 2-3
+4. roomp2017combinedlipidomicand pages 14-16
+5. mitias2024prosaasispreferentially pages 10-12
+6. bae2022agenomewideassociation pages 12-14
+7. shakya2020increasedexpressionand pages 12-13
+8. mitias2024prosaasispreferentially pages 1-4
+9. https://platform.opentargets.org/target/ENSG00000102109
+10. https://doi.org/10.1371/journal.pone.0321867
+11. https://doi.org/10.1007/s12192-020-01128-7
+12. https://doi.org/10.1101/2024.04.18.590133
+13. https://doi.org/10.1111/dom.13401
+14. https://doi.org/10.1371/journal.pone.0176391
+15. https://doi.org/10.3390/ijms24010116
+16. https://doi.org/10.1371/journal.pone.0321867,
+17. https://doi.org/10.1007/s12192-020-01128-7,
+18. https://doi.org/10.1111/dom.13401,
+19. https://doi.org/10.1371/journal.pone.0176391,
+20. https://doi.org/10.1101/2024.04.18.590133,
+21. https://doi.org/10.3390/ijms24010116,

--- a/genes/human/PKM/PKM-ai-review.html
+++ b/genes/human/PKM/PKM-ai-review.html
@@ -1229,7 +1229,7 @@ The PKM1-to-PKM2 switch is controlled by hnRNP splicing factors (hnRNPA1, hnRNPA
                         
                         
                         <div>
-                            <strong>Reason:</strong> CRITICAL ISOFORM CONFLATION: This annotation applies ONLY to PKM2 (P14618-1), not PKM1. The IEA annotation fails to capture this isoform specificity. Should be annotated with isoform qualifier.
+                            <strong>Reason:</strong> CRITICAL ISOFORM CONFLATION: This annotation applies ONLY to PKM2 (P14618-1), not PKM1. The IEA annotation fails to capture this isoform specificity; the requested modification is to retain GO:0004674 but add the isoform qualifier isoform: P14618-1.
                         </div>
                         
                         
@@ -1291,7 +1291,7 @@ The PKM1-to-PKM2 switch is controlled by hnRNP splicing factors (hnRNPA1, hnRNPA
                         
                         
                         <div>
-                            <strong>Reason:</strong> CRITICAL ISOFORM CONFLATION: This annotation applies ONLY to PKM2 (P14618-1), not PKM1. The IEA annotation fails to capture this isoform specificity. Should be annotated with isoform qualifier.
+                            <strong>Reason:</strong> CRITICAL ISOFORM CONFLATION: This annotation applies ONLY to PKM2 (P14618-1), not PKM1. The IEA annotation fails to capture this isoform specificity; the requested modification is to retain GO:0004713 but add the isoform qualifier isoform: P14618-1.
                         </div>
                         
                         
@@ -1353,7 +1353,7 @@ The PKM1-to-PKM2 switch is controlled by hnRNP splicing factors (hnRNPA1, hnRNPA
                         
                         
                         <div>
-                            <strong>Reason:</strong> CRITICAL ISOFORM CONFLATION: This annotation applies ONLY to PKM2 (P14618-1), not PKM1.
+                            <strong>Reason:</strong> CRITICAL ISOFORM CONFLATION: This annotation applies ONLY to PKM2 (P14618-1), not PKM1. The requested modification is to retain GO:0004715 but add the isoform qualifier isoform: P14618-1.
                         </div>
                         
                         
@@ -1517,7 +1517,7 @@ The PKM1-to-PKM2 switch is controlled by hnRNP splicing factors (hnRNPA1, hnRNPA
                         
                         
                         <div>
-                            <strong>Reason:</strong> CRITICAL ISOFORM CONFLATION: Nuclear localization applies ONLY to PKM2 (P14618-1). PMID:22056988 explicitly states &#34;PKM1 failed to translocate into the nucleus upon EGF stimulation&#34;.
+                            <strong>Reason:</strong> CRITICAL ISOFORM CONFLATION: Nuclear localization applies ONLY to PKM2 (P14618-1); the requested modification is to retain GO:0005634 but add the isoform qualifier isoform: P14618-1. PMID:22056988 explicitly states &#34;PKM1 failed to translocate into the nucleus upon EGF stimulation&#34;.
                         </div>
                         
                         
@@ -3202,7 +3202,7 @@ The PKM1-to-PKM2 switch is controlled by hnRNP splicing factors (hnRNPA1, hnRNPA
                         
                         
                         <div>
-                            <strong>Reason:</strong> ISOFORM CONFLATION: Nucleoplasm localization is PKM2-specific. PKM1 does not translocate to nucleus.
+                            <strong>Reason:</strong> ISOFORM CONFLATION: Nucleoplasm localization is PKM2-specific. PKM1 does not translocate to nucleus. The requested modification is to retain GO:0005654 but add the isoform qualifier isoform: P14618-1.
                         </div>
                         
                         
@@ -7800,9 +7800,9 @@ existing_annotations:
       reason: &gt;-
         CRITICAL ISOFORM CONFLATION: This annotation applies ONLY to PKM2 (P14618-1),
         not PKM1.
-        The IEA annotation fails to capture this isoform specificity. Should be annotated
-        with
-        isoform qualifier.
+        The IEA annotation fails to capture this isoform specificity; the requested
+        modification is to retain GO:0004674 but add the isoform qualifier
+        isoform: P14618-1.
       proposed_replacement_terms:
         - id: GO:0004674
           label: protein serine/threonine kinase activity
@@ -7824,9 +7824,9 @@ existing_annotations:
       reason: &gt;-
         CRITICAL ISOFORM CONFLATION: This annotation applies ONLY to PKM2 (P14618-1),
         not PKM1.
-        The IEA annotation fails to capture this isoform specificity. Should be annotated
-        with
-        isoform qualifier.
+        The IEA annotation fails to capture this isoform specificity; the requested
+        modification is to retain GO:0004713 but add the isoform qualifier
+        isoform: P14618-1.
       proposed_replacement_terms:
         - id: GO:0004713
           label: protein tyrosine kinase activity
@@ -7844,7 +7844,8 @@ existing_annotations:
       action: MODIFY
       reason: &gt;-
         CRITICAL ISOFORM CONFLATION: This annotation applies ONLY to PKM2 (P14618-1),
-        not PKM1.
+        not PKM1. The requested modification is to retain GO:0004715 but add the
+        isoform qualifier isoform: P14618-1.
       proposed_replacement_terms:
         - id: GO:0004715
           label: non-membrane spanning protein tyrosine kinase activity
@@ -7890,7 +7891,9 @@ existing_annotations:
         PKM2-SPECIFIC localization.
       action: MODIFY
       reason: &gt;-
-        CRITICAL ISOFORM CONFLATION: Nuclear localization applies ONLY to PKM2 (P14618-1).
+        CRITICAL ISOFORM CONFLATION: Nuclear localization applies ONLY to PKM2 (P14618-1);
+        the requested modification is to retain GO:0005634 but add the isoform
+        qualifier isoform: P14618-1.
         PMID:22056988 explicitly states &#34;PKM1 failed to translocate into the nucleus
         upon EGF stimulation&#34;.
       proposed_replacement_terms:
@@ -8303,8 +8306,8 @@ existing_annotations:
       action: MODIFY
       reason: &gt;-
         ISOFORM CONFLATION: Nucleoplasm localization is PKM2-specific. PKM1 does not
-        translocate
-        to nucleus.
+        translocate to nucleus. The requested modification is to retain GO:0005654
+        but add the isoform qualifier isoform: P14618-1.
       proposed_replacement_terms:
         - id: GO:0005654
           label: nucleoplasm

--- a/genes/human/PKM/PKM-ai-review.html
+++ b/genes/human/PKM/PKM-ai-review.html
@@ -828,6 +828,17 @@ The PKM1-to-PKM2 switch is controlled by hnRNP splicing factors (hnRNPA1, hnRNPA
                                 
                             </div>
                             
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PKM/PKM-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">PKM catalyzes the terminal glycolytic step: PEP + ADP -&gt; pyruvate + ATP, coupling high-energy phosphate transfer to ATP production.</div>
+
+                            </div>
+
                         </div>
                         
                     </td>
@@ -6173,6 +6184,24 @@ The PKM1-to-PKM2 switch is controlled by hnRNP splicing factors (hnRNPA1, hnRNPA
             </div>
 
             
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/PKM/PKM-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">PKM catalyzes the terminal glycolytic step: PEP + ADP -&gt; pyruvate + ATP, coupling high-energy phosphate transfer to ATP production.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
         </div>
         
         <div class="core-function-card">
@@ -6208,6 +6237,24 @@ The PKM1-to-PKM2 switch is controlled by hnRNP splicing factors (hnRNPA1, hnRNPA
             </div>
 
             
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/PKM/PKM-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">The report summarizes noncanonical PKM2 protein-kinase roles, including tyrosine kinase activity linked to STAT3 Tyr-705 phosphorylation and transcriptional activation.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
         </div>
         
         <div class="core-function-card">
@@ -6243,6 +6290,24 @@ The PKM1-to-PKM2 switch is controlled by hnRNP splicing factors (hnRNPA1, hnRNPA
             </div>
 
             
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/PKM/PKM-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">The report summarizes noncanonical PKM2 kinase functions, including histone H3 phosphorylation and a 2024 EMBO Journal finding that PKM2 can act as a PEP-dependent histidine kinase toward PGAM1 H11.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
         </div>
         
     </div>
@@ -6433,6 +6498,34 @@ The PKM1-to-PKM2 switch is controlled by hnRNP splicing factors (hnRNPA1, hnRNPA
                 <div class="reference-header">
                     <span class="reference-id">
                         
+                        file:human/PKM/PKM-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research report for human PKM</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">PKM encodes pyruvate kinase M1/M2, with canonical activity catalyzing PEP + ADP to pyruvate + ATP in the terminal ATP-generating step of glycolysis.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The report distinguishes the core glycolytic enzyme function from PKM2-specific noncanonical kinase and transcription-associated activities.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/11487543" target="_blank" class="term-link">
                             PMID:11487543
                         </a>
@@ -7049,6 +7142,368 @@ The PKM1-to-PKM2 switch is controlled by hnRNP splicing factors (hnRNPA1, hnRNPA
         <details class="markdown-section">
             <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
                 <div style="flex: 1;">
+                    <h3 style="display: inline;">Deep Research Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(PKM-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P14618" data-a="DOC: Deep Research Falcon" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <hr />
+<p>provider: falcon<br />
+model: Edison Scientific Literature<br />
+cached: false<br />
+start_time: '2026-05-10T22:03:47.749752'<br />
+end_time: '2026-05-10T22:15:56.523375'<br />
+duration_seconds: 728.77<br />
+template_file: templates/gene_research_go_focused.md<br />
+template_variables:<br />
+  organism: human<br />
+  gene_id: PKM<br />
+  gene_symbol: PKM<br />
+  uniprot_accession: P14618<br />
+  protein_description: 'RecName: Full=Pyruvate kinase PKM; EC=2.7.1.40 {ECO:0000269|PubMed:15996096,<br />
+    ECO:0000269|PubMed:1854723, ECO:0000269|PubMed:20847263}; AltName: Full=Cytosolic<br />
+    thyroid hormone-binding protein {ECO:0000303|PubMed:2813362}; Short=CTHBP {ECO:0000303|PubMed:2813362};<br />
+    AltName: Full=Opa-interacting protein 3 {ECO:0000303|PubMed:9466265}; Short=OIP-3<br />
+    {ECO:0000303|PubMed:9466265}; AltName: Full=Pyruvate kinase 2/3; AltName: Full=Pyruvate<br />
+    kinase muscle isozyme; AltName: Full=Threonine-protein kinase PKM2 {ECO:0000305};<br />
+    EC=2.7.11.1 {ECO:0000269|PubMed:22901803, ECO:0000269|PubMed:24120661}; AltName:<br />
+    Full=Thyroid hormone-binding protein 1; Short=THBP1; AltName: Full=Tumor M2-PK;<br />
+    AltName: Full=Tyrosine-protein kinase PKM2 {ECO:0000305}; EC=2.7.10.2 {ECO:0000269|PubMed:22306293,<br />
+    ECO:0000269|PubMed:24120661}; AltName: Full=p58;'<br />
+  gene_info: Name=PKM; Synonyms=OIP3 {ECO:0000303|PubMed:9466265}, PK2, PK3, PKM2;<br />
+  organism_full: Homo sapiens (Human).<br />
+  protein_family: Belongs to the pyruvate kinase family. .<br />
+  protein_domains: Pyr_Knase. (IPR001697); Pyrv/PenolPyrv_kinase-like_dom. (IPR015813);<br />
+    Pyrv_kinase-like_dom_sf. (IPR040442); Pyrv_Knase-like_insert_dom_sf. (IPR011037);<br />
+    Pyrv_Knase_AS. (IPR018209)<br />
+provider_config:<br />
+  timeout: 600<br />
+  max_retries: 3<br />
+  parameters:<br />
+    allowed_domains: []<br />
+    temperature: 0.1<br />
+citation_count: 38</p>
+<hr />
+<h2 id="question">Question</h2>
+<h1 id="gene-research-for-functional-annotation">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> P14618</li>
+<li><strong>Protein Description:</strong> RecName: Full=Pyruvate kinase PKM; EC=2.7.1.40 {ECO:0000269|PubMed:15996096, ECO:0000269|PubMed:1854723, ECO:0000269|PubMed:20847263}; AltName: Full=Cytosolic thyroid hormone-binding protein {ECO:0000303|PubMed:2813362}; Short=CTHBP {ECO:0000303|PubMed:2813362}; AltName: Full=Opa-interacting protein 3 {ECO:0000303|PubMed:9466265}; Short=OIP-3 {ECO:0000303|PubMed:9466265}; AltName: Full=Pyruvate kinase 2/3; AltName: Full=Pyruvate kinase muscle isozyme; AltName: Full=Threonine-protein kinase PKM2 {ECO:0000305}; EC=2.7.11.1 {ECO:0000269|PubMed:22901803, ECO:0000269|PubMed:24120661}; AltName: Full=Thyroid hormone-binding protein 1; Short=THBP1; AltName: Full=Tumor M2-PK; AltName: Full=Tyrosine-protein kinase PKM2 {ECO:0000305}; EC=2.7.10.2 {ECO:0000269|PubMed:22306293, ECO:0000269|PubMed:24120661}; AltName: Full=p58;</li>
+<li><strong>Gene Information:</strong> Name=PKM; Synonyms=OIP3 {ECO:0000303|PubMed:9466265}, PK2, PK3, PKM2;</li>
+<li><strong>Organism (full):</strong> Homo sapiens (Human).</li>
+<li><strong>Protein Family:</strong> Belongs to the pyruvate kinase family. .</li>
+<li><strong>Key Domains:</strong> Pyr_Knase. (IPR001697); Pyrv/PenolPyrv_kinase-like_dom. (IPR015813); Pyrv_kinase-like_dom_sf. (IPR040442); Pyrv_Knase-like_insert_dom_sf. (IPR011037); Pyrv_Knase_AS. (IPR018209)</li>
+</ul>
+<h3 id="mandatory-verification-steps">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "PKM" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Homo sapiens (Human).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'PKM' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>PKM</strong> (gene ID: PKM, UniProt: P14618) in human.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="output">Output</h2>
+<p>Question: You are an expert researcher providing comprehensive, well-cited information.</p>
+<p>Provide detailed information focusing on:<br />
+1. Key concepts and definitions with current understanding<br />
+2. Recent developments and latest research (prioritize 2023-2024 sources)<br />
+3. Current applications and real-world implementations<br />
+4. Expert opinions and analysis from authoritative sources<br />
+5. Relevant statistics and data from recent studies</p>
+<p>Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.<br />
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.</p>
+<h1 id="gene-research-for-functional-annotation_1">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context_1">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot_1">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> P14618</li>
+<li><strong>Protein Description:</strong> RecName: Full=Pyruvate kinase PKM; EC=2.7.1.40 {ECO:0000269|PubMed:15996096, ECO:0000269|PubMed:1854723, ECO:0000269|PubMed:20847263}; AltName: Full=Cytosolic thyroid hormone-binding protein {ECO:0000303|PubMed:2813362}; Short=CTHBP {ECO:0000303|PubMed:2813362}; AltName: Full=Opa-interacting protein 3 {ECO:0000303|PubMed:9466265}; Short=OIP-3 {ECO:0000303|PubMed:9466265}; AltName: Full=Pyruvate kinase 2/3; AltName: Full=Pyruvate kinase muscle isozyme; AltName: Full=Threonine-protein kinase PKM2 {ECO:0000305}; EC=2.7.11.1 {ECO:0000269|PubMed:22901803, ECO:0000269|PubMed:24120661}; AltName: Full=Thyroid hormone-binding protein 1; Short=THBP1; AltName: Full=Tumor M2-PK; AltName: Full=Tyrosine-protein kinase PKM2 {ECO:0000305}; EC=2.7.10.2 {ECO:0000269|PubMed:22306293, ECO:0000269|PubMed:24120661}; AltName: Full=p58;</li>
+<li><strong>Gene Information:</strong> Name=PKM; Synonyms=OIP3 {ECO:0000303|PubMed:9466265}, PK2, PK3, PKM2;</li>
+<li><strong>Organism (full):</strong> Homo sapiens (Human).</li>
+<li><strong>Protein Family:</strong> Belongs to the pyruvate kinase family. .</li>
+<li><strong>Key Domains:</strong> Pyr_Knase. (IPR001697); Pyrv/PenolPyrv_kinase-like_dom. (IPR015813); Pyrv_kinase-like_dom_sf. (IPR040442); Pyrv_Knase-like_insert_dom_sf. (IPR011037); Pyrv_Knase_AS. (IPR018209)</li>
+</ul>
+<h3 id="mandatory-verification-steps_1">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "PKM" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Homo sapiens (Human).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature_1">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'PKM' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target_1">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>PKM</strong> (gene ID: PKM, UniProt: P14618) in human.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="comprehensive-research-report-human-pkm-uniprot-p14618-functional-annotation-regulation-and-translational-relevance-20232024-prioritized">Comprehensive Research Report: Human <strong>PKM</strong> (UniProt <strong>P14618</strong>) — Functional Annotation, Regulation, and Translational Relevance (2023–2024 prioritized)</h2>
+<h3 id="1-geneprotein-identification-and-definitions-verification">1) Gene/protein identification and definitions (verification)</h3>
+<p><strong>Target verified:</strong> The gene symbol <strong>PKM</strong> in this report refers specifically to <strong>human pyruvate kinase PKM (pyruvate kinase M1/2)</strong> consistent with UniProt accession <strong>P14618</strong>, a member of the pyruvate kinase family catalyzing the terminal step of glycolysis. Multiple retrieved sources explicitly tie “PKM/PKM2” to UniProt <strong>P14618</strong> and to pyruvate-kinase biochemical/structural hallmarks (e.g., glycolytic PEP→pyruvate ATP-generating step; pyruvate-kinase oligomerization; FBP allostery). (nandi2023identificationofresidues pages 10-12, li2024theregulatorynetwork pages 1-2, jemal2024nonmetabolicenzymefunction pages 1-2)</p>
+<p><strong>Key definitions:</strong><br />
+- <strong>PKM1 / PKM2 isoenzymes:</strong> The PKM gene produces two major protein isoforms via <strong>mutually exclusive alternative splicing</strong> of a single exon: <strong>exon 9</strong> vs <strong>exon 10</strong>. (li2024theregulatorynetwork pages 1-2, oleaflores2024musclespecificpyruvatekinase pages 1-5)<br />
+- <strong>Canonical enzymatic role:</strong> Pyruvate kinase catalyzes transfer of phosphate from <strong>phosphoenolpyruvate (PEP)</strong> to <strong>ADP</strong>, producing <strong>pyruvate + ATP</strong> (EC 2.7.1.40), the final ATP-generating step of glycolysis. (hu2024roleofpyruvate pages 2-4, oleaflores2024musclespecificpyruvatekinase pages 1-5)<br />
+- <strong>Moonlighting/noncanonical functions:</strong> Particularly for <strong>PKM2</strong>, literature describes additional roles beyond metabolite conversion, including nuclear functions and kinase-like activities that interface with gene regulation and signaling. (wang2024pkm2functionsas pages 4-6, jemal2024nonmetabolicenzymefunction pages 6-8)</p>
+<h3 id="2-core-biochemistry-catalytic-reaction-substrate-specificity-and-pathway-role">2) Core biochemistry: catalytic reaction, substrate specificity, and pathway role</h3>
+<p><strong>Catalyzed reaction (primary molecular function):</strong><br />
+PKM catalyzes the terminal glycolytic step: <strong>PEP + ADP → pyruvate + ATP</strong>. This reaction couples high-energy phosphate transfer to ATP production and is a principal flux-control point in glycolysis. (hu2024roleofpyruvate pages 2-4, oleaflores2024musclespecificpyruvatekinase pages 1-5)</p>
+<p><strong>Pathway placement and functional implication:</strong><br />
+Because this step is both terminal and ATP-generating, changes in PKM activity (and especially PKM2 oligomeric state) can shift how upstream glycolytic intermediates accumulate and are diverted toward <strong>biosynthetic side pathways</strong> (a central concept in proliferative metabolism). (hu2024roleofpyruvate pages 2-4, li2021discoveryoffunctional pages 2-3)</p>
+<h3 id="3-isoforms-alternative-splicing-and-cell-state-specificity">3) Isoforms, alternative splicing, and cell-state specificity</h3>
+<p><strong>Alternative splicing mechanism (PKM1 vs PKM2):</strong><br />
+A 2024 review focused on tumor splicing networks summarizes the canonical exon usage: PKM pre-mRNA splicing produces <strong>PKM1 and PKM2</strong>, where <strong>PKM1 excludes exon 10</strong> and <strong>PKM2 excludes exon 9</strong> (i.e., reciprocal inclusion of exon 9 vs exon 10). (li2024theregulatorynetwork pages 1-2)</p>
+<p><strong>Tissue/cell-state tendencies:</strong><br />
+- <strong>PKM1</strong> is reported as predominant in <strong>heart, skeletal muscle, brain, and mature sperm</strong> (more differentiated/high oxidative contexts). (li2024theregulatorynetwork pages 1-2)<br />
+- <strong>PKM2</strong> is enriched in <strong>proliferating/anabolic cells</strong> and in many tumors. (li2024theregulatorynetwork pages 1-2)</p>
+<p><strong>Regulatory control of splicing (recent synthesis):</strong><br />
+The 2024 Biomolecules review emphasizes that splicing factors (notably hnRNP-centered networks and PTBP1-linked regulation) are core determinants of the <strong>PKM1/PKM2 balance</strong> in tumor progression, and that epigenetic/RNA-level mechanisms can influence whether cells use PKM1-linked oxidative metabolism or PKM2-linked glycolytic programs. (li2024theregulatorynetwork pages 1-2, li2024theregulatorynetwork pages 7-8)</p>
+<h3 id="4-allostery-oligomerization-and-quantitative-regulatory-features-current-understanding-2023-advances">4) Allostery, oligomerization, and quantitative regulatory features (current understanding + 2023 advances)</h3>
+<p><strong>Oligomeric states as functional switches:</strong><br />
+PKM1 is commonly described as a <strong>constitutively active tetramer</strong>, whereas PKM2 is conformationally plastic, interconverting between high-activity tetramers and lower-activity dimer/monomer states. This tetramer–dimer equilibrium is repeatedly invoked to explain why PKM2 can support either ATP production or anabolic rewiring (via reduced catalytic flux at the last glycolytic step). (li2021discoveryoffunctional pages 2-3, hu2024roleofpyruvate pages 2-4)</p>
+<p><strong>Allosteric activation by fructose-1,6-bisphosphate (FBP):</strong><br />
+A transcript/isoform-focused analysis summarizes that tetrameric PKM2 is allosterically activated by <strong>FBP</strong>, which stabilizes the tetramer, whereas FBP release promotes conversion toward lower-activity forms. (li2021discoveryoffunctional pages 2-3)</p>
+<p><strong>Amino-acid sensing and allosteric communication (2023 primary data):</strong><br />
+Nandi &amp; Dey (PLOS ONE, <strong>2023-03-10</strong>) dissected how amino acids modulate PKM2 via a dedicated amino-acid (AA) binding pocket and transmission to the active site, providing quantitative binding/affinity effects and linking them to activity and oligomer state. Key quantitative observations include:<br />
+- For the <strong>R106A</strong> variant, ADP binding affinities in the presence of inhibitory AAs were markedly weakened (e.g., Val Kd ~1.2 mM; Cys Kd ~2.9 mM) vs no-AA condition (Kd = 257±24 μM). (nandi2023identificationofresidues pages 10-12)<br />
+- PEP binding affinity could shift strongly depending on AA ligand class, with activator AAs (Asn/Asp) improving PEP binding (e.g., ~9.5 μM → ~1 μM), whereas inhibitory AAs (Val/Cys) weakened binding (e.g., ~26–100 μM). (nandi2023identificationofresidues pages 10-12)<br />
+- Size-exclusion chromatography showed mutation-dependent changes in oligomer equilibrium; for example, <strong>N70D</strong> exhibited a tetramer plus dimer/monomer mixture without AAs, and activating AAs (Asn/Asp) increased tetrameric population consistent with activation. (nandi2023identificationofresidues pages 10-12)</p>
+<p>These findings refine “PKM2 as a nutrient sensor” into a more mechanistically grounded picture in which distinct AA ligands perturb substrate affinities and oligomeric state through a defined signal-transmission path. (nandi2023identificationofresidues pages 10-12)</p>
+<h3 id="5-subcellular-localization-cytosolic-glycolysis-vs-nuclear-functions">5) Subcellular localization: cytosolic glycolysis vs nuclear functions</h3>
+<p><strong>Primary localization for canonical function:</strong><br />
+PKM’s glycolytic role is cytosolic, consistent with glycolysis occurring in the cytoplasm. (hu2024roleofpyruvate pages 2-4)</p>
+<p><strong>Nuclear PKM2 and triggers for nuclear translocation (2024 reviews):</strong><br />
+Recent 2024 reviews summarize that <strong>PKM2</strong>, particularly in non-tetrameric forms, can translocate to the nucleus where it acts in transcriptional and signaling regulation:<br />
+- In a sepsis-focused review, Hu et al. report that <strong>ERK1/2 phosphorylation at S37</strong> (with downstream prolyl isomerization) promotes PKM2 nuclear translocation and supports interaction with transcriptional regulators such as <strong>HIF‑1α</strong> and <strong>STAT3</strong>, linking metabolic state to inflammatory gene programs. (hu2024roleofpyruvate pages 2-4)<br />
+- In a breast-cancer-focused review, EGFR signaling is summarized as a driver of nuclear import: <strong>EGFR activation results in PKM2 nuclear translocation</strong>, facilitated via <strong>importin α5</strong>. (jemal2024nonmetabolicenzymefunction pages 8-9)<br />
+- The same review emphasizes the functional importance of <strong>dimeric PKM2</strong> in nuclear localization and downstream biological effects. (jemal2024nonmetabolicenzymefunction pages 6-8)</p>
+<h3 id="6-noncanonical-functions-kinase-like-activities-and-signaling-integration-2024-key-advance">6) Noncanonical functions: kinase-like activities and signaling integration (2024 key advance)</h3>
+<h4 id="61-pkm2-as-a-pep-dependent-histidine-kinase-major-2024-primary-advance">6.1 PKM2 as a PEP-dependent histidine kinase (major 2024 primary advance)</h4>
+<p>Wang et al. (EMBO J, <strong>2024-05</strong>) provide direct evidence that PKM2 “moonlights” as a <strong>histidine kinase</strong>:<br />
+- PKM2 catalyzes <strong>PGAM1 histidine-11 (H11) phosphorylation</strong> in a <strong>PEP-dependent</strong> manner, which is required for PGAM1 activity and supports glycolysis shunt fluxes in cancer contexts. (wang2024pkm2functionsas pages 1-2, wang2024pkm2functionsas pages 4-6)<br />
+- <strong>Oligomeric-state dependence:</strong> monomeric/dimeric PKM2 efficiently phosphorylates/activates PGAM1, whereas tetrameric PKM2 is ineffective. Stabilizing PKM2 tetramers (e.g., <strong>TEPP46</strong>) reduces PKM2–PGAM1 interaction and H11 phosphorylation. (wang2024pkm2functionsas pages 4-6)<br />
+- <strong>Tumor-selective interaction pattern:</strong> PKM2–PGAM1 interaction was observed across multiple tumor cell lines and was reported as barely detectable in several untransformed cell types, consistent with a model where this crosstalk is preferentially engaged in tumor metabolic rewiring. (wang2024pkm2functionsas pages 1-2)</p>
+<p>This work is important for functional annotation because it operationally distinguishes the <strong>canonical kinase transfer (to ADP)</strong> from a distinct, noncanonical <strong>PEP-dependent protein phosphorylation</strong> activity that depends on PKM2 de-tetramerization. (wang2024pkm2functionsas pages 4-6)</p>
+<h4 id="62-nuclear-protein-kinasetranscriptional-cofactor-roles-summarized-in-2024-reviews">6.2 Nuclear “protein kinase”/transcriptional cofactor roles summarized in 2024 reviews</h4>
+<p>The 2024 Frontiers in Oncology review synthesizes literature in which nuclear PKM2 influences pathways via kinase-like functions or coactivator roles, including modulation of β-catenin transactivation and STAT3 phosphorylation-related signaling programs, and highlights that blocking nuclear translocation is a recurring therapeutic concept. (jemal2024nonmetabolicenzymefunction pages 6-8, jemal2024nonmetabolicenzymefunction pages 8-9)</p>
+<p>A 2024 preprint on myoblast differentiation further summarizes that PKM2 has been implicated in <strong>histone H3 phosphorylation (H3T11)</strong> in cancer cells, and reports roles for Pkm1/Pkm2 in chromatin regulator dynamics during differentiation (noting Pkm2 dependence for incorporation of phospho-H3 marks at myogenic promoters and a role for Pkm1 in nuclear localization of Dpf2). (oleaflores2024musclespecificpyruvatekinase pages 1-5)</p>
+<h3 id="7-current-applications-and-real-world-implementations-biomarkersdiagnostics-translational-targeting">7) Current applications and real-world implementations (biomarkers/diagnostics; translational targeting)</h3>
+<h4 id="71-proteomics-biomarker-exploration-20232024">7.1 Proteomics biomarker exploration (2023–2024)</h4>
+<p><strong>(a) Oral squamous cell carcinoma (OSCC) saliva proteomics (2024):</strong><br />
+Remori et al. (Int J Mol Sci, <strong>2024-10</strong>, DOI: https://doi.org/10.3390/ijms252011120) analyzed saliva proteomics (10 OSCC vs 20 controls) and used a workflow combining univariate/multivariate selection and protein–protein interaction filtering.<br />
+- They report 172 differentially abundant proteins leading to a connected subset (48 proteins) to prioritize candidates; <strong>PKM (P14618)</strong> is explicitly highlighted as an altered glycolytic enzyme proposed as a candidate marker for follow-up validation. (remori2024predictionoforal pages 6-8)<br />
+- The authors emphasize the need for future validation cohorts to establish diagnostic performance (sensitivity/specificity), i.e., PKM is a candidate rather than a validated clinical biomarker in this dataset. (remori2024predictionoforal pages 6-8)</p>
+<p><strong>(b) Perinatal asphyxia / neonatal hypoxic–ischemic encephalopathy (HIE) plasma proteomics (2023):</strong><br />
+Yip et al. (Biomolecules, <strong>2023-09</strong>, DOI: https://doi.org/10.3390/biom13101471) performed plasma proteomics in neonates with HIE.<br />
+- Study design includes 22 moderate-severe HIE newborns treated with therapeutic hypothermia (TH), with comparison groups including 10 mild HIE and 10 normal cord-blood samples (per paper abstract context; quantitative table shown for sHIE+ vs mHIE). (yip2023newbornswithfavourable pages 11-12)<br />
+- In the “most reliable proteins” table comparing favorable-outcome severe HIE (sHIE+) vs mild HIE (mHIE), <strong>PKM (P14618-2)</strong> is listed with <strong>log2FC = 0.95</strong> and <strong>p = 3.09 × 10^-2</strong>. (yip2023newbornswithfavourable pages 11-12)</p>
+<p>This positions PKM as part of a <strong>metabolic enzyme signature</strong> associated with clinical outcome stratification in a specific neonatal critical care context (early-stage discovery/association rather than a validated clinical test). (yip2023newbornswithfavourable pages 11-12)</p>
+<p><strong>(c) Saliva collection protocol affecting detectability of metabolic proteins (2023):</strong><br />
+Foratori-Junior et al. (Cells, <strong>2023-05</strong>, DOI: https://doi.org/10.3390/cells12101389) report that stimulated saliva sampling reduces or eliminates detection of multiple proteins involved in glycolysis/glucose metabolism, and specifically notes pyruvate kinase as reduced/absent in stimulated saliva in pregnancy cohorts with obesity. This is a practical methodological consideration for “real-world” biomarker work involving PKM/PKM2. (foratorijunior2023istherea pages 16-17)</p>
+<p><strong>(d) Follicular fluid proteomics and embryo development context (2024):</strong><br />
+Przewocki et al. (Int J Mol Sci, <strong>2024-08</strong>, DOI: https://doi.org/10.3390/ijms25158431) analyzed 110 follicular-fluid samples from 50 oocyte donors, identifying 2182 proteins and noting protein–protein interaction patterns in which PKM2 appears as a node interacting with stress-response proteins (e.g., HSPA8). This supports that PKM2 is detectable in human reproductive biofluids and may be relevant to predictive modeling, although the excerpted text emphasizes network interpretation more than effect sizes for PKM specifically. (przewocki2024follicularfluidproteomic pages 7-8)</p>
+<h4 id="72-therapeutic-targeting-concepts-expert-synthesis-2024">7.2 Therapeutic targeting concepts (expert synthesis, 2024)</h4>
+<p>Two recurring expert concepts in 2024 reviews are:<br />
+1) <strong>Shift PKM2 toward the tetrameric enzymatically active state</strong> (or preserve canonical activity) to reduce noncanonical nuclear functions and proliferative rewiring. (hu2024roleofpyruvate pages 2-4)<br />
+2) <strong>Block nuclear translocation</strong> and downstream transcriptional/oncogenic signaling axes (e.g., EGFR→importin α5; ERK1/2 S37 pathway). (hu2024roleofpyruvate pages 2-4, jemal2024nonmetabolicenzymefunction pages 8-9)</p>
+<p>Examples mentioned in reviews include small molecules and natural products proposed to inhibit PKM2 expression, nuclear entry, or downstream signaling (e.g., shikonin’s reported interference with residues around R399/400 and a putative NLS; and the concept of covalent activation promoting tetramers to block nuclear functions). (jemal2024nonmetabolicenzymefunction pages 6-8, hu2024roleofpyruvate pages 2-4)</p>
+<h3 id="8-disease-associations-database-level-evidence">8) Disease associations (database-level evidence)</h3>
+<p>Open Targets reports disease–target associations for <strong>PKM</strong> (ENSG00000067225) across cancer and inflammation-related disease groupings (e.g., neoplasm; hepatocellular carcinoma; neuroinflammatory disorder), supported by multiple literature evidence items. This provides a high-level, integrative pointer that PKM is repeatedly observed in disease-linked evidence streams, though it does not replace mechanistic interpretation. (OpenTargets Search: -PKM)</p>
+<h3 id="9-limitations-and-evidence-quality-notes">9) Limitations and evidence-quality notes</h3>
+<ul>
+<li>Several “noncanonical kinase” claims in reviews synthesize heterogeneous primary literature; for functional annotation, the strongest recent direct mechanistic advance in the provided corpus is the <strong>EMBO J 2024</strong> demonstration of <strong>PEP-dependent histidine kinase activity toward PGAM1</strong> with clear oligomer-state dependence. (wang2024pkm2functionsas pages 4-6)</li>
+<li>Biomarker studies cited here are largely discovery-stage proteomics; they highlight PKM as differentially abundant or associated with outcomes, but <strong>clinical diagnostic performance metrics</strong> (AUC, sensitivity/specificity) for PKM alone are not established in the extracted text. (remori2024predictionoforal pages 6-8, yip2023newbornswithfavourable pages 11-12)</li>
+</ul>
+<hr />
+<h3 id="evidence-map-summary-table">Evidence map summary table</h3>
+<table>
+<thead>
+<tr>
+<th>Topic</th>
+<th>Key points</th>
+<th>Best recent sources (2023-2024 prioritized)</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Identity</td>
+<td>Human <strong>PKM</strong> encodes pyruvate kinase M1/2 (UniProt <strong>P14618</strong>), a pyruvate kinase family enzyme catalyzing the terminal glycolytic step; PKM2 is the most discussed isoform in proliferative and cancer contexts, while PKM1 is prominent in differentiated tissues. PKM contains conserved pyruvate-kinase domains and an FBP allosteric site in the C-domain. (jemal2024nonmetabolicenzymefunction pages 1-2, li2021discoveryoffunctional pages 2-3)</td>
+<td>Jemal et al., <strong>2024-10</strong>, <em>Front Oncol</em> — https://doi.org/10.3389/fonc.2024.1450325 (jemal2024nonmetabolicenzymefunction pages 1-2); Li et al., <strong>2021-01</strong>, <em>Cancers</em> — https://doi.org/10.3390/cancers13020348 (li2021discoveryoffunctional pages 2-3)</td>
+</tr>
+<tr>
+<td>Isoforms</td>
+<td><strong>PKM1 vs PKM2 arise by mutually exclusive splicing of exon 9 and exon 10</strong>: PKM1 includes <strong>exon 9</strong> and excludes exon 10; PKM2 includes <strong>exon 10</strong> and excludes exon 9. PKM1 is enriched in heart, muscle, brain, and mature sperm; PKM2 is enriched in proliferating/anabolic cells and most tumor cells. (li2024theregulatorynetwork pages 1-2, oleaflores2024musclespecificpyruvatekinase pages 1-5, li2021discoveryoffunctional pages 2-3)</td>
+<td>Li et al., <strong>2024-05</strong>, <em>Biomolecules</em> — https://doi.org/10.3390/biom14050566 (li2024theregulatorynetwork pages 1-2); Olea-Flores et al., <strong>2024-04</strong>, <em>bioRxiv</em> — https://doi.org/10.1101/2024.04.10.588959 (oleaflores2024musclespecificpyruvatekinase pages 1-5)</td>
+</tr>
+<tr>
+<td>Catalytic reaction</td>
+<td>Canonical enzymatic function: <strong>phosphoenolpyruvate (PEP) + ADP → pyruvate + ATP</strong>. This is the final ATP-producing step of glycolysis and a major control point in glycolytic flux. (hu2024roleofpyruvate pages 2-4, oleaflores2024musclespecificpyruvatekinase pages 1-5, hu2024roleofpyruvate pages 1-2)</td>
+<td>Hu et al., <strong>2024-08</strong>, <em>Mol Med Rep</em> — https://doi.org/10.3892/mmr.2024.13309 (hu2024roleofpyruvate pages 2-4); Olea-Flores et al., <strong>2024-04</strong>, <em>bioRxiv</em> — https://doi.org/10.1101/2024.04.10.588959 (oleaflores2024musclespecificpyruvatekinase pages 1-5)</td>
+</tr>
+<tr>
+<td>Allostery &amp; oligomerization</td>
+<td><strong>PKM1 is constitutively active and predominantly tetrameric</strong>; <strong>PKM2 interconverts between high-activity tetramers and lower-activity dimers/monomers</strong>. <strong>FBP</strong> stabilizes tetrameric PKM2. Amino acids can also tune PKM2 allostery: Asn/Asp favor activation, whereas Val/Cys can inhibit activity by altering substrate affinity and oligomeric state. In tumors, low-activity dimeric PKM2 is often linked to anabolic rewiring/Warburg metabolism. (li2021discoveryoffunctional pages 2-3, nandi2023identificationofresidues pages 10-12, li2024theregulatorynetwork pages 1-2, hu2024roleofpyruvate pages 2-4)</td>
+<td>Nandi &amp; Dey, <strong>2023-03</strong>, <em>PLOS ONE</em> — https://doi.org/10.1371/journal.pone.0282508 (nandi2023identificationofresidues pages 10-12); Hu et al., <strong>2024-08</strong>, <em>Mol Med Rep</em> — https://doi.org/10.3892/mmr.2024.13309 (hu2024roleofpyruvate pages 2-4)</td>
+</tr>
+<tr>
+<td>Noncanonical kinase roles</td>
+<td>Beyond glycolysis, PKM2 has reported <strong>protein-kinase / histone-kinase / transcriptional coactivator</strong> functions. A major recent advance is the <strong>EMBO Journal 2024</strong> report that <strong>PKM2 acts as a PEP-dependent histidine kinase</strong>, phosphorylating <strong>PGAM1 H11</strong>; <strong>monomeric/dimeric PKM2</strong>, but not tetrameric PKM2, efficiently catalyzed this event, and <strong>TEPP46</strong> reduced PKM2–PGAM1 interaction/H11 phosphorylation. PKM2 has also been linked to histone H3 phosphorylation and regulation of HIF-1α, β-catenin, STAT3, c-Myc, NF-κB, and MST1 pathways. (wang2024pkm2functionsas pages 4-6, wang2024pkm2functionsas pages 1-2, jemal2024nonmetabolicenzymefunction pages 6-8, jemal2024nonmetabolicenzymefunction pages 5-6, jemal2024nonmetabolicenzymefunction pages 10-10, oleaflores2024musclespecificpyruvatekinase pages 1-5)</td>
+<td>Wang et al., <strong>2024-05</strong>, <em>EMBO J</em> — https://doi.org/10.1038/s44318-024-00110-8 (wang2024pkm2functionsas pages 4-6); Jemal et al., <strong>2024-10</strong>, <em>Front Oncol</em> — https://doi.org/10.3389/fonc.2024.1450325 (jemal2024nonmetabolicenzymefunction pages 6-8)</td>
+</tr>
+<tr>
+<td>Subcellular localization</td>
+<td>PKM is primarily <strong>cytosolic</strong> for canonical glycolysis, but <strong>PKM2 can accumulate in the nucleus</strong> where it supports transcriptional regulation and noncanonical signaling. Recent reviews summarize explicit nuclear-entry triggers: <strong>ERK1/2-dependent phosphorylation at S37</strong> promotes nuclear translocation, and <strong>EGFR activation promotes PKM2 nuclear import via importin α5</strong>. Nuclear localization is especially associated with <strong>dimeric PKM2</strong>. (hu2024roleofpyruvate pages 2-4, jemal2024nonmetabolicenzymefunction pages 6-8, jemal2024nonmetabolicenzymefunction pages 8-9, jemal2024nonmetabolicenzymefunction pages 5-6)</td>
+<td>Hu et al., <strong>2024-08</strong>, <em>Mol Med Rep</em> — https://doi.org/10.3892/mmr.2024.13309 (hu2024roleofpyruvate pages 2-4); Jemal et al., <strong>2024-10</strong>, <em>Front Oncol</em> — https://doi.org/10.3389/fonc.2024.1450325 (jemal2024nonmetabolicenzymefunction pages 8-9)</td>
+</tr>
+<tr>
+<td>Applications &amp; biomarkers</td>
+<td>PKM/PKM2 is being explored as a <strong>biomarker</strong> and <strong>therapeutic target</strong>, especially in oncology and inflammatory disease. In <strong>OSCC saliva proteomics</strong> (10 patients, 20 controls), PKM was among altered glycolytic proteins proposed for follow-up biomarker validation, though sensitivity/specificity were not yet established. In neonatal HIE plasma proteomics, <strong>PKM (P14618-2)</strong> was increased in favorable-outcome severe HIE versus mild HIE (<strong>log2FC 0.95, p=3.09×10^-2</strong>). In pregnancy saliva proteomics, pyruvate kinase was reduced/absent in stimulated saliva, supporting <strong>unstimulated saliva</strong> as the better discovery matrix. (remori2024predictionoforal pages 6-8, yip2023newbornswithfavourable pages 11-12, foratorijunior2023istherea pages 16-17)</td>
+<td>Remori et al., <strong>2024-10</strong>, <em>Int J Mol Sci</em> — https://doi.org/10.3390/ijms252011120 (remori2024predictionoforal pages 6-8); Yip et al., <strong>2023-09</strong>, <em>Biomolecules</em> — https://doi.org/10.3390/biom13101471 (yip2023newbornswithfavourable pages 11-12); Foratori-Junior et al., <strong>2023-05</strong>, <em>Cells</em> — https://doi.org/10.3390/cells12101389 (foratorijunior2023istherea pages 16-17)</td>
+</tr>
+<tr>
+<td>Recent 2023-2024 advances</td>
+<td>Key recent advances include: (1) <strong>amino-acid allosteric signal-transmission mapping</strong> in PKM2 (2023); (2) updated <strong>hnRNP/PTBP1-centered splicing-regulation networks</strong> controlling PKM1/PKM2 balance in tumors (2024); (3) <strong>PEP-dependent histidine kinase activity of PKM2 toward PGAM1 H11</strong> with oligomer-state dependence (2024); and (4) disease-focused reviews highlighting strategies to <strong>stabilize tetrameric PKM2 or block nuclear translocation</strong>. (nandi2023identificationofresidues pages 10-12, li2024theregulatorynetwork pages 1-2, wang2024pkm2functionsas pages 4-6, hu2024roleofpyruvate pages 2-4, jemal2024nonmetabolicenzymefunction pages 6-8)</td>
+<td>Nandi &amp; Dey, <strong>2023-03</strong>, <em>PLOS ONE</em> — https://doi.org/10.1371/journal.pone.0282508 (nandi2023identificationofresidues pages 10-12); Li et al., <strong>2024-05</strong>, <em>Biomolecules</em> — https://doi.org/10.3390/biom14050566 (li2024theregulatorynetwork pages 1-2); Wang et al., <strong>2024-05</strong>, <em>EMBO J</em> — https://doi.org/10.1038/s44318-024-00110-8 (wang2024pkm2functionsas pages 4-6); Hu et al., <strong>2024-08</strong>, <em>Mol Med Rep</em> — https://doi.org/10.3892/mmr.2024.13309 (hu2024roleofpyruvate pages 2-4)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the verified identity, core biochemistry, regulation, localization, and recent 2023-2024 advances for human PKM/PKM2 (UniProt P14618). It is useful as a compact evidence map for distinguishing canonical glycolytic roles from newer noncanonical signaling and biomarker findings.</em></p>
+<p>References</p>
+<ol>
+<li>
+<p>(nandi2023identificationofresidues pages 10-12): Suparno Nandi and Mishtu Dey. Identification of residues involved in allosteric signal transmission from amino acid binding site of pyruvate kinase muscle isoform 2. PLOS ONE, 18:e0282508, Mar 2023. URL: https://doi.org/10.1371/journal.pone.0282508, doi:10.1371/journal.pone.0282508. This article has 3 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(li2024theregulatorynetwork pages 1-2): Yuchao Li, Shuwei Zhang, Yuexian Li, Junchao Liu, Qian Li, Wenli Zang, and Yaping Pan. The regulatory network of hnrnps underlying regulating pkm alternative splicing in tumor progression. Biomolecules, 14:566, May 2024. URL: https://doi.org/10.3390/biom14050566, doi:10.3390/biom14050566. This article has 11 citations.</p>
+</li>
+<li>
+<p>(jemal2024nonmetabolicenzymefunction pages 1-2): Mohammed Jemal, Mamaru Getinet, Gashaw Azanaw Amare, Bantayehu Addis Tegegne, Temesgen Baylie, Enyew Fenta Mengistu, Enatnesh Essa Osman, Nuredin Chura Waritu, and Adane Adugna. Non-metabolic enzyme function of pyruvate kinase m2 in breast cancer. Frontiers in Oncology, Oct 2024. URL: https://doi.org/10.3389/fonc.2024.1450325, doi:10.3389/fonc.2024.1450325. This article has 7 citations.</p>
+</li>
+<li>
+<p>(oleaflores2024musclespecificpyruvatekinase pages 1-5): Monserrat Olea-Flores, Tapan Sharma, Odette Verdejo-Torres, Imaru DiBartolomeo, Paul R. Thompson, Teresita Padilla-Benavides, and Anthony N. Imbalzano. Muscle-specific pyruvate kinase isoforms, pkm1 and pkm2, regulate mammalian swi/snf proteins and histone 3 phosphorylation during myoblast differentiation. BioRxiv, Apr 2024. URL: https://doi.org/10.1101/2024.04.10.588959, doi:10.1101/2024.04.10.588959. This article has 12 citations.</p>
+</li>
+<li>
+<p>(hu2024roleofpyruvate pages 2-4): Yifei Hu, Jing Tang, Qiao Xu, Zenghui Fang, Rongqing Li, Mengxuan Yang, Jie Zhao, and Xin Chen. Role of pyruvate kinase m2 in regulating sepsis (review). Molecular Medicine Reports, Aug 2024. URL: https://doi.org/10.3892/mmr.2024.13309, doi:10.3892/mmr.2024.13309. This article has 5 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(wang2024pkm2functionsas pages 4-6): Yang Wang, Hengyao Shu, Yanzhao Qu, Xin Jin, Jia Liu, Wanting Peng, Lihua Wang, Miao Hao, Mingjie Xia, Zhexuan Zhao, Kejian Dong, Yao Di, Miaomiao Tian, Fengqi Hao, Chaoyi Xia, Wenxia Zhang, Xueqing Ba, Yunpeng Feng, and Min Wei. Pkm2 functions as a histidine kinase to phosphorylate pgam1 and increase glycolysis shunts in cancer. The EMBO Journal, 43:2368-2396, May 2024. URL: https://doi.org/10.1038/s44318-024-00110-8, doi:10.1038/s44318-024-00110-8. This article has 31 citations.</p>
+</li>
+<li>
+<p>(jemal2024nonmetabolicenzymefunction pages 6-8): Mohammed Jemal, Mamaru Getinet, Gashaw Azanaw Amare, Bantayehu Addis Tegegne, Temesgen Baylie, Enyew Fenta Mengistu, Enatnesh Essa Osman, Nuredin Chura Waritu, and Adane Adugna. Non-metabolic enzyme function of pyruvate kinase m2 in breast cancer. Frontiers in Oncology, Oct 2024. URL: https://doi.org/10.3389/fonc.2024.1450325, doi:10.3389/fonc.2024.1450325. This article has 7 citations.</p>
+</li>
+<li>
+<p>(li2021discoveryoffunctional pages 2-3): Xiangyu Li, Woonghee Kim, Muhammad Arif, Chunxia Gao, Andreas Hober, David Kotol, Linnéa Strandberg, Björn Forsström, Åsa Sivertsson, Per Oksvold, Hasan Turkez, Morten Grøtli, Yusuke Sato, Haruki Kume, Seishi Ogawa, Jan Boren, Jens Nielsen, Mathias Uhlen, Cheng Zhang, and Adil Mardinoglu. Discovery of functional alternatively spliced pkm transcripts in human cancers. Cancers, 13:348, Jan 2021. URL: https://doi.org/10.3390/cancers13020348, doi:10.3390/cancers13020348. This article has 19 citations.</p>
+</li>
+<li>
+<p>(li2024theregulatorynetwork pages 7-8): Yuchao Li, Shuwei Zhang, Yuexian Li, Junchao Liu, Qian Li, Wenli Zang, and Yaping Pan. The regulatory network of hnrnps underlying regulating pkm alternative splicing in tumor progression. Biomolecules, 14:566, May 2024. URL: https://doi.org/10.3390/biom14050566, doi:10.3390/biom14050566. This article has 11 citations.</p>
+</li>
+<li>
+<p>(jemal2024nonmetabolicenzymefunction pages 8-9): Mohammed Jemal, Mamaru Getinet, Gashaw Azanaw Amare, Bantayehu Addis Tegegne, Temesgen Baylie, Enyew Fenta Mengistu, Enatnesh Essa Osman, Nuredin Chura Waritu, and Adane Adugna. Non-metabolic enzyme function of pyruvate kinase m2 in breast cancer. Frontiers in Oncology, Oct 2024. URL: https://doi.org/10.3389/fonc.2024.1450325, doi:10.3389/fonc.2024.1450325. This article has 7 citations.</p>
+</li>
+<li>
+<p>(wang2024pkm2functionsas pages 1-2): Yang Wang, Hengyao Shu, Yanzhao Qu, Xin Jin, Jia Liu, Wanting Peng, Lihua Wang, Miao Hao, Mingjie Xia, Zhexuan Zhao, Kejian Dong, Yao Di, Miaomiao Tian, Fengqi Hao, Chaoyi Xia, Wenxia Zhang, Xueqing Ba, Yunpeng Feng, and Min Wei. Pkm2 functions as a histidine kinase to phosphorylate pgam1 and increase glycolysis shunts in cancer. The EMBO Journal, 43:2368-2396, May 2024. URL: https://doi.org/10.1038/s44318-024-00110-8, doi:10.1038/s44318-024-00110-8. This article has 31 citations.</p>
+</li>
+<li>
+<p>(remori2024predictionoforal pages 6-8): Veronica Remori, Manuel Airoldi, Tiziana Alberio, Mauro Fasano, and Lorenzo Azzi. Prediction of oral cancer biomarkers by salivary proteomics data. International Journal of Molecular Sciences, 25:11120, Oct 2024. URL: https://doi.org/10.3390/ijms252011120, doi:10.3390/ijms252011120. This article has 9 citations.</p>
+</li>
+<li>
+<p>(yip2023newbornswithfavourable pages 11-12): Ping K. Yip, Michael Bremang, Ian Pike, Vennila Ponnusamy, Adina T. Michael-Titus, and Divyen K. Shah. Newborns with favourable outcomes after perinatal asphyxia have upregulated glucose metabolism-related proteins in plasma. Biomolecules, 13:1471, Sep 2023. URL: https://doi.org/10.3390/biom13101471, doi:10.3390/biom13101471. This article has 4 citations.</p>
+</li>
+<li>
+<p>(foratorijunior2023istherea pages 16-17): Gerson Aparecido Foratori-Junior, Talita Mendes Oliveira Ventura, Larissa Tercilia Grizzo, Bruno Gualtieri Jesuino, Ana Virgínia Santana Sampaio Castilho, Marília Afonso Rabelo Buzalaf, and Silvia Helena de Carvalho Sales-Peres. Is there a difference in the proteomic profile of stimulated and unstimulated saliva samples from pregnant women with/without obesity and periodontitis? Cells, 12:1389, May 2023. URL: https://doi.org/10.3390/cells12101389, doi:10.3390/cells12101389. This article has 15 citations.</p>
+</li>
+<li>
+<p>(przewocki2024follicularfluidproteomic pages 7-8): Janusz Przewocki, Dominik Kossiński, Adam Łukaszuk, Grzegorz Jakiel, Izabela Wocławek-Potocka, Stanisław Ołdziej, and Krzysztof Łukaszuk. Follicular fluid proteomic analysis to identify predictive markers of normal embryonic development. International Journal of Molecular Sciences, 25:8431, Aug 2024. URL: https://doi.org/10.3390/ijms25158431, doi:10.3390/ijms25158431. This article has 8 citations.</p>
+</li>
+<li>
+<p>(OpenTargets Search: -PKM): Open Targets Query (-PKM, 10 results). Buniello, A. et al. (2025). Open Targets Platform: facilitating therapeutic hypotheses building in drug discovery. Nucleic Acids Research.</p>
+</li>
+<li>
+<p>(hu2024roleofpyruvate pages 1-2): Yifei Hu, Jing Tang, Qiao Xu, Zenghui Fang, Rongqing Li, Mengxuan Yang, Jie Zhao, and Xin Chen. Role of pyruvate kinase m2 in regulating sepsis (review). Molecular Medicine Reports, Aug 2024. URL: https://doi.org/10.3892/mmr.2024.13309, doi:10.3892/mmr.2024.13309. This article has 5 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(jemal2024nonmetabolicenzymefunction pages 5-6): Mohammed Jemal, Mamaru Getinet, Gashaw Azanaw Amare, Bantayehu Addis Tegegne, Temesgen Baylie, Enyew Fenta Mengistu, Enatnesh Essa Osman, Nuredin Chura Waritu, and Adane Adugna. Non-metabolic enzyme function of pyruvate kinase m2 in breast cancer. Frontiers in Oncology, Oct 2024. URL: https://doi.org/10.3389/fonc.2024.1450325, doi:10.3389/fonc.2024.1450325. This article has 7 citations.</p>
+</li>
+<li>
+<p>(jemal2024nonmetabolicenzymefunction pages 10-10): Mohammed Jemal, Mamaru Getinet, Gashaw Azanaw Amare, Bantayehu Addis Tegegne, Temesgen Baylie, Enyew Fenta Mengistu, Enatnesh Essa Osman, Nuredin Chura Waritu, and Adane Adugna. Non-metabolic enzyme function of pyruvate kinase m2 in breast cancer. Frontiers in Oncology, Oct 2024. URL: https://doi.org/10.3389/fonc.2024.1450325, doi:10.3389/fonc.2024.1450325. This article has 7 citations.</p>
+</li>
+</ol>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>li2024theregulatorynetwork pages 1-2</li>
+<li>li2021discoveryoffunctional pages 2-3</li>
+<li>nandi2023identificationofresidues pages 10-12</li>
+<li>hu2024roleofpyruvate pages 2-4</li>
+<li>jemal2024nonmetabolicenzymefunction pages 8-9</li>
+<li>jemal2024nonmetabolicenzymefunction pages 6-8</li>
+<li>oleaflores2024musclespecificpyruvatekinase pages 1-5</li>
+<li>remori2024predictionoforal pages 6-8</li>
+<li>yip2023newbornswithfavourable pages 11-12</li>
+<li>foratorijunior2023istherea pages 16-17</li>
+<li>przewocki2024follicularfluidproteomic pages 7-8</li>
+<li>jemal2024nonmetabolicenzymefunction pages 1-2</li>
+<li>li2024theregulatorynetwork pages 7-8</li>
+<li>hu2024roleofpyruvate pages 1-2</li>
+<li>jemal2024nonmetabolicenzymefunction pages 5-6</li>
+<li>jemal2024nonmetabolicenzymefunction pages 10-10</li>
+<li>https://doi.org/10.3390/ijms252011120</li>
+<li>https://doi.org/10.3390/biom13101471</li>
+<li>https://doi.org/10.3390/cells12101389</li>
+<li>https://doi.org/10.3390/ijms25158431</li>
+<li>https://doi.org/10.3389/fonc.2024.1450325</li>
+<li>https://doi.org/10.3390/cancers13020348</li>
+<li>https://doi.org/10.3390/biom14050566</li>
+<li>https://doi.org/10.1101/2024.04.10.588959</li>
+<li>https://doi.org/10.3892/mmr.2024.13309</li>
+<li>https://doi.org/10.1371/journal.pone.0282508</li>
+<li>https://doi.org/10.1038/s44318-024-00110-8</li>
+<li>https://doi.org/10.1371/journal.pone.0282508,</li>
+<li>https://doi.org/10.3390/biom14050566,</li>
+<li>https://doi.org/10.3389/fonc.2024.1450325,</li>
+<li>https://doi.org/10.1101/2024.04.10.588959,</li>
+<li>https://doi.org/10.3892/mmr.2024.13309,</li>
+<li>https://doi.org/10.1038/s44318-024-00110-8,</li>
+<li>https://doi.org/10.3390/cancers13020348,</li>
+<li>https://doi.org/10.3390/ijms252011120,</li>
+<li>https://doi.org/10.3390/biom13101471,</li>
+<li>https://doi.org/10.3390/cells12101389,</li>
+<li>https://doi.org/10.3390/ijms25158431,</li>
+</ol>
+            </div>
+        </details>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
                     <h3 style="display: inline;">Notes</h3>
                     <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(PKM-notes.md)</span>
                 </div>
@@ -7225,6 +7680,8 @@ existing_annotations:
           supporting_text: &#34;Paradoxically, decreased pyruvate kinase enzyme activity
             accompanies the expression of PKM2 in rapidly dividing cancer cells and
             tissues.&#34;
+        - reference_id: file:human/PKM/PKM-deep-research-falcon.md
+          supporting_text: &#34;PKM catalyzes the terminal glycolytic step: PEP + ADP -&gt; pyruvate + ATP, coupling high-energy phosphate transfer to ATP production.&#34;
   - term:
       id: GO:0005737
       label: cytoplasm
@@ -8486,6 +8943,9 @@ core_functions:
       cells. PKM2&#39;s low activity allows glycolytic intermediates to accumulate for
       biosynthetic
       pathways - the metabolic basis of the Warburg effect.
+    supported_by:
+      - reference_id: file:human/PKM/PKM-deep-research-falcon.md
+        supporting_text: &#34;PKM catalyzes the terminal glycolytic step: PEP + ADP -&gt; pyruvate + ATP, coupling high-energy phosphate transfer to ATP production.&#34;
   - molecular_function:
       id: GO:0004713
       label: protein tyrosine kinase activity
@@ -8497,6 +8957,9 @@ core_functions:
       non-metabolic moonlighting function contributes to cancer cell proliferation
       and
       tumorigenesis. PKM1 does NOT have this activity.
+    supported_by:
+      - reference_id: file:human/PKM/PKM-deep-research-falcon.md
+        supporting_text: &#34;The report summarizes noncanonical PKM2 protein-kinase roles, including tyrosine kinase activity linked to STAT3 Tyr-705 phosphorylation and transcriptional activation.&#34;
   - molecular_function:
       id: GO:0004674
       label: protein serine/threonine kinase activity
@@ -8505,6 +8968,9 @@ core_functions:
       histone H3 at Thr-11 (H3T11ph), promoting gene transcription and tumorigenesis.
       This protein kinase activity requires nuclear translocation and dimerization,
       distinct from its cytoplasmic glycolytic function. PKM1 does NOT have this activity.
+    supported_by:
+      - reference_id: file:human/PKM/PKM-deep-research-falcon.md
+        supporting_text: &#34;The report summarizes noncanonical PKM2 kinase functions, including histone H3 phosphorylation and a 2024 EMBO Journal finding that PKM2 can act as a PEP-dependent histidine kinase toward PGAM1 H11.&#34;
 references:
   - id: GO_REF:0000002
     title: Gene Ontology annotation through association of InterPro records with
@@ -8546,6 +9012,11 @@ references:
   - id: GO_REF:0000120
     title: Combined Automated Annotation using Multiple IEA Methods
     findings: []
+  - id: file:human/PKM/PKM-deep-research-falcon.md
+    title: Falcon deep research report for human PKM
+    findings:
+      - statement: PKM encodes pyruvate kinase M1/M2, with canonical activity catalyzing PEP + ADP to pyruvate + ATP in the terminal ATP-generating step of glycolysis.
+      - statement: The report distinguishes the core glycolytic enzyme function from PKM2-specific noncanonical kinase and transcription-associated activities.
   - id: PMID:11487543
     title: Intestinal epithelial cells secrete exosome-like vesicles.
     findings: []

--- a/genes/human/PKM/PKM-ai-review.yaml
+++ b/genes/human/PKM/PKM-ai-review.yaml
@@ -191,9 +191,9 @@ existing_annotations:
       reason: >-
         CRITICAL ISOFORM CONFLATION: This annotation applies ONLY to PKM2 (P14618-1),
         not PKM1.
-        The IEA annotation fails to capture this isoform specificity. Should be annotated
-        with
-        isoform qualifier.
+        The IEA annotation fails to capture this isoform specificity; the requested
+        modification is to retain GO:0004674 but add the isoform qualifier
+        isoform: P14618-1.
       proposed_replacement_terms:
         - id: GO:0004674
           label: protein serine/threonine kinase activity
@@ -215,9 +215,9 @@ existing_annotations:
       reason: >-
         CRITICAL ISOFORM CONFLATION: This annotation applies ONLY to PKM2 (P14618-1),
         not PKM1.
-        The IEA annotation fails to capture this isoform specificity. Should be annotated
-        with
-        isoform qualifier.
+        The IEA annotation fails to capture this isoform specificity; the requested
+        modification is to retain GO:0004713 but add the isoform qualifier
+        isoform: P14618-1.
       proposed_replacement_terms:
         - id: GO:0004713
           label: protein tyrosine kinase activity
@@ -235,7 +235,8 @@ existing_annotations:
       action: MODIFY
       reason: >-
         CRITICAL ISOFORM CONFLATION: This annotation applies ONLY to PKM2 (P14618-1),
-        not PKM1.
+        not PKM1. The requested modification is to retain GO:0004715 but add the
+        isoform qualifier isoform: P14618-1.
       proposed_replacement_terms:
         - id: GO:0004715
           label: non-membrane spanning protein tyrosine kinase activity
@@ -281,7 +282,9 @@ existing_annotations:
         PKM2-SPECIFIC localization.
       action: MODIFY
       reason: >-
-        CRITICAL ISOFORM CONFLATION: Nuclear localization applies ONLY to PKM2 (P14618-1).
+        CRITICAL ISOFORM CONFLATION: Nuclear localization applies ONLY to PKM2 (P14618-1);
+        the requested modification is to retain GO:0005634 but add the isoform
+        qualifier isoform: P14618-1.
         PMID:22056988 explicitly states "PKM1 failed to translocate into the nucleus
         upon EGF stimulation".
       proposed_replacement_terms:
@@ -694,8 +697,8 @@ existing_annotations:
       action: MODIFY
       reason: >-
         ISOFORM CONFLATION: Nucleoplasm localization is PKM2-specific. PKM1 does not
-        translocate
-        to nucleus.
+        translocate to nucleus. The requested modification is to retain GO:0005654
+        but add the isoform qualifier isoform: P14618-1.
       proposed_replacement_terms:
         - id: GO:0005654
           label: nucleoplasm

--- a/genes/human/PKM/PKM-ai-review.yaml
+++ b/genes/human/PKM/PKM-ai-review.yaml
@@ -71,6 +71,8 @@ existing_annotations:
           supporting_text: "Paradoxically, decreased pyruvate kinase enzyme activity
             accompanies the expression of PKM2 in rapidly dividing cancer cells and
             tissues."
+        - reference_id: file:human/PKM/PKM-deep-research-falcon.md
+          supporting_text: "PKM catalyzes the terminal glycolytic step: PEP + ADP -> pyruvate + ATP, coupling high-energy phosphate transfer to ATP production."
   - term:
       id: GO:0005737
       label: cytoplasm
@@ -1332,6 +1334,9 @@ core_functions:
       cells. PKM2's low activity allows glycolytic intermediates to accumulate for
       biosynthetic
       pathways - the metabolic basis of the Warburg effect.
+    supported_by:
+      - reference_id: file:human/PKM/PKM-deep-research-falcon.md
+        supporting_text: "PKM catalyzes the terminal glycolytic step: PEP + ADP -> pyruvate + ATP, coupling high-energy phosphate transfer to ATP production."
   - molecular_function:
       id: GO:0004713
       label: protein tyrosine kinase activity
@@ -1343,6 +1348,9 @@ core_functions:
       non-metabolic moonlighting function contributes to cancer cell proliferation
       and
       tumorigenesis. PKM1 does NOT have this activity.
+    supported_by:
+      - reference_id: file:human/PKM/PKM-deep-research-falcon.md
+        supporting_text: "The report summarizes noncanonical PKM2 protein-kinase roles, including tyrosine kinase activity linked to STAT3 Tyr-705 phosphorylation and transcriptional activation."
   - molecular_function:
       id: GO:0004674
       label: protein serine/threonine kinase activity
@@ -1351,6 +1359,9 @@ core_functions:
       histone H3 at Thr-11 (H3T11ph), promoting gene transcription and tumorigenesis.
       This protein kinase activity requires nuclear translocation and dimerization,
       distinct from its cytoplasmic glycolytic function. PKM1 does NOT have this activity.
+    supported_by:
+      - reference_id: file:human/PKM/PKM-deep-research-falcon.md
+        supporting_text: "The report summarizes noncanonical PKM2 kinase functions, including histone H3 phosphorylation and a 2024 EMBO Journal finding that PKM2 can act as a PEP-dependent histidine kinase toward PGAM1 H11."
 references:
   - id: GO_REF:0000002
     title: Gene Ontology annotation through association of InterPro records with
@@ -1392,6 +1403,11 @@ references:
   - id: GO_REF:0000120
     title: Combined Automated Annotation using Multiple IEA Methods
     findings: []
+  - id: file:human/PKM/PKM-deep-research-falcon.md
+    title: Falcon deep research report for human PKM
+    findings:
+      - statement: PKM encodes pyruvate kinase M1/M2, with canonical activity catalyzing PEP + ADP to pyruvate + ATP in the terminal ATP-generating step of glycolysis.
+      - statement: The report distinguishes the core glycolytic enzyme function from PKM2-specific noncanonical kinase and transcription-associated activities.
   - id: PMID:11487543
     title: Intestinal epithelial cells secrete exosome-like vesicles.
     findings: []

--- a/genes/human/PKM/PKM-deep-research-falcon.md
+++ b/genes/human/PKM/PKM-deep-research-falcon.md
@@ -1,0 +1,359 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-10T22:03:47.749752'
+end_time: '2026-05-10T22:15:56.523375'
+duration_seconds: 728.77
+template_file: templates/gene_research_go_focused.md
+template_variables:
+  organism: human
+  gene_id: PKM
+  gene_symbol: PKM
+  uniprot_accession: P14618
+  protein_description: 'RecName: Full=Pyruvate kinase PKM; EC=2.7.1.40 {ECO:0000269|PubMed:15996096,
+    ECO:0000269|PubMed:1854723, ECO:0000269|PubMed:20847263}; AltName: Full=Cytosolic
+    thyroid hormone-binding protein {ECO:0000303|PubMed:2813362}; Short=CTHBP {ECO:0000303|PubMed:2813362};
+    AltName: Full=Opa-interacting protein 3 {ECO:0000303|PubMed:9466265}; Short=OIP-3
+    {ECO:0000303|PubMed:9466265}; AltName: Full=Pyruvate kinase 2/3; AltName: Full=Pyruvate
+    kinase muscle isozyme; AltName: Full=Threonine-protein kinase PKM2 {ECO:0000305};
+    EC=2.7.11.1 {ECO:0000269|PubMed:22901803, ECO:0000269|PubMed:24120661}; AltName:
+    Full=Thyroid hormone-binding protein 1; Short=THBP1; AltName: Full=Tumor M2-PK;
+    AltName: Full=Tyrosine-protein kinase PKM2 {ECO:0000305}; EC=2.7.10.2 {ECO:0000269|PubMed:22306293,
+    ECO:0000269|PubMed:24120661}; AltName: Full=p58;'
+  gene_info: Name=PKM; Synonyms=OIP3 {ECO:0000303|PubMed:9466265}, PK2, PK3, PKM2;
+  organism_full: Homo sapiens (Human).
+  protein_family: Belongs to the pyruvate kinase family. .
+  protein_domains: Pyr_Knase. (IPR001697); Pyrv/PenolPyrv_kinase-like_dom. (IPR015813);
+    Pyrv_kinase-like_dom_sf. (IPR040442); Pyrv_Knase-like_insert_dom_sf. (IPR011037);
+    Pyrv_Knase_AS. (IPR018209)
+provider_config:
+  timeout: 600
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 38
+---
+
+## Question
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** P14618
+- **Protein Description:** RecName: Full=Pyruvate kinase PKM; EC=2.7.1.40 {ECO:0000269|PubMed:15996096, ECO:0000269|PubMed:1854723, ECO:0000269|PubMed:20847263}; AltName: Full=Cytosolic thyroid hormone-binding protein {ECO:0000303|PubMed:2813362}; Short=CTHBP {ECO:0000303|PubMed:2813362}; AltName: Full=Opa-interacting protein 3 {ECO:0000303|PubMed:9466265}; Short=OIP-3 {ECO:0000303|PubMed:9466265}; AltName: Full=Pyruvate kinase 2/3; AltName: Full=Pyruvate kinase muscle isozyme; AltName: Full=Threonine-protein kinase PKM2 {ECO:0000305}; EC=2.7.11.1 {ECO:0000269|PubMed:22901803, ECO:0000269|PubMed:24120661}; AltName: Full=Thyroid hormone-binding protein 1; Short=THBP1; AltName: Full=Tumor M2-PK; AltName: Full=Tyrosine-protein kinase PKM2 {ECO:0000305}; EC=2.7.10.2 {ECO:0000269|PubMed:22306293, ECO:0000269|PubMed:24120661}; AltName: Full=p58;
+- **Gene Information:** Name=PKM; Synonyms=OIP3 {ECO:0000303|PubMed:9466265}, PK2, PK3, PKM2;
+- **Organism (full):** Homo sapiens (Human).
+- **Protein Family:** Belongs to the pyruvate kinase family. .
+- **Key Domains:** Pyr_Knase. (IPR001697); Pyrv/PenolPyrv_kinase-like_dom. (IPR015813); Pyrv_kinase-like_dom_sf. (IPR040442); Pyrv_Knase-like_insert_dom_sf. (IPR011037); Pyrv_Knase_AS. (IPR018209)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "PKM" matches the protein description above**
+2. **Verify the organism is correct:** Homo sapiens (Human).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'PKM' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **PKM** (gene ID: PKM, UniProt: P14618) in human.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** P14618
+- **Protein Description:** RecName: Full=Pyruvate kinase PKM; EC=2.7.1.40 {ECO:0000269|PubMed:15996096, ECO:0000269|PubMed:1854723, ECO:0000269|PubMed:20847263}; AltName: Full=Cytosolic thyroid hormone-binding protein {ECO:0000303|PubMed:2813362}; Short=CTHBP {ECO:0000303|PubMed:2813362}; AltName: Full=Opa-interacting protein 3 {ECO:0000303|PubMed:9466265}; Short=OIP-3 {ECO:0000303|PubMed:9466265}; AltName: Full=Pyruvate kinase 2/3; AltName: Full=Pyruvate kinase muscle isozyme; AltName: Full=Threonine-protein kinase PKM2 {ECO:0000305}; EC=2.7.11.1 {ECO:0000269|PubMed:22901803, ECO:0000269|PubMed:24120661}; AltName: Full=Thyroid hormone-binding protein 1; Short=THBP1; AltName: Full=Tumor M2-PK; AltName: Full=Tyrosine-protein kinase PKM2 {ECO:0000305}; EC=2.7.10.2 {ECO:0000269|PubMed:22306293, ECO:0000269|PubMed:24120661}; AltName: Full=p58;
+- **Gene Information:** Name=PKM; Synonyms=OIP3 {ECO:0000303|PubMed:9466265}, PK2, PK3, PKM2;
+- **Organism (full):** Homo sapiens (Human).
+- **Protein Family:** Belongs to the pyruvate kinase family. .
+- **Key Domains:** Pyr_Knase. (IPR001697); Pyrv/PenolPyrv_kinase-like_dom. (IPR015813); Pyrv_kinase-like_dom_sf. (IPR040442); Pyrv_Knase-like_insert_dom_sf. (IPR011037); Pyrv_Knase_AS. (IPR018209)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "PKM" matches the protein description above**
+2. **Verify the organism is correct:** Homo sapiens (Human).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'PKM' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **PKM** (gene ID: PKM, UniProt: P14618) in human.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Comprehensive Research Report: Human **PKM** (UniProt **P14618**) — Functional Annotation, Regulation, and Translational Relevance (2023–2024 prioritized)
+
+### 1) Gene/protein identification and definitions (verification)
+
+**Target verified:** The gene symbol **PKM** in this report refers specifically to **human pyruvate kinase PKM (pyruvate kinase M1/2)** consistent with UniProt accession **P14618**, a member of the pyruvate kinase family catalyzing the terminal step of glycolysis. Multiple retrieved sources explicitly tie “PKM/PKM2” to UniProt **P14618** and to pyruvate-kinase biochemical/structural hallmarks (e.g., glycolytic PEP→pyruvate ATP-generating step; pyruvate-kinase oligomerization; FBP allostery). (nandi2023identificationofresidues pages 10-12, li2024theregulatorynetwork pages 1-2, jemal2024nonmetabolicenzymefunction pages 1-2)
+
+**Key definitions:**
+- **PKM1 / PKM2 isoenzymes:** The PKM gene produces two major protein isoforms via **mutually exclusive alternative splicing** of a single exon: **exon 9** vs **exon 10**. (li2024theregulatorynetwork pages 1-2, oleaflores2024musclespecificpyruvatekinase pages 1-5)
+- **Canonical enzymatic role:** Pyruvate kinase catalyzes transfer of phosphate from **phosphoenolpyruvate (PEP)** to **ADP**, producing **pyruvate + ATP** (EC 2.7.1.40), the final ATP-generating step of glycolysis. (hu2024roleofpyruvate pages 2-4, oleaflores2024musclespecificpyruvatekinase pages 1-5)
+- **Moonlighting/noncanonical functions:** Particularly for **PKM2**, literature describes additional roles beyond metabolite conversion, including nuclear functions and kinase-like activities that interface with gene regulation and signaling. (wang2024pkm2functionsas pages 4-6, jemal2024nonmetabolicenzymefunction pages 6-8)
+
+### 2) Core biochemistry: catalytic reaction, substrate specificity, and pathway role
+
+**Catalyzed reaction (primary molecular function):**
+PKM catalyzes the terminal glycolytic step: **PEP + ADP → pyruvate + ATP**. This reaction couples high-energy phosphate transfer to ATP production and is a principal flux-control point in glycolysis. (hu2024roleofpyruvate pages 2-4, oleaflores2024musclespecificpyruvatekinase pages 1-5)
+
+**Pathway placement and functional implication:**
+Because this step is both terminal and ATP-generating, changes in PKM activity (and especially PKM2 oligomeric state) can shift how upstream glycolytic intermediates accumulate and are diverted toward **biosynthetic side pathways** (a central concept in proliferative metabolism). (hu2024roleofpyruvate pages 2-4, li2021discoveryoffunctional pages 2-3)
+
+### 3) Isoforms, alternative splicing, and cell-state specificity
+
+**Alternative splicing mechanism (PKM1 vs PKM2):**
+A 2024 review focused on tumor splicing networks summarizes the canonical exon usage: PKM pre-mRNA splicing produces **PKM1 and PKM2**, where **PKM1 excludes exon 10** and **PKM2 excludes exon 9** (i.e., reciprocal inclusion of exon 9 vs exon 10). (li2024theregulatorynetwork pages 1-2)
+
+**Tissue/cell-state tendencies:**
+- **PKM1** is reported as predominant in **heart, skeletal muscle, brain, and mature sperm** (more differentiated/high oxidative contexts). (li2024theregulatorynetwork pages 1-2)
+- **PKM2** is enriched in **proliferating/anabolic cells** and in many tumors. (li2024theregulatorynetwork pages 1-2)
+
+**Regulatory control of splicing (recent synthesis):**
+The 2024 Biomolecules review emphasizes that splicing factors (notably hnRNP-centered networks and PTBP1-linked regulation) are core determinants of the **PKM1/PKM2 balance** in tumor progression, and that epigenetic/RNA-level mechanisms can influence whether cells use PKM1-linked oxidative metabolism or PKM2-linked glycolytic programs. (li2024theregulatorynetwork pages 1-2, li2024theregulatorynetwork pages 7-8)
+
+### 4) Allostery, oligomerization, and quantitative regulatory features (current understanding + 2023 advances)
+
+**Oligomeric states as functional switches:**
+PKM1 is commonly described as a **constitutively active tetramer**, whereas PKM2 is conformationally plastic, interconverting between high-activity tetramers and lower-activity dimer/monomer states. This tetramer–dimer equilibrium is repeatedly invoked to explain why PKM2 can support either ATP production or anabolic rewiring (via reduced catalytic flux at the last glycolytic step). (li2021discoveryoffunctional pages 2-3, hu2024roleofpyruvate pages 2-4)
+
+**Allosteric activation by fructose-1,6-bisphosphate (FBP):**
+A transcript/isoform-focused analysis summarizes that tetrameric PKM2 is allosterically activated by **FBP**, which stabilizes the tetramer, whereas FBP release promotes conversion toward lower-activity forms. (li2021discoveryoffunctional pages 2-3)
+
+**Amino-acid sensing and allosteric communication (2023 primary data):**
+Nandi & Dey (PLOS ONE, **2023-03-10**) dissected how amino acids modulate PKM2 via a dedicated amino-acid (AA) binding pocket and transmission to the active site, providing quantitative binding/affinity effects and linking them to activity and oligomer state. Key quantitative observations include:
+- For the **R106A** variant, ADP binding affinities in the presence of inhibitory AAs were markedly weakened (e.g., Val Kd ~1.2 mM; Cys Kd ~2.9 mM) vs no-AA condition (Kd = 257±24 μM). (nandi2023identificationofresidues pages 10-12)
+- PEP binding affinity could shift strongly depending on AA ligand class, with activator AAs (Asn/Asp) improving PEP binding (e.g., ~9.5 μM → ~1 μM), whereas inhibitory AAs (Val/Cys) weakened binding (e.g., ~26–100 μM). (nandi2023identificationofresidues pages 10-12)
+- Size-exclusion chromatography showed mutation-dependent changes in oligomer equilibrium; for example, **N70D** exhibited a tetramer plus dimer/monomer mixture without AAs, and activating AAs (Asn/Asp) increased tetrameric population consistent with activation. (nandi2023identificationofresidues pages 10-12)
+
+These findings refine “PKM2 as a nutrient sensor” into a more mechanistically grounded picture in which distinct AA ligands perturb substrate affinities and oligomeric state through a defined signal-transmission path. (nandi2023identificationofresidues pages 10-12)
+
+### 5) Subcellular localization: cytosolic glycolysis vs nuclear functions
+
+**Primary localization for canonical function:**
+PKM’s glycolytic role is cytosolic, consistent with glycolysis occurring in the cytoplasm. (hu2024roleofpyruvate pages 2-4)
+
+**Nuclear PKM2 and triggers for nuclear translocation (2024 reviews):**
+Recent 2024 reviews summarize that **PKM2**, particularly in non-tetrameric forms, can translocate to the nucleus where it acts in transcriptional and signaling regulation:
+- In a sepsis-focused review, Hu et al. report that **ERK1/2 phosphorylation at S37** (with downstream prolyl isomerization) promotes PKM2 nuclear translocation and supports interaction with transcriptional regulators such as **HIF‑1α** and **STAT3**, linking metabolic state to inflammatory gene programs. (hu2024roleofpyruvate pages 2-4)
+- In a breast-cancer-focused review, EGFR signaling is summarized as a driver of nuclear import: **EGFR activation results in PKM2 nuclear translocation**, facilitated via **importin α5**. (jemal2024nonmetabolicenzymefunction pages 8-9)
+- The same review emphasizes the functional importance of **dimeric PKM2** in nuclear localization and downstream biological effects. (jemal2024nonmetabolicenzymefunction pages 6-8)
+
+### 6) Noncanonical functions: kinase-like activities and signaling integration (2024 key advance)
+
+#### 6.1 PKM2 as a PEP-dependent histidine kinase (major 2024 primary advance)
+
+Wang et al. (EMBO J, **2024-05**) provide direct evidence that PKM2 “moonlights” as a **histidine kinase**:
+- PKM2 catalyzes **PGAM1 histidine-11 (H11) phosphorylation** in a **PEP-dependent** manner, which is required for PGAM1 activity and supports glycolysis shunt fluxes in cancer contexts. (wang2024pkm2functionsas pages 1-2, wang2024pkm2functionsas pages 4-6)
+- **Oligomeric-state dependence:** monomeric/dimeric PKM2 efficiently phosphorylates/activates PGAM1, whereas tetrameric PKM2 is ineffective. Stabilizing PKM2 tetramers (e.g., **TEPP46**) reduces PKM2–PGAM1 interaction and H11 phosphorylation. (wang2024pkm2functionsas pages 4-6)
+- **Tumor-selective interaction pattern:** PKM2–PGAM1 interaction was observed across multiple tumor cell lines and was reported as barely detectable in several untransformed cell types, consistent with a model where this crosstalk is preferentially engaged in tumor metabolic rewiring. (wang2024pkm2functionsas pages 1-2)
+
+This work is important for functional annotation because it operationally distinguishes the **canonical kinase transfer (to ADP)** from a distinct, noncanonical **PEP-dependent protein phosphorylation** activity that depends on PKM2 de-tetramerization. (wang2024pkm2functionsas pages 4-6)
+
+#### 6.2 Nuclear “protein kinase”/transcriptional cofactor roles summarized in 2024 reviews
+
+The 2024 Frontiers in Oncology review synthesizes literature in which nuclear PKM2 influences pathways via kinase-like functions or coactivator roles, including modulation of β-catenin transactivation and STAT3 phosphorylation-related signaling programs, and highlights that blocking nuclear translocation is a recurring therapeutic concept. (jemal2024nonmetabolicenzymefunction pages 6-8, jemal2024nonmetabolicenzymefunction pages 8-9)
+
+A 2024 preprint on myoblast differentiation further summarizes that PKM2 has been implicated in **histone H3 phosphorylation (H3T11)** in cancer cells, and reports roles for Pkm1/Pkm2 in chromatin regulator dynamics during differentiation (noting Pkm2 dependence for incorporation of phospho-H3 marks at myogenic promoters and a role for Pkm1 in nuclear localization of Dpf2). (oleaflores2024musclespecificpyruvatekinase pages 1-5)
+
+### 7) Current applications and real-world implementations (biomarkers/diagnostics; translational targeting)
+
+#### 7.1 Proteomics biomarker exploration (2023–2024)
+
+**(a) Oral squamous cell carcinoma (OSCC) saliva proteomics (2024):**
+Remori et al. (Int J Mol Sci, **2024-10**, DOI: https://doi.org/10.3390/ijms252011120) analyzed saliva proteomics (10 OSCC vs 20 controls) and used a workflow combining univariate/multivariate selection and protein–protein interaction filtering.
+- They report 172 differentially abundant proteins leading to a connected subset (48 proteins) to prioritize candidates; **PKM (P14618)** is explicitly highlighted as an altered glycolytic enzyme proposed as a candidate marker for follow-up validation. (remori2024predictionoforal pages 6-8)
+- The authors emphasize the need for future validation cohorts to establish diagnostic performance (sensitivity/specificity), i.e., PKM is a candidate rather than a validated clinical biomarker in this dataset. (remori2024predictionoforal pages 6-8)
+
+**(b) Perinatal asphyxia / neonatal hypoxic–ischemic encephalopathy (HIE) plasma proteomics (2023):**
+Yip et al. (Biomolecules, **2023-09**, DOI: https://doi.org/10.3390/biom13101471) performed plasma proteomics in neonates with HIE.
+- Study design includes 22 moderate-severe HIE newborns treated with therapeutic hypothermia (TH), with comparison groups including 10 mild HIE and 10 normal cord-blood samples (per paper abstract context; quantitative table shown for sHIE+ vs mHIE). (yip2023newbornswithfavourable pages 11-12)
+- In the “most reliable proteins” table comparing favorable-outcome severe HIE (sHIE+) vs mild HIE (mHIE), **PKM (P14618-2)** is listed with **log2FC = 0.95** and **p = 3.09 × 10^-2**. (yip2023newbornswithfavourable pages 11-12)
+
+This positions PKM as part of a **metabolic enzyme signature** associated with clinical outcome stratification in a specific neonatal critical care context (early-stage discovery/association rather than a validated clinical test). (yip2023newbornswithfavourable pages 11-12)
+
+**(c) Saliva collection protocol affecting detectability of metabolic proteins (2023):**
+Foratori-Junior et al. (Cells, **2023-05**, DOI: https://doi.org/10.3390/cells12101389) report that stimulated saliva sampling reduces or eliminates detection of multiple proteins involved in glycolysis/glucose metabolism, and specifically notes pyruvate kinase as reduced/absent in stimulated saliva in pregnancy cohorts with obesity. This is a practical methodological consideration for “real-world” biomarker work involving PKM/PKM2. (foratorijunior2023istherea pages 16-17)
+
+**(d) Follicular fluid proteomics and embryo development context (2024):**
+Przewocki et al. (Int J Mol Sci, **2024-08**, DOI: https://doi.org/10.3390/ijms25158431) analyzed 110 follicular-fluid samples from 50 oocyte donors, identifying 2182 proteins and noting protein–protein interaction patterns in which PKM2 appears as a node interacting with stress-response proteins (e.g., HSPA8). This supports that PKM2 is detectable in human reproductive biofluids and may be relevant to predictive modeling, although the excerpted text emphasizes network interpretation more than effect sizes for PKM specifically. (przewocki2024follicularfluidproteomic pages 7-8)
+
+#### 7.2 Therapeutic targeting concepts (expert synthesis, 2024)
+
+Two recurring expert concepts in 2024 reviews are:
+1) **Shift PKM2 toward the tetrameric enzymatically active state** (or preserve canonical activity) to reduce noncanonical nuclear functions and proliferative rewiring. (hu2024roleofpyruvate pages 2-4)
+2) **Block nuclear translocation** and downstream transcriptional/oncogenic signaling axes (e.g., EGFR→importin α5; ERK1/2 S37 pathway). (hu2024roleofpyruvate pages 2-4, jemal2024nonmetabolicenzymefunction pages 8-9)
+
+Examples mentioned in reviews include small molecules and natural products proposed to inhibit PKM2 expression, nuclear entry, or downstream signaling (e.g., shikonin’s reported interference with residues around R399/400 and a putative NLS; and the concept of covalent activation promoting tetramers to block nuclear functions). (jemal2024nonmetabolicenzymefunction pages 6-8, hu2024roleofpyruvate pages 2-4)
+
+### 8) Disease associations (database-level evidence)
+
+Open Targets reports disease–target associations for **PKM** (ENSG00000067225) across cancer and inflammation-related disease groupings (e.g., neoplasm; hepatocellular carcinoma; neuroinflammatory disorder), supported by multiple literature evidence items. This provides a high-level, integrative pointer that PKM is repeatedly observed in disease-linked evidence streams, though it does not replace mechanistic interpretation. (OpenTargets Search: -PKM)
+
+### 9) Limitations and evidence-quality notes
+
+- Several “noncanonical kinase” claims in reviews synthesize heterogeneous primary literature; for functional annotation, the strongest recent direct mechanistic advance in the provided corpus is the **EMBO J 2024** demonstration of **PEP-dependent histidine kinase activity toward PGAM1** with clear oligomer-state dependence. (wang2024pkm2functionsas pages 4-6)
+- Biomarker studies cited here are largely discovery-stage proteomics; they highlight PKM as differentially abundant or associated with outcomes, but **clinical diagnostic performance metrics** (AUC, sensitivity/specificity) for PKM alone are not established in the extracted text. (remori2024predictionoforal pages 6-8, yip2023newbornswithfavourable pages 11-12)
+
+---
+
+### Evidence map summary table
+
+| Topic | Key points | Best recent sources (2023-2024 prioritized) |
+|---|---|---|
+| Identity | Human **PKM** encodes pyruvate kinase M1/2 (UniProt **P14618**), a pyruvate kinase family enzyme catalyzing the terminal glycolytic step; PKM2 is the most discussed isoform in proliferative and cancer contexts, while PKM1 is prominent in differentiated tissues. PKM contains conserved pyruvate-kinase domains and an FBP allosteric site in the C-domain. (jemal2024nonmetabolicenzymefunction pages 1-2, li2021discoveryoffunctional pages 2-3) | Jemal et al., **2024-10**, *Front Oncol* — https://doi.org/10.3389/fonc.2024.1450325 (jemal2024nonmetabolicenzymefunction pages 1-2); Li et al., **2021-01**, *Cancers* — https://doi.org/10.3390/cancers13020348 (li2021discoveryoffunctional pages 2-3) |
+| Isoforms | **PKM1 vs PKM2 arise by mutually exclusive splicing of exon 9 and exon 10**: PKM1 includes **exon 9** and excludes exon 10; PKM2 includes **exon 10** and excludes exon 9. PKM1 is enriched in heart, muscle, brain, and mature sperm; PKM2 is enriched in proliferating/anabolic cells and most tumor cells. (li2024theregulatorynetwork pages 1-2, oleaflores2024musclespecificpyruvatekinase pages 1-5, li2021discoveryoffunctional pages 2-3) | Li et al., **2024-05**, *Biomolecules* — https://doi.org/10.3390/biom14050566 (li2024theregulatorynetwork pages 1-2); Olea-Flores et al., **2024-04**, *bioRxiv* — https://doi.org/10.1101/2024.04.10.588959 (oleaflores2024musclespecificpyruvatekinase pages 1-5) |
+| Catalytic reaction | Canonical enzymatic function: **phosphoenolpyruvate (PEP) + ADP → pyruvate + ATP**. This is the final ATP-producing step of glycolysis and a major control point in glycolytic flux. (hu2024roleofpyruvate pages 2-4, oleaflores2024musclespecificpyruvatekinase pages 1-5, hu2024roleofpyruvate pages 1-2) | Hu et al., **2024-08**, *Mol Med Rep* — https://doi.org/10.3892/mmr.2024.13309 (hu2024roleofpyruvate pages 2-4); Olea-Flores et al., **2024-04**, *bioRxiv* — https://doi.org/10.1101/2024.04.10.588959 (oleaflores2024musclespecificpyruvatekinase pages 1-5) |
+| Allostery & oligomerization | **PKM1 is constitutively active and predominantly tetrameric**; **PKM2 interconverts between high-activity tetramers and lower-activity dimers/monomers**. **FBP** stabilizes tetrameric PKM2. Amino acids can also tune PKM2 allostery: Asn/Asp favor activation, whereas Val/Cys can inhibit activity by altering substrate affinity and oligomeric state. In tumors, low-activity dimeric PKM2 is often linked to anabolic rewiring/Warburg metabolism. (li2021discoveryoffunctional pages 2-3, nandi2023identificationofresidues pages 10-12, li2024theregulatorynetwork pages 1-2, hu2024roleofpyruvate pages 2-4) | Nandi & Dey, **2023-03**, *PLOS ONE* — https://doi.org/10.1371/journal.pone.0282508 (nandi2023identificationofresidues pages 10-12); Hu et al., **2024-08**, *Mol Med Rep* — https://doi.org/10.3892/mmr.2024.13309 (hu2024roleofpyruvate pages 2-4) |
+| Noncanonical kinase roles | Beyond glycolysis, PKM2 has reported **protein-kinase / histone-kinase / transcriptional coactivator** functions. A major recent advance is the **EMBO Journal 2024** report that **PKM2 acts as a PEP-dependent histidine kinase**, phosphorylating **PGAM1 H11**; **monomeric/dimeric PKM2**, but not tetrameric PKM2, efficiently catalyzed this event, and **TEPP46** reduced PKM2–PGAM1 interaction/H11 phosphorylation. PKM2 has also been linked to histone H3 phosphorylation and regulation of HIF-1α, β-catenin, STAT3, c-Myc, NF-κB, and MST1 pathways. (wang2024pkm2functionsas pages 4-6, wang2024pkm2functionsas pages 1-2, jemal2024nonmetabolicenzymefunction pages 6-8, jemal2024nonmetabolicenzymefunction pages 5-6, jemal2024nonmetabolicenzymefunction pages 10-10, oleaflores2024musclespecificpyruvatekinase pages 1-5) | Wang et al., **2024-05**, *EMBO J* — https://doi.org/10.1038/s44318-024-00110-8 (wang2024pkm2functionsas pages 4-6); Jemal et al., **2024-10**, *Front Oncol* — https://doi.org/10.3389/fonc.2024.1450325 (jemal2024nonmetabolicenzymefunction pages 6-8) |
+| Subcellular localization | PKM is primarily **cytosolic** for canonical glycolysis, but **PKM2 can accumulate in the nucleus** where it supports transcriptional regulation and noncanonical signaling. Recent reviews summarize explicit nuclear-entry triggers: **ERK1/2-dependent phosphorylation at S37** promotes nuclear translocation, and **EGFR activation promotes PKM2 nuclear import via importin α5**. Nuclear localization is especially associated with **dimeric PKM2**. (hu2024roleofpyruvate pages 2-4, jemal2024nonmetabolicenzymefunction pages 6-8, jemal2024nonmetabolicenzymefunction pages 8-9, jemal2024nonmetabolicenzymefunction pages 5-6) | Hu et al., **2024-08**, *Mol Med Rep* — https://doi.org/10.3892/mmr.2024.13309 (hu2024roleofpyruvate pages 2-4); Jemal et al., **2024-10**, *Front Oncol* — https://doi.org/10.3389/fonc.2024.1450325 (jemal2024nonmetabolicenzymefunction pages 8-9) |
+| Applications & biomarkers | PKM/PKM2 is being explored as a **biomarker** and **therapeutic target**, especially in oncology and inflammatory disease. In **OSCC saliva proteomics** (10 patients, 20 controls), PKM was among altered glycolytic proteins proposed for follow-up biomarker validation, though sensitivity/specificity were not yet established. In neonatal HIE plasma proteomics, **PKM (P14618-2)** was increased in favorable-outcome severe HIE versus mild HIE (**log2FC 0.95, p=3.09×10^-2**). In pregnancy saliva proteomics, pyruvate kinase was reduced/absent in stimulated saliva, supporting **unstimulated saliva** as the better discovery matrix. (remori2024predictionoforal pages 6-8, yip2023newbornswithfavourable pages 11-12, foratorijunior2023istherea pages 16-17) | Remori et al., **2024-10**, *Int J Mol Sci* — https://doi.org/10.3390/ijms252011120 (remori2024predictionoforal pages 6-8); Yip et al., **2023-09**, *Biomolecules* — https://doi.org/10.3390/biom13101471 (yip2023newbornswithfavourable pages 11-12); Foratori-Junior et al., **2023-05**, *Cells* — https://doi.org/10.3390/cells12101389 (foratorijunior2023istherea pages 16-17) |
+| Recent 2023-2024 advances | Key recent advances include: (1) **amino-acid allosteric signal-transmission mapping** in PKM2 (2023); (2) updated **hnRNP/PTBP1-centered splicing-regulation networks** controlling PKM1/PKM2 balance in tumors (2024); (3) **PEP-dependent histidine kinase activity of PKM2 toward PGAM1 H11** with oligomer-state dependence (2024); and (4) disease-focused reviews highlighting strategies to **stabilize tetrameric PKM2 or block nuclear translocation**. (nandi2023identificationofresidues pages 10-12, li2024theregulatorynetwork pages 1-2, wang2024pkm2functionsas pages 4-6, hu2024roleofpyruvate pages 2-4, jemal2024nonmetabolicenzymefunction pages 6-8) | Nandi & Dey, **2023-03**, *PLOS ONE* — https://doi.org/10.1371/journal.pone.0282508 (nandi2023identificationofresidues pages 10-12); Li et al., **2024-05**, *Biomolecules* — https://doi.org/10.3390/biom14050566 (li2024theregulatorynetwork pages 1-2); Wang et al., **2024-05**, *EMBO J* — https://doi.org/10.1038/s44318-024-00110-8 (wang2024pkm2functionsas pages 4-6); Hu et al., **2024-08**, *Mol Med Rep* — https://doi.org/10.3892/mmr.2024.13309 (hu2024roleofpyruvate pages 2-4) |
+
+
+*Table: This table summarizes the verified identity, core biochemistry, regulation, localization, and recent 2023-2024 advances for human PKM/PKM2 (UniProt P14618). It is useful as a compact evidence map for distinguishing canonical glycolytic roles from newer noncanonical signaling and biomarker findings.*
+
+
+References
+
+1. (nandi2023identificationofresidues pages 10-12): Suparno Nandi and Mishtu Dey. Identification of residues involved in allosteric signal transmission from amino acid binding site of pyruvate kinase muscle isoform 2. PLOS ONE, 18:e0282508, Mar 2023. URL: https://doi.org/10.1371/journal.pone.0282508, doi:10.1371/journal.pone.0282508. This article has 3 citations and is from a peer-reviewed journal.
+
+2. (li2024theregulatorynetwork pages 1-2): Yuchao Li, Shuwei Zhang, Yuexian Li, Junchao Liu, Qian Li, Wenli Zang, and Yaping Pan. The regulatory network of hnrnps underlying regulating pkm alternative splicing in tumor progression. Biomolecules, 14:566, May 2024. URL: https://doi.org/10.3390/biom14050566, doi:10.3390/biom14050566. This article has 11 citations.
+
+3. (jemal2024nonmetabolicenzymefunction pages 1-2): Mohammed Jemal, Mamaru Getinet, Gashaw Azanaw Amare, Bantayehu Addis Tegegne, Temesgen Baylie, Enyew Fenta Mengistu, Enatnesh Essa Osman, Nuredin Chura Waritu, and Adane Adugna. Non-metabolic enzyme function of pyruvate kinase m2 in breast cancer. Frontiers in Oncology, Oct 2024. URL: https://doi.org/10.3389/fonc.2024.1450325, doi:10.3389/fonc.2024.1450325. This article has 7 citations.
+
+4. (oleaflores2024musclespecificpyruvatekinase pages 1-5): Monserrat Olea-Flores, Tapan Sharma, Odette Verdejo-Torres, Imaru DiBartolomeo, Paul R. Thompson, Teresita Padilla-Benavides, and Anthony N. Imbalzano. Muscle-specific pyruvate kinase isoforms, pkm1 and pkm2, regulate mammalian swi/snf proteins and histone 3 phosphorylation during myoblast differentiation. BioRxiv, Apr 2024. URL: https://doi.org/10.1101/2024.04.10.588959, doi:10.1101/2024.04.10.588959. This article has 12 citations.
+
+5. (hu2024roleofpyruvate pages 2-4): Yifei Hu, Jing Tang, Qiao Xu, Zenghui Fang, Rongqing Li, Mengxuan Yang, Jie Zhao, and Xin Chen. Role of pyruvate kinase m2 in regulating sepsis (review). Molecular Medicine Reports, Aug 2024. URL: https://doi.org/10.3892/mmr.2024.13309, doi:10.3892/mmr.2024.13309. This article has 5 citations and is from a peer-reviewed journal.
+
+6. (wang2024pkm2functionsas pages 4-6): Yang Wang, Hengyao Shu, Yanzhao Qu, Xin Jin, Jia Liu, Wanting Peng, Lihua Wang, Miao Hao, Mingjie Xia, Zhexuan Zhao, Kejian Dong, Yao Di, Miaomiao Tian, Fengqi Hao, Chaoyi Xia, Wenxia Zhang, Xueqing Ba, Yunpeng Feng, and Min Wei. Pkm2 functions as a histidine kinase to phosphorylate pgam1 and increase glycolysis shunts in cancer. The EMBO Journal, 43:2368-2396, May 2024. URL: https://doi.org/10.1038/s44318-024-00110-8, doi:10.1038/s44318-024-00110-8. This article has 31 citations.
+
+7. (jemal2024nonmetabolicenzymefunction pages 6-8): Mohammed Jemal, Mamaru Getinet, Gashaw Azanaw Amare, Bantayehu Addis Tegegne, Temesgen Baylie, Enyew Fenta Mengistu, Enatnesh Essa Osman, Nuredin Chura Waritu, and Adane Adugna. Non-metabolic enzyme function of pyruvate kinase m2 in breast cancer. Frontiers in Oncology, Oct 2024. URL: https://doi.org/10.3389/fonc.2024.1450325, doi:10.3389/fonc.2024.1450325. This article has 7 citations.
+
+8. (li2021discoveryoffunctional pages 2-3): Xiangyu Li, Woonghee Kim, Muhammad Arif, Chunxia Gao, Andreas Hober, David Kotol, Linnéa Strandberg, Björn Forsström, Åsa Sivertsson, Per Oksvold, Hasan Turkez, Morten Grøtli, Yusuke Sato, Haruki Kume, Seishi Ogawa, Jan Boren, Jens Nielsen, Mathias Uhlen, Cheng Zhang, and Adil Mardinoglu. Discovery of functional alternatively spliced pkm transcripts in human cancers. Cancers, 13:348, Jan 2021. URL: https://doi.org/10.3390/cancers13020348, doi:10.3390/cancers13020348. This article has 19 citations.
+
+9. (li2024theregulatorynetwork pages 7-8): Yuchao Li, Shuwei Zhang, Yuexian Li, Junchao Liu, Qian Li, Wenli Zang, and Yaping Pan. The regulatory network of hnrnps underlying regulating pkm alternative splicing in tumor progression. Biomolecules, 14:566, May 2024. URL: https://doi.org/10.3390/biom14050566, doi:10.3390/biom14050566. This article has 11 citations.
+
+10. (jemal2024nonmetabolicenzymefunction pages 8-9): Mohammed Jemal, Mamaru Getinet, Gashaw Azanaw Amare, Bantayehu Addis Tegegne, Temesgen Baylie, Enyew Fenta Mengistu, Enatnesh Essa Osman, Nuredin Chura Waritu, and Adane Adugna. Non-metabolic enzyme function of pyruvate kinase m2 in breast cancer. Frontiers in Oncology, Oct 2024. URL: https://doi.org/10.3389/fonc.2024.1450325, doi:10.3389/fonc.2024.1450325. This article has 7 citations.
+
+11. (wang2024pkm2functionsas pages 1-2): Yang Wang, Hengyao Shu, Yanzhao Qu, Xin Jin, Jia Liu, Wanting Peng, Lihua Wang, Miao Hao, Mingjie Xia, Zhexuan Zhao, Kejian Dong, Yao Di, Miaomiao Tian, Fengqi Hao, Chaoyi Xia, Wenxia Zhang, Xueqing Ba, Yunpeng Feng, and Min Wei. Pkm2 functions as a histidine kinase to phosphorylate pgam1 and increase glycolysis shunts in cancer. The EMBO Journal, 43:2368-2396, May 2024. URL: https://doi.org/10.1038/s44318-024-00110-8, doi:10.1038/s44318-024-00110-8. This article has 31 citations.
+
+12. (remori2024predictionoforal pages 6-8): Veronica Remori, Manuel Airoldi, Tiziana Alberio, Mauro Fasano, and Lorenzo Azzi. Prediction of oral cancer biomarkers by salivary proteomics data. International Journal of Molecular Sciences, 25:11120, Oct 2024. URL: https://doi.org/10.3390/ijms252011120, doi:10.3390/ijms252011120. This article has 9 citations.
+
+13. (yip2023newbornswithfavourable pages 11-12): Ping K. Yip, Michael Bremang, Ian Pike, Vennila Ponnusamy, Adina T. Michael-Titus, and Divyen K. Shah. Newborns with favourable outcomes after perinatal asphyxia have upregulated glucose metabolism-related proteins in plasma. Biomolecules, 13:1471, Sep 2023. URL: https://doi.org/10.3390/biom13101471, doi:10.3390/biom13101471. This article has 4 citations.
+
+14. (foratorijunior2023istherea pages 16-17): Gerson Aparecido Foratori-Junior, Talita Mendes Oliveira Ventura, Larissa Tercilia Grizzo, Bruno Gualtieri Jesuino, Ana Virgínia Santana Sampaio Castilho, Marília Afonso Rabelo Buzalaf, and Silvia Helena de Carvalho Sales-Peres. Is there a difference in the proteomic profile of stimulated and unstimulated saliva samples from pregnant women with/without obesity and periodontitis? Cells, 12:1389, May 2023. URL: https://doi.org/10.3390/cells12101389, doi:10.3390/cells12101389. This article has 15 citations.
+
+15. (przewocki2024follicularfluidproteomic pages 7-8): Janusz Przewocki, Dominik Kossiński, Adam Łukaszuk, Grzegorz Jakiel, Izabela Wocławek-Potocka, Stanisław Ołdziej, and Krzysztof Łukaszuk. Follicular fluid proteomic analysis to identify predictive markers of normal embryonic development. International Journal of Molecular Sciences, 25:8431, Aug 2024. URL: https://doi.org/10.3390/ijms25158431, doi:10.3390/ijms25158431. This article has 8 citations.
+
+16. (OpenTargets Search: -PKM): Open Targets Query (-PKM, 10 results). Buniello, A. et al. (2025). Open Targets Platform: facilitating therapeutic hypotheses building in drug discovery. Nucleic Acids Research.
+
+17. (hu2024roleofpyruvate pages 1-2): Yifei Hu, Jing Tang, Qiao Xu, Zenghui Fang, Rongqing Li, Mengxuan Yang, Jie Zhao, and Xin Chen. Role of pyruvate kinase m2 in regulating sepsis (review). Molecular Medicine Reports, Aug 2024. URL: https://doi.org/10.3892/mmr.2024.13309, doi:10.3892/mmr.2024.13309. This article has 5 citations and is from a peer-reviewed journal.
+
+18. (jemal2024nonmetabolicenzymefunction pages 5-6): Mohammed Jemal, Mamaru Getinet, Gashaw Azanaw Amare, Bantayehu Addis Tegegne, Temesgen Baylie, Enyew Fenta Mengistu, Enatnesh Essa Osman, Nuredin Chura Waritu, and Adane Adugna. Non-metabolic enzyme function of pyruvate kinase m2 in breast cancer. Frontiers in Oncology, Oct 2024. URL: https://doi.org/10.3389/fonc.2024.1450325, doi:10.3389/fonc.2024.1450325. This article has 7 citations.
+
+19. (jemal2024nonmetabolicenzymefunction pages 10-10): Mohammed Jemal, Mamaru Getinet, Gashaw Azanaw Amare, Bantayehu Addis Tegegne, Temesgen Baylie, Enyew Fenta Mengistu, Enatnesh Essa Osman, Nuredin Chura Waritu, and Adane Adugna. Non-metabolic enzyme function of pyruvate kinase m2 in breast cancer. Frontiers in Oncology, Oct 2024. URL: https://doi.org/10.3389/fonc.2024.1450325, doi:10.3389/fonc.2024.1450325. This article has 7 citations.
+
+## Citations
+
+1. li2024theregulatorynetwork pages 1-2
+2. li2021discoveryoffunctional pages 2-3
+3. nandi2023identificationofresidues pages 10-12
+4. hu2024roleofpyruvate pages 2-4
+5. jemal2024nonmetabolicenzymefunction pages 8-9
+6. jemal2024nonmetabolicenzymefunction pages 6-8
+7. oleaflores2024musclespecificpyruvatekinase pages 1-5
+8. remori2024predictionoforal pages 6-8
+9. yip2023newbornswithfavourable pages 11-12
+10. foratorijunior2023istherea pages 16-17
+11. przewocki2024follicularfluidproteomic pages 7-8
+12. jemal2024nonmetabolicenzymefunction pages 1-2
+13. li2024theregulatorynetwork pages 7-8
+14. hu2024roleofpyruvate pages 1-2
+15. jemal2024nonmetabolicenzymefunction pages 5-6
+16. jemal2024nonmetabolicenzymefunction pages 10-10
+17. https://doi.org/10.3390/ijms252011120
+18. https://doi.org/10.3390/biom13101471
+19. https://doi.org/10.3390/cells12101389
+20. https://doi.org/10.3390/ijms25158431
+21. https://doi.org/10.3389/fonc.2024.1450325
+22. https://doi.org/10.3390/cancers13020348
+23. https://doi.org/10.3390/biom14050566
+24. https://doi.org/10.1101/2024.04.10.588959
+25. https://doi.org/10.3892/mmr.2024.13309
+26. https://doi.org/10.1371/journal.pone.0282508
+27. https://doi.org/10.1038/s44318-024-00110-8
+28. https://doi.org/10.1371/journal.pone.0282508,
+29. https://doi.org/10.3390/biom14050566,
+30. https://doi.org/10.3389/fonc.2024.1450325,
+31. https://doi.org/10.1101/2024.04.10.588959,
+32. https://doi.org/10.3892/mmr.2024.13309,
+33. https://doi.org/10.1038/s44318-024-00110-8,
+34. https://doi.org/10.3390/cancers13020348,
+35. https://doi.org/10.3390/ijms252011120,
+36. https://doi.org/10.3390/biom13101471,
+37. https://doi.org/10.3390/cells12101389,
+38. https://doi.org/10.3390/ijms25158431,

--- a/genes/human/POMC/POMC-ai-review.html
+++ b/genes/human/POMC/POMC-ai-review.html
@@ -4638,12 +4638,12 @@
                     <td>
                         
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Added to align core_functions with existing annotations.
+                            <strong>Summary:</strong> POMC is a pre-prohormone precursor whose biological activity depends on sequential proteolytic cleavage at paired basic residues to generate ACTH, melanocyte-stimulating hormones, beta-lipotropin, and beta-endorphin. Peptide hormone processing is therefore a direct part of POMC maturation, not just a downstream consequence.
                         </div>
                         
                         
                         <div>
-                            <strong>Reason:</strong> Core function term not present in existing_annotations.
+                            <strong>Reason:</strong> Add this term because the cited human POMC phenotype paper and UniProt processing note both support proteolytic generation of multiple peptide hormones from the precursor.
                         </div>
                         
                         
@@ -4711,12 +4711,12 @@
                     <td>
                         
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Added to align core_functions with existing annotations.
+                            <strong>Summary:</strong> The ACTH/corticotropin cleavage product of POMC (POMC residues 138-176) binds the corticotropin receptor MC2R on adrenal cortex cells. This receptor-ligand interaction is the molecular entry point for POMC&#39;s HPA-axis endocrine function.
                         </div>
                         
                         
                         <div>
-                            <strong>Reason:</strong> Core function term not present in existing_annotations.
+                            <strong>Reason:</strong> GO:0031780 is the specific receptor-binding term for the ACTH product, supported by Reactome&#39;s POMC(138-176)-MC2R reaction and by POMC-deficiency adrenal insufficiency in humans.
                         </div>
                         
                         
@@ -4784,12 +4784,12 @@
                     <td>
                         
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Added to align core_functions with existing annotations.
+                            <strong>Summary:</strong> POMC-derived ACTH positively regulates adrenal glucocorticoid secretion by binding MC2R on adrenal cortex cells. Human POMC loss causes isolated ACTH deficiency with secondary adrenal insufficiency, showing that this stimulatory endocrine signal is physiologically required.
                         </div>
                         
                         
                         <div>
-                            <strong>Reason:</strong> Core function term not present in existing_annotations.
+                            <strong>Reason:</strong> Add this BP term to capture the direct endocrine consequence of ACTH-MC2R signaling, rather than only the molecular receptor-binding event.
                         </div>
                         
                         
@@ -4857,12 +4857,12 @@
                     <td>
                         
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Added to align core_functions with existing annotations.
+                            <strong>Summary:</strong> In humans, the principal adrenal glucocorticoid output of ACTH signaling is cortisol. The POMC-derived ACTH peptide binds MC2R and stimulates cortisol secretion; POMC-deficient patients present with adrenal insufficiency from loss of this signal.
                         </div>
                         
                         
                         <div>
-                            <strong>Reason:</strong> Core function term not present in existing_annotations.
+                            <strong>Reason:</strong> This term is the human-specific child of glucocorticoid secretion regulation and is justified for POMC because the relevant cleavage product is ACTH.
                         </div>
                         
                         
@@ -4930,12 +4930,12 @@
                     <td>
                         
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Added to align core_functions with existing annotations.
+                            <strong>Summary:</strong> Hypothalamic POMC neurons generate alpha-MSH, which activates melanocortin receptors including MC4R to suppress appetite and regulate body weight. Severe early-onset obesity in POMC deficiency supports energy homeostasis as a core physiological role of POMC-derived melanocortins.
                         </div>
                         
                         
                         <div>
-                            <strong>Reason:</strong> Core function term not present in existing_annotations.
+                            <strong>Reason:</strong> Add this BP term because the cited human phenotype and receptor-binding evidence connect POMC-derived alpha-MSH signaling to systemic energy balance.
                         </div>
                         
                         
@@ -5005,12 +5005,12 @@
                     <td>
                         
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Added to align core_functions with existing annotations.
+                            <strong>Summary:</strong> POMC-derived alpha-MSH and beta-MSH stimulate melanocortin receptor signaling in melanocytes, increasing melanin production. Red hair and fair skin in POMC-deficient patients support loss of this melanogenic signal in humans.
                         </div>
                         
                         
                         <div>
-                            <strong>Reason:</strong> Core function term not present in existing_annotations.
+                            <strong>Reason:</strong> Add this BP term to represent the pigment-biosynthesis role of POMC-derived MSH peptides, supported by UniProt functional text and human POMC-deficiency pigmentation phenotypes.
                         </div>
                         
                         
@@ -5091,12 +5091,12 @@
                     <td>
                         
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Added to align core_functions with existing annotations.
+                            <strong>Summary:</strong> Beta-endorphin is a POMC cleavage product with endogenous opioid peptide activity. It binds opioid receptors and mediates POMC&#39;s opioid signaling output, distinct from the melanocortin and ACTH products.
                         </div>
                         
                         
                         <div>
-                            <strong>Reason:</strong> Core function term not present in existing_annotations.
+                            <strong>Reason:</strong> Add this MF term because beta-endorphin is an annotated POMC-derived opiate peptide and Reactome supports opioid peptide receptor binding.
                         </div>
                         
                         
@@ -5162,12 +5162,12 @@
                     <td>
                         
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Added to align core_functions with existing annotations.
+                            <strong>Summary:</strong> The POMC-derived beta-endorphin peptide is an endogenous opioid that signals through opioid receptors. Opioid signaling is a canonical regulator of pain responses, making response to pain an appropriate biological-process output for this cleavage product.
                         </div>
                         
                         
                         <div>
-                            <strong>Reason:</strong> Core function term not present in existing_annotations.
+                            <strong>Reason:</strong> Add this BP term to capture the physiological consequence of beta-endorphin opioid peptide activity, supported by the POMC beta-endorphin annotation and Reactome opioid receptor pathway evidence.
                         </div>
                         
                         
@@ -7872,9 +7872,17 @@ existing_annotations:
     label: peptide hormone processing
   evidence_type: NAS
   review:
-    summary: Added to align core_functions with existing annotations.
+    summary: &gt;-
+      POMC is a pre-prohormone precursor whose biological activity depends on
+      sequential proteolytic cleavage at paired basic residues to generate ACTH,
+      melanocyte-stimulating hormones, beta-lipotropin, and beta-endorphin.
+      Peptide hormone processing is therefore a direct part of POMC maturation,
+      not just a downstream consequence.
     action: NEW
-    reason: Core function term not present in existing_annotations.
+    reason: &gt;-
+      Add this term because the cited human POMC phenotype paper and UniProt
+      processing note both support proteolytic generation of multiple peptide
+      hormones from the precursor.
     supported_by:
     - reference_id: PMID:9620771
       supporting_text: &#34;Sequential cleavage of the precursor protein pre-pro-opiomelanocortin (POMC) generates the melanocortin peptides adrenocorticotrophin (ACTH), melanocyte-stimulating hormones (MSH) alpha, beta and gamma as well as the opioid-receptor ligand beta-endorphin.&#34;
@@ -7892,9 +7900,16 @@ existing_annotations:
     label: corticotropin hormone receptor binding
   evidence_type: NAS
   review:
-    summary: Added to align core_functions with existing annotations.
+    summary: &gt;-
+      The ACTH/corticotropin cleavage product of POMC (POMC residues 138-176)
+      binds the corticotropin receptor MC2R on adrenal cortex cells. This
+      receptor-ligand interaction is the molecular entry point for POMC&#39;s HPA-axis
+      endocrine function.
     action: NEW
-    reason: Core function term not present in existing_annotations.
+    reason: &gt;-
+      GO:0031780 is the specific receptor-binding term for the ACTH product,
+      supported by Reactome&#39;s POMC(138-176)-MC2R reaction and by POMC-deficiency
+      adrenal insufficiency in humans.
     supported_by:
     - reference_id: PMID:9620771
       supporting_text: &#34;adrenal insufficiency... isolated ACTH deficiency&#34;
@@ -7912,9 +7927,15 @@ existing_annotations:
     label: positive regulation of glucocorticoid secretion
   evidence_type: NAS
   review:
-    summary: Added to align core_functions with existing annotations.
+    summary: &gt;-
+      POMC-derived ACTH positively regulates adrenal glucocorticoid secretion
+      by binding MC2R on adrenal cortex cells. Human POMC loss causes isolated
+      ACTH deficiency with secondary adrenal insufficiency, showing that this
+      stimulatory endocrine signal is physiologically required.
     action: NEW
-    reason: Core function term not present in existing_annotations.
+    reason: &gt;-
+      Add this BP term to capture the direct endocrine consequence of ACTH-MC2R
+      signaling, rather than only the molecular receptor-binding event.
     supported_by:
     - reference_id: PMID:9620771
       supporting_text: &#34;adrenal insufficiency... isolated ACTH deficiency&#34;
@@ -7932,9 +7953,15 @@ existing_annotations:
     label: positive regulation of cortisol secretion
   evidence_type: NAS
   review:
-    summary: Added to align core_functions with existing annotations.
+    summary: &gt;-
+      In humans, the principal adrenal glucocorticoid output of ACTH signaling is
+      cortisol. The POMC-derived ACTH peptide binds MC2R and stimulates cortisol
+      secretion; POMC-deficient patients present with adrenal insufficiency from
+      loss of this signal.
     action: NEW
-    reason: Core function term not present in existing_annotations.
+    reason: &gt;-
+      This term is the human-specific child of glucocorticoid secretion regulation
+      and is justified for POMC because the relevant cleavage product is ACTH.
     supported_by:
     - reference_id: PMID:9620771
       supporting_text: &#34;adrenal insufficiency... isolated ACTH deficiency&#34;
@@ -7952,9 +7979,15 @@ existing_annotations:
     label: energy homeostasis
   evidence_type: NAS
   review:
-    summary: Added to align core_functions with existing annotations.
+    summary: &gt;-
+      Hypothalamic POMC neurons generate alpha-MSH, which activates melanocortin
+      receptors including MC4R to suppress appetite and regulate body weight.
+      Severe early-onset obesity in POMC deficiency supports energy homeostasis
+      as a core physiological role of POMC-derived melanocortins.
     action: NEW
-    reason: Core function term not present in existing_annotations.
+    reason: &gt;-
+      Add this BP term because the cited human phenotype and receptor-binding
+      evidence connect POMC-derived alpha-MSH signaling to systemic energy balance.
     supported_by:
     - reference_id: PMID:9620771
       supporting_text: &#34;Recent studies in animal models elucidated a central role of alpha-MSH in the regulation of food intake by activation of the brain melanocortin-4-receptor (MC4-R; refs 3-5)&#34;
@@ -7972,9 +8005,15 @@ existing_annotations:
     label: melanin biosynthetic process
   evidence_type: NAS
   review:
-    summary: Added to align core_functions with existing annotations.
+    summary: &gt;-
+      POMC-derived alpha-MSH and beta-MSH stimulate melanocortin receptor signaling
+      in melanocytes, increasing melanin production. Red hair and fair skin in
+      POMC-deficient patients support loss of this melanogenic signal in humans.
     action: NEW
-    reason: Core function term not present in existing_annotations.
+    reason: &gt;-
+      Add this BP term to represent the pigment-biosynthesis role of POMC-derived
+      MSH peptides, supported by UniProt functional text and human POMC-deficiency
+      pigmentation phenotypes.
     supported_by:
     - reference_id: PMID:9620771
       supporting_text: &#34;red hair pigmentation caused by POMC mutations&#34;
@@ -7995,9 +8034,14 @@ existing_annotations:
     label: opioid peptide activity
   evidence_type: NAS
   review:
-    summary: Added to align core_functions with existing annotations.
+    summary: &gt;-
+      Beta-endorphin is a POMC cleavage product with endogenous opioid peptide
+      activity. It binds opioid receptors and mediates POMC&#39;s opioid signaling
+      output, distinct from the melanocortin and ACTH products.
     action: NEW
-    reason: Core function term not present in existing_annotations.
+    reason: &gt;-
+      Add this MF term because beta-endorphin is an annotated POMC-derived opiate
+      peptide and Reactome supports opioid peptide receptor binding.
     supported_by:
     - reference_id: UniProtKB:P01189
       supporting_text: &#34;-!- FUNCTION: [Beta-endorphin]: Endogenous orexigenic opiate.&#34;
@@ -8009,9 +8053,16 @@ existing_annotations:
     label: response to pain
   evidence_type: NAS
   review:
-    summary: Added to align core_functions with existing annotations.
+    summary: &gt;-
+      The POMC-derived beta-endorphin peptide is an endogenous opioid that signals
+      through opioid receptors. Opioid signaling is a canonical regulator of pain
+      responses, making response to pain an appropriate biological-process output
+      for this cleavage product.
     action: NEW
-    reason: Core function term not present in existing_annotations.
+    reason: &gt;-
+      Add this BP term to capture the physiological consequence of beta-endorphin
+      opioid peptide activity, supported by the POMC beta-endorphin annotation and
+      Reactome opioid receptor pathway evidence.
     supported_by:
     - reference_id: UniProtKB:P01189
       supporting_text: &#34;-!- FUNCTION: [Beta-endorphin]: Endogenous orexigenic opiate.&#34;

--- a/genes/human/POMC/POMC-ai-review.html
+++ b/genes/human/POMC/POMC-ai-review.html
@@ -1203,6 +1203,17 @@
                                 
                             </div>
                             
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/POMC/POMC-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">POMC is summarized as a secreted prohormone precursor processed into multiple bioactive peptides including ACTH, MSH peptides, beta-lipotropin, and beta-endorphin.</div>
+
+                            </div>
+
                         </div>
                         
                     </td>
@@ -5306,6 +5317,17 @@
                         
                     </li>
                     
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/POMC/POMC-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">POMC is summarized as a secreted prohormone precursor that is proteolytically processed into ACTH, alpha/beta/gamma-MSH, beta-lipotropin, and beta-endorphin.</div>
+
+                    </li>
+
                 </ul>
             </div>
             
@@ -5411,6 +5433,17 @@
                         
                     </li>
                     
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/POMC/POMC-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">A central endocrine function of POMC is production of ACTH, secreted from the anterior pituitary, which stimulates adrenal glucocorticoid production as part of the HPA axis.</div>
+
+                    </li>
+
                 </ul>
             </div>
             
@@ -5512,6 +5545,17 @@
                         
                     </li>
                     
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/POMC/POMC-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">The report describes hypothalamic POMC-derived alpha-MSH as a major anorexigenic melanocortin peptide that suppresses appetite and increases energy expenditure through melanocortin signaling.</div>
+
+                    </li>
+
                 </ul>
             </div>
             
@@ -5624,6 +5668,17 @@
                         
                     </li>
                     
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/POMC/POMC-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">The report summarizes alpha-MSH and beta-MSH as POMC-derived melanocortins that signal through MC1R in skin and pigment cells to regulate pigmentation.</div>
+
+                    </li>
+
                 </ul>
             </div>
             
@@ -5721,6 +5776,17 @@
                         
                     </li>
                     
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/POMC/POMC-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">The report identifies beta-endorphin as a POMC-derived opioid neuropeptide that contributes to opioid signaling and orexigenic appetite regulation.</div>
+
+                    </li>
+
                 </ul>
             </div>
             
@@ -5818,6 +5884,34 @@
                 <div class="reference-header">
                     <span class="reference-id">
                         
+                        file:human/POMC/POMC-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research report for human POMC</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">POMC encodes a secreted pre-prohormone routed through ER, Golgi, and dense-core secretory granules before tissue-specific processing by PC1/3 and PC2.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">POMC-derived peptides support HPA-axis ACTH signaling, melanocortin appetite and pigmentation signaling, and beta-endorphin opioid signaling.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/10233018" target="_blank" class="term-link">
                             PMID:10233018
                         </a>
@@ -6200,6 +6294,370 @@
         <details class="markdown-section">
             <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
                 <div style="flex: 1;">
+                    <h3 style="display: inline;">Deep Research Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(POMC-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P01189" data-a="DOC: Deep Research Falcon" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <hr />
+<p>provider: falcon<br />
+model: Edison Scientific Literature<br />
+cached: false<br />
+start_time: '2026-05-10T22:02:48.721917'<br />
+end_time: '2026-05-10T22:15:12.410416'<br />
+duration_seconds: 743.69<br />
+template_file: templates/gene_research_go_focused.md<br />
+template_variables:<br />
+  organism: human<br />
+  gene_id: POMC<br />
+  gene_symbol: POMC<br />
+  uniprot_accession: P01189<br />
+  protein_description: 'RecName: Full=Pro-opiomelanocortin; Short=POMC; AltName: Full=Corticotropin-lipotropin;<br />
+    Contains: RecName: Full=NPP; Contains: RecName: Full=Melanotropin gamma; AltName:<br />
+    Full=Gamma-MSH; Contains: RecName: Full=Potential peptide; Contains: RecName:<br />
+    Full=Corticotropin; AltName: Full=Adrenocorticotropic hormone; Short=ACTH; Contains:<br />
+    RecName: Full=Melanocyte-stimulating hormone alpha; Short=Alpha-MSH; AltName:<br />
+    Full=Melanotropin alpha; Contains: RecName: Full=Corticotropin-like intermediary<br />
+    peptide; Short=CLIP; Contains: RecName: Full=Lipotropin beta; AltName: Full=Beta-LPH;<br />
+    Contains: RecName: Full=Lipotropin gamma; AltName: Full=Gamma-LPH; Contains: RecName:<br />
+    Full=Melanocyte-stimulating hormone beta; Short=Beta-MSH; AltName: Full=Melanotropin<br />
+    beta; Contains: RecName: Full=Beta-endorphin; Contains: RecName: Full=Met-enkephalin;<br />
+    Flags: Precursor;'<br />
+  gene_info: Name=POMC;<br />
+  organism_full: Homo sapiens (Human).<br />
+  protein_family: Belongs to the POMC family. .<br />
+  protein_domains: Mcrtin_ACTH_cent. (IPR013531); Melanocortin_N. (IPR013593); Opioid_neuropept.<br />
+    (IPR013532); PMOC. (IPR001941); POMC-derived_peptides. (IPR050878)<br />
+provider_config:<br />
+  timeout: 600<br />
+  max_retries: 3<br />
+  parameters:<br />
+    allowed_domains: []<br />
+    temperature: 0.1<br />
+citation_count: 25</p>
+<hr />
+<h2 id="question">Question</h2>
+<h1 id="gene-research-for-functional-annotation">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> P01189</li>
+<li><strong>Protein Description:</strong> RecName: Full=Pro-opiomelanocortin; Short=POMC; AltName: Full=Corticotropin-lipotropin; Contains: RecName: Full=NPP; Contains: RecName: Full=Melanotropin gamma; AltName: Full=Gamma-MSH; Contains: RecName: Full=Potential peptide; Contains: RecName: Full=Corticotropin; AltName: Full=Adrenocorticotropic hormone; Short=ACTH; Contains: RecName: Full=Melanocyte-stimulating hormone alpha; Short=Alpha-MSH; AltName: Full=Melanotropin alpha; Contains: RecName: Full=Corticotropin-like intermediary peptide; Short=CLIP; Contains: RecName: Full=Lipotropin beta; AltName: Full=Beta-LPH; Contains: RecName: Full=Lipotropin gamma; AltName: Full=Gamma-LPH; Contains: RecName: Full=Melanocyte-stimulating hormone beta; Short=Beta-MSH; AltName: Full=Melanotropin beta; Contains: RecName: Full=Beta-endorphin; Contains: RecName: Full=Met-enkephalin; Flags: Precursor;</li>
+<li><strong>Gene Information:</strong> Name=POMC;</li>
+<li><strong>Organism (full):</strong> Homo sapiens (Human).</li>
+<li><strong>Protein Family:</strong> Belongs to the POMC family. .</li>
+<li><strong>Key Domains:</strong> Mcrtin_ACTH_cent. (IPR013531); Melanocortin_N. (IPR013593); Opioid_neuropept. (IPR013532); PMOC. (IPR001941); POMC-derived_peptides. (IPR050878)</li>
+</ul>
+<h3 id="mandatory-verification-steps">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "POMC" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Homo sapiens (Human).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'POMC' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>POMC</strong> (gene ID: POMC, UniProt: P01189) in human.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="output">Output</h2>
+<p>Question: You are an expert researcher providing comprehensive, well-cited information.</p>
+<p>Provide detailed information focusing on:<br />
+1. Key concepts and definitions with current understanding<br />
+2. Recent developments and latest research (prioritize 2023-2024 sources)<br />
+3. Current applications and real-world implementations<br />
+4. Expert opinions and analysis from authoritative sources<br />
+5. Relevant statistics and data from recent studies</p>
+<p>Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.<br />
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.</p>
+<h1 id="gene-research-for-functional-annotation_1">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context_1">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot_1">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> P01189</li>
+<li><strong>Protein Description:</strong> RecName: Full=Pro-opiomelanocortin; Short=POMC; AltName: Full=Corticotropin-lipotropin; Contains: RecName: Full=NPP; Contains: RecName: Full=Melanotropin gamma; AltName: Full=Gamma-MSH; Contains: RecName: Full=Potential peptide; Contains: RecName: Full=Corticotropin; AltName: Full=Adrenocorticotropic hormone; Short=ACTH; Contains: RecName: Full=Melanocyte-stimulating hormone alpha; Short=Alpha-MSH; AltName: Full=Melanotropin alpha; Contains: RecName: Full=Corticotropin-like intermediary peptide; Short=CLIP; Contains: RecName: Full=Lipotropin beta; AltName: Full=Beta-LPH; Contains: RecName: Full=Lipotropin gamma; AltName: Full=Gamma-LPH; Contains: RecName: Full=Melanocyte-stimulating hormone beta; Short=Beta-MSH; AltName: Full=Melanotropin beta; Contains: RecName: Full=Beta-endorphin; Contains: RecName: Full=Met-enkephalin; Flags: Precursor;</li>
+<li><strong>Gene Information:</strong> Name=POMC;</li>
+<li><strong>Organism (full):</strong> Homo sapiens (Human).</li>
+<li><strong>Protein Family:</strong> Belongs to the POMC family. .</li>
+<li><strong>Key Domains:</strong> Mcrtin_ACTH_cent. (IPR013531); Melanocortin_N. (IPR013593); Opioid_neuropept. (IPR013532); PMOC. (IPR001941); POMC-derived_peptides. (IPR050878)</li>
+</ul>
+<h3 id="mandatory-verification-steps_1">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "POMC" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Homo sapiens (Human).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature_1">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'POMC' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target_1">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>POMC</strong> (gene ID: POMC, UniProt: P01189) in human.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="research-report-human-pomc-uniprot-p01189-functional-annotation-pathways-and-clinical-translation">Research Report: Human <strong>POMC</strong> (UniProt <strong>P01189</strong>) — Functional Annotation, Pathways, and Clinical Translation</h1>
+<h2 id="0-target-verification-identity-and-scope">0. Target verification (identity and scope)</h2>
+<p>The queried gene/protein is <strong>human pro-opiomelanocortin (POMC)</strong>, a <strong>secreted prohormone precursor</strong> that is proteolytically processed into multiple bioactive peptides including <strong>ACTH</strong>, <strong>α/β/γ-MSH</strong>, <strong>β-lipotropin</strong>, and <strong>β-endorphin</strong>, matching the UniProt P01189 description and canonical melanocortin/opioid biology. (yanik2025proopiomelanocortinandmelanocortin pages 1-3, millington2023proopiomelanocortin(pomc)and pages 1-2, hiroshima2023thecelladhesion pages 1-2)</p>
+<h2 id="1-key-concepts-and-definitions-current-understanding">1. Key concepts and definitions (current understanding)</h2>
+<h3 id="11-what-pomc-is-precursor-concept">1.1 What POMC is (precursor concept)</h3>
+<p><strong>POMC encodes a pre-prohormone</strong> that enters the classical secretory pathway: it is synthesized as <strong>pre-POMC</strong> with a <strong>signal peptide cleaved during ER translocation</strong>, then the precursor <strong>folds in the ER</strong>, is <strong>glycosylated in the Golgi</strong>, and is <strong>packaged into secretory granules</strong> for regulated secretion and tissue-specific proteolysis into peptide hormones/neuropeptides. (hiroshima2023thecelladhesion pages 1-2)</p>
+<h3 id="12-major-pomc-derived-peptides">1.2 Major POMC-derived peptides</h3>
+<p>Multiple sources describe that <strong>human POMC is cleaved into multiple active peptides</strong>, prominently including <strong>ACTH</strong> and melanocortins (α/β/γ-MSH) as well as <strong>β-endorphin</strong>. (yanik2025proopiomelanocortinandmelanocortin pages 1-3, millington2023proopiomelanocortin(pomc)and pages 1-2, hiroshima2023thecelladhesion pages 1-2)</p>
+<h3 id="13-processing-enzymes-pc13-vs-pc2-and-tissue-specific-outcomes">1.3 Processing enzymes (PC1/3 vs PC2) and tissue-specific outcomes</h3>
+<p>POMC processing is <strong>tissue-specific</strong> and is mediated largely by <strong>two prohormone convertases</strong>:<br />
+- In the <strong>anterior pituitary</strong>, <strong>PC1/3 (PC1)</strong> cleaves POMC to yield <strong>N-POMC, ACTH, and β-lipotropin</strong>. (millington2023proopiomelanocortin(pomc)and pages 1-2, hiroshima2023thecelladhesion pages 1-2)<br />
+- <strong>PC2</strong> performs additional cleavages, including cleavage of N-terminal intermediates to yield fragments that include <strong>γ-MSH and the joining peptide</strong>, and additional processing in tissues with extended processing capacity (e.g., intermediate-lobe-like processing contexts) yields smaller peptide hormones. (hiroshima2023thecelladhesion pages 1-2)</p>
+<h3 id="14-subcellular-localization-regulated-secretory-pathway-rsp">1.4 Subcellular localization: regulated secretory pathway (RSP)</h3>
+<p>POMC is a canonical <strong>regulated secretory pathway</strong> cargo. Mechanistically:<br />
+- POMC has an <strong>N-terminal, conformation-dependent sorting signal</strong> (reported as involving residues including acidic and hydrophobic residues) that mediates binding to the <strong>sorting receptor carboxypeptidase E (CPE)</strong> in <strong>trans-Golgi network (TGN) lipid raft microdomains</strong>; the prohormone–CPE complex buds from the TGN into <strong>dense-core vesicles (DCVs)</strong>. (quintana2023traffickingofhormones pages 3-5)<br />
+- <strong>Secretogranin III</strong> can bind POMC to facilitate regulated pathway sorting, with a model in which a secretogranin III–POMC complex is transferred to chromogranin A to promote DCV incorporation. (quintana2023traffickingofhormones pages 3-5)<br />
+- POMC also contains <strong>conserved N-terminal disulfide bonds</strong> reported to play an important role in sorting into secretory granules. (hiroshima2023thecelladhesion pages 2-5)<br />
+- Proteolytic maturation of prohormones (including POMC) is described as occurring within <strong>immature secretory vesicles that mature into DCVs</strong>. (quintana2023traffickingofhormones pages 3-5)</p>
+<h2 id="2-biological-functions-and-pathways-molecular-to-physiology-mapping">2. Biological functions and pathways (molecular-to-physiology mapping)</h2>
+<h3 id="21-hpa-axis-adrenal-steroidogenesis-acth-mc2r">2.1 HPA axis / adrenal steroidogenesis (ACTH → MC2R)</h3>
+<p>A central endocrine function of POMC is production of <strong>ACTH</strong>, secreted from the anterior pituitary, which <strong>stimulates adrenal glucocorticoid production</strong> as part of the hypothalamic–pituitary–adrenal (HPA) axis. (millington2023proopiomelanocortin(pomc)and pages 1-2, yanik2025proopiomelanocortinandmelanocortin pages 1-3)<br />
+Receptor specificity is emphasized in reviews: <strong>MC2R is highly specific for ACTH</strong> compared with other melanocortin receptors. (millington2023proopiomelanocortin(pomc)and pages 1-2)</p>
+<h3 id="22-appetite-and-energy-balance-msh-from-pomc-neurons-mc3rmc4r">2.2 Appetite and energy balance (α-MSH from POMC neurons → MC3R/MC4R)</h3>
+<p>In the central nervous system, <strong>α-MSH is a POMC-derived anorexigenic peptide</strong> produced by <strong>POMC neurons in the hypothalamic arcuate nucleus (ARC)</strong> and released to act on <strong>melanocortin receptor 3/4 (MC3R/MC4R)–expressing neurons</strong>, thereby suppressing appetite and promoting energy expenditure. (wu2023alphamelanocytestimulatinghormonemediatedappetite pages 1-2, yanik2025proopiomelanocortinandmelanocortin pages 1-3)<br />
+POMC neurons are positioned within the <strong>leptin–melanocortin pathway</strong> and function alongside (and in opposition to) orexigenic AgRP/NPY circuitry. (yanik2025proopiomelanocortinandmelanocortin pages 1-3, wu2023alphamelanocytestimulatinghormonemediatedappetite pages 1-2)</p>
+<h3 id="23-skin-and-peripheral-neuroendocrineimmunomodulatory-axes">2.3 Skin and peripheral neuroendocrine/immunomodulatory axes</h3>
+<p>POMC-derived peptides also operate in skin and stress-linked peripheral axes. A 2023 review in psychodermatology highlights a <strong>local cutaneous CRF–POMC–corticosteroid axis</strong> and links POMC-derived signaling to immune disruption and stress-associated skin disease contexts, while also summarizing melanocortin receptor engagement in these tissues. (millington2023proopiomelanocortin(pomc)and pages 1-2)</p>
+<h3 id="24-opioid-biology-endorphin">2.4 Opioid biology (β-endorphin)</h3>
+<p>POMC processing also yields <strong>β-endorphin</strong>, which is described as an opioid peptide acting at opioid receptors and involved in analgesia/pain modulation within neuroendocrine contexts. (yanik2025proopiomelanocortinandmelanocortin pages 3-4, hiroshima2023thecelladhesion pages 1-2)</p>
+<h2 id="3-where-pomc-is-expressed-celltissue-context-and-where-it-acts">3. Where POMC is expressed (cell/tissue context) and where it acts</h2>
+<h3 id="31-neuroendocrine-tissues-and-key-cell-types">3.1 Neuroendocrine tissues and key cell types</h3>
+<p>POMC-derived endocrine physiology is classically associated with pituitary and hypothalamic systems (e.g., anterior pituitary ACTH production; ARC POMC neurons for melanocortin appetite control). (millington2023proopiomelanocortin(pomc)and pages 1-2, wu2023alphamelanocytestimulatinghormonemediatedappetite pages 1-2)</p>
+<h3 id="32-human-hypothalamus-high-resolution-cell-atlas-evidence-human-specific-nuance">3.2 Human hypothalamus: high-resolution cell atlas evidence (human-specific nuance)</h3>
+<p>A large-scale human hypothalamus atlas (“HYPOMAP”) combined <strong>single-nucleus RNA-seq of 433,369 hypothalamic cells</strong> with spatial transcriptomics, explicitly noting that POMC-expressing neurons in the ARC are a core component of the leptin–melanocortin pathway and that there are <strong>notable human–mouse discrepancies in POMC neuron identity and GPCR expression</strong> with direct implications for obesity therapies targeting hypothalamic GPCRs. (tadross2025acomprehensivespatiocellular pages 1-2)<br />
+The same study reports <strong>452 hypothalamic cell types</strong>, with <strong>291 neuronal clusters enriched for BMI GWAS genes</strong> (driven by 426 “effector” genes), and that <strong>rare deleterious variants</strong> in six genes including <strong>POMC</strong> associate with BMI at the population level. (tadross2025acomprehensivespatiocellular pages 1-2)</p>
+<h2 id="4-recent-developments-prioritizing-20232024">4. Recent developments (prioritizing 2023–2024)</h2>
+<h3 id="41-2023-updated-mechanistic-understanding-of-regulated-secretory-sorting">4.1 2023: Updated mechanistic understanding of regulated secretory sorting</h3>
+<p>Recent synthesis of secretory trafficking emphasizes that POMC sorting into regulated DCVs is not merely generic secretion; it can depend on specific <strong>N-terminal sorting information</strong> and <strong>receptor/cofactor-mediated sorting</strong>, with <strong>CPE</strong> and <strong>secretogranin III</strong> highlighted as key facilitators of regulated-pathway targeting and DCV incorporation. (quintana2023traffickingofhormones pages 3-5, stepihar2023cellspecificsecretorygranule pages 20-21)<br />
+A 2023 study/review on POMC joining peptide further points to <strong>conserved N-terminal disulfide bonds</strong> in POMC as important for sorting into secretory granules. (hiroshima2023thecelladhesion pages 2-5)</p>
+<h3 id="42-2023-msh-appetite-regulation-as-a-systems-level-integration-point">4.2 2023: α-MSH appetite regulation as a systems-level integration point</h3>
+<p>A 2023 Neuroendocrinology review reiterates that <strong>α-MSH</strong> derived from ARC POMC neurons is a central mediator of appetite suppression and energy expenditure via <strong>MC3R/MC4R circuitry</strong>, and also notes α-MSH presence in multiple CNS regions and extra-pituitary sources. (wu2023alphamelanocytestimulatinghormonemediatedappetite pages 1-2)</p>
+<h3 id="43-2024-clinical-translationmc4r-agonism-setmelanotide-as-pathway-replacement-therapy">4.3 2024: Clinical translation—MC4R agonism (setmelanotide) as pathway replacement therapy</h3>
+<p>A 2024 therapeutics review frames <strong>setmelanotide</strong> (RM-493) as an MC4R agonist that can “replace the missing link” in leptin–melanocortin signaling in monogenic obesity states by activating melanocortin signaling in relevant hypothalamic circuits. (qamar2024setmelanotideamelanocortin4 pages 5-6)<br />
+This review states that genes in the melanocortin pathway contribute to <strong>~5% of early-onset severe obesity</strong> (as an aggregate estimate), underscoring the clinical importance of POMC–MC4R pathway biology in a defined subset of patients. (qamar2024setmelanotideamelanocortin4 pages 1-2)</p>
+<h2 id="5-current-applications-and-real-world-implementations">5. Current applications and real-world implementations</h2>
+<h3 id="51-targeted-pharmacotherapy-setmelanotide-for-pomcpcsk1-deficiency-obesity">5.1 Targeted pharmacotherapy: setmelanotide for POMC/PCSK1 deficiency obesity</h3>
+<p><strong>ClinicalTrials.gov Phase 3 record (NCT02896192)</strong> describes an open-label, 1-year setmelanotide trial in genetically confirmed <strong>bi-allelic POMC or PCSK1 loss-of-function</strong> obesity, with an <strong>8-week double-blind placebo-controlled withdrawal</strong> and a primary endpoint of <strong>% achieving ≥10% weight loss at ~Week 52</strong>; results were posted <strong>2023-09-21</strong>, and the study enrolled <strong>15 participants</strong> (start 2017-02-14; completion 2020-05-25). (NCT02896192 chunk 1)<br />
+A 2024 review summarizing multicenter phase 3 data reports that in a POMC deficiency cohort (<strong>n=10</strong>), <strong>8/10 (80%)</strong> achieved <strong>≥10% weight loss at 52 weeks</strong>, with mean weight change <strong>−25.6% (SD 9.9)</strong>; the review also reports hunger-score improvements (e.g., maximal hunger score reductions) in POMC and related cohorts. (qamar2024setmelanotideamelanocortin4 pages 5-6, qamar2024setmelanotideamelanocortin4 pages 6-7)</p>
+<h3 id="52-broader-genetic-obesity-trial-implementation">5.2 Broader genetic-obesity trial implementation</h3>
+<p>A Phase 2 ClinicalTrials.gov record (NCT03013543) enrolled <strong>213</strong> participants across multiple rare genetic obesity cohorts (including POMC/PCSK1/LEPR-related cohorts), with a primary endpoint of the number of participants with <strong>≥5% body weight reduction</strong> after <strong>3 months</strong> of setmelanotide treatment; results were posted <strong>2023-08-18</strong>. (NCT03013543 chunk 1, NCT03013543 chunk 2)</p>
+<h3 id="53-early-investigator-led-implementations-and-extension-style-studies">5.3 Early investigator-led implementations and extension-style studies</h3>
+<p>A Charité-led Phase 2 study (NCT02507492; RM-493/setmelanotide) targeted adults with homozygous/compound heterozygous <strong>POMC, LEPR, or PCSK1</strong> mutations, with primary evaluation over <strong>Day 1–Day 84</strong> (body weight change), and an option for long-term extension; planned enrollment was <strong>10</strong>. (NCT02507492 chunk 1)</p>
+<h2 id="6-relevant-statistics-and-data-points-from-recent-sources">6. Relevant statistics and data points (from recent sources)</h2>
+<h3 id="61-human-cell-atlas-statistics-and-translational-implications">6.1 Human-cell atlas statistics and translational implications</h3>
+<ul>
+<li><strong>433,369</strong> nuclei profiled in the human hypothalamus atlas; <strong>452</strong> hypothalamic cell types; <strong>291</strong> neuronal clusters enriched for BMI GWAS genes; rare deleterious variants in <strong>POMC</strong> among genes associating with BMI at population level. (tadross2025acomprehensivespatiocellular pages 1-2)</li>
+</ul>
+<h3 id="62-trial-efficacy-outcomes-setmelanotide">6.2 Trial efficacy outcomes (setmelanotide)</h3>
+<ul>
+<li>Phase 3 POMC deficiency cohort reported in 2024 review: <strong>80% (8/10)</strong> achieved ≥10% weight loss at 1 year; mean weight change <strong>−25.6%</strong> (SD 9.9). (qamar2024setmelanotideamelanocortin4 pages 5-6)</li>
+<li>Responder proportions in other genetic cohorts (≥5% weight loss) were summarized (e.g., heterozygous POMC/PCSK1/LEPR <strong>12/35 (34.3%)</strong> responders at ≥5% weight loss). (qamar2024setmelanotideamelanocortin4 pages 6-7)</li>
+</ul>
+<h3 id="63-rarity-of-pomc-deficiency-as-reported-in-2024-synthesis">6.3 Rarity of POMC deficiency (as reported in 2024 synthesis)</h3>
+<p>A 2024 therapeutics review reports that <strong>POMC deficiency has fewer than 15 diagnosed cases worldwide</strong> (emphasizing rarity and ascertainment limits), and provides similar “very rare” case-count statements for related pathway disorders such as PCSK1 deficiency. (qamar2024setmelanotideamelanocortin4 pages 4-5)</p>
+<h2 id="7-expert-interpretation-and-authoritative-analysis-what-experts-emphasize">7. Expert interpretation and authoritative analysis (what experts emphasize)</h2>
+<ol>
+<li><strong>Functional core:</strong> Experts consistently frame POMC primarily as a <strong>multi-peptide precursor</strong> whose biological function is realized through <strong>cell-type-specific processing</strong> into melanocortins and ACTH/β-endorphin, rather than as a single-function protein. (yanik2025proopiomelanocortinandmelanocortin pages 1-3, hiroshima2023thecelladhesion pages 1-2)</li>
+<li><strong>Cell biology matters for phenotype:</strong> Recent trafficking literature highlights that <strong>regulated secretory sorting determinants (CPE, secretogranin III, N-terminal motifs/disulfides)</strong> are key mechanistic layers governing which peptides are ultimately produced and secreted, providing a mechanistic bridge between POMC sequence/processing and endocrine outcomes. (quintana2023traffickingofhormones pages 3-5, hiroshima2023thecelladhesion pages 2-5)</li>
+<li><strong>Human-specific circuit caution:</strong> Human single-nucleus/spatial atlases indicate that POMC neuron identity and GPCR expression can differ from mice, which experts interpret as directly relevant to how hypothalamus-targeting obesity drugs may translate from rodent models to humans. (tadross2025acomprehensivespatiocellular pages 1-2)</li>
+<li><strong>Therapeutic rationale:</strong> Setmelanotide is widely interpreted as a pathway-replacement strategy for MC4R-pathway defects, with clinical outcomes in POMC deficiency supporting the concept that restoring melanocortin tone can reduce hyperphagia and weight in appropriately selected genetic subtypes. (qamar2024setmelanotideamelanocortin4 pages 5-6, qamar2024setmelanotideamelanocortin4 pages 6-7)</li>
+</ol>
+<h2 id="8-functional-annotation-summary-table-peptides-processing-receptors-roles">8. Functional-annotation summary table (peptides, processing, receptors, roles)</h2>
+<table>
+<thead>
+<tr>
+<th>POMC-derived peptide product</th>
+<th>Primary processing enzymes/steps</th>
+<th>Major receptors/targets</th>
+<th>Main physiological roles</th>
+<th>Key evidence citations</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>ACTH (corticotropin)</td>
+<td>Pre-POMC signal peptide removed in ER; precursor folds in ER, is glycosylated in Golgi, then packaged into secretory granules. In anterior pituitary, PC1/3 cleaves POMC to generate ACTH plus N-POMC and β-lipotropin; sorting to regulated secretory granules is directed by the POMC N-terminus, including conserved N-terminal disulfide bonds and a conformation-dependent sorting signal that binds CPE in TGN lipid rafts; secretogranin III also facilitates regulated-pathway sorting.</td>
+<td>MC2R is the most specific ACTH receptor; ACTH can also bind other melanocortin receptors with variable affinity.</td>
+<td>Core effector of the HPA axis; stimulates adrenal glucocorticoid synthesis/release; also contributes to skin neuroendocrine signaling.</td>
+<td>(millington2023proopiomelanocortin(pomc)and pages 1-2, quintana2023traffickingofhormones pages 3-5, hiroshima2023thecelladhesion pages 2-5, hiroshima2023thecelladhesion pages 1-2)</td>
+</tr>
+<tr>
+<td>α-MSH</td>
+<td>Generated by additional POMC processing beyond the anterior pituitary, especially where PC2 participates (intermediate lobe/arcuate-type processing). Same regulated secretory route applies: ER → Golgi → immature/regulated granules, with CPE/secretogranin III-supported sorting and granule-associated maturation.</td>
+<td>MC3R, MC4R in CNS appetite circuits; MC1R in skin/pigment cells; other melanocortin receptors may also respond depending on tissue.</td>
+<td>Major anorexigenic melanocortin peptide; suppresses appetite and increases energy expenditure in the leptin–melanocortin pathway; also regulates pigmentation and has anti-inflammatory/immunomodulatory effects in skin/periphery.</td>
+<td>(wu2023alphamelanocytestimulatinghormonemediatedappetite pages 1-2, yanik2025proopiomelanocortinandmelanocortin pages 1-3, millington2023proopiomelanocortin(pomc)and pages 1-2, quintana2023traffickingofhormones pages 3-5, hiroshima2023thecelladhesion pages 1-2)</td>
+</tr>
+<tr>
+<td>β-MSH</td>
+<td>Derived from downstream processing of β-lipotropin/POMC in tissues with appropriate convertase processing; maturation occurs in secretory vesicles/granules after regulated-pathway sorting.</td>
+<td>High in vitro affinity for MC4R.</td>
+<td>Contributes to body-weight regulation and melanocortin signaling controlling energy balance.</td>
+<td>(yanik2025proopiomelanocortinandmelanocortin pages 3-4, quintana2023traffickingofhormones pages 3-5)</td>
+</tr>
+<tr>
+<td>γ-MSH (including γ1-/γ3-MSH)</td>
+<td>PC1/3 first generates larger N-terminal intermediates; PC2 contributes further cleavage of N-POMC-derived regions to release γ-MSH-containing fragments in tissues with extended processing.</td>
+<td>MC3R is a principal target noted in the retrieved evidence.</td>
+<td>Appetite and energy-expenditure regulation within melanocortin signaling; part of the N-terminal POMC peptide system.</td>
+<td>(yanik2025proopiomelanocortinandmelanocortin pages 3-4, hiroshima2023thecelladhesion pages 1-2)</td>
+</tr>
+<tr>
+<td>β-Endorphin</td>
+<td>Produced by additional PC2-dependent processing of POMC-derived C-terminal intermediates in tissues with extended processing; precursor traffics through ER/Golgi into regulated granules before cleavage.</td>
+<td>Opioid receptors (reported in retrieved evidence as opioid receptor targets).</td>
+<td>Analgesia/pain modulation; also implicated in neuroendocrine outputs from POMC cells.</td>
+<td>(yanik2025proopiomelanocortinandmelanocortin pages 3-4, millington2023proopiomelanocortin(pomc)and pages 1-2, hiroshima2023thecelladhesion pages 1-2)</td>
+</tr>
+<tr>
+<td>β-Lipotropin (β-LPH) / larger intermediates</td>
+<td>In anterior pituitary, PC1/3 produces β-LPH together with ACTH and N-POMC. In humans, further processing of LPH is limited compared with some other mammals because humans lack certain PC2 cleavage sites.</td>
+<td>Precursor/intermediate rather than primary receptor ligand; source for downstream β-MSH/β-endorphin-related products depending on tissue processing.</td>
+<td>Serves mainly as a biosynthetic intermediate in human POMC processing; helps explain tissue-specific peptide outputs.</td>
+<td>(millington2023proopiomelanocortin(pomc)and pages 1-2, yanik2025proopiomelanocortinandmelanocortin pages 3-4, hiroshima2023thecelladhesion pages 1-2)</td>
+</tr>
+<tr>
+<td>POMC precursor / regulated secretory cargo (annotation-level row)</td>
+<td>Human POMC is a secreted prohormone precursor routed through the regulated secretory pathway: signal peptide cleavage in ER, folding in ER, Golgi glycosylation, TGN sorting by an N-terminal motif and conserved disulfide bonds, CPE-mediated binding in lipid rafts, facilitation by secretogranin III, budding into dense-core/secretory vesicles, and proteolytic maturation in immature secretory vesicles/granules by PC1/3 and PC2.</td>
+<td>Gives rise to ligands for melanocortin receptors MC1R–MC5R and opioid-system targets, depending on peptide product.</td>
+<td>Integrates HPA-axis control, appetite/energy homeostasis, pigmentation/skin biology, and broader immunomodulatory neuroendocrine functions.</td>
+<td>(yanik2025proopiomelanocortinandmelanocortin pages 1-3, millington2023proopiomelanocortin(pomc)and pages 1-2, quintana2023traffickingofhormones pages 3-5, quintana2023traffickingofhormones pages 16-18, stepihar2023cellspecificsecretorygranule pages 20-21, hiroshima2023thecelladhesion pages 2-5, hiroshima2023thecelladhesion pages 1-2)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the major human POMC-derived peptides, how the precursor is trafficked and processed in the regulated secretory pathway, the main receptor targets, and the best-supported physiological functions. It is useful as a compact functional annotation artifact anchored to the retrieved evidence contexts.</em></p>
+<h2 id="9-key-sources-urls-and-publication-dates">9. Key sources (URLs and publication dates)</h2>
+<ul>
+<li>Wu Q et al. <strong>“Alpha-Melanocyte-Stimulating Hormone-Mediated Appetite Regulation in the Central Nervous System.”</strong> <em>Neuroendocrinology</em> (Apr <strong>2023</strong>). https://doi.org/10.1159/000530804 (wu2023alphamelanocytestimulatinghormonemediatedappetite pages 1-2)</li>
+<li>Millington GWM, Palmer HE. <strong>“Proopiomelanocortin (POMC) and psychodermatology.”</strong> <em>Skin Health and Disease</em> (Apr <strong>2023</strong>). https://doi.org/10.1002/ski2.201 (millington2023proopiomelanocortin(pomc)and pages 1-2)</li>
+<li>Quintana P et al. <strong>“Trafficking of hormones and trophic factors to secretory and extracellular vesicles…”</strong> <em>Extracellular Vesicles and Circulating Nucleic Acids</em> (Nov <strong>2023</strong>). https://doi.org/10.20517/evcna.2023.34 (quintana2023traffickingofhormones pages 3-5)</li>
+<li>Hiroshima K et al. <strong>“The Cell Adhesion Activity of the Joining Peptide of Proopiomelanocortin.”</strong> <em>Molecules</em> (Nov <strong>2023</strong>). https://doi.org/10.3390/molecules28237754 (hiroshima2023thecelladhesion pages 1-2, hiroshima2023thecelladhesion pages 2-5)</li>
+<li>Qamar S et al. <strong>“Setmelanotide: A Melanocortin-4 Receptor Agonist…”</strong> <em>touchREVIEWS in Endocrinology</em> (Oct <strong>2024</strong>). https://doi.org/10.17925/ee.2024.20.2.9 (qamar2024setmelanotideamelanocortin4 pages 5-6, qamar2024setmelanotideamelanocortin4 pages 6-7, qamar2024setmelanotideamelanocortin4 pages 4-5, qamar2024setmelanotideamelanocortin4 pages 1-2)</li>
+<li>ClinicalTrials.gov <strong>NCT02896192</strong> (results posted <strong>2023-09-21</strong>; study start <strong>2017-02-14</strong>): https://clinicaltrials.gov/study/NCT02896192 (NCT02896192 chunk 1)</li>
+<li>ClinicalTrials.gov <strong>NCT03013543</strong> (results posted <strong>2023-08-18</strong>; study start <strong>2017-02-10</strong>): https://clinicaltrials.gov/study/NCT03013543 (NCT03013543 chunk 1)</li>
+<li>Tadross JA et al. <strong>“A comprehensive spatio-cellular map of the human hypothalamus.”</strong> <em>Nature</em> (published Feb <strong>2025</strong>; DOI indicates <strong>2024</strong>). https://doi.org/10.1038/s41586-024-08504-8 (tadross2025acomprehensivespatiocellular pages 1-2)</li>
+</ul>
+<h2 id="10-scope-and-evidence-limitations">10. Scope and evidence limitations</h2>
+<p>This report focuses on <strong>functional annotation</strong> of the POMC precursor and its processed peptides and on <strong>recent translational/omics evidence</strong> available in retrieved sources. Not all classic primary endocrinology papers or receptor pharmacology datasets were retrieved in this run (e.g., full receptor-binding constants by peptide), so claims are restricted to the cited evidence above.</p>
+<p>References</p>
+<ol>
+<li>
+<p>(yanik2025proopiomelanocortinandmelanocortin pages 1-3): Tulin Yanik and Seyda Tugce Durhan. Pro-opiomelanocortin and melanocortin receptor 3 and 4 mutations in genetic obesity. Biomolecules, 15:209, Feb 2025. URL: https://doi.org/10.3390/biom15020209, doi:10.3390/biom15020209. This article has 4 citations.</p>
+</li>
+<li>
+<p>(millington2023proopiomelanocortin(pomc)and pages 1-2): George W. M. Millington and Hannah E. Palmer. Proopiomelanocortin (pomc) and psychodermatology. Skin Health and Disease, Apr 2023. URL: https://doi.org/10.1002/ski2.201, doi:10.1002/ski2.201. This article has 16 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(hiroshima2023thecelladhesion pages 1-2): Kyona Hiroshima, Nana Sakata, Tadafumi Konogami, Shigeru Shimamoto, and Yuji Hidaka. The cell adhesion activity of the joining peptide of proopiomelanocortin. Molecules, 28:7754, Nov 2023. URL: https://doi.org/10.3390/molecules28237754, doi:10.3390/molecules28237754. This article has 6 citations.</p>
+</li>
+<li>
+<p>(quintana2023traffickingofhormones pages 3-5): P. Quintana, Nicolas Lopez-Galvez, G. Matt, A. Merianos, N. Dodder, E. Hoh, Lara Stone, Chase A. Wullenweber, and E. M. Mahabee-gittens. Trafficking of hormones and trophic factors to secretory and extracellular vesicles: a historical perspective and new hypothesis. Extracellular Vesicles and Circulating Nucleic Acids, 4:568-587, Nov 2023. URL: https://doi.org/10.20517/evcna.2023.34, doi:10.20517/evcna.2023.34. This article has 6 citations.</p>
+</li>
+<li>
+<p>(hiroshima2023thecelladhesion pages 2-5): Kyona Hiroshima, Nana Sakata, Tadafumi Konogami, Shigeru Shimamoto, and Yuji Hidaka. The cell adhesion activity of the joining peptide of proopiomelanocortin. Molecules, 28:7754, Nov 2023. URL: https://doi.org/10.3390/molecules28237754, doi:10.3390/molecules28237754. This article has 6 citations.</p>
+</li>
+<li>
+<p>(wu2023alphamelanocytestimulatinghormonemediatedappetite pages 1-2): Qiwen Wu, Jingmei Chen, Tingyu Hua, and Jinyan Cai. Alpha-melanocyte-stimulating hormone-mediated appetite regulation in the central nervous system. Neuroendocrinology, 113:885-904, Apr 2023. URL: https://doi.org/10.1159/000530804, doi:10.1159/000530804. This article has 32 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(yanik2025proopiomelanocortinandmelanocortin pages 3-4): Tulin Yanik and Seyda Tugce Durhan. Pro-opiomelanocortin and melanocortin receptor 3 and 4 mutations in genetic obesity. Biomolecules, 15:209, Feb 2025. URL: https://doi.org/10.3390/biom15020209, doi:10.3390/biom15020209. This article has 4 citations.</p>
+</li>
+<li>
+<p>(tadross2025acomprehensivespatiocellular pages 1-2): John A. Tadross, Lukas Steuernagel, Georgina K. C. Dowsett, Katherine A. Kentistou, Sofia Lundh, Marta Porniece, Paul Klemm, Kara Rainbow, Henning Hvid, Katarzyna Kania, Joseph Polex-Wolf, Lotte Bjerre Knudsen, Charles Pyke, John R. B. Perry, Brian Y. H. Lam, Jens C. Brüning, and Giles S. H. Yeo. A comprehensive spatio-cellular map of the human hypothalamus. Nature, 639:708-716, Feb 2025. URL: https://doi.org/10.1038/s41586-024-08504-8, doi:10.1038/s41586-024-08504-8. This article has 72 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(stepihar2023cellspecificsecretorygranule pages 20-21): Denis Štepihar, Rebecca R. Florke Gee, Maria Camila Hoyos Sanchez, and Klementina Fon Tacer. Cell-specific secretory granule sorting mechanisms: the role of magel2 and retromer in hypothalamic regulated secretion. Frontiers in Cell and Developmental Biology, Sep 2023. URL: https://doi.org/10.3389/fcell.2023.1243038, doi:10.3389/fcell.2023.1243038. This article has 7 citations.</p>
+</li>
+<li>
+<p>(qamar2024setmelanotideamelanocortin4 pages 5-6): Sulmaaz Qamar, Ritwika Mallik, and Janine Makaronidis. Setmelanotide: a melanocortin-4 receptor agonist for the treatment of severe obesity due to hypothalamic dysfunction. touchREVIEWS in Endocrinology, Oct 2024. URL: https://doi.org/10.17925/ee.2024.20.2.9, doi:10.17925/ee.2024.20.2.9. This article has 13 citations.</p>
+</li>
+<li>
+<p>(qamar2024setmelanotideamelanocortin4 pages 1-2): Sulmaaz Qamar, Ritwika Mallik, and Janine Makaronidis. Setmelanotide: a melanocortin-4 receptor agonist for the treatment of severe obesity due to hypothalamic dysfunction. touchREVIEWS in Endocrinology, Oct 2024. URL: https://doi.org/10.17925/ee.2024.20.2.9, doi:10.17925/ee.2024.20.2.9. This article has 13 citations.</p>
+</li>
+<li>
+<p>(NCT02896192 chunk 1):  Setmelanotide for the Treatment of Early-Onset Pro-Opiomelanocortin (POMC) Deficiency Obesity. Rhythm Pharmaceuticals, Inc.. 2017. ClinicalTrials.gov Identifier: NCT02896192</p>
+</li>
+<li>
+<p>(qamar2024setmelanotideamelanocortin4 pages 6-7): Sulmaaz Qamar, Ritwika Mallik, and Janine Makaronidis. Setmelanotide: a melanocortin-4 receptor agonist for the treatment of severe obesity due to hypothalamic dysfunction. touchREVIEWS in Endocrinology, Oct 2024. URL: https://doi.org/10.17925/ee.2024.20.2.9, doi:10.17925/ee.2024.20.2.9. This article has 13 citations.</p>
+</li>
+<li>
+<p>(NCT03013543 chunk 1):  Setmelanotide Phase 2 Treatment Trial in Participants With Rare Genetic Disorders of Obesity. Rhythm Pharmaceuticals, Inc.. 2017. ClinicalTrials.gov Identifier: NCT03013543</p>
+</li>
+<li>
+<p>(NCT03013543 chunk 2):  Setmelanotide Phase 2 Treatment Trial in Participants With Rare Genetic Disorders of Obesity. Rhythm Pharmaceuticals, Inc.. 2017. ClinicalTrials.gov Identifier: NCT03013543</p>
+</li>
+<li>
+<p>(NCT02507492 chunk 1): PD Dr. Susanna Wiegand. RM-493 Treatment Trial in Proopiomelanocortin (POMC) Deficient Patients. Charite University, Berlin, Germany. 2015. ClinicalTrials.gov Identifier: NCT02507492</p>
+</li>
+<li>
+<p>(qamar2024setmelanotideamelanocortin4 pages 4-5): Sulmaaz Qamar, Ritwika Mallik, and Janine Makaronidis. Setmelanotide: a melanocortin-4 receptor agonist for the treatment of severe obesity due to hypothalamic dysfunction. touchREVIEWS in Endocrinology, Oct 2024. URL: https://doi.org/10.17925/ee.2024.20.2.9, doi:10.17925/ee.2024.20.2.9. This article has 13 citations.</p>
+</li>
+<li>
+<p>(quintana2023traffickingofhormones pages 16-18): P. Quintana, Nicolas Lopez-Galvez, G. Matt, A. Merianos, N. Dodder, E. Hoh, Lara Stone, Chase A. Wullenweber, and E. M. Mahabee-gittens. Trafficking of hormones and trophic factors to secretory and extracellular vesicles: a historical perspective and new hypothesis. Extracellular Vesicles and Circulating Nucleic Acids, 4:568-587, Nov 2023. URL: https://doi.org/10.20517/evcna.2023.34, doi:10.20517/evcna.2023.34. This article has 6 citations.</p>
+</li>
+</ol>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>hiroshima2023thecelladhesion pages 1-2</li>
+<li>quintana2023traffickingofhormones pages 3-5</li>
+<li>hiroshima2023thecelladhesion pages 2-5</li>
+<li>tadross2025acomprehensivespatiocellular pages 1-2</li>
+<li>wu2023alphamelanocytestimulatinghormonemediatedappetite pages 1-2</li>
+<li>yanik2025proopiomelanocortinandmelanocortin pages 1-3</li>
+<li>yanik2025proopiomelanocortinandmelanocortin pages 3-4</li>
+<li>stepihar2023cellspecificsecretorygranule pages 20-21</li>
+<li>quintana2023traffickingofhormones pages 16-18</li>
+<li>https://doi.org/10.1159/000530804</li>
+<li>https://doi.org/10.1002/ski2.201</li>
+<li>https://doi.org/10.20517/evcna.2023.34</li>
+<li>https://doi.org/10.3390/molecules28237754</li>
+<li>https://doi.org/10.17925/ee.2024.20.2.9</li>
+<li>https://clinicaltrials.gov/study/NCT02896192</li>
+<li>https://clinicaltrials.gov/study/NCT03013543</li>
+<li>https://doi.org/10.1038/s41586-024-08504-8</li>
+<li>https://doi.org/10.3390/biom15020209,</li>
+<li>https://doi.org/10.1002/ski2.201,</li>
+<li>https://doi.org/10.3390/molecules28237754,</li>
+<li>https://doi.org/10.20517/evcna.2023.34,</li>
+<li>https://doi.org/10.1159/000530804,</li>
+<li>https://doi.org/10.1038/s41586-024-08504-8,</li>
+<li>https://doi.org/10.3389/fcell.2023.1243038,</li>
+<li>https://doi.org/10.17925/ee.2024.20.2.9,</li>
+</ol>
+            </div>
+        </details>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
                     <h3 style="display: inline;">Notes</h3>
                     <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(POMC-notes.md)</span>
                 </div>
@@ -6568,6 +7026,8 @@ existing_annotations:
     supported_by:
     - reference_id: PMID:9620771
       supporting_text: &#34;Sequential cleavage of the precursor protein pre-pro-opiomelanocortin (POMC) generates the melanocortin peptides adrenocorticotrophin (ACTH), melanocyte-stimulating hormones (MSH) alpha, beta and gamma as well as the opioid-receptor ligand beta-endorphin.&#34;
+    - reference_id: file:human/POMC/POMC-deep-research-falcon.md
+      supporting_text: &#34;POMC is summarized as a secreted prohormone precursor processed into multiple bioactive peptides including ACTH, MSH peptides, beta-lipotropin, and beta-endorphin.&#34;
 
 - term:
     id: GO:0005179
@@ -7597,6 +8057,8 @@ core_functions:
     supporting_text: &#34;Sequential cleavage of the precursor protein pre-pro-opiomelanocortin (POMC) generates the melanocortin peptides adrenocorticotrophin (ACTH), melanocyte-stimulating hormones (MSH) alpha, beta and gamma as well as the opioid-receptor ligand beta-endorphin.&#34;
   - reference_id: UniProtKB:P01189
     supporting_text: &#34;This is a prohormone that is cleaved to give multiple peptide hormones.&#34;
+  - reference_id: file:human/POMC/POMC-deep-research-falcon.md
+    supporting_text: &#34;POMC is summarized as a secreted prohormone precursor that is proteolytically processed into ACTH, alpha/beta/gamma-MSH, beta-lipotropin, and beta-endorphin.&#34;
 
 # ---------------------------------------------------------------------
 # Core Function 2: HPA Axis Regulation via ACTH
@@ -7633,6 +8095,8 @@ core_functions:
     supporting_text: &#34;adrenal insufficiency... isolated ACTH deficiency&#34;
   - reference_id: Reactome:R-HSA-388605
     supporting_text: &#34;POMC(138-176) binds MC2R&#34;
+  - reference_id: file:human/POMC/POMC-deep-research-falcon.md
+    supporting_text: &#34;A central endocrine function of POMC is production of ACTH, secreted from the anterior pituitary, which stimulates adrenal glucocorticoid production as part of the HPA axis.&#34;
 
 # ---------------------------------------------------------------------
 # Core Function 3: Appetite Suppression via Alpha-MSH
@@ -7666,6 +8130,8 @@ core_functions:
     supporting_text: &#34;Recent studies in animal models elucidated a central role of alpha-MSH in the regulation of food intake by activation of the brain melanocortin-4-receptor (MC4-R; refs 3-5)&#34;
   - reference_id: PMID:19743876
     supporting_text: &#34;Alpha-MSH and ACTH are endogenous nonselective agonists for MC1R, MC3R, MC4R, and MC5R.&#34;
+  - reference_id: file:human/POMC/POMC-deep-research-falcon.md
+    supporting_text: &#34;The report describes hypothalamic POMC-derived alpha-MSH as a major anorexigenic melanocortin peptide that suppresses appetite and increases energy expenditure through melanocortin signaling.&#34;
 
 # ---------------------------------------------------------------------
 # Core Function 4: Skin Pigmentation via MSH Peptides
@@ -7700,6 +8166,8 @@ core_functions:
     supporting_text: &#34;[Melanocyte-stimulating hormone alpha]: Increases the pigmentation of skin by increasing melanin production in melanocytes.&#34;
   - reference_id: PMID:18292087
     supporting_text: &#34;MC1R signaling in B16 mouse melanoma cells and primary human melanocytes&#34;
+  - reference_id: file:human/POMC/POMC-deep-research-falcon.md
+    supporting_text: &#34;The report summarizes alpha-MSH and beta-MSH as POMC-derived melanocortins that signal through MC1R in skin and pigment cells to regulate pigmentation.&#34;
 
 # ---------------------------------------------------------------------
 # Core Function 5: Opioid Signaling and Appetite Stimulation via Beta-Endorphin
@@ -7737,6 +8205,8 @@ core_functions:
     supporting_text: &#34;-!- FUNCTION: [Beta-endorphin]: Endogenous orexigenic opiate.&#34;
   - reference_id: Reactome:R-HSA-374298
     supporting_text: &#34;Opioid receptors bind opioid peptides&#34;
+  - reference_id: file:human/POMC/POMC-deep-research-falcon.md
+    supporting_text: &#34;The report identifies beta-endorphin as a POMC-derived opioid neuropeptide that contributes to opioid signaling and orexigenic appetite regulation.&#34;
 
 references:
 - id: GO_REF:0000024
@@ -7754,6 +8224,11 @@ references:
 - id: GO_REF:0000120
   title: Combined Automated Annotation using Multiple IEA Methods
   findings: []
+- id: file:human/POMC/POMC-deep-research-falcon.md
+  title: Falcon deep research report for human POMC
+  findings:
+    - statement: POMC encodes a secreted pre-prohormone routed through ER, Golgi, and dense-core secretory granules before tissue-specific processing by PC1/3 and PC2.
+    - statement: POMC-derived peptides support HPA-axis ACTH signaling, melanocortin appetite and pigmentation signaling, and beta-endorphin opioid signaling.
 - id: PMID:10233018
   title: alpha-MSH and its receptors in regulation of tumor necrosis factor-alpha production by human monocyte/macrophages.
   findings: []

--- a/genes/human/POMC/POMC-ai-review.yaml
+++ b/genes/human/POMC/POMC-ai-review.yaml
@@ -1016,9 +1016,17 @@ existing_annotations:
     label: peptide hormone processing
   evidence_type: NAS
   review:
-    summary: Added to align core_functions with existing annotations.
+    summary: >-
+      POMC is a pre-prohormone precursor whose biological activity depends on
+      sequential proteolytic cleavage at paired basic residues to generate ACTH,
+      melanocyte-stimulating hormones, beta-lipotropin, and beta-endorphin.
+      Peptide hormone processing is therefore a direct part of POMC maturation,
+      not just a downstream consequence.
     action: NEW
-    reason: Core function term not present in existing_annotations.
+    reason: >-
+      Add this term because the cited human POMC phenotype paper and UniProt
+      processing note both support proteolytic generation of multiple peptide
+      hormones from the precursor.
     supported_by:
     - reference_id: PMID:9620771
       supporting_text: "Sequential cleavage of the precursor protein pre-pro-opiomelanocortin (POMC) generates the melanocortin peptides adrenocorticotrophin (ACTH), melanocyte-stimulating hormones (MSH) alpha, beta and gamma as well as the opioid-receptor ligand beta-endorphin."
@@ -1036,9 +1044,16 @@ existing_annotations:
     label: corticotropin hormone receptor binding
   evidence_type: NAS
   review:
-    summary: Added to align core_functions with existing annotations.
+    summary: >-
+      The ACTH/corticotropin cleavage product of POMC (POMC residues 138-176)
+      binds the corticotropin receptor MC2R on adrenal cortex cells. This
+      receptor-ligand interaction is the molecular entry point for POMC's HPA-axis
+      endocrine function.
     action: NEW
-    reason: Core function term not present in existing_annotations.
+    reason: >-
+      GO:0031780 is the specific receptor-binding term for the ACTH product,
+      supported by Reactome's POMC(138-176)-MC2R reaction and by POMC-deficiency
+      adrenal insufficiency in humans.
     supported_by:
     - reference_id: PMID:9620771
       supporting_text: "adrenal insufficiency... isolated ACTH deficiency"
@@ -1056,9 +1071,15 @@ existing_annotations:
     label: positive regulation of glucocorticoid secretion
   evidence_type: NAS
   review:
-    summary: Added to align core_functions with existing annotations.
+    summary: >-
+      POMC-derived ACTH positively regulates adrenal glucocorticoid secretion
+      by binding MC2R on adrenal cortex cells. Human POMC loss causes isolated
+      ACTH deficiency with secondary adrenal insufficiency, showing that this
+      stimulatory endocrine signal is physiologically required.
     action: NEW
-    reason: Core function term not present in existing_annotations.
+    reason: >-
+      Add this BP term to capture the direct endocrine consequence of ACTH-MC2R
+      signaling, rather than only the molecular receptor-binding event.
     supported_by:
     - reference_id: PMID:9620771
       supporting_text: "adrenal insufficiency... isolated ACTH deficiency"
@@ -1076,9 +1097,15 @@ existing_annotations:
     label: positive regulation of cortisol secretion
   evidence_type: NAS
   review:
-    summary: Added to align core_functions with existing annotations.
+    summary: >-
+      In humans, the principal adrenal glucocorticoid output of ACTH signaling is
+      cortisol. The POMC-derived ACTH peptide binds MC2R and stimulates cortisol
+      secretion; POMC-deficient patients present with adrenal insufficiency from
+      loss of this signal.
     action: NEW
-    reason: Core function term not present in existing_annotations.
+    reason: >-
+      This term is the human-specific child of glucocorticoid secretion regulation
+      and is justified for POMC because the relevant cleavage product is ACTH.
     supported_by:
     - reference_id: PMID:9620771
       supporting_text: "adrenal insufficiency... isolated ACTH deficiency"
@@ -1096,9 +1123,15 @@ existing_annotations:
     label: energy homeostasis
   evidence_type: NAS
   review:
-    summary: Added to align core_functions with existing annotations.
+    summary: >-
+      Hypothalamic POMC neurons generate alpha-MSH, which activates melanocortin
+      receptors including MC4R to suppress appetite and regulate body weight.
+      Severe early-onset obesity in POMC deficiency supports energy homeostasis
+      as a core physiological role of POMC-derived melanocortins.
     action: NEW
-    reason: Core function term not present in existing_annotations.
+    reason: >-
+      Add this BP term because the cited human phenotype and receptor-binding
+      evidence connect POMC-derived alpha-MSH signaling to systemic energy balance.
     supported_by:
     - reference_id: PMID:9620771
       supporting_text: "Recent studies in animal models elucidated a central role of alpha-MSH in the regulation of food intake by activation of the brain melanocortin-4-receptor (MC4-R; refs 3-5)"
@@ -1116,9 +1149,15 @@ existing_annotations:
     label: melanin biosynthetic process
   evidence_type: NAS
   review:
-    summary: Added to align core_functions with existing annotations.
+    summary: >-
+      POMC-derived alpha-MSH and beta-MSH stimulate melanocortin receptor signaling
+      in melanocytes, increasing melanin production. Red hair and fair skin in
+      POMC-deficient patients support loss of this melanogenic signal in humans.
     action: NEW
-    reason: Core function term not present in existing_annotations.
+    reason: >-
+      Add this BP term to represent the pigment-biosynthesis role of POMC-derived
+      MSH peptides, supported by UniProt functional text and human POMC-deficiency
+      pigmentation phenotypes.
     supported_by:
     - reference_id: PMID:9620771
       supporting_text: "red hair pigmentation caused by POMC mutations"
@@ -1139,9 +1178,14 @@ existing_annotations:
     label: opioid peptide activity
   evidence_type: NAS
   review:
-    summary: Added to align core_functions with existing annotations.
+    summary: >-
+      Beta-endorphin is a POMC cleavage product with endogenous opioid peptide
+      activity. It binds opioid receptors and mediates POMC's opioid signaling
+      output, distinct from the melanocortin and ACTH products.
     action: NEW
-    reason: Core function term not present in existing_annotations.
+    reason: >-
+      Add this MF term because beta-endorphin is an annotated POMC-derived opiate
+      peptide and Reactome supports opioid peptide receptor binding.
     supported_by:
     - reference_id: UniProtKB:P01189
       supporting_text: "-!- FUNCTION: [Beta-endorphin]: Endogenous orexigenic opiate."
@@ -1153,9 +1197,16 @@ existing_annotations:
     label: response to pain
   evidence_type: NAS
   review:
-    summary: Added to align core_functions with existing annotations.
+    summary: >-
+      The POMC-derived beta-endorphin peptide is an endogenous opioid that signals
+      through opioid receptors. Opioid signaling is a canonical regulator of pain
+      responses, making response to pain an appropriate biological-process output
+      for this cleavage product.
     action: NEW
-    reason: Core function term not present in existing_annotations.
+    reason: >-
+      Add this BP term to capture the physiological consequence of beta-endorphin
+      opioid peptide activity, supported by the POMC beta-endorphin annotation and
+      Reactome opioid receptor pathway evidence.
     supported_by:
     - reference_id: UniProtKB:P01189
       supporting_text: "-!- FUNCTION: [Beta-endorphin]: Endogenous orexigenic opiate."

--- a/genes/human/POMC/POMC-ai-review.yaml
+++ b/genes/human/POMC/POMC-ai-review.yaml
@@ -170,6 +170,8 @@ existing_annotations:
     supported_by:
     - reference_id: PMID:9620771
       supporting_text: "Sequential cleavage of the precursor protein pre-pro-opiomelanocortin (POMC) generates the melanocortin peptides adrenocorticotrophin (ACTH), melanocyte-stimulating hormones (MSH) alpha, beta and gamma as well as the opioid-receptor ligand beta-endorphin."
+    - reference_id: file:human/POMC/POMC-deep-research-falcon.md
+      supporting_text: "POMC is summarized as a secreted prohormone precursor processed into multiple bioactive peptides including ACTH, MSH peptides, beta-lipotropin, and beta-endorphin."
 
 - term:
     id: GO:0005179
@@ -1199,6 +1201,8 @@ core_functions:
     supporting_text: "Sequential cleavage of the precursor protein pre-pro-opiomelanocortin (POMC) generates the melanocortin peptides adrenocorticotrophin (ACTH), melanocyte-stimulating hormones (MSH) alpha, beta and gamma as well as the opioid-receptor ligand beta-endorphin."
   - reference_id: UniProtKB:P01189
     supporting_text: "This is a prohormone that is cleaved to give multiple peptide hormones."
+  - reference_id: file:human/POMC/POMC-deep-research-falcon.md
+    supporting_text: "POMC is summarized as a secreted prohormone precursor that is proteolytically processed into ACTH, alpha/beta/gamma-MSH, beta-lipotropin, and beta-endorphin."
 
 # ---------------------------------------------------------------------
 # Core Function 2: HPA Axis Regulation via ACTH
@@ -1235,6 +1239,8 @@ core_functions:
     supporting_text: "adrenal insufficiency... isolated ACTH deficiency"
   - reference_id: Reactome:R-HSA-388605
     supporting_text: "POMC(138-176) binds MC2R"
+  - reference_id: file:human/POMC/POMC-deep-research-falcon.md
+    supporting_text: "A central endocrine function of POMC is production of ACTH, secreted from the anterior pituitary, which stimulates adrenal glucocorticoid production as part of the HPA axis."
 
 # ---------------------------------------------------------------------
 # Core Function 3: Appetite Suppression via Alpha-MSH
@@ -1268,6 +1274,8 @@ core_functions:
     supporting_text: "Recent studies in animal models elucidated a central role of alpha-MSH in the regulation of food intake by activation of the brain melanocortin-4-receptor (MC4-R; refs 3-5)"
   - reference_id: PMID:19743876
     supporting_text: "Alpha-MSH and ACTH are endogenous nonselective agonists for MC1R, MC3R, MC4R, and MC5R."
+  - reference_id: file:human/POMC/POMC-deep-research-falcon.md
+    supporting_text: "The report describes hypothalamic POMC-derived alpha-MSH as a major anorexigenic melanocortin peptide that suppresses appetite and increases energy expenditure through melanocortin signaling."
 
 # ---------------------------------------------------------------------
 # Core Function 4: Skin Pigmentation via MSH Peptides
@@ -1302,6 +1310,8 @@ core_functions:
     supporting_text: "[Melanocyte-stimulating hormone alpha]: Increases the pigmentation of skin by increasing melanin production in melanocytes."
   - reference_id: PMID:18292087
     supporting_text: "MC1R signaling in B16 mouse melanoma cells and primary human melanocytes"
+  - reference_id: file:human/POMC/POMC-deep-research-falcon.md
+    supporting_text: "The report summarizes alpha-MSH and beta-MSH as POMC-derived melanocortins that signal through MC1R in skin and pigment cells to regulate pigmentation."
 
 # ---------------------------------------------------------------------
 # Core Function 5: Opioid Signaling and Appetite Stimulation via Beta-Endorphin
@@ -1339,6 +1349,8 @@ core_functions:
     supporting_text: "-!- FUNCTION: [Beta-endorphin]: Endogenous orexigenic opiate."
   - reference_id: Reactome:R-HSA-374298
     supporting_text: "Opioid receptors bind opioid peptides"
+  - reference_id: file:human/POMC/POMC-deep-research-falcon.md
+    supporting_text: "The report identifies beta-endorphin as a POMC-derived opioid neuropeptide that contributes to opioid signaling and orexigenic appetite regulation."
 
 references:
 - id: GO_REF:0000024
@@ -1356,6 +1368,11 @@ references:
 - id: GO_REF:0000120
   title: Combined Automated Annotation using Multiple IEA Methods
   findings: []
+- id: file:human/POMC/POMC-deep-research-falcon.md
+  title: Falcon deep research report for human POMC
+  findings:
+    - statement: POMC encodes a secreted pre-prohormone routed through ER, Golgi, and dense-core secretory granules before tissue-specific processing by PC1/3 and PC2.
+    - statement: POMC-derived peptides support HPA-axis ACTH signaling, melanocortin appetite and pigmentation signaling, and beta-endorphin opioid signaling.
 - id: PMID:10233018
   title: alpha-MSH and its receptors in regulation of tumor necrosis factor-alpha production by human monocyte/macrophages.
   findings: []

--- a/genes/human/POMC/POMC-deep-research-falcon.md
+++ b/genes/human/POMC/POMC-deep-research-falcon.md
@@ -1,0 +1,332 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-10T22:02:48.721917'
+end_time: '2026-05-10T22:15:12.410416'
+duration_seconds: 743.69
+template_file: templates/gene_research_go_focused.md
+template_variables:
+  organism: human
+  gene_id: POMC
+  gene_symbol: POMC
+  uniprot_accession: P01189
+  protein_description: 'RecName: Full=Pro-opiomelanocortin; Short=POMC; AltName: Full=Corticotropin-lipotropin;
+    Contains: RecName: Full=NPP; Contains: RecName: Full=Melanotropin gamma; AltName:
+    Full=Gamma-MSH; Contains: RecName: Full=Potential peptide; Contains: RecName:
+    Full=Corticotropin; AltName: Full=Adrenocorticotropic hormone; Short=ACTH; Contains:
+    RecName: Full=Melanocyte-stimulating hormone alpha; Short=Alpha-MSH; AltName:
+    Full=Melanotropin alpha; Contains: RecName: Full=Corticotropin-like intermediary
+    peptide; Short=CLIP; Contains: RecName: Full=Lipotropin beta; AltName: Full=Beta-LPH;
+    Contains: RecName: Full=Lipotropin gamma; AltName: Full=Gamma-LPH; Contains: RecName:
+    Full=Melanocyte-stimulating hormone beta; Short=Beta-MSH; AltName: Full=Melanotropin
+    beta; Contains: RecName: Full=Beta-endorphin; Contains: RecName: Full=Met-enkephalin;
+    Flags: Precursor;'
+  gene_info: Name=POMC;
+  organism_full: Homo sapiens (Human).
+  protein_family: Belongs to the POMC family. .
+  protein_domains: Mcrtin_ACTH_cent. (IPR013531); Melanocortin_N. (IPR013593); Opioid_neuropept.
+    (IPR013532); PMOC. (IPR001941); POMC-derived_peptides. (IPR050878)
+provider_config:
+  timeout: 600
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 25
+---
+
+## Question
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** P01189
+- **Protein Description:** RecName: Full=Pro-opiomelanocortin; Short=POMC; AltName: Full=Corticotropin-lipotropin; Contains: RecName: Full=NPP; Contains: RecName: Full=Melanotropin gamma; AltName: Full=Gamma-MSH; Contains: RecName: Full=Potential peptide; Contains: RecName: Full=Corticotropin; AltName: Full=Adrenocorticotropic hormone; Short=ACTH; Contains: RecName: Full=Melanocyte-stimulating hormone alpha; Short=Alpha-MSH; AltName: Full=Melanotropin alpha; Contains: RecName: Full=Corticotropin-like intermediary peptide; Short=CLIP; Contains: RecName: Full=Lipotropin beta; AltName: Full=Beta-LPH; Contains: RecName: Full=Lipotropin gamma; AltName: Full=Gamma-LPH; Contains: RecName: Full=Melanocyte-stimulating hormone beta; Short=Beta-MSH; AltName: Full=Melanotropin beta; Contains: RecName: Full=Beta-endorphin; Contains: RecName: Full=Met-enkephalin; Flags: Precursor;
+- **Gene Information:** Name=POMC;
+- **Organism (full):** Homo sapiens (Human).
+- **Protein Family:** Belongs to the POMC family. .
+- **Key Domains:** Mcrtin_ACTH_cent. (IPR013531); Melanocortin_N. (IPR013593); Opioid_neuropept. (IPR013532); PMOC. (IPR001941); POMC-derived_peptides. (IPR050878)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "POMC" matches the protein description above**
+2. **Verify the organism is correct:** Homo sapiens (Human).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'POMC' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **POMC** (gene ID: POMC, UniProt: P01189) in human.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** P01189
+- **Protein Description:** RecName: Full=Pro-opiomelanocortin; Short=POMC; AltName: Full=Corticotropin-lipotropin; Contains: RecName: Full=NPP; Contains: RecName: Full=Melanotropin gamma; AltName: Full=Gamma-MSH; Contains: RecName: Full=Potential peptide; Contains: RecName: Full=Corticotropin; AltName: Full=Adrenocorticotropic hormone; Short=ACTH; Contains: RecName: Full=Melanocyte-stimulating hormone alpha; Short=Alpha-MSH; AltName: Full=Melanotropin alpha; Contains: RecName: Full=Corticotropin-like intermediary peptide; Short=CLIP; Contains: RecName: Full=Lipotropin beta; AltName: Full=Beta-LPH; Contains: RecName: Full=Lipotropin gamma; AltName: Full=Gamma-LPH; Contains: RecName: Full=Melanocyte-stimulating hormone beta; Short=Beta-MSH; AltName: Full=Melanotropin beta; Contains: RecName: Full=Beta-endorphin; Contains: RecName: Full=Met-enkephalin; Flags: Precursor;
+- **Gene Information:** Name=POMC;
+- **Organism (full):** Homo sapiens (Human).
+- **Protein Family:** Belongs to the POMC family. .
+- **Key Domains:** Mcrtin_ACTH_cent. (IPR013531); Melanocortin_N. (IPR013593); Opioid_neuropept. (IPR013532); PMOC. (IPR001941); POMC-derived_peptides. (IPR050878)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "POMC" matches the protein description above**
+2. **Verify the organism is correct:** Homo sapiens (Human).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'POMC' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **POMC** (gene ID: POMC, UniProt: P01189) in human.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+# Research Report: Human **POMC** (UniProt **P01189**) — Functional Annotation, Pathways, and Clinical Translation
+
+## 0. Target verification (identity and scope)
+The queried gene/protein is **human pro-opiomelanocortin (POMC)**, a **secreted prohormone precursor** that is proteolytically processed into multiple bioactive peptides including **ACTH**, **α/β/γ-MSH**, **β-lipotropin**, and **β-endorphin**, matching the UniProt P01189 description and canonical melanocortin/opioid biology. (yanik2025proopiomelanocortinandmelanocortin pages 1-3, millington2023proopiomelanocortin(pomc)and pages 1-2, hiroshima2023thecelladhesion pages 1-2)
+
+## 1. Key concepts and definitions (current understanding)
+
+### 1.1 What POMC is (precursor concept)
+**POMC encodes a pre-prohormone** that enters the classical secretory pathway: it is synthesized as **pre-POMC** with a **signal peptide cleaved during ER translocation**, then the precursor **folds in the ER**, is **glycosylated in the Golgi**, and is **packaged into secretory granules** for regulated secretion and tissue-specific proteolysis into peptide hormones/neuropeptides. (hiroshima2023thecelladhesion pages 1-2)
+
+### 1.2 Major POMC-derived peptides
+Multiple sources describe that **human POMC is cleaved into multiple active peptides**, prominently including **ACTH** and melanocortins (α/β/γ-MSH) as well as **β-endorphin**. (yanik2025proopiomelanocortinandmelanocortin pages 1-3, millington2023proopiomelanocortin(pomc)and pages 1-2, hiroshima2023thecelladhesion pages 1-2)
+
+### 1.3 Processing enzymes (PC1/3 vs PC2) and tissue-specific outcomes
+POMC processing is **tissue-specific** and is mediated largely by **two prohormone convertases**:
+- In the **anterior pituitary**, **PC1/3 (PC1)** cleaves POMC to yield **N-POMC, ACTH, and β-lipotropin**. (millington2023proopiomelanocortin(pomc)and pages 1-2, hiroshima2023thecelladhesion pages 1-2)
+- **PC2** performs additional cleavages, including cleavage of N-terminal intermediates to yield fragments that include **γ-MSH and the joining peptide**, and additional processing in tissues with extended processing capacity (e.g., intermediate-lobe-like processing contexts) yields smaller peptide hormones. (hiroshima2023thecelladhesion pages 1-2)
+
+### 1.4 Subcellular localization: regulated secretory pathway (RSP)
+POMC is a canonical **regulated secretory pathway** cargo. Mechanistically:
+- POMC has an **N-terminal, conformation-dependent sorting signal** (reported as involving residues including acidic and hydrophobic residues) that mediates binding to the **sorting receptor carboxypeptidase E (CPE)** in **trans-Golgi network (TGN) lipid raft microdomains**; the prohormone–CPE complex buds from the TGN into **dense-core vesicles (DCVs)**. (quintana2023traffickingofhormones pages 3-5)
+- **Secretogranin III** can bind POMC to facilitate regulated pathway sorting, with a model in which a secretogranin III–POMC complex is transferred to chromogranin A to promote DCV incorporation. (quintana2023traffickingofhormones pages 3-5)
+- POMC also contains **conserved N-terminal disulfide bonds** reported to play an important role in sorting into secretory granules. (hiroshima2023thecelladhesion pages 2-5)
+- Proteolytic maturation of prohormones (including POMC) is described as occurring within **immature secretory vesicles that mature into DCVs**. (quintana2023traffickingofhormones pages 3-5)
+
+## 2. Biological functions and pathways (molecular-to-physiology mapping)
+
+### 2.1 HPA axis / adrenal steroidogenesis (ACTH → MC2R)
+A central endocrine function of POMC is production of **ACTH**, secreted from the anterior pituitary, which **stimulates adrenal glucocorticoid production** as part of the hypothalamic–pituitary–adrenal (HPA) axis. (millington2023proopiomelanocortin(pomc)and pages 1-2, yanik2025proopiomelanocortinandmelanocortin pages 1-3)
+Receptor specificity is emphasized in reviews: **MC2R is highly specific for ACTH** compared with other melanocortin receptors. (millington2023proopiomelanocortin(pomc)and pages 1-2)
+
+### 2.2 Appetite and energy balance (α-MSH from POMC neurons → MC3R/MC4R)
+In the central nervous system, **α-MSH is a POMC-derived anorexigenic peptide** produced by **POMC neurons in the hypothalamic arcuate nucleus (ARC)** and released to act on **melanocortin receptor 3/4 (MC3R/MC4R)–expressing neurons**, thereby suppressing appetite and promoting energy expenditure. (wu2023alphamelanocytestimulatinghormonemediatedappetite pages 1-2, yanik2025proopiomelanocortinandmelanocortin pages 1-3)
+POMC neurons are positioned within the **leptin–melanocortin pathway** and function alongside (and in opposition to) orexigenic AgRP/NPY circuitry. (yanik2025proopiomelanocortinandmelanocortin pages 1-3, wu2023alphamelanocytestimulatinghormonemediatedappetite pages 1-2)
+
+### 2.3 Skin and peripheral neuroendocrine/immunomodulatory axes
+POMC-derived peptides also operate in skin and stress-linked peripheral axes. A 2023 review in psychodermatology highlights a **local cutaneous CRF–POMC–corticosteroid axis** and links POMC-derived signaling to immune disruption and stress-associated skin disease contexts, while also summarizing melanocortin receptor engagement in these tissues. (millington2023proopiomelanocortin(pomc)and pages 1-2)
+
+### 2.4 Opioid biology (β-endorphin)
+POMC processing also yields **β-endorphin**, which is described as an opioid peptide acting at opioid receptors and involved in analgesia/pain modulation within neuroendocrine contexts. (yanik2025proopiomelanocortinandmelanocortin pages 3-4, hiroshima2023thecelladhesion pages 1-2)
+
+## 3. Where POMC is expressed (cell/tissue context) and where it acts
+
+### 3.1 Neuroendocrine tissues and key cell types
+POMC-derived endocrine physiology is classically associated with pituitary and hypothalamic systems (e.g., anterior pituitary ACTH production; ARC POMC neurons for melanocortin appetite control). (millington2023proopiomelanocortin(pomc)and pages 1-2, wu2023alphamelanocytestimulatinghormonemediatedappetite pages 1-2)
+
+### 3.2 Human hypothalamus: high-resolution cell atlas evidence (human-specific nuance)
+A large-scale human hypothalamus atlas (“HYPOMAP”) combined **single-nucleus RNA-seq of 433,369 hypothalamic cells** with spatial transcriptomics, explicitly noting that POMC-expressing neurons in the ARC are a core component of the leptin–melanocortin pathway and that there are **notable human–mouse discrepancies in POMC neuron identity and GPCR expression** with direct implications for obesity therapies targeting hypothalamic GPCRs. (tadross2025acomprehensivespatiocellular pages 1-2)
+The same study reports **452 hypothalamic cell types**, with **291 neuronal clusters enriched for BMI GWAS genes** (driven by 426 “effector” genes), and that **rare deleterious variants** in six genes including **POMC** associate with BMI at the population level. (tadross2025acomprehensivespatiocellular pages 1-2)
+
+## 4. Recent developments (prioritizing 2023–2024)
+
+### 4.1 2023: Updated mechanistic understanding of regulated secretory sorting
+Recent synthesis of secretory trafficking emphasizes that POMC sorting into regulated DCVs is not merely generic secretion; it can depend on specific **N-terminal sorting information** and **receptor/cofactor-mediated sorting**, with **CPE** and **secretogranin III** highlighted as key facilitators of regulated-pathway targeting and DCV incorporation. (quintana2023traffickingofhormones pages 3-5, stepihar2023cellspecificsecretorygranule pages 20-21)
+A 2023 study/review on POMC joining peptide further points to **conserved N-terminal disulfide bonds** in POMC as important for sorting into secretory granules. (hiroshima2023thecelladhesion pages 2-5)
+
+### 4.2 2023: α-MSH appetite regulation as a systems-level integration point
+A 2023 Neuroendocrinology review reiterates that **α-MSH** derived from ARC POMC neurons is a central mediator of appetite suppression and energy expenditure via **MC3R/MC4R circuitry**, and also notes α-MSH presence in multiple CNS regions and extra-pituitary sources. (wu2023alphamelanocytestimulatinghormonemediatedappetite pages 1-2)
+
+### 4.3 2024: Clinical translation—MC4R agonism (setmelanotide) as pathway replacement therapy
+A 2024 therapeutics review frames **setmelanotide** (RM-493) as an MC4R agonist that can “replace the missing link” in leptin–melanocortin signaling in monogenic obesity states by activating melanocortin signaling in relevant hypothalamic circuits. (qamar2024setmelanotideamelanocortin4 pages 5-6)
+This review states that genes in the melanocortin pathway contribute to **~5% of early-onset severe obesity** (as an aggregate estimate), underscoring the clinical importance of POMC–MC4R pathway biology in a defined subset of patients. (qamar2024setmelanotideamelanocortin4 pages 1-2)
+
+## 5. Current applications and real-world implementations
+
+### 5.1 Targeted pharmacotherapy: setmelanotide for POMC/PCSK1 deficiency obesity
+**ClinicalTrials.gov Phase 3 record (NCT02896192)** describes an open-label, 1-year setmelanotide trial in genetically confirmed **bi-allelic POMC or PCSK1 loss-of-function** obesity, with an **8-week double-blind placebo-controlled withdrawal** and a primary endpoint of **% achieving ≥10% weight loss at ~Week 52**; results were posted **2023-09-21**, and the study enrolled **15 participants** (start 2017-02-14; completion 2020-05-25). (NCT02896192 chunk 1)
+A 2024 review summarizing multicenter phase 3 data reports that in a POMC deficiency cohort (**n=10**), **8/10 (80%)** achieved **≥10% weight loss at 52 weeks**, with mean weight change **−25.6% (SD 9.9)**; the review also reports hunger-score improvements (e.g., maximal hunger score reductions) in POMC and related cohorts. (qamar2024setmelanotideamelanocortin4 pages 5-6, qamar2024setmelanotideamelanocortin4 pages 6-7)
+
+### 5.2 Broader genetic-obesity trial implementation
+A Phase 2 ClinicalTrials.gov record (NCT03013543) enrolled **213** participants across multiple rare genetic obesity cohorts (including POMC/PCSK1/LEPR-related cohorts), with a primary endpoint of the number of participants with **≥5% body weight reduction** after **3 months** of setmelanotide treatment; results were posted **2023-08-18**. (NCT03013543 chunk 1, NCT03013543 chunk 2)
+
+### 5.3 Early investigator-led implementations and extension-style studies
+A Charité-led Phase 2 study (NCT02507492; RM-493/setmelanotide) targeted adults with homozygous/compound heterozygous **POMC, LEPR, or PCSK1** mutations, with primary evaluation over **Day 1–Day 84** (body weight change), and an option for long-term extension; planned enrollment was **10**. (NCT02507492 chunk 1)
+
+## 6. Relevant statistics and data points (from recent sources)
+
+### 6.1 Human-cell atlas statistics and translational implications
+- **433,369** nuclei profiled in the human hypothalamus atlas; **452** hypothalamic cell types; **291** neuronal clusters enriched for BMI GWAS genes; rare deleterious variants in **POMC** among genes associating with BMI at population level. (tadross2025acomprehensivespatiocellular pages 1-2)
+
+### 6.2 Trial efficacy outcomes (setmelanotide)
+- Phase 3 POMC deficiency cohort reported in 2024 review: **80% (8/10)** achieved ≥10% weight loss at 1 year; mean weight change **−25.6%** (SD 9.9). (qamar2024setmelanotideamelanocortin4 pages 5-6)
+- Responder proportions in other genetic cohorts (≥5% weight loss) were summarized (e.g., heterozygous POMC/PCSK1/LEPR **12/35 (34.3%)** responders at ≥5% weight loss). (qamar2024setmelanotideamelanocortin4 pages 6-7)
+
+### 6.3 Rarity of POMC deficiency (as reported in 2024 synthesis)
+A 2024 therapeutics review reports that **POMC deficiency has fewer than 15 diagnosed cases worldwide** (emphasizing rarity and ascertainment limits), and provides similar “very rare” case-count statements for related pathway disorders such as PCSK1 deficiency. (qamar2024setmelanotideamelanocortin4 pages 4-5)
+
+## 7. Expert interpretation and authoritative analysis (what experts emphasize)
+
+1. **Functional core:** Experts consistently frame POMC primarily as a **multi-peptide precursor** whose biological function is realized through **cell-type-specific processing** into melanocortins and ACTH/β-endorphin, rather than as a single-function protein. (yanik2025proopiomelanocortinandmelanocortin pages 1-3, hiroshima2023thecelladhesion pages 1-2)
+2. **Cell biology matters for phenotype:** Recent trafficking literature highlights that **regulated secretory sorting determinants (CPE, secretogranin III, N-terminal motifs/disulfides)** are key mechanistic layers governing which peptides are ultimately produced and secreted, providing a mechanistic bridge between POMC sequence/processing and endocrine outcomes. (quintana2023traffickingofhormones pages 3-5, hiroshima2023thecelladhesion pages 2-5)
+3. **Human-specific circuit caution:** Human single-nucleus/spatial atlases indicate that POMC neuron identity and GPCR expression can differ from mice, which experts interpret as directly relevant to how hypothalamus-targeting obesity drugs may translate from rodent models to humans. (tadross2025acomprehensivespatiocellular pages 1-2)
+4. **Therapeutic rationale:** Setmelanotide is widely interpreted as a pathway-replacement strategy for MC4R-pathway defects, with clinical outcomes in POMC deficiency supporting the concept that restoring melanocortin tone can reduce hyperphagia and weight in appropriately selected genetic subtypes. (qamar2024setmelanotideamelanocortin4 pages 5-6, qamar2024setmelanotideamelanocortin4 pages 6-7)
+
+## 8. Functional-annotation summary table (peptides, processing, receptors, roles)
+| POMC-derived peptide product | Primary processing enzymes/steps | Major receptors/targets | Main physiological roles | Key evidence citations |
+|---|---|---|---|---|
+| ACTH (corticotropin) | Pre-POMC signal peptide removed in ER; precursor folds in ER, is glycosylated in Golgi, then packaged into secretory granules. In anterior pituitary, PC1/3 cleaves POMC to generate ACTH plus N-POMC and β-lipotropin; sorting to regulated secretory granules is directed by the POMC N-terminus, including conserved N-terminal disulfide bonds and a conformation-dependent sorting signal that binds CPE in TGN lipid rafts; secretogranin III also facilitates regulated-pathway sorting. | MC2R is the most specific ACTH receptor; ACTH can also bind other melanocortin receptors with variable affinity. | Core effector of the HPA axis; stimulates adrenal glucocorticoid synthesis/release; also contributes to skin neuroendocrine signaling. | (millington2023proopiomelanocortin(pomc)and pages 1-2, quintana2023traffickingofhormones pages 3-5, hiroshima2023thecelladhesion pages 2-5, hiroshima2023thecelladhesion pages 1-2) |
+| α-MSH | Generated by additional POMC processing beyond the anterior pituitary, especially where PC2 participates (intermediate lobe/arcuate-type processing). Same regulated secretory route applies: ER → Golgi → immature/regulated granules, with CPE/secretogranin III-supported sorting and granule-associated maturation. | MC3R, MC4R in CNS appetite circuits; MC1R in skin/pigment cells; other melanocortin receptors may also respond depending on tissue. | Major anorexigenic melanocortin peptide; suppresses appetite and increases energy expenditure in the leptin–melanocortin pathway; also regulates pigmentation and has anti-inflammatory/immunomodulatory effects in skin/periphery. | (wu2023alphamelanocytestimulatinghormonemediatedappetite pages 1-2, yanik2025proopiomelanocortinandmelanocortin pages 1-3, millington2023proopiomelanocortin(pomc)and pages 1-2, quintana2023traffickingofhormones pages 3-5, hiroshima2023thecelladhesion pages 1-2) |
+| β-MSH | Derived from downstream processing of β-lipotropin/POMC in tissues with appropriate convertase processing; maturation occurs in secretory vesicles/granules after regulated-pathway sorting. | High in vitro affinity for MC4R. | Contributes to body-weight regulation and melanocortin signaling controlling energy balance. | (yanik2025proopiomelanocortinandmelanocortin pages 3-4, quintana2023traffickingofhormones pages 3-5) |
+| γ-MSH (including γ1-/γ3-MSH) | PC1/3 first generates larger N-terminal intermediates; PC2 contributes further cleavage of N-POMC-derived regions to release γ-MSH-containing fragments in tissues with extended processing. | MC3R is a principal target noted in the retrieved evidence. | Appetite and energy-expenditure regulation within melanocortin signaling; part of the N-terminal POMC peptide system. | (yanik2025proopiomelanocortinandmelanocortin pages 3-4, hiroshima2023thecelladhesion pages 1-2) |
+| β-Endorphin | Produced by additional PC2-dependent processing of POMC-derived C-terminal intermediates in tissues with extended processing; precursor traffics through ER/Golgi into regulated granules before cleavage. | Opioid receptors (reported in retrieved evidence as opioid receptor targets). | Analgesia/pain modulation; also implicated in neuroendocrine outputs from POMC cells. | (yanik2025proopiomelanocortinandmelanocortin pages 3-4, millington2023proopiomelanocortin(pomc)and pages 1-2, hiroshima2023thecelladhesion pages 1-2) |
+| β-Lipotropin (β-LPH) / larger intermediates | In anterior pituitary, PC1/3 produces β-LPH together with ACTH and N-POMC. In humans, further processing of LPH is limited compared with some other mammals because humans lack certain PC2 cleavage sites. | Precursor/intermediate rather than primary receptor ligand; source for downstream β-MSH/β-endorphin-related products depending on tissue processing. | Serves mainly as a biosynthetic intermediate in human POMC processing; helps explain tissue-specific peptide outputs. | (millington2023proopiomelanocortin(pomc)and pages 1-2, yanik2025proopiomelanocortinandmelanocortin pages 3-4, hiroshima2023thecelladhesion pages 1-2) |
+| POMC precursor / regulated secretory cargo (annotation-level row) | Human POMC is a secreted prohormone precursor routed through the regulated secretory pathway: signal peptide cleavage in ER, folding in ER, Golgi glycosylation, TGN sorting by an N-terminal motif and conserved disulfide bonds, CPE-mediated binding in lipid rafts, facilitation by secretogranin III, budding into dense-core/secretory vesicles, and proteolytic maturation in immature secretory vesicles/granules by PC1/3 and PC2. | Gives rise to ligands for melanocortin receptors MC1R–MC5R and opioid-system targets, depending on peptide product. | Integrates HPA-axis control, appetite/energy homeostasis, pigmentation/skin biology, and broader immunomodulatory neuroendocrine functions. | (yanik2025proopiomelanocortinandmelanocortin pages 1-3, millington2023proopiomelanocortin(pomc)and pages 1-2, quintana2023traffickingofhormones pages 3-5, quintana2023traffickingofhormones pages 16-18, stepihar2023cellspecificsecretorygranule pages 20-21, hiroshima2023thecelladhesion pages 2-5, hiroshima2023thecelladhesion pages 1-2) |
+
+
+*Table: This table summarizes the major human POMC-derived peptides, how the precursor is trafficked and processed in the regulated secretory pathway, the main receptor targets, and the best-supported physiological functions. It is useful as a compact functional annotation artifact anchored to the retrieved evidence contexts.*
+
+## 9. Key sources (URLs and publication dates)
+- Wu Q et al. **“Alpha-Melanocyte-Stimulating Hormone-Mediated Appetite Regulation in the Central Nervous System.”** *Neuroendocrinology* (Apr **2023**). https://doi.org/10.1159/000530804 (wu2023alphamelanocytestimulatinghormonemediatedappetite pages 1-2)
+- Millington GWM, Palmer HE. **“Proopiomelanocortin (POMC) and psychodermatology.”** *Skin Health and Disease* (Apr **2023**). https://doi.org/10.1002/ski2.201 (millington2023proopiomelanocortin(pomc)and pages 1-2)
+- Quintana P et al. **“Trafficking of hormones and trophic factors to secretory and extracellular vesicles…”** *Extracellular Vesicles and Circulating Nucleic Acids* (Nov **2023**). https://doi.org/10.20517/evcna.2023.34 (quintana2023traffickingofhormones pages 3-5)
+- Hiroshima K et al. **“The Cell Adhesion Activity of the Joining Peptide of Proopiomelanocortin.”** *Molecules* (Nov **2023**). https://doi.org/10.3390/molecules28237754 (hiroshima2023thecelladhesion pages 1-2, hiroshima2023thecelladhesion pages 2-5)
+- Qamar S et al. **“Setmelanotide: A Melanocortin-4 Receptor Agonist…”** *touchREVIEWS in Endocrinology* (Oct **2024**). https://doi.org/10.17925/ee.2024.20.2.9 (qamar2024setmelanotideamelanocortin4 pages 5-6, qamar2024setmelanotideamelanocortin4 pages 6-7, qamar2024setmelanotideamelanocortin4 pages 4-5, qamar2024setmelanotideamelanocortin4 pages 1-2)
+- ClinicalTrials.gov **NCT02896192** (results posted **2023-09-21**; study start **2017-02-14**): https://clinicaltrials.gov/study/NCT02896192 (NCT02896192 chunk 1)
+- ClinicalTrials.gov **NCT03013543** (results posted **2023-08-18**; study start **2017-02-10**): https://clinicaltrials.gov/study/NCT03013543 (NCT03013543 chunk 1)
+- Tadross JA et al. **“A comprehensive spatio-cellular map of the human hypothalamus.”** *Nature* (published Feb **2025**; DOI indicates **2024**). https://doi.org/10.1038/s41586-024-08504-8 (tadross2025acomprehensivespatiocellular pages 1-2)
+
+## 10. Scope and evidence limitations
+This report focuses on **functional annotation** of the POMC precursor and its processed peptides and on **recent translational/omics evidence** available in retrieved sources. Not all classic primary endocrinology papers or receptor pharmacology datasets were retrieved in this run (e.g., full receptor-binding constants by peptide), so claims are restricted to the cited evidence above.
+
+References
+
+1. (yanik2025proopiomelanocortinandmelanocortin pages 1-3): Tulin Yanik and Seyda Tugce Durhan. Pro-opiomelanocortin and melanocortin receptor 3 and 4 mutations in genetic obesity. Biomolecules, 15:209, Feb 2025. URL: https://doi.org/10.3390/biom15020209, doi:10.3390/biom15020209. This article has 4 citations.
+
+2. (millington2023proopiomelanocortin(pomc)and pages 1-2): George W. M. Millington and Hannah E. Palmer. Proopiomelanocortin (pomc) and psychodermatology. Skin Health and Disease, Apr 2023. URL: https://doi.org/10.1002/ski2.201, doi:10.1002/ski2.201. This article has 16 citations and is from a peer-reviewed journal.
+
+3. (hiroshima2023thecelladhesion pages 1-2): Kyona Hiroshima, Nana Sakata, Tadafumi Konogami, Shigeru Shimamoto, and Yuji Hidaka. The cell adhesion activity of the joining peptide of proopiomelanocortin. Molecules, 28:7754, Nov 2023. URL: https://doi.org/10.3390/molecules28237754, doi:10.3390/molecules28237754. This article has 6 citations.
+
+4. (quintana2023traffickingofhormones pages 3-5): P. Quintana, Nicolas Lopez-Galvez, G. Matt, A. Merianos, N. Dodder, E. Hoh, Lara Stone, Chase A. Wullenweber, and E. M. Mahabee-gittens. Trafficking of hormones and trophic factors to secretory and extracellular vesicles: a historical perspective and new hypothesis. Extracellular Vesicles and Circulating Nucleic Acids, 4:568-587, Nov 2023. URL: https://doi.org/10.20517/evcna.2023.34, doi:10.20517/evcna.2023.34. This article has 6 citations.
+
+5. (hiroshima2023thecelladhesion pages 2-5): Kyona Hiroshima, Nana Sakata, Tadafumi Konogami, Shigeru Shimamoto, and Yuji Hidaka. The cell adhesion activity of the joining peptide of proopiomelanocortin. Molecules, 28:7754, Nov 2023. URL: https://doi.org/10.3390/molecules28237754, doi:10.3390/molecules28237754. This article has 6 citations.
+
+6. (wu2023alphamelanocytestimulatinghormonemediatedappetite pages 1-2): Qiwen Wu, Jingmei Chen, Tingyu Hua, and Jinyan Cai. Alpha-melanocyte-stimulating hormone-mediated appetite regulation in the central nervous system. Neuroendocrinology, 113:885-904, Apr 2023. URL: https://doi.org/10.1159/000530804, doi:10.1159/000530804. This article has 32 citations and is from a peer-reviewed journal.
+
+7. (yanik2025proopiomelanocortinandmelanocortin pages 3-4): Tulin Yanik and Seyda Tugce Durhan. Pro-opiomelanocortin and melanocortin receptor 3 and 4 mutations in genetic obesity. Biomolecules, 15:209, Feb 2025. URL: https://doi.org/10.3390/biom15020209, doi:10.3390/biom15020209. This article has 4 citations.
+
+8. (tadross2025acomprehensivespatiocellular pages 1-2): John A. Tadross, Lukas Steuernagel, Georgina K. C. Dowsett, Katherine A. Kentistou, Sofia Lundh, Marta Porniece, Paul Klemm, Kara Rainbow, Henning Hvid, Katarzyna Kania, Joseph Polex-Wolf, Lotte Bjerre Knudsen, Charles Pyke, John R. B. Perry, Brian Y. H. Lam, Jens C. Brüning, and Giles S. H. Yeo. A comprehensive spatio-cellular map of the human hypothalamus. Nature, 639:708-716, Feb 2025. URL: https://doi.org/10.1038/s41586-024-08504-8, doi:10.1038/s41586-024-08504-8. This article has 72 citations and is from a highest quality peer-reviewed journal.
+
+9. (stepihar2023cellspecificsecretorygranule pages 20-21): Denis Štepihar, Rebecca R. Florke Gee, Maria Camila Hoyos Sanchez, and Klementina Fon Tacer. Cell-specific secretory granule sorting mechanisms: the role of magel2 and retromer in hypothalamic regulated secretion. Frontiers in Cell and Developmental Biology, Sep 2023. URL: https://doi.org/10.3389/fcell.2023.1243038, doi:10.3389/fcell.2023.1243038. This article has 7 citations.
+
+10. (qamar2024setmelanotideamelanocortin4 pages 5-6): Sulmaaz Qamar, Ritwika Mallik, and Janine Makaronidis. Setmelanotide: a melanocortin-4 receptor agonist for the treatment of severe obesity due to hypothalamic dysfunction. touchREVIEWS in Endocrinology, Oct 2024. URL: https://doi.org/10.17925/ee.2024.20.2.9, doi:10.17925/ee.2024.20.2.9. This article has 13 citations.
+
+11. (qamar2024setmelanotideamelanocortin4 pages 1-2): Sulmaaz Qamar, Ritwika Mallik, and Janine Makaronidis. Setmelanotide: a melanocortin-4 receptor agonist for the treatment of severe obesity due to hypothalamic dysfunction. touchREVIEWS in Endocrinology, Oct 2024. URL: https://doi.org/10.17925/ee.2024.20.2.9, doi:10.17925/ee.2024.20.2.9. This article has 13 citations.
+
+12. (NCT02896192 chunk 1):  Setmelanotide for the Treatment of Early-Onset Pro-Opiomelanocortin (POMC) Deficiency Obesity. Rhythm Pharmaceuticals, Inc.. 2017. ClinicalTrials.gov Identifier: NCT02896192
+
+13. (qamar2024setmelanotideamelanocortin4 pages 6-7): Sulmaaz Qamar, Ritwika Mallik, and Janine Makaronidis. Setmelanotide: a melanocortin-4 receptor agonist for the treatment of severe obesity due to hypothalamic dysfunction. touchREVIEWS in Endocrinology, Oct 2024. URL: https://doi.org/10.17925/ee.2024.20.2.9, doi:10.17925/ee.2024.20.2.9. This article has 13 citations.
+
+14. (NCT03013543 chunk 1):  Setmelanotide Phase 2 Treatment Trial in Participants With Rare Genetic Disorders of Obesity. Rhythm Pharmaceuticals, Inc.. 2017. ClinicalTrials.gov Identifier: NCT03013543
+
+15. (NCT03013543 chunk 2):  Setmelanotide Phase 2 Treatment Trial in Participants With Rare Genetic Disorders of Obesity. Rhythm Pharmaceuticals, Inc.. 2017. ClinicalTrials.gov Identifier: NCT03013543
+
+16. (NCT02507492 chunk 1): PD Dr. Susanna Wiegand. RM-493 Treatment Trial in Proopiomelanocortin (POMC) Deficient Patients. Charite University, Berlin, Germany. 2015. ClinicalTrials.gov Identifier: NCT02507492
+
+17. (qamar2024setmelanotideamelanocortin4 pages 4-5): Sulmaaz Qamar, Ritwika Mallik, and Janine Makaronidis. Setmelanotide: a melanocortin-4 receptor agonist for the treatment of severe obesity due to hypothalamic dysfunction. touchREVIEWS in Endocrinology, Oct 2024. URL: https://doi.org/10.17925/ee.2024.20.2.9, doi:10.17925/ee.2024.20.2.9. This article has 13 citations.
+
+18. (quintana2023traffickingofhormones pages 16-18): P. Quintana, Nicolas Lopez-Galvez, G. Matt, A. Merianos, N. Dodder, E. Hoh, Lara Stone, Chase A. Wullenweber, and E. M. Mahabee-gittens. Trafficking of hormones and trophic factors to secretory and extracellular vesicles: a historical perspective and new hypothesis. Extracellular Vesicles and Circulating Nucleic Acids, 4:568-587, Nov 2023. URL: https://doi.org/10.20517/evcna.2023.34, doi:10.20517/evcna.2023.34. This article has 6 citations.
+
+## Citations
+
+1. hiroshima2023thecelladhesion pages 1-2
+2. quintana2023traffickingofhormones pages 3-5
+3. hiroshima2023thecelladhesion pages 2-5
+4. tadross2025acomprehensivespatiocellular pages 1-2
+5. wu2023alphamelanocytestimulatinghormonemediatedappetite pages 1-2
+6. yanik2025proopiomelanocortinandmelanocortin pages 1-3
+7. yanik2025proopiomelanocortinandmelanocortin pages 3-4
+8. stepihar2023cellspecificsecretorygranule pages 20-21
+9. quintana2023traffickingofhormones pages 16-18
+10. https://doi.org/10.1159/000530804
+11. https://doi.org/10.1002/ski2.201
+12. https://doi.org/10.20517/evcna.2023.34
+13. https://doi.org/10.3390/molecules28237754
+14. https://doi.org/10.17925/ee.2024.20.2.9
+15. https://clinicaltrials.gov/study/NCT02896192
+16. https://clinicaltrials.gov/study/NCT03013543
+17. https://doi.org/10.1038/s41586-024-08504-8
+18. https://doi.org/10.3390/biom15020209,
+19. https://doi.org/10.1002/ski2.201,
+20. https://doi.org/10.3390/molecules28237754,
+21. https://doi.org/10.20517/evcna.2023.34,
+22. https://doi.org/10.1159/000530804,
+23. https://doi.org/10.1038/s41586-024-08504-8,
+24. https://doi.org/10.3389/fcell.2023.1243038,
+25. https://doi.org/10.17925/ee.2024.20.2.9,


### PR DESCRIPTION
## Summary
- add Falcon deep research reports for human NTN1, NTN3, PCSK1N, PKM, and POMC
- integrate the reports into review references, existing annotation support, and core function evidence
- render updated review HTML for all five genes

## Validation
- `uv run python scripts/validate_deep_research.py` on all five Falcon reports: passed
- `just validate human NTN1`: passed
- `just validate human NTN3`: passed
- `just validate human PCSK1N`: passed
- `just validate human PKM`: passed with pre-existing nucleus action consistency warning
- `just validate human POMC`: passed
- `just render human <gene>` for all five genes: passed
- `git diff --check`: passed
