### PR TITLE
[codex] Add falcon deep research batch 6

### DIFF
--- a/genes/human/ATP7B/ATP7B-ai-review.html
+++ b/genes/human/ATP7B/ATP7B-ai-review.html
@@ -671,33 +671,33 @@
     <div class="header">
         <h1>ATP7B</h1>
         <div class="gene-info">
-            
+
             <div class="info-item">
-                
+
                 <span class="info-label">UniProt ID:</span>
                 <span>
                     <a href="https://www.uniprot.org/uniprotkb/P35670" target="_blank" class="term-link">
                         P35670
                     </a>
                 </span>
-                
+
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Organism:</span>
                 <span>Homo sapiens</span>
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
-                <span class="status-badge status-in-progress">
-                    IN PROGRESS
+                <span class="status-badge status-complete">
+                    COMPLETE
                 </span>
             </div>
-            
-            
+
+
         </div>
         <div style="margin-top: 1rem; text-align: center;">
             <a id="feedback-form-link"
@@ -728,7 +728,7 @@
         </div>
     </div>
 
-    
+
     <div class="description-card">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <h2>Gene Description</h2>
@@ -739,13 +739,13 @@
         </div>
         <p>ATP7B (copper-transporting ATPase 2) is a P1B-type ATPase (EC 7.2.2.8) predominantly expressed in hepatocytes. It has two main physiological roles: (1) biosynthetic copper delivery to cuproenzymes (particularly ceruloplasmin) at the trans-Golgi network, and (2) biliary copper excretion via copper-responsive vesicular trafficking. Under basal copper conditions, ATP7B resides in the TGN where it loads copper into the secretory pathway. When intracellular copper rises, ATP7B traffics to pericanalicular vesicles that sequester excess copper and subsequently undergo exocytosis to excrete copper into bile. This vesicular sequestration mechanism (not direct plasma membrane transport) is the primary route for biliary copper elimination. ATP7B contains six N-terminal heavy metal-associated (HMA) domains, each with a GMXCXXC copper-binding motif, eight transmembrane domains with a conserved CPC motif essential for transport, and cytoplasmic nucleotide-binding and phosphorylation domains. The copper chaperone ATOX1 delivers copper to ATP7B and stimulates its catalytic activity. Loss-of-function mutations cause Wilson disease (MIM:277900), an autosomal recessive disorder of hepatic copper accumulation leading to liver cirrhosis and neurological damage.</p>
     </div>
-    
 
-    
 
-    
 
-    
+
+
+
+
     <div class="section">
         <h2 class="section-title">Existing Annotations Review</h2>
         <table class="annotations-table">
@@ -758,43 +758,43 @@
                 </tr>
             </thead>
             <tbody>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140581" target="_blank" class="term-link">
                                     GO:0140581
                                 </a>
                             </span>
                             <span class="term-label">P-type monovalent copper transporter activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9837819" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:9837819
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Functional characterization of missense mutations in ATP7B: ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -806,77 +806,88 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IMP evidence from Forbes &amp; Cox (1998) demonstrating that mutation of the CPC motif abolishes copper transport, directly establishing ATP7B as a P-type copper transporter. This is the strongest experimental evidence for this term.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core molecular function of ATP7B. The CPC motif mutagenesis study directly demonstrates copper transport activity. This is the best evidence code for this annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9837819" target="_blank" class="term-link">
                                         PMID:9837819
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Mutation of the CPC motif resulted in a nonfunctional protein, which demonstrates that this motif is essential for copper transport by ATP7B.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/22240481" target="_blank" class="term-link">
                                         PMID:22240481
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Properties of ATP7B variants with pathogenic amino-acid substitution varied greatly even if substitutions were in the same functional domain. Some variants had complete loss of catalytic and transport activity, whereas others lost transport activity but retained phosphor-intermediate formation or had partial losses of activity.</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ATP7B/ATP7B-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ATP7B is the human Wilson disease protein, a P1B-1 copper-transporting P-type ATPase that transports Cu(I) and functions in hepatocytes to lower cytosolic copper and support cuproenzyme biosynthesis.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140581" target="_blank" class="term-link">
                                     GO:0140581
                                 </a>
                             </span>
                             <span class="term-label">P-type monovalent copper transporter activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -888,46 +899,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Phylogenetic inference consistent with direct experimental evidence. Redundant with the IMP annotation from PMID:9837819.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Redundant with the IMP evidence. IBA is consistent but adds no new information beyond the direct experimental demonstration.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140581" target="_blank" class="term-link">
                                     GO:0140581
                                 </a>
                             </span>
                             <span class="term-label">P-type monovalent copper transporter activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -939,57 +950,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Electronic annotation redundant with IMP evidence.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Redundant with IMP from PMID:9837819.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140581" target="_blank" class="term-link">
                                     GO:0140581
                                 </a>
                             </span>
                             <span class="term-label">P-type monovalent copper transporter activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">NAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/12763797" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:12763797
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Functional properties of the human copper-transporting ATPas...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1001,57 +1012,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> NAS from Tsivkovskii et al. (2002) on functional properties of ATP7B. Redundant with IMP evidence.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Redundant with IMP from PMID:9837819.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140581" target="_blank" class="term-link">
                                     GO:0140581
                                 </a>
                             </span>
                             <span class="term-label">P-type monovalent copper transporter activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16472602" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16472602
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     ATP7B mediates vesicular sequestration of copper: insight in...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1063,46 +1074,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS from Cater et al. (2006) vesicular sequestration study. Redundant with IMP evidence.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Redundant with IMP from PMID:9837819.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140581" target="_blank" class="term-link">
                                     GO:0140581
                                 </a>
                             </span>
                             <span class="term-label">P-type monovalent copper transporter activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-936895
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1114,46 +1125,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Reactome pathway annotation for ATP7B transporting Cu1+ to Golgi lumen. Redundant with IMP evidence.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Redundant with IMP from PMID:9837819.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005375" target="_blank" class="term-link">
                                     GO:0005375
                                 </a>
                             </span>
                             <span class="term-label">copper ion transmembrane transporter activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -1165,68 +1176,68 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Electronic annotation. This is a parent term of GO:0140581 (P-type monovalent copper transporter activity). The more specific term is preferred.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Redundant with the more specific GO:0140581. The parent term adds no information beyond what the child term already captures.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140581" target="_blank" class="term-link">
                                     P-type monovalent copper transporter activity
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005375" target="_blank" class="term-link">
                                     GO:0005375
                                 </a>
                             </span>
                             <span class="term-label">copper ion transmembrane transporter activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/26004889" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:26004889
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Functional characterization of new mutations in Wilson disea...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -1238,57 +1249,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA from functional characterization of ATP7B mutations using yeast complementation assay. Correct but less specific than GO:0140581.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The IDA evidence is strong but should use the more specific child term GO:0140581 (P-type monovalent copper transporter activity) since ATP7B is a P-type ATPase.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140581" target="_blank" class="term-link">
                                     P-type monovalent copper transporter activity
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019829" target="_blank" class="term-link">
                                     GO:0019829
                                 </a>
                             </span>
                             <span class="term-label">ATPase-coupled monoatomic cation transmembrane transporter activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1300,57 +1311,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Electronic annotation. Parent term of GO:0140581.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Overly general. Redundant with the more specific GO:0140581.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005507" target="_blank" class="term-link">
                                     GO:0005507
                                 </a>
                             </span>
                             <span class="term-label">copper ion binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/12029094" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:12029094
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Metallochaperone Atox1 transfers copper to the NH2-terminal ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1362,75 +1373,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA from Walker et al. (2002) demonstrating that ATOX1 transfers copper to ATP7B N-terminal domain in a saturable manner, and that copper binding stimulates catalytic activity.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Directly demonstrated copper binding to the N-terminal HMA domains. Core to ATP7B function as each of the six HMA domains binds Cu(I).
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/12029094" target="_blank" class="term-link">
                                         PMID:12029094
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">We demonstrate that Atox1 transfers copper to the purified amino-terminal domain of WNDP (N-WNDP) in a dose-dependent and saturable manner.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005507" target="_blank" class="term-link">
                                     GO:0005507
                                 </a>
                             </span>
                             <span class="term-label">copper ion binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/14709553" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:14709553
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Binding of copper(I) by the Wilson disease protein and its c...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1442,64 +1453,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA from Lutsenko group quantifying copper binding stoichiometry to ATP7B and its chaperone ATOX1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Provides additional quantitative evidence for copper binding. Confirms Cu(I) binding via six N-terminal HMA domains with CXXC motifs.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/14709553" target="_blank" class="term-link">
                                         PMID:14709553
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The WND and Menkes proteins are distinguished from other P-type ATPases by the presence of six soluble N-terminal metal-binding domains containing a conserved CXXC metal-binding motif.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005507" target="_blank" class="term-link">
                                     GO:0005507
                                 </a>
                             </span>
                             <span class="term-label">copper ion binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1511,46 +1522,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Phylogenetic inference consistent with IDA evidence.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Redundant with IDA evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005507" target="_blank" class="term-link">
                                     GO:0005507
                                 </a>
                             </span>
                             <span class="term-label">copper ion binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1562,57 +1573,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Electronic annotation redundant with IDA evidence.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Redundant with IDA from PMID:12029094.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005524" target="_blank" class="term-link">
                                     GO:0005524
                                 </a>
                             </span>
                             <span class="term-label">ATP binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16567646" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16567646
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Solution structure of the N-domain of Wilson disease protein...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1624,75 +1635,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA from Dmitriev &amp; Bhattacharjee (2006) NMR solution structure of the N-domain, showing distinct nucleotide-binding environment.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> ATP binding is essential for the catalytic cycle of this P-type ATPase. The N-domain structure reveals the nucleotide-binding site.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/16567646" target="_blank" class="term-link">
                                         PMID:16567646
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">the nucleotide coordination environment of ATP7B within this fold is different. The residues H1069, G1099, G1101, I1102, G1149, and N1150 conserved in the P(1B)-ATPase subfamily contribute to ATP binding.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005524" target="_blank" class="term-link">
                                     GO:0005524
                                 </a>
                             </span>
                             <span class="term-label">ATP binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/15205462" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:15205462
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The distinct functional properties of the nucleotide-binding...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -1704,46 +1715,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA from Tsivkovskii et al. (2004) analyzing nucleotide-binding domain properties and Wilson disease mutations affecting ATP binding.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Additional IDA evidence for ATP binding, confirms functional importance. Redundant with PMID:16567646.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005524" target="_blank" class="term-link">
                                     GO:0005524
                                 </a>
                             </span>
                             <span class="term-label">ATP binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -1755,46 +1766,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Electronic annotation redundant with IDA evidence.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Redundant with IDA from PMID:16567646.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000166" target="_blank" class="term-link">
                                     GO:0000166
                                 </a>
                             </span>
                             <span class="term-label">nucleotide binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1806,46 +1817,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Overly general parent term of GO:0005524 (ATP binding).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Redundant with the more specific GO:0005524 (ATP binding) which has IDA support.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016887" target="_blank" class="term-link">
                                     GO:0016887
                                 </a>
                             </span>
                             <span class="term-label">ATP hydrolysis activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -1857,46 +1868,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> ATP hydrolysis is integral to the P-type ATPase catalytic cycle. However, this is implicit in the GO:0140581 (P-type monovalent copper transporter activity) annotation.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> While correct, the ATPase activity is part of the copper transport mechanism already captured by GO:0140581. Acceptable as supplementary.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046872" target="_blank" class="term-link">
                                     GO:0046872
                                 </a>
                             </span>
                             <span class="term-label">metal ion binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1908,57 +1919,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Overly general parent of GO:0005507 (copper ion binding).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Too general. The specific copper ion binding term (GO:0005507) with IDA evidence is preferred.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/12968035" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:12968035
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The copper toxicosis gene product Murr1 directly interacts w...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1970,75 +1981,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI for interaction with COMMD1/MURR1. The term &#34;protein binding&#34; is uninformative per curation guidelines.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Per GO curation guidelines, &#34;protein binding&#34; (GO:0005515) is too vague and does not convey the specific biological role of the interaction. COMMD1 interaction is relevant to copper homeostasis and ATP7B stability/degradation, but a more specific MF term should be used if available.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/12968035" target="_blank" class="term-link">
                                         PMID:12968035
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">the Wilson disease protein directly interacts with the human homologue of Murr1 in vitro and in vivo and that this interaction is mediated via the copper binding, amino terminus of this ATPase.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17919502" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:17919502
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Distinct Wilson&#39;s disease mutations in ATP7B are associated ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2050,75 +2061,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI for interactions with COMMD1 and ATOX1. Uninformative term.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> &#34;Protein binding&#34; is uninformative. The ATOX1 interaction represents copper chaperone-mediated metal transfer, and COMMD1 interaction affects ATP7B stability.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/17919502" target="_blank" class="term-link">
                                         PMID:17919502
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Four WD patient-derived mutations in this region of ATP7B significantly increased its binding to COMMD1. Two of these mutations also resulted in mislocalization and increased degradation rate of ATP7B.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16554302" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16554302
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Copper-dependent interaction of dynactin subunit p62 with th...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2130,57 +2141,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI for copper-dependent interaction with DCTN4 (dynactin p62). Uninformative term.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> &#34;Protein binding&#34; is uninformative. The DCTN4 interaction is copper-dependent and likely facilitates retrograde trafficking.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16884690" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16884690
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Copper-dependent interaction of glutaredoxin with the N term...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2192,57 +2203,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI for copper-dependent interaction with glutaredoxin (GRX1). Uninformative term.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> &#34;Protein binding&#34; is uninformative. GRX1 interaction may facilitate copper binding by reducing disulfide bridges in HMA domains.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16676348" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16676348
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A new hepatocytic isoform of PLZF lacking the BTB domain int...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2254,57 +2265,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI for interaction with ZBTB16/PLZF hepatocytic isoform. Uninformative term.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> &#34;Protein binding&#34; is uninformative. The PLZF interaction connects ATP7B to ERK signaling but the functional significance is less clear.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006825" target="_blank" class="term-link">
                                     GO:0006825
                                 </a>
                             </span>
                             <span class="term-label">copper ion transport</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/26004889" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:26004889
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Functional characterization of new mutations in Wilson disea...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2316,75 +2327,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA from yeast complementation assay showing ATP7B variants affect copper transport.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core biological process of ATP7B. Directly demonstrated by functional assays.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/26004889" target="_blank" class="term-link">
                                         PMID:26004889
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Expression of human wild type ATP7B gene in ccc2Δ mutant yeast restored the growth deficiency and copper transport activity; however, expression of the mutant forms did not restore the copper transport functions and only partially supported the cell growth.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006825" target="_blank" class="term-link">
                                     GO:0006825
                                 </a>
                             </span>
                             <span class="term-label">copper ion transport</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IGI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/26004889" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:26004889
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Functional characterization of new mutations in Wilson disea...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -2396,57 +2407,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IGI evidence from same study, likely from genetic interaction data in yeast.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Redundant with IDA from same publication.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006825" target="_blank" class="term-link">
                                     GO:0006825
                                 </a>
                             </span>
                             <span class="term-label">copper ion transport</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9837819" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:9837819
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Functional characterization of missense mutations in ATP7B: ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -2458,57 +2469,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IMP from CPC motif mutagenesis study showing loss of copper transport.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Strong evidence but redundant with IDA from PMID:26004889 for the same term.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006825" target="_blank" class="term-link">
                                     GO:0006825
                                 </a>
                             </span>
                             <span class="term-label">copper ion transport</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IGI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/12572677" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:12572677
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Copper-induced trafficking of the cU-ATPases: a key mechanis...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -2520,46 +2531,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IGI from Schaefer &amp; Bhatt (2003) on copper-induced trafficking of Cu-ATPases.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Redundant with other evidence for this term.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0060003" target="_blank" class="term-link">
                                     GO:0060003
                                 </a>
                             </span>
                             <span class="term-label">copper ion export</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2571,77 +2582,88 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Phylogenetic inference that ATP7B mediates copper ion export. This is the correct directional term - ATP7B exports copper out of the cytoplasm into the Golgi lumen and vesicles.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Correct and important annotation. ATP7B mediates copper export from the cytoplasm into the TGN lumen (for ceruloplasmin biosynthesis) and into vesicles (for biliary excretion). Well supported by literature.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/16472602" target="_blank" class="term-link">
                                         PMID:16472602
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">This report provides compelling evidence that the primary mechanism of biliary copper excretion involves ATP7B-mediated vesicular sequestration of copper rather than direct copper translocation across the canalicular membrane.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/12763797" target="_blank" class="term-link">
                                         PMID:12763797
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Wilson&#39;s disease protein (WNDP) is a copper-transporting P(1)-type ATPase which plays a key role in normal distribution of copper in a number of tissues, particularly in the liver and the brain.</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ATP7B/ATP7B-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ATP7B has two principal hepatic functions: loading copper into the secretory pathway for ceruloplasmin metallation and exporting excess copper into bile.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015677" target="_blank" class="term-link">
                                     GO:0015677
                                 </a>
                             </span>
                             <span class="term-label">copper ion import</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -2653,77 +2675,77 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> INCORRECT annotation. ATP7B mediates copper EXPORT (into Golgi/vesicles/bile), NOT import into the cell. Copper import into cells is performed by CTR1/SLC31A1. The IBA phylogenetic inference has incorrectly assigned the direction of transport.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> ATP7B is a copper exporter, not importer. It transports copper from the cytoplasm into the Golgi lumen and vesicles. Copper import into cells is mediated by CTR1 (SLC31A1). This is a fundamental error in the phylogenetic inference.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/16472602" target="_blank" class="term-link">
                                         PMID:16472602
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The Wilson protein (ATP7B) regulates levels of systemic copper by excreting excess copper into bile.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/12763797" target="_blank" class="term-link">
                                         PMID:12763797
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Wilson&#39;s disease protein (WNDP) is a copper-transporting P(1)-type ATPase which plays a key role in normal distribution of copper in a number of tissues, particularly in the liver and the brain.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006878" target="_blank" class="term-link">
                                     GO:0006878
                                 </a>
                             </span>
                             <span class="term-label">intracellular copper ion homeostasis</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2735,75 +2757,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> ATP7B is central to intracellular copper homeostasis in hepatocytes, maintaining copper balance through biosynthetic copper loading and biliary excretion.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core biological process. ATP7B directly maintains copper homeostasis by exporting excess copper. Loss of function causes copper accumulation (Wilson disease).
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/16472602" target="_blank" class="term-link">
                                         PMID:16472602
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The Wilson protein (ATP7B) regulates levels of systemic copper by excreting excess copper into bile.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006878" target="_blank" class="term-link">
                                     GO:0006878
                                 </a>
                             </span>
                             <span class="term-label">intracellular copper ion homeostasis</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16554302" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16554302
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Copper-dependent interaction of dynactin subunit p62 with th...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -2815,57 +2837,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS from DCTN4 interaction study, which discusses ATP7B role in copper homeostasis.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Redundant with IBA annotation for same term.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1990880" target="_blank" class="term-link">
                                     GO:1990880
                                 </a>
                             </span>
                             <span class="term-label">cellular detoxification of copper ion</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16472602" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16472602
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     ATP7B mediates vesicular sequestration of copper: insight in...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2877,75 +2899,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA from Cater et al. (2006) demonstrating ATP7B mediates vesicular sequestration of excess copper for subsequent exocytosis.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Directly demonstrated by immunofluorescence and copper accumulation studies in hepatoma cells. The vesicular sequestration mechanism specifically serves copper detoxification.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/16472602" target="_blank" class="term-link">
                                         PMID:16472602
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Expression of wild-type and mutant ATP7B caused Chinese hamster ovary cells to accumulate copper in vesicles, which subsequently undergo exocytosis, releasing copper across the plasma membrane.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1990961" target="_blank" class="term-link">
                                     GO:1990961
                                 </a>
                             </span>
                             <span class="term-label">xenobiotic detoxification by transmembrane export across the plasma membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IC</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9837819" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:9837819
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Functional characterization of missense mutations in ATP7B: ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -2957,64 +2979,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> INCORRECT mechanism. ATP7B does NOT export copper directly across the plasma membrane. Per PMID:16472602, ATP7B mediates vesicular sequestration of copper, which subsequently undergoes exocytosis. Furthermore, copper is an essential element, not a xenobiotic.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Two errors: (1) ATP7B uses vesicular sequestration, not direct plasma membrane export. Cater et al. (2006) explicitly showed ATP7B traffics to pericanalicular vesicles, NOT the canalicular membrane. (2) Copper is an endogenous essential metal, not a xenobiotic. The correct term is GO:1990880 (cellular detoxification of copper ion) which is already annotated with IDA evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/16472602" target="_blank" class="term-link">
                                         PMID:16472602
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">In HepG2 cells, elevated copper levels stimulated trafficking of ATP7B to pericanalicular vesicles and not to the canalicular membrane as previously reported.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006812" target="_blank" class="term-link">
                                     GO:0006812
                                 </a>
                             </span>
                             <span class="term-label">monoatomic cation transport</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -3026,46 +3048,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Overly general parent of copper ion transport.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Too general. The specific copper ion transport term (GO:0006825) with IDA evidence is preferred.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034220" target="_blank" class="term-link">
                                     GO:0034220
                                 </a>
                             </span>
                             <span class="term-label">monoatomic ion transmembrane transport</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-936837
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -3077,57 +3099,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Reactome pathway annotation for ion transport by P-type ATPases. General term.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Correct but overly general. Subsumed by more specific copper transport annotations.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046688" target="_blank" class="term-link">
                                     GO:0046688
                                 </a>
                             </span>
                             <span class="term-label">response to copper ion</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16472602" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16472602
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     ATP7B mediates vesicular sequestration of copper: insight in...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3139,75 +3161,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA showing ATP7B undergoes copper-responsive trafficking from TGN to pericanalicular vesicles in HepG2 cells.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The copper-responsive trafficking of ATP7B is a well-established phenomenon central to its homeostatic function. Elevated copper triggers relocalization from TGN to vesicles.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/16472602" target="_blank" class="term-link">
                                         PMID:16472602
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">In HepG2 cells, elevated copper levels stimulated trafficking of ATP7B to pericanalicular vesicles and not to the canalicular membrane as previously reported.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046688" target="_blank" class="term-link">
                                     GO:0046688
                                 </a>
                             </span>
                             <span class="term-label">response to copper ion</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16939419" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16939419
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Copper binding to the N-terminal metal-binding sites or the ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -3219,64 +3241,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA from Cater et al. (2006) showing copper-induced trafficking occurs even without N-terminal metal-binding sites or CPC motif.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Provides mechanistic insight but redundant with PMID:16472602 IDA for the same term.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/16939419" target="_blank" class="term-link">
                                         PMID:16939419
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Copper binding to the N-terminal metal-binding sites or the CPC motif is not essential for copper-induced trafficking of the human Wilson protein (ATP7B).</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046688" target="_blank" class="term-link">
                                     GO:0046688
                                 </a>
                             </span>
                             <span class="term-label">response to copper ion</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -3288,57 +3310,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Electronic annotation redundant with IDA evidence.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Redundant with IDA from PMID:16472602.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046688" target="_blank" class="term-link">
                                     GO:0046688
                                 </a>
                             </span>
                             <span class="term-label">response to copper ion</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/15269005" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:15269005
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Signals regulating trafficking of Menkes (MNK; ATP7A) copper...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -3350,57 +3372,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> WRONG GENE. PMID:15269005 (Greenough et al. 2004) is about ATP7A (Menkes protein) trafficking in MDCK cells, NOT ATP7B. This annotation has been mis-attributed.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> PMID:15269005 studied ATP7A (Menkes), not ATP7B. The paper title explicitly states &#34;Signals regulating trafficking of Menkes (MNK; ATP7A) copper-translocating P-type ATPase in polarized MDCK cells.&#34; This is a mis-annotation error.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032588" target="_blank" class="term-link">
                                     GO:0032588
                                 </a>
                             </span>
                             <span class="term-label">trans-Golgi network membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9837819" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:9837819
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Functional characterization of missense mutations in ATP7B: ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3412,64 +3434,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA from Forbes &amp; Cox (1998) showing ATP7B localizes to TGN membrane under basal copper conditions.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Well-established primary localization of ATP7B. The TGN is where ATP7B performs its biosynthetic role of loading copper into ceruloplasmin and other cuproenzymes.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9837819" target="_blank" class="term-link">
                                         PMID:9837819
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Wilson disease is an autosomal recessive disorder of copper transport that causes hepatic and/or neurological disease resulting from copper accumulation in the liver and brain. The protein defective in this disorder is a putative copper-transporting P-type ATPase, ATP7B.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032588" target="_blank" class="term-link">
                                     GO:0032588
                                 </a>
                             </span>
                             <span class="term-label">trans-Golgi network membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -3481,57 +3503,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Electronic annotation redundant with IDA evidence.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Redundant with IDA from PMID:9837819.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005802" target="_blank" class="term-link">
                                     GO:0005802
                                 </a>
                             </span>
                             <span class="term-label">trans-Golgi network</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16472602" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16472602
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     ATP7B mediates vesicular sequestration of copper: insight in...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3543,64 +3565,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA from Cater et al. (2006) showing ATP7B localizes to TGN in HepG2 hepatoma cells under basal conditions.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Confirmed TGN localization using endogenous ATP7B in hepatoma cells, which is more physiologically relevant than overexpression systems.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/16472602" target="_blank" class="term-link">
                                         PMID:16472602
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Immunofluorescence microscopy was used to investigate the effect of copper concentration on the localization of endogenous ATP7B in HepG2 cells.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005802" target="_blank" class="term-link">
                                     GO:0005802
                                 </a>
                             </span>
                             <span class="term-label">trans-Golgi network</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -3612,57 +3634,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Electronic annotation from Ensembl Compara orthology transfer.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Redundant with IDA from PMID:16472602.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005802" target="_blank" class="term-link">
                                     GO:0005802
                                 </a>
                             </span>
                             <span class="term-label">trans-Golgi network</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/15269005" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:15269005
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Signals regulating trafficking of Menkes (MNK; ATP7A) copper...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -3674,46 +3696,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> WRONG GENE. PMID:15269005 is about ATP7A (Menkes), not ATP7B. Mis-attributed annotation.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> PMID:15269005 studied ATP7A trafficking in MDCK cells. While ATP7B does localize to TGN (confirmed by other papers), this specific evidence is incorrectly attributed.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005794" target="_blank" class="term-link">
                                     GO:0005794
                                 </a>
                             </span>
                             <span class="term-label">Golgi apparatus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000052
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -3725,46 +3747,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA from immunofluorescence curation. Less specific than TGN membrane.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Correct but less specific than GO:0032588 (trans-Golgi network membrane). Acceptable as supporting evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005794" target="_blank" class="term-link">
                                     GO:0005794
                                 </a>
                             </span>
                             <span class="term-label">Golgi apparatus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -3776,46 +3798,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Electronic annotation, less specific than TGN.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Redundant with more specific TGN annotations.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000139" target="_blank" class="term-link">
                                     GO:0000139
                                 </a>
                             </span>
                             <span class="term-label">Golgi membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -3827,46 +3849,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Electronic annotation. Less specific than GO:0032588 (TGN membrane).
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Redundant with the more specific GO:0032588 (trans-Golgi network membrane) which has IDA support.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000139" target="_blank" class="term-link">
                                     GO:0000139
                                 </a>
                             </span>
                             <span class="term-label">Golgi membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-936895
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -3878,57 +3900,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Reactome annotation. Less specific than TGN membrane.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Redundant with more specific TGN membrane annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031410" target="_blank" class="term-link">
                                     GO:0031410
                                 </a>
                             </span>
                             <span class="term-label">cytoplasmic vesicle</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16472602" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16472602
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     ATP7B mediates vesicular sequestration of copper: insight in...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3940,75 +3962,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA showing ATP7B traffics to pericanalicular cytoplasmic vesicles under elevated copper conditions.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Copper-induced vesicular localization is essential for the biliary excretion function of ATP7B. Well demonstrated in HepG2 cells.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/16472602" target="_blank" class="term-link">
                                         PMID:16472602
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Mutation of an endocytic retrieval signal in ATP7B caused the protein to constitutively localize to vesicles and not to the plasma membrane, suggesting that a vesicular compartment(s) is the final trafficking destination for ATP7B.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005770" target="_blank" class="term-link">
                                     GO:0005770
                                 </a>
                             </span>
                             <span class="term-label">late endosome</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/15681833" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:15681833
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The Wilson disease protein ATP7B resides in the late endosom...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -4020,64 +4042,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA from Harada et al. (2005) reporting ATP7B co-localizes with Rab7 and NPC1 in late endosomes. This represents a minority view in the field; most groups report TGN as the primary compartment.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> While experimentally supported, this may represent a post-Golgi trafficking intermediate rather than the primary steady-state compartment. The TGN model is more widely accepted and consistent with the ceruloplasmin biosynthesis role.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/15681833" target="_blank" class="term-link">
                                         PMID:15681833
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">We have confirmed that ATP7B is a late endosome-associated membrane protein.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005770" target="_blank" class="term-link">
                                     GO:0005770
                                 </a>
                             </span>
                             <span class="term-label">late endosome</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -4089,57 +4111,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Electronic annotation consistent with Harada study.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> See IDA late endosome annotation above.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0048471" target="_blank" class="term-link">
                                     GO:0048471
                                 </a>
                             </span>
                             <span class="term-label">perinuclear region of cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16939419" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16939419
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Copper binding to the N-terminal metal-binding sites or the ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -4151,46 +4173,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA showing ATP7B at the perinuclear region, consistent with TGN localization.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The TGN is perinuclear, so this is consistent but less informative than the TGN annotation. Acceptable as supporting.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
                                     GO:0005886
                                 </a>
                             </span>
                             <span class="term-label">plasma membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -4202,75 +4224,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IBA phylogenetic inference. QUESTIONABLE for ATP7B. Unlike ATP7A which traffics to the basolateral plasma membrane, ATP7B traffics to pericanalicular vesicles, NOT the plasma membrane.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> ATP7B does not localize to the plasma membrane. Per PMID:16472602, ATP7B traffics to pericanalicular vesicles and NOT to the canalicular membrane. Mutation of the endocytic retrieval signal causes constitutive vesicular localization, not PM localization. The IBA inference likely transferred from ATP7A which does traffic to PM.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/16472602" target="_blank" class="term-link">
                                         PMID:16472602
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Mutation of an endocytic retrieval signal in ATP7B caused the protein to constitutively localize to vesicles and not to the plasma membrane, suggesting that a vesicular compartment(s) is the final trafficking destination for ATP7B.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
                                     GO:0005886
                                 </a>
                             </span>
                             <span class="term-label">plasma membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/8298641" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:8298641
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The Wilson disease gene is a copper transporting ATPase with...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -4282,57 +4304,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TAS from the original 1993 Wilson disease gene cloning paper (Tanzi et al.). This predates the detailed trafficking studies and was based on the assumption that a transmembrane transporter must be at the PM.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Outdated annotation from 1993 before ATP7B trafficking was understood. Subsequent studies (PMID:16472602, PMID:16939419) have definitively shown ATP7B traffics to TGN and vesicles, not the plasma membrane.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016323" target="_blank" class="term-link">
                                     GO:0016323
                                 </a>
                             </span>
                             <span class="term-label">basolateral plasma membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/15269005" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:15269005
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Signals regulating trafficking of Menkes (MNK; ATP7A) copper...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -4344,46 +4366,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> WRONG GENE. PMID:15269005 is about ATP7A (Menkes protein) in polarized MDCK cells. ATP7A traffics to the basolateral membrane; ATP7B traffics to the apical/canalicular side via vesicular intermediates.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Mis-attributed annotation. PMID:15269005 studied ATP7A (Menkes), not ATP7B. The paper explicitly describes &#34;Menkes (MNK; ATP7A)&#34; in the title. Basolateral PM is the correct localization for ATP7A but incorrect for ATP7B, which traffics to apical/pericanalicular vesicles.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
                                     GO:0016020
                                 </a>
                             </span>
                             <span class="term-label">membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -4395,57 +4417,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Very generic membrane annotation.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Too general. More specific membrane annotations (TGN membrane, cytoplasmic vesicle) are available with IDA support.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
                                     GO:0016020
                                 </a>
                             </span>
                             <span class="term-label">membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19946888" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19946888
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Defining the membrane proteome of NK cells.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -4457,46 +4479,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HDA from NK cell membrane proteome study. Identifies ATP7B as a membrane protein, which is correct but uninformative.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Generic membrane annotation. The HDA from an NK cell proteomics study is not informative for ATP7B&#39;s specific subcellular localization.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -4508,46 +4530,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Electronic annotation mapping from UniProt subcellular location. May relate to isoform 2 which is cytoplasmic.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This may refer to isoform 2 (P35670-2) which lacks transmembrane domains and is cytoplasmic. Acceptable as a general annotation but isoform-specificity should be noted.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
                                     GO:0005739
                                 </a>
                             </span>
                             <span class="term-label">mitochondrion</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -4559,57 +4581,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Electronic annotation from UniProt mapping. Based on the WND/140 kDa proteolytic fragment reported by one group (PMID:9600907). Not the primary localization of full-length ATP7B.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The mitochondrial localization was reported for a 140 kDa N-terminally cleaved fragment, not full-length ATP7B. This finding (PMID:9600907) has not been widely reproduced and does not reflect the primary subcellular localization of the protein.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
                                     GO:0005739
                                 </a>
                             </span>
                             <span class="term-label">mitochondrion</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HTP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:34800366
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Quantitative high-confidence human mitochondrial proteome an...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -4621,788 +4643,1442 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HTP from large-scale mitochondrial proteomics study. May represent contamination or the cleaved fragment.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> High-throughput proteomics can detect contaminating proteins or low-abundance fragments. The primary localization of ATP7B is TGN, not mitochondria. This HTP finding is inconsistent with the extensive cell biology literature.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
             </tbody>
         </table>
     </div>
-    
 
-    
 
-    
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>ATP7B is a P1B-type Cu(I)-transporting ATPase whose core molecular function is ATP-coupled movement of copper out of the cytosol into the secretory pathway and copper-responsive vesicular/apical routes in hepatocytes. This activity supports both cuproenzyme metallation and detoxifying copper excretion.</h3>
+                <span class="vote-buttons" data-g="P35670" data-a="FUNCTION: ATP7B is a P1B-type Cu(I)-transporting ATPase whos..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140581" target="_blank" class="term-link">
+                            P-type monovalent copper transporter activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006825" target="_blank" class="term-link">
+                                copper ion transport
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0060003" target="_blank" class="term-link">
+                                copper ion export
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032588" target="_blank" class="term-link">
+                                trans-Golgi network membrane
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031410" target="_blank" class="term-link">
+                                cytoplasmic vesicle
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>ATP7B contains N-terminal metal-binding domains with CXXC motifs that bind copper delivered by ATOX1 and regulate copper transfer to the P-type ATPase core. Copper binding is mechanistically coupled to ATP7B transport and trafficking, but the transporter activity is the primary core function.</h3>
+                <span class="vote-buttons" data-g="P35670" data-a="FUNCTION: ATP7B contains N-terminal metal-binding domains wi..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005507" target="_blank" class="term-link">
+                            copper ion binding
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006825" target="_blank" class="term-link">
+                                copper ion transport
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032588" target="_blank" class="term-link">
+                                trans-Golgi network membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+        </div>
+
+    </div>
+
+
+
     <div class="section">
         <h2 class="section-title collapsible">References</h2>
         <div class="collapse-content">
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
+                        file:human/ATP7B/ATP7B-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research report for ATP7B</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Falcon corroborates ATP7B as a hepatocyte P1B-type Cu(I)-transporting ATPase that loads copper into the secretory pathway and supports biliary copper excretion through copper-responsive trafficking.</div>
+
+                        <div class="finding-text">"ATP7B has two principal hepatic functions: loading copper into the secretory pathway for ceruloplasmin metallation and exporting excess copper into bile."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
                             GO_REF:0000002
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
                             GO_REF:0000033
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Annotation inferences using phylogenetic trees</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
                             GO_REF:0000044
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000052.md" target="_blank" class="term-link">
                             GO_REF:0000052
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on curation of immunofluorescence data</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000107.md" target="_blank" class="term-link">
                             GO_REF:0000107
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Automatic transfer of experimentally verified manual GO annotation data to orthologs using Ensembl Compara</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
                             GO_REF:0000117
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
                             GO_REF:0000120
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/8298641" target="_blank" class="term-link">
                             PMID:8298641
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The Wilson disease gene is a copper transporting ATPase with homology to the Menkes disease gene.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Original identification of ATP7B as the Wilson disease gene with 76% amino acid homology to ATP7A (Menkes disease gene).</div>
-                        
+
                         <div class="finding-text">"The predicted functional properties of the pWD gene together with its strong homology to Mc1, genetic mapping data and identification of four independent disease-specific mutations, provide convincing evidence that pWD is the Wilson disease gene."</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/9837819" target="_blank" class="term-link">
                             PMID:9837819
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Functional characterization of missense mutations in ATP7B: Wilson disease mutation or normal variant?</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">CPC motif is essential for ATP7B copper transport activity.</div>
-                        
+
                         <div class="finding-text">"Mutation of the CPC motif resulted in a nonfunctional protein, which demonstrates that this motif is essential for copper transport by ATP7B."</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/12029094" target="_blank" class="term-link">
                             PMID:12029094
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Metallochaperone Atox1 transfers copper to the NH2-terminal domain of the Wilson&#39;s disease protein and regulates its catalytic activity.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">ATOX1 transfers copper to ATP7B and stimulates its catalytic activity.</div>
-                        
+
                         <div class="finding-text">"We demonstrate that Atox1 transfers copper to the purified amino-terminal domain of WNDP (N-WNDP) in a dose-dependent and saturable manner."</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/12572677" target="_blank" class="term-link">
                             PMID:12572677
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Copper-induced trafficking of the cU-ATPases: a key mechanism for copper homeostasis.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Copper-induced trafficking of Cu-ATPases is a key homeostatic mechanism.</div>
-                        
+
                         <div class="finding-text">"In cells cultured in low copper concentration MNK and WND localize to the transGolgi network but in high copper relocalize either to the plasma membrane (MNK) or a vesicular compartment (WND)."</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/12763797" target="_blank" class="term-link">
                             PMID:12763797
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Functional properties of the human copper-transporting ATPase ATP7B (the Wilson&#39;s disease protein) and regulation by metallochaperone Atox1.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">ATP7B catalytic activity is stimulated by copper and ATOX1.</div>
-                        
+
                         <div class="finding-text">"Wilson&#39;s disease protein (WNDP) is a copper-transporting P(1)-type ATPase which plays a key role in normal distribution of copper in a number of tissues, particularly in the liver and the brain."</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/12968035" target="_blank" class="term-link">
                             PMID:12968035
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The copper toxicosis gene product Murr1 directly interacts with the Wilson disease protein.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">COMMD1 (Murr1) directly interacts with ATP7B.</div>
-                        
+
                         <div class="finding-text">"the Wilson disease protein directly interacts with the human homologue of Murr1 in vitro and in vivo and that this interaction is mediated via the copper binding, amino terminus of this ATPase."</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/14709553" target="_blank" class="term-link">
                             PMID:14709553
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Binding of copper(I) by the Wilson disease protein and its copper chaperone.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">ATP7B binds Cu(I) via six N-terminal HMA domains with CXXC motifs.</div>
-                        
+
                         <div class="finding-text">"The WND and Menkes proteins are distinguished from other P-type ATPases by the presence of six soluble N-terminal metal-binding domains containing a conserved CXXC metal-binding motif."</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/15205462" target="_blank" class="term-link">
                             PMID:15205462
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The distinct functional properties of the nucleotide-binding domain of ATP7B, the human copper-transporting ATPase.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Wilson disease mutations affect ATP binding and catalytic activity.</div>
-                        
+
                         <div class="finding-text">"Mutations of the invariant WNDP residues E1064A and H1069Q drastically reduce nucleotide affinities, pointing to the likely role of these residues in nucleotide coordination."</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/15269005" target="_blank" class="term-link">
                             PMID:15269005
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Signals regulating trafficking of Menkes (MNK; ATP7A) copper-translocating P-type ATPase in polarized MDCK cells.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">This paper is about ATP7A (Menkes), NOT ATP7B. Annotations attributed to ATP7B from this paper are mis-annotations.</div>
-                        
+
                         <div class="finding-text">"we demonstrate that MNK relocalizes from the Golgi to the basolateral (BL) membrane under elevated copper conditions."</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/15681833" target="_blank" class="term-link">
                             PMID:15681833
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The Wilson disease protein ATP7B resides in the late endosomes with Rab7 and the Niemann-Pick C1 protein.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">ATP7B co-localizes with Rab7 and NPC1 in late endosomes (minority view).</div>
-                        
+
                         <div class="finding-text">"We have confirmed that ATP7B is a late endosome-associated membrane protein."</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/16472602" target="_blank" class="term-link">
                             PMID:16472602
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">ATP7B mediates vesicular sequestration of copper: insight into biliary copper excretion.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">ATP7B mediates copper excretion via vesicular sequestration, not direct plasma membrane transport.</div>
-                        
+
                         <div class="finding-text">"In HepG2 cells, elevated copper levels stimulated trafficking of ATP7B to pericanalicular vesicles and not to the canalicular membrane as previously reported."</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Vesicles, not plasma membrane, are the final trafficking destination for ATP7B.</div>
-                        
+
                         <div class="finding-text">"Mutation of an endocytic retrieval signal in ATP7B caused the protein to constitutively localize to vesicles and not to the plasma membrane, suggesting that a vesicular compartment(s) is the final trafficking destination for ATP7B."</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/16554302" target="_blank" class="term-link">
                             PMID:16554302
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Copper-dependent interaction of dynactin subunit p62 with the N terminus of ATP7B but not ATP7A.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">DCTN4 (p62) interacts specifically with ATP7B N-terminus in a copper-dependent manner.</div>
-                        
+
                         <div class="finding-text">"The dynactin complex binds cargo, such as vesicles and organelles, to cytoplasmic dynein for retrograde microtubule-mediated trafficking and could feasibly be involved in the copper-regulated trafficking of ATP7B."</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/16567646" target="_blank" class="term-link">
                             PMID:16567646
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Solution structure of the N-domain of Wilson disease protein: distinct nucleotide-binding environment and effects of disease mutations.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">NMR structure reveals distinct nucleotide-binding environment in ATP7B N-domain.</div>
-                        
+
                         <div class="finding-text">"the nucleotide coordination environment of ATP7B within this fold is different. The residues H1069, G1099, G1101, I1102, G1149, and N1150 conserved in the P(1B)-ATPase subfamily contribute to ATP binding."</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/16676348" target="_blank" class="term-link">
                             PMID:16676348
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A new hepatocytic isoform of PLZF lacking the BTB domain interacts with ATP7B, the Wilson disease protein, and positively regulates ERK signal transduction.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Hepatocytic ZBTB16/PLZF isoform interacts with ATP7B C-terminus.</div>
-                        
+
                         <div class="finding-text">"These data suggest the existence of a mechanism that regulates ERK signaling via the C-terminus of ATP7B and the ATP7B-interacting hepatocytic PLZF."</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/16884690" target="_blank" class="term-link">
                             PMID:16884690
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Copper-dependent interaction of glutaredoxin with the N termini of the copper-ATPases (ATP7A and ATP7B) defective in Menkes and Wilson diseases.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">GRX1 interacts with ATP7B N-terminus in a copper-dependent manner.</div>
-                        
+
                         <div class="finding-text">"We propose that GRX1 is essential for ATPase function and catalyses either the reduction of intramolecular disulphide bonds or the deglutathionylation of the cysteine residues within the CxxC motifs to facilitate copper-binding for subsequent transport."</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/16939419" target="_blank" class="term-link">
                             PMID:16939419
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Copper binding to the N-terminal metal-binding sites or the CPC motif is not essential for copper-induced trafficking of the human Wilson protein (ATP7B).</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">ATP7B copper-induced trafficking is coupled to catalytic cycle, not direct copper binding.</div>
-                        
+
                         <div class="finding-text">"ATP7B trafficking is regulated with its copper-translocation cycle, with cytosolic vesicular localization associated with the acyl-phosphate intermediate."</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/17919502" target="_blank" class="term-link">
                             PMID:17919502
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Distinct Wilson&#39;s disease mutations in ATP7B are associated with enhanced binding to COMMD1 and reduced stability of ATP7B.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Wilson disease mutations enhance COMMD1 binding and reduce ATP7B stability.</div>
-                        
+
                         <div class="finding-text">"Four WD patient-derived mutations in this region of ATP7B significantly increased its binding to COMMD1. Two of these mutations also resulted in mislocalization and increased degradation rate of ATP7B."</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/19946888" target="_blank" class="term-link">
                             PMID:19946888
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Defining the membrane proteome of NK cells.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">ATP7B detected in NK cell membrane proteomics.</div>
-                        
+
                         <div class="finding-text">"Mass spectrometric analysis identified 1843 proteins with high confidence scores."</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/22240481" target="_blank" class="term-link">
                             PMID:22240481
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Diverse functional properties of Wilson disease ATP7B variants.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Comprehensive functional characterization of 27 Wilson disease variants.</div>
-                        
+
                         <div class="finding-text">"Properties of ATP7B variants with pathogenic amino-acid substitution varied greatly even if substitutions were in the same functional domain. Some variants had complete loss of catalytic and transport activity, whereas others lost transport activity but retained phosphor-intermediate formation or had partial losses of activity."</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/26004889" target="_blank" class="term-link">
                             PMID:26004889
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Functional characterization of new mutations in Wilson disease gene (ATP7B) using the yeast model.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Yeast complementation demonstrates ATP7B copper transport activity.</div>
-                        
+
                         <div class="finding-text">"Expression of human wild type ATP7B gene in ccc2Δ mutant yeast restored the growth deficiency and copper transport activity; however, expression of the mutant forms did not restore the copper transport functions and only partially supported the cell growth."</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link">
                             PMID:34800366
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Quantitative high-confidence human mitochondrial proteome and its dynamics in cellular context.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">ATP7B detected in high-throughput mitochondrial proteomics.</div>
-                        
+
                         <div class="finding-text">"We classified &gt;8,000 proteins in mitochondrial preparations of human cells and defined a mitochondrial high-confidence proteome of &gt;1,100 proteins (MitoCoP)."</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-936837
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Ion transport by P-type ATPases</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">ATP7B is part of the P-type ATPase ion transport pathway.</div>
-                        
+
                         <div class="finding-text">"The P-type ATPases (E1-E2 ATPases) are a large group of evolutionarily related ion pumps that are found in bacteria, archaea  and eukaryotes."</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-936895
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">ATP7B transports cytosolic Cu1+ to Golgi lumen</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">ATP7B transports Cu(I) from cytosol to Golgi lumen coupled to ATP hydrolysis.</div>
-                        
+
                         <div class="finding-text">"ATP7B resides on the trans-Golgi membrane where it it thought to sequester copper from the cytosol into the golgi (Yang et al, 1997)."</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
         </div>
     </div>
-    
 
 
-    
 
-    
 
-    
+
+
+
+
 
     <!-- Computational Predictions Section -->
-    
+
 
     <!-- Additional Documentation Sections -->
-    
+
     <div class="section">
         <h2 class="section-title">📚 Additional Documentation</h2>
-        
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Deep Research Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(ATP7B-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P35670" data-a="DOC: Deep Research Falcon" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <hr />
+<p>provider: falcon<br />
+model: Edison Scientific Literature<br />
+cached: false<br />
+start_time: '2026-05-11T02:08:36.993256'<br />
+end_time: '2026-05-11T02:26:19.698530'<br />
+duration_seconds: 1062.71<br />
+template_file: templates/gene_research_go_focused.md<br />
+template_variables:<br />
+  organism: human<br />
+  gene_id: ATP7B<br />
+  gene_symbol: ATP7B<br />
+  uniprot_accession: P35670<br />
+  protein_description: 'RecName: Full=Copper-transporting ATPase 2; EC=7.2.2.8 {ECO:0000269|PubMed:22240481};<br />
+    AltName: Full=Copper pump 2; AltName: Full=Wilson disease-associated protein;<br />
+    Contains: RecName: Full=WND/140 kDa {ECO:0000303|PubMed:9600907};'<br />
+  gene_info: Name=ATP7B; Synonyms=PWD, WC1, WND;<br />
+  organism_full: Homo sapiens (Human).<br />
+  protein_family: Belongs to the cation transport ATPase (P-type) (TC 3.A.3)<br />
+  protein_domains: ATPase_P-typ_cyto_dom_N. (IPR023299); ATPase_P-typ_P_site. (IPR018303);<br />
+    ATPase_P-typ_TM_dom_sf. (IPR023298); ATPase_P-typ_transduc_dom_A_sf. (IPR008250);<br />
+    ATPase_P-type_domA. (IPR059000)<br />
+provider_config:<br />
+  timeout: 600<br />
+  max_retries: 3<br />
+  parameters:<br />
+    allowed_domains: []<br />
+    temperature: 0.1<br />
+citation_count: 32</p>
+<hr />
+<h2 id="question">Question</h2>
+<h1 id="gene-research-for-functional-annotation">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> P35670</li>
+<li><strong>Protein Description:</strong> RecName: Full=Copper-transporting ATPase 2; EC=7.2.2.8 {ECO:0000269|PubMed:22240481}; AltName: Full=Copper pump 2; AltName: Full=Wilson disease-associated protein; Contains: RecName: Full=WND/140 kDa {ECO:0000303|PubMed:9600907};</li>
+<li><strong>Gene Information:</strong> Name=ATP7B; Synonyms=PWD, WC1, WND;</li>
+<li><strong>Organism (full):</strong> Homo sapiens (Human).</li>
+<li><strong>Protein Family:</strong> Belongs to the cation transport ATPase (P-type) (TC 3.A.3)</li>
+<li><strong>Key Domains:</strong> ATPase_P-typ_cyto_dom_N. (IPR023299); ATPase_P-typ_P_site. (IPR018303); ATPase_P-typ_TM_dom_sf. (IPR023298); ATPase_P-typ_transduc_dom_A_sf. (IPR008250); ATPase_P-type_domA. (IPR059000)</li>
+</ul>
+<h3 id="mandatory-verification-steps">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "ATP7B" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Homo sapiens (Human).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'ATP7B' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>ATP7B</strong> (gene ID: ATP7B, UniProt: P35670) in human.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="output">Output</h2>
+<p>Question: You are an expert researcher providing comprehensive, well-cited information.</p>
+<p>Provide detailed information focusing on:<br />
+1. Key concepts and definitions with current understanding<br />
+2. Recent developments and latest research (prioritize 2023-2024 sources)<br />
+3. Current applications and real-world implementations<br />
+4. Expert opinions and analysis from authoritative sources<br />
+5. Relevant statistics and data from recent studies</p>
+<p>Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.<br />
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.</p>
+<h1 id="gene-research-for-functional-annotation_1">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context_1">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot_1">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> P35670</li>
+<li><strong>Protein Description:</strong> RecName: Full=Copper-transporting ATPase 2; EC=7.2.2.8 {ECO:0000269|PubMed:22240481}; AltName: Full=Copper pump 2; AltName: Full=Wilson disease-associated protein; Contains: RecName: Full=WND/140 kDa {ECO:0000303|PubMed:9600907};</li>
+<li><strong>Gene Information:</strong> Name=ATP7B; Synonyms=PWD, WC1, WND;</li>
+<li><strong>Organism (full):</strong> Homo sapiens (Human).</li>
+<li><strong>Protein Family:</strong> Belongs to the cation transport ATPase (P-type) (TC 3.A.3)</li>
+<li><strong>Key Domains:</strong> ATPase_P-typ_cyto_dom_N. (IPR023299); ATPase_P-typ_P_site. (IPR018303); ATPase_P-typ_TM_dom_sf. (IPR023298); ATPase_P-typ_transduc_dom_A_sf. (IPR008250); ATPase_P-type_domA. (IPR059000)</li>
+</ul>
+<h3 id="mandatory-verification-steps_1">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "ATP7B" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Homo sapiens (Human).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature_1">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'ATP7B' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target_1">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>ATP7B</strong> (gene ID: ATP7B, UniProt: P35670) in human.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="comprehensive-research-report-human-atp7b-uniprot-p35670-functional-annotation-mechanism-localization-and-translational-landscape">Comprehensive Research Report: Human <strong>ATP7B</strong> (UniProt <strong>P35670</strong>) — Functional Annotation, Mechanism, Localization, and Translational Landscape</h2>
+<h3 id="1-target-verification-critical-identity-check">1) Target verification (critical identity check)</h3>
+<p>The UniProt accession <strong>P35670</strong> corresponds to <strong>human ATP7B</strong> (ATPase copper transporting beta), historically termed the <strong>Wilson disease protein</strong>. The literature reviewed here describes ATP7B as a <strong>P1B-1 (Cu+) P-type ATPase</strong> with canonical cytosolic <strong>A/N/P</strong> catalytic domains and multiple N-terminal <strong>copper-binding metal-binding domains (MBDs)</strong>, consistent with the UniProt entry and distinguishing it from the homolog <strong>ATP7A</strong> (Menkes disease protein). (ovchinnikova2024epidemiologyofwilson’s pages 3-6, guo2024diverserolesof pages 1-2, gourdon2012structuralmodelsof pages 1-4)</p>
+<h3 id="2-key-concepts-and-definitions-current-understanding">2) Key concepts and definitions (current understanding)</h3>
+<h4 id="21-what-atp7b-is-protein-class-and-what-it-transports">2.1 What ATP7B is (protein class) and what it transports</h4>
+<p>ATP7B is an <strong>ATP-dependent primary active transporter</strong> (P-type ATPase) that translocates <strong>copper, predominantly Cu(I)</strong> across membranes as part of mammalian copper homeostasis. It is particularly important in <strong>hepatocytes</strong>, where it supports both <strong>copper incorporation into secretory cuproproteins</strong> and <strong>copper excretion into bile</strong>. (ovchinnikova2024epidemiologyofwilson’s pages 3-6, guo2024diverserolesof pages 1-2, petruzzelli2026copperinhuman pages 3-4)</p>
+<h4 id="22-post-albers-cycle-and-p-type-atpase-catalysis-definition">2.2 “Post-Albers cycle” and P-type ATPase catalysis (definition)</h4>
+<p>ATP7B follows the <strong>Post-Albers E1/E1P/E2P/E2</strong> conformational cycle typical of P-type ATPases, coupling <strong>ATP binding/hydrolysis</strong> to <strong>transient autophosphorylation</strong> of a conserved Asp in the P-domain and subsequent dephosphorylation to drive ion transport. This framework is central to interpreting ATP7B variant effects (e.g., catalytic vs trafficking defects). (guo2024diverserolesof pages 1-2, gourdon2012structuralmodelsof pages 1-4)</p>
+<h4 id="23-atp7bs-two-principal-hepatic-functions-definition">2.3 ATP7B’s two principal hepatic functions (definition)</h4>
+<p>A widely used functional partitioning (also reflected in modern reviews) is:<br />
+1) <strong>Biosynthetic role</strong>: delivering Cu into the <strong>trans-Golgi network (TGN)</strong> lumen for <strong>ceruloplasmin metallation</strong>; and<br />
+2) <strong>Detox/excretory role</strong>: exporting excess Cu into bile via <strong>copper-responsive vesicles/lysosomes and apical (canalicular) routes</strong>. (petruzzelli2026copperinhuman pages 30-35, ovchinnikova2024epidemiologyofwilson’s pages 3-6, petruzzelli2026copperinhuman pages 3-4)</p>
+<h3 id="3-molecular-function-domains-motifs-and-biochemical-mechanism">3) Molecular function: domains, motifs, and biochemical mechanism</h3>
+<h4 id="31-domain-architecture-and-key-motifs">3.1 Domain architecture and key motifs</h4>
+<p>ATP7B is described as having:<br />
+- <strong>Six N-terminal MBDs</strong> with surface-exposed <strong>CXXC</strong> motifs (Cu-binding); <br />
+- Cytosolic catalytic <strong>N domain</strong> (nucleotide-binding), <strong>P domain</strong> (phosphorylation), and <strong>A domain</strong> (actuator);<br />
+- A multi-pass <strong>transmembrane core</strong> (reviews describe eight TM segments for ATP7B), forming the copper-translocation pathway; and<br />
+- A C-terminal region containing trafficking signals (e.g., <strong>trileucine motif</strong>) implicated in intracellular routing. (ovchinnikova2024epidemiologyofwilson’s pages 3-6, gourdon2012structuralmodelsof pages 1-4, guo2024diverserolesof media 2f81ca0e)</p>
+<p>Catalytic motifs emphasized across mechanistic sources include the <strong>DKTGT</strong> P-domain motif (phosphorylation loop) and <strong>TGE</strong> motif in the A-domain that mediates dephosphorylation. (guo2024diverserolesof pages 1-2, gourdon2012structuralmodelsof pages 1-4, guo2024diverserolesof media 2f81ca0e)</p>
+<p>A specific ATP7B residue highlighted in a 2024 review is the invariant phosphorylated Asp <strong>Asp1027</strong>, consistent with P-type ATPase chemistry. (ovchinnikova2024epidemiologyofwilson’s pages 3-6)</p>
+<h4 id="32-copper-delivery-to-atp7b-substrate-handling">3.2 Copper delivery to ATP7B (substrate handling)</h4>
+<p>Mechanistically, copper is thought to be delivered to ATP7B from the cytosol via chaperones such as <strong>ATOX1</strong> to the N-terminal MBDs and/or near-core sites, supporting vectorial copper transfer into the transport pathway. (guo2024diverserolesof pages 1-2, gourdon2012structuralmodelsof pages 1-4)</p>
+<h4 id="33-recent-mechanistic-advances-2024-roles-of-near-core-metal-binding-domains">3.3 Recent mechanistic advances (2024): roles of near-core metal-binding domains</h4>
+<p>A 2024 structural/mechanistic study (cryo-EM + MD) of a eukaryotic P1B-1 ATPase system provides an updated model in which the MBD immediately proximal to the ATPase core (<strong>MBD−1</strong>) can serve a <strong>structural role</strong> (remodeling the ion-uptake region), while an adjacent domain (<strong>MBD−2</strong>) more likely supports <strong>copper delivery</strong> to the core. While not exclusive to ATP7B, the authors explicitly connect these findings to the mechanistic interpretation of ATP7B/ATP7A-like Cu+-ATPases. (guo2024diverserolesof pages 1-2)</p>
+<p>A visual summary of this domain organization and the transport cycle is provided in <strong>Figure 1</strong> of Guo et al. 2024. (guo2024diverserolesof media 2f81ca0e, guo2024diverserolesof media 44828a63)</p>
+<h3 id="4-cellular-localization-and-copper-dependent-trafficking-where-atp7b-functions">4) Cellular localization and copper-dependent trafficking (where ATP7B functions)</h3>
+<h4 id="41-basal-localization-tgn-centric-biosynthetic-role">4.1 Basal localization: TGN-centric biosynthetic role</h4>
+<p>Under low/basal copper, ATP7B localizes predominantly to the <strong>TGN</strong>, consistent with its role in loading copper into newly synthesized secretory proteins such as ceruloplasmin. (petruzzelli2026copperinhuman pages 30-35, ovchinnikova2024epidemiologyofwilson’s pages 3-6, petruzzelli2026copperinhuman pages 3-4)</p>
+<h4 id="42-copper-stimulated-relocation-to-vesicularlysosomal-and-apical-compartments">4.2 Copper-stimulated relocation to vesicular/lysosomal and apical compartments</h4>
+<p>When cellular copper increases, ATP7B redistributes from the TGN to <strong>endo-lysosomal / copper-responsive vesicular compartments</strong> and ultimately toward the <strong>apical (canalicular) domain</strong> in hepatocytes. This trafficking enables copper detoxification and biliary elimination. (petruzzelli2026copperinhuman pages 30-35, petruzzelli2026copperinhuman pages 18-19, petruzzelli2026copperinhuman pages 3-4)</p>
+<p>A detailed trafficking model described in a recent physiology review proposes that ATP7B-positive lysosomes can reach the canalicular region and remove copper by two complementary mechanisms:<br />
+- <strong>Lysosomal exocytosis</strong> (releasing stored copper into canalicular space), and<br />
+- <strong>Lysosomal fusion with the apical membrane</strong> (delivering ATP7B to the canalicular membrane to export copper directly into bile). (petruzzelli2026copperinhuman pages 18-19)</p>
+<h4 id="43-regulators-of-polarity-and-trafficking-adaptor-complexes-and-cytoskeleton">4.3 Regulators of polarity and trafficking (adaptor complexes and cytoskeleton)</h4>
+<p>Trafficking polarity of ATP7B involves adaptor machinery. In polarized epithelial models, <strong>AP-1 complexes</strong> influence TGN retention and apical delivery, with AP-1A implicated in TGN retention/directional trafficking and AP-1B in copper-independent apical delivery in MDCK systems; however, hepatocyte-specific rules may differ and remain an active area for clarification. (petruzzelli2026copperinhuman pages 19-21)</p>
+<p>A microtubule linkage mechanism is also described: a <strong>copper-dependent interaction with p62/DNCT4</strong> can connect ATP7B-positive lysosomes to microtubules and promote apical trafficking; p62 knockdown reduces ATP7B delivery/exocytosis in the cited model. (petruzzelli2026copperinhuman pages 18-19)</p>
+<h3 id="5-pathways-and-biological-processes">5) Pathways and biological processes</h3>
+<h4 id="51-copper-homeostasis-pathway-placement">5.1 Copper homeostasis pathway placement</h4>
+<p>ATP7B sits at a key hepatic “node” integrating:<br />
+- <strong>Secretory pathway copper loading</strong> (TGN lumen; ceruloplasmin maturation), and<br />
+- <strong>Systemic copper elimination</strong> via <strong>biliary excretion</strong>.<br />
+Loss of ATP7B disrupts both processes, leading to hepatic copper overload and downstream multi-organ toxicity (Wilson disease). (petruzzelli2026copperinhuman pages 30-35, ovchinnikova2024epidemiologyofwilson’s pages 3-6, petruzzelli2026copperinhuman pages 3-4)</p>
+<h4 id="52-wilson-disease-atp7b-loss-of-function-as-a-functional-readout">5.2 Wilson disease (ATP7B loss-of-function) as a functional readout</h4>
+<p>Wilson disease is caused by pathogenic ATP7B variants that can impair <strong>enzymatic activity</strong> and/or <strong>trafficking</strong>, preventing ceruloplasmin metallation and biliary copper excretion. A common European variant, <strong>p.H1069Q</strong>, is highlighted as causing misfolding with ER retention/degradation and low ceruloplasmin/high free copper, illustrating how variant class maps onto functional outcomes. (petruzzelli2026copperinhuman pages 30-35, ovchinnikova2024epidemiologyofwilson’s pages 3-6)</p>
+<h3 id="6-recent-developments-and-latest-research-prioritizing-20232024">6) Recent developments and latest research (prioritizing 2023–2024)</h3>
+<h4 id="61-2023-c-terminal-trafficking-mutations-and-cell-polarization-effects">6.1 2023: C-terminal trafficking mutations and cell polarization effects</h4>
+<p>A 2023 Metallomics study tested Wilson-disease–associated ATP7B mutations (including C-terminal variants <strong>S1423N, S1426I, T1434M</strong>) in polarized vs unpolarized/differentiation-state cell models. It concluded that the <strong>distal C-terminus</strong> dictates <strong>cell-type/polarization-specific TGN retention and Golgi exit</strong>, with some C-terminal mutants showing corrected localization/trafficking in differentiated cells—proposed as a mechanism for milder clinical phenotypes for certain variants. (Chakraborty et al., 2023, https://doi.org/10.1093/mtomcs/mfad051; published Sep 2023) (chakraborty2023wilsondiseasecausing pages 1-2)</p>
+<h4 id="62-2024-cryo-emmd-driven-refinement-of-cu-atpase-transport-mechanism">6.2 2024: Cryo-EM/MD-driven refinement of Cu+-ATPase transport mechanism</h4>
+<p>A 2024 Nature Communications paper provides cryo-EM structures and mechanistic interpretation for P1B-1 Cu+-ATPases, clarifying how near-core MBDs can contribute differently to structural remodeling vs copper delivery, and implicating conserved TM residues in copper handling. This supports more precise hypotheses about how ATP7B variants in MBDs/TMs alter copper uptake/release and conformational cycling. (Guo et al., 2024, https://doi.org/10.1038/s41467-024-47001-4; published Mar 2024) (guo2024diverserolesof pages 1-2, guo2024diverserolesof media 2f81ca0e)</p>
+<h4 id="63-2024-updated-epidemiology-and-variant-landscape-synthesis">6.3 2024: Updated epidemiology and variant landscape synthesis</h4>
+<p>A 2024 review consolidates ATP7B structure/function and highlights that <strong>&gt;900 pathogenic ATP7B variants</strong> have been described, with strong geographic variability and persistent gaps in experimental functional characterization for most variants. (Ovchinnikova et al., 2024, https://doi.org/10.3390/ijms25042402; published Feb 2024) (ovchinnikova2024epidemiologyofwilson’s pages 3-6, ovchinnikova2024epidemiologyofwilson’s pages 2-3)</p>
+<h4 id="64-2024-translational-emphasis-on-delivery-constraints-for-genetic-medicines">6.4 2024: Translational emphasis on delivery constraints for genetic medicines</h4>
+<p>A 2024 review on CRISPR/Cas for Wilson disease emphasizes that <strong>in vivo delivery</strong> is the key limiting factor, with AAV payload capacity driving strategies such as <strong>mini-ATP7B</strong>, split approaches, and compact regulatory elements; it also notes two AAV programs in clinical testing (UX701 and VTX-801). (Choi et al., 2024, https://doi.org/10.3390/cells13141214; published Jul 2024) (choi2024navigatingthecrisprcas pages 16-17)</p>
+<h3 id="7-current-applications-and-real-world-implementations">7) Current applications and real-world implementations</h3>
+<h4 id="71-diagnostics-and-monitoring">7.1 Diagnostics and monitoring</h4>
+<p><strong>Epidemiologic/diagnostic shift with NGS:</strong> historical clinical prevalence estimates cited in a 2024 review are ~<strong>1:35,000–45,000</strong>, whereas large molecular genetic studies cited there suggest a detected frequency around <strong>1:7,026</strong>, reflecting increased ascertainment using NGS and registries. (Ovchinnikova et al., 2024, https://doi.org/10.3390/ijms25042402; published Feb 2024) (ovchinnikova2024epidemiologyofwilson’s pages 1-2)</p>
+<p><strong>Copper speciation / non-ceruloplasmin copper metrics (diagnostic/monitoring):</strong> a 2025 review describes a speciation method (SAX-ICP-MS-MS) to directly measure ceruloplasmin and its copper content and compute <strong>ANCC</strong> and <strong>RelANCC</strong>. In the cited cohort, <strong>RelANCC</strong> was higher in a naive WD patient (37.07%) and treated WD patients (median 30.64%) than non-WD (median 9.66%; p&lt;0.05). (Mariño &amp; Schilsky, 2025, https://doi.org/10.1055/a-2460-8999; published Nov 2025) (marino2025wilsondiseasenovel pages 7-8)</p>
+<p><strong>Newborn screening–adjacent approach (DBS ATP7B peptides):</strong> the same 2025 review describes an immunoaffinity enrichment + SRM method to quantify <strong>ATP7B peptides from dried blood spots</strong>, reported across <strong>206 WD patients</strong>, positioning blood ATP7B as a surrogate for hepatic ATP7B and a candidate tool for screening/diagnosis. (Mariño &amp; Schilsky, 2025, https://doi.org/10.1055/a-2460-8999; published Nov 2025) (marino2025wilsondiseasenovel pages 7-8)</p>
+<h4 id="72-standard-therapies-in-practice">7.2 Standard therapies in practice</h4>
+<p>Recent reviews summarize standard-of-care as <strong>chelators (D-penicillamine, trientine)</strong> and <strong>zinc salts</strong>, with <strong>liver transplantation</strong> as definitive therapy for acute liver failure or refractory/end-stage disease. Zinc is described as better tolerated but slower acting and not suitable for acute presentations, whereas chelators can have significant adverse effects (including neurologic worsening in some contexts). (ivanenko2025therapeuticstrategiesfor pages 1-2, teschke2024wilsondiseasecoppermediated pages 19-21)</p>
+<h4 id="73-emerging-therapies-and-real-world-clinical-trials-genemrna">7.3 Emerging therapies and real-world clinical trials (gene/mRNA)</h4>
+<p>Multiple <strong>in-human trials</strong> are active or initiating, targeting restoration of ATP7B function via AAV gene transfer or mRNA delivery.</p>
+<table>
+<thead>
+<tr>
+<th>Program/Intervention</th>
+<th>Modality</th>
+<th>Trial ID (NCT)</th>
+<th>Phase</th>
+<th>Status</th>
+<th style="text-align: right;">Enrollment</th>
+<th>Dosing/Regimen</th>
+<th>Primary outcomes (brief)</th>
+<th>Key notes</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>UX701 (rivunatpagene miziparvovec)</td>
+<td>AAV gene therapy</td>
+<td>NCT04884815</td>
+<td>Phase 1/2/3</td>
+<td>Active, not recruiting</td>
+<td style="text-align: right;">82</td>
+<td>Single peripheral IV infusion; Stage 1 dose-finding across 4 dose levels, Stage 2 randomized open-label vs standard of care, Stage 3 long-term follow-up ≥5 years</td>
+<td>Safety through Week 52 (TEAEs/TESAEs/AESIs) plus copper biomarkers including 24-hour urinary copper, total copper, ceruloplasmin-bound copper, NCC/free copper, ceruloplasmin activity</td>
+<td>AAV9-based; requires biallelic ATP7B mutations; excludes detectable anti-AAV9 antibodies, prior liver transplant, MELD &gt;13, prior gene transfer exposure (NCT04884815 chunk 1, NCT04884815 chunk 2)</td>
+</tr>
+<tr>
+<td>VTX-801</td>
+<td>AAV gene therapy</td>
+<td>NCT04537377</td>
+<td>Phase 1/2</td>
+<td>Active, not recruiting</td>
+<td style="text-align: right;">4</td>
+<td>Single IV dose-escalation, up to 3 dose levels; 5-year follow-up</td>
+<td>Safety/tolerability (including TEAEs) through ~1 year; secondary measures include free serum Cu, total serum Cu, 24-hour urinary Cu, ceruloplasmin activity, responder status using radiocopper PK and copper parameters</td>
+<td>Replication-deficient rAAV carrying a shortened/mini ATP7B transgene; adult Wilson disease patients; multicenter, non-randomized, open-label GATEWAY study (NCT04537377 chunk 1, choi2024navigatingthecrisprcas pages 16-17)</td>
+</tr>
+<tr>
+<td>DSL101 (ATP7B mRNA/LNP)</td>
+<td>mRNA-LNP replacement therapy</td>
+<td>NCT07240896</td>
+<td>Early Phase 1</td>
+<td>Recruiting</td>
+<td style="text-align: right;">18</td>
+<td>IV infusion every 4 weeks; low-dose accelerated titration, medium/high-dose 3+3 with sentinel approach</td>
+<td>Incidence of AEs/SAEs up to 56 weeks; secondary outcomes include 24-hour urine copper, serum free copper, ceruloplasmin and activity, liver tests, UWDRS score, PK, immunogenicity</td>
+<td>Requires confirmed biallelic ATP7B mutations, Leipzig score ≥4, ceruloplasmin &lt;0.1 g/L; participants may continue standard copper therapies (NCT07240896 chunk 1)</td>
+</tr>
+<tr>
+<td>GC310 injection</td>
+<td>AAV gene therapy</td>
+<td>NCT07173933</td>
+<td>Phase 1/2</td>
+<td>Not yet recruiting</td>
+<td style="text-align: right;">15</td>
+<td>Single IV administration; 2 dose cohorts (3.0E+13 and 6.0E+13 d.vg/kg); 52-week follow-up</td>
+<td>Incidence of AEs (12 weeks), dose-limiting toxicities (4 weeks), change in serum ceruloplasmin and 24-hour urinary copper excretion (52 weeks)</td>
+<td>AAV5 vector delivering truncated human ATP7B; secondary measures include ALT/AST, imaging, Kayser-Fleischer ring change, anti-AAV5/anti-ATP7B antibodies, vector genomes, shedding; excludes anti-AAV5 NAb titre &gt;1:100 (NCT07173933 chunk 1)</td>
+</tr>
+<tr>
+<td>Prime Medicine prescreening study</td>
+<td>Gene-editing trial prescreening / observational genomics</td>
+<td>NCT07226622</td>
+<td>Observational</td>
+<td>Recruiting</td>
+<td style="text-align: right;">30</td>
+<td>No therapeutic intervention; single blood draw, targeted ATP7B sequencing if needed, chart review, patient attitudes survey; ~90-day participation</td>
+<td>Primary outcome is gene-editing interest/attitudes survey; secondary outcomes include serum ceruloplasmin distribution, ATP7B mutational landscape, aggregated WD-related health characteristics</td>
+<td>Designed to identify candidates for future gene-editing trial; enriches for p.H1069Q and p.R778L carriers; excludes prior liver transplant or prior WD gene therapy (NCT07226622 chunk 1)</td>
+</tr>
+<tr>
+<td>LY-M003 injection</td>
+<td>Gene therapy / advanced therapeutic candidate</td>
+<td>NCT06650319</td>
+<td>Early Phase 1</td>
+<td>Recruiting</td>
+<td style="text-align: right;">18</td>
+<td>Regimen details not available in gathered evidence</td>
+<td>Safety and efficacy study in Wilson disease</td>
+<td>Listed in ClinicalTrials.gov search results as a recruiting early-phase study; detailed vector/platform and endpoints were not available in the gathered evidence, so specifics should be interpreted cautiously (OpenTargets Search: Wilson disease-ATP7B)</td>
+</tr>
+<tr>
+<td>TETA4 (trientine tetrahydrochloride)</td>
+<td>Improved chelator formulation</td>
+<td>NCT06128954</td>
+<td>Phase 1</td>
+<td>Completed/performed in healthy volunteers; results pending in review summary</td>
+<td style="text-align: right;">26</td>
+<td>Single-dose phase 1 study</td>
+<td>Pharmacokinetics/safety supporting potential once-daily regimen</td>
+<td>Not ATP7B replacement/editing, but a recent advanced therapeutic development in WD care pipeline; reviewed as a new formulation intended to improve maintenance treatment convenience (marino2025wilsondiseasenovel pages 11-12)</td>
+</tr>
+<tr>
+<td>miniATP7B hepatotropic AAV8 programs (preclinical/ongoing company programs referenced in review)</td>
+<td>AAV gene therapy</td>
+<td>Not specified in gathered evidence</td>
+<td>Preclinical to clinical transition</td>
+<td>Ongoing clinical development referenced</td>
+<td style="text-align: right;">Not specified</td>
+<td>Single-dose liver-directed AAV delivery in preclinical studies</td>
+<td>Restoration of copper metabolism and physiologic copper excretion in rodent models</td>
+<td>Full-length ATP7B is too large for standard AAV packaging, prompting truncated/miniATP7B constructs; Vivet and other companies referenced as pursuing clinical translation (marino2025wilsondiseasenovel pages 11-12, choi2024navigatingthecrisprcas pages 16-17, zeng2025evaluationofefficacy pages 1-2)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes current clinical trials and advanced therapeutic programs targeting ATP7B/Wilson disease, including AAV gene therapies, mRNA-LNP replacement, and gene-editing prescreening. It is useful for quickly comparing modality, development stage, dosing, endpoints, and trial-specific design features from the gathered evidence.</em></p>
+<p>Key examples from ClinicalTrials.gov include:<br />
+- <strong>UX701 (AAV9)</strong>: operationally seamless Phase 1/2/3 trial with copper biomarkers as key endpoints (NCT04884815; started 2021-09-27). (https://clinicaltrials.gov/study/NCT04884815; posted/record 2021; see record for updates) (NCT04884815 chunk 1)<br />
+- <strong>VTX-801 (rAAV, miniATP7B)</strong>: Phase 1/2, single-dose escalation, long-term follow-up, with copper measures and responder definitions including radiocopper PK elements (NCT04537377). (https://clinicaltrials.gov/study/NCT04537377; posted/record 2021; see record for updates) (NCT04537377 chunk 1)<br />
+- <strong>DSL101 (ATP7B mRNA/LNP)</strong>: Early Phase 1, repeated IV infusions every 4 weeks with copper biochemistry and UWDRS as outcomes (NCT07240896). (https://clinicaltrials.gov/study/NCT07240896; posted/record 2025; see record for updates) (NCT07240896 chunk 1)<br />
+- <strong>GC310 (AAV5 truncated ATP7B)</strong>: Phase 1/2, single-dose escalation; includes immunogenicity, vector shedding, and copper endpoints (NCT07173933). (https://clinicaltrials.gov/study/NCT07173933; posted/record 2025; see record for updates) (NCT07173933 chunk 1)</p>
+<h3 id="8-expert-opinions-and-analysis-authoritative-synthesis">8) Expert opinions and analysis (authoritative synthesis)</h3>
+<p>1) <strong>Mechanism-to-phenotype framing:</strong> Contemporary reviews emphasize that Wilson disease mutations can impair ATP7B via <strong>catalytic defects</strong> or <strong>trafficking defects</strong>, and both mechanisms can converge on the same physiological outcomes (low ceruloplasmin metallation and reduced biliary copper excretion). This classification is essential for precision strategies (e.g., trafficking-correctors vs gene replacement). (petruzzelli2026copperinhuman pages 30-35, ovchinnikova2024epidemiologyofwilson’s pages 3-6)</p>
+<p>2) <strong>Delivery is the bottleneck for curative genetic therapies:</strong> The 2024 CRISPR/gene-therapy review emphasizes that vector payload limits and in vivo delivery constraints dominate translational feasibility, explaining why <strong>miniATP7B</strong> and other engineered constructs are prominent in clinical programs. (choi2024navigatingthecrisprcas pages 16-17)</p>
+<p>3) <strong>Trafficking is cell-context dependent:</strong> The 2023 mutation study provides experimental evidence that ATP7B localization and copper-responsive Golgi exit can depend on cellular differentiation/polarization state, implying that variant interpretation should consider tissue context and polarity-specific trafficking pathways. (chakraborty2023wilsondiseasecausing pages 1-2)</p>
+<h3 id="9-relevant-statistics-and-recent-data-points">9) Relevant statistics and recent data points</h3>
+<h4 id="91-prevalence-and-carrier-frequency">9.1 Prevalence and carrier frequency</h4>
+<ul>
+<li>Historical clinical prevalence estimates summarized in a 2024 review: <strong>~1:35,000–45,000</strong>. (ovchinnikova2024epidemiologyofwilson’s pages 1-2)</li>
+<li>Carrier frequency estimate cited in the same review: <strong>~1 in 90</strong> heterozygous carriers of ATP7B pathogenic variants. (ovchinnikova2024epidemiologyofwilson’s pages 2-3)</li>
+<li>Genetic-screening–based frequency reported by large molecular genetic studies cited in that review: <strong>~1:7,026</strong>. (ovchinnikova2024epidemiologyofwilson’s pages 1-2)</li>
+<li>Regional prevalence values summarized in 2024 include (examples): <strong>Sardinia 36.6/100,000</strong>, <strong>Great Britain 14.2/100,000</strong>, <strong>Korea 13/100,000</strong>. (ovchinnikova2024epidemiologyofwilson’s pages 3-6)</li>
+</ul>
+<h4 id="92-variant-burden">9.2 Variant burden</h4>
+<p>A 2024 review highlights that <strong>&gt;900 ATP7B pathogenic variants</strong> have been identified and that variant spectra differ by geography/ethnicity; most variants still lack deep functional characterization. (ovchinnikova2024epidemiologyofwilson’s pages 2-3, ovchinnikova2024epidemiologyofwilson’s pages 3-6)</p>
+<h4 id="93-biomarker-performance-data-recent">9.3 Biomarker performance data (recent)</h4>
+<p>Copper-speciation monitoring: <strong>RelANCC</strong> discrimination (treated vs non-WD medians) is reported as above, supporting a quantitative monitoring/diagnostic approach based on copper speciation rather than indirect calculations. (marino2025wilsondiseasenovel pages 7-8)</p>
+<h3 id="10-visual-evidence-domain-architecture-and-transport-cycle">10) Visual evidence (domain architecture and transport cycle)</h3>
+<p>Guo et al. 2024 provide a schematic of P1B-ATPase domain architecture and the Post-Albers transport cycle (including E1/E1P/E2P/E2 states) that is directly relevant to ATP7B’s mechanism and domain organization. (guo2024diverserolesof media 2f81ca0e, guo2024diverserolesof media 44828a63)</p>
+<h3 id="11-consolidated-functional-annotation-summary">11) Consolidated functional annotation summary</h3>
+<p>The table below consolidates ATP7B’s primary function, mechanism, domain organization, localization/trafficking, and variant-driven dysfunction.</p>
+<table>
+<thead>
+<tr>
+<th>Aspect</th>
+<th>Key points</th>
+<th>Key evidence</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Protein class / substrate</td>
+<td>ATP7B (UniProt P35670) is the human Wilson disease protein, a P1B-1 copper-transporting P-type ATPase that transports Cu(I) and functions in hepatocytes to lower cytosolic copper and support cuproenzyme biosynthesis. It is distinct from ATP7A, the related Menkes protein.</td>
+<td>(ovchinnikova2024epidemiologyofwilson’s pages 3-6, guo2024diverserolesof pages 1-2, gourdon2012structuralmodelsof pages 1-4)</td>
+</tr>
+<tr>
+<td>Catalytic mechanism</td>
+<td>ATP7B uses the canonical P-type ATPase/Post-Albers cycle (E1-E1P-E2P-E2). ATP binding and hydrolysis drive transient phosphorylation of the invariant Asp in the P-domain (Asp1027 in ATP7B), while the A-domain TGE motif mediates dephosphorylation and interdomain rearrangements required for Cu translocation.</td>
+<td>(ovchinnikova2024epidemiologyofwilson’s pages 3-6, guo2024diverserolesof pages 1-2, gourdon2012structuralmodelsof pages 1-4)</td>
+</tr>
+<tr>
+<td>Domain architecture / motifs</td>
+<td>ATP7B contains six N-terminal metal-binding domains with CXXC motifs, cytosolic N, P, and A domains, and a transmembrane core with eight helices in ATP7B-specific descriptions; conserved catalytic motifs include DKTGT in the P-domain and TGE in the A-domain. Structural modeling/review literature also highlights the CPC motif in TM4 and a C-terminal trileucine motif important for trafficking regulation.</td>
+<td>(ovchinnikova2024epidemiologyofwilson’s pages 3-6, gourdon2012structuralmodelsof pages 1-4, guo2024diverserolesof media 2f81ca0e)</td>
+</tr>
+<tr>
+<td>Copper chaperone delivery</td>
+<td>Cytosolic copper is delivered to ATP7B primarily by the copper chaperone ATOX1; thermodynamic studies support vectorial transfer from ATOX1 to ATP7B metal-binding domains, and recent structural work suggests distinct roles for the two MBDs nearest the core in copper delivery versus structural remodeling.</td>
+<td>(guo2024diverserolesof pages 1-2, gourdon2012structuralmodelsof pages 1-4)</td>
+</tr>
+<tr>
+<td>Baseline localization</td>
+<td>Under low/basal copper, ATP7B localizes mainly to the trans-Golgi network (TGN); in hepatocytes it can also occupy a TGN-proximal lysosomal compartment. This positioning supports biosynthetic copper delivery to the secretory pathway.</td>
+<td>(petruzzelli2026copperinhuman pages 30-35, petruzzelli2026copperinhuman pages 19-21, petruzzelli2026copperinhuman pages 18-19, petruzzelli2026copperinhuman pages 3-4)</td>
+</tr>
+<tr>
+<td>Copper-stimulated trafficking route(s)</td>
+<td>As cellular copper rises, ATP7B exits the TGN and traffics to endo-lysosomal/copper-responsive vesicles and then toward apical/canalicular compartments. In hepatocytes, ATP7B-positive lysosomes can undergo lysosomal exocytosis into the canalicular space or fuse with the apical membrane, placing ATP7B at the canalicular surface for direct biliary copper export. AP-1 adaptors and microtubule-linked factors such as p62/DNCT4 regulate polarity and apical delivery.</td>
+<td>(petruzzelli2026copperinhuman pages 30-35, petruzzelli2026copperinhuman pages 19-21, petruzzelli2026copperinhuman pages 18-19, petruzzelli2026copperinhuman pages 3-4)</td>
+</tr>
+<tr>
+<td>Physiological roles</td>
+<td>ATP7B has two principal hepatic functions: loading copper into the secretory pathway for ceruloplasmin metallation and exporting excess copper into bile. These functions integrate ATP7B into systemic copper homeostasis by coupling copper storage, secretory maturation, and detoxifying excretion.</td>
+<td>(petruzzelli2026copperinhuman pages 30-35, ovchinnikova2024epidemiologyofwilson’s pages 3-6, petruzzelli2026copperinhuman pages 3-4)</td>
+</tr>
+<tr>
+<td>Consequences of loss-of-function</td>
+<td>Pathogenic ATP7B variants impair enzymatic activity and/or trafficking, blocking ceruloplasmin metallation and biliary copper excretion. The result is hepatic copper accumulation, elevated free copper, and subsequent injury to liver and extrahepatic organs; His1069Gln is specifically associated with folding defects, ER retention/degradation, low ceruloplasmin, and neuropsychiatric-predominant disease.</td>
+<td>(petruzzelli2026copperinhuman pages 30-35, ovchinnikova2024epidemiologyofwilson’s pages 3-6)</td>
+</tr>
+<tr>
+<td>Example mutations affecting trafficking</td>
+<td>C-terminal ATP7B variants S1423N, S1426I, and T1434M alter TGN retention and Cu-responsive Golgi exit in a cell-polarization-dependent manner; S1423N shows incomplete rescue of trafficking in differentiated cells, whereas S1426I and T1434M show corrected localization/trafficking in differentiated models. The study concludes that distal C-terminus helps govern cell-specific TGN localization and exit.</td>
+<td>(chakraborty2023wilsondiseasecausing pages 1-2)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the core functional annotation of human ATP7B, including substrate, mechanism, domain features, localization, copper-dependent trafficking, and disease-relevant consequences. It condenses the most relevant evidence gathered for a functional annotation-focused research report.</em></p>
+<h3 id="12-notes-on-evidence-scope-and-recency">12) Notes on evidence scope and recency</h3>
+<p>This report prioritizes 2023–2024 sources for mechanistic and trafficking updates (e.g., Chakraborty 2023; Guo 2024; Ovchinnikova 2024; Choi 2024). For some clinically actionable diagnostic details (DBS ATP7B peptide quantification; copper speciation metrics), the most explicit data located in the retrieved corpus came from a 2025 hepatology review, which is included because it provides concrete quantitative performance details and describes ongoing trial directions. (marino2025wilsondiseasenovel pages 7-8)</p>
+<p>References</p>
+<ol>
+<li>
+<p>(ovchinnikova2024epidemiologyofwilson’s pages 3-6): Elena Vasilievna Ovchinnikova, Mikhail Maksimovich Garbuz, Anna Aleksandrovna Ovchinnikova, and Vadim Vladimirovich Kumeiko. Epidemiology of wilson’s disease and pathogenic variants of the atp7b gene leading to diversified protein disfunctions. International Journal of Molecular Sciences, 25:2402, Feb 2024. URL: https://doi.org/10.3390/ijms25042402, doi:10.3390/ijms25042402. This article has 51 citations.</p>
+</li>
+<li>
+<p>(guo2024diverserolesof pages 1-2): Zongxin Guo, Fredrik Orädd, Viktoria Bågenholm, Christina Grønberg, Jian Feng Ma, Peter Ott, Yong Wang, Magnus Andersson, Per Amstrup Pedersen, Kaituo Wang, and Pontus Gourdon. Diverse roles of the metal binding domains and transport mechanism of copper transporting p-type atpases. Nature Communications, Mar 2024. URL: https://doi.org/10.1038/s41467-024-47001-4, doi:10.1038/s41467-024-47001-4. This article has 20 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(gourdon2012structuralmodelsof pages 1-4): Pontus Gourdon, Oleg Sitsel, Jesper Lykkegaard Karlsen, Lisbeth Birk Møller, and Poul Nissen. Structural models of the human copper p-type atpases atp7a and atp7b. bchm, 393:205-216, Apr 2012. URL: https://doi.org/10.1515/hsz-2011-0249, doi:10.1515/hsz-2011-0249. This article has 74 citations.</p>
+</li>
+<li>
+<p>(petruzzelli2026copperinhuman pages 3-4): Raffaella Petruzzelli, Elena Polishchuk, and Roman Polishchuk. Copper in human health and disease: insights from inherited disorders. Physiology, Nov 2026. URL: https://doi.org/10.1152/physiol.00032.2025, doi:10.1152/physiol.00032.2025. This article has 6 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(petruzzelli2026copperinhuman pages 30-35): Raffaella Petruzzelli, Elena Polishchuk, and Roman Polishchuk. Copper in human health and disease: insights from inherited disorders. Physiology, Nov 2026. URL: https://doi.org/10.1152/physiol.00032.2025, doi:10.1152/physiol.00032.2025. This article has 6 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(guo2024diverserolesof media 2f81ca0e): Zongxin Guo, Fredrik Orädd, Viktoria Bågenholm, Christina Grønberg, Jian Feng Ma, Peter Ott, Yong Wang, Magnus Andersson, Per Amstrup Pedersen, Kaituo Wang, and Pontus Gourdon. Diverse roles of the metal binding domains and transport mechanism of copper transporting p-type atpases. Nature Communications, Mar 2024. URL: https://doi.org/10.1038/s41467-024-47001-4, doi:10.1038/s41467-024-47001-4. This article has 20 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(guo2024diverserolesof media 44828a63): Zongxin Guo, Fredrik Orädd, Viktoria Bågenholm, Christina Grønberg, Jian Feng Ma, Peter Ott, Yong Wang, Magnus Andersson, Per Amstrup Pedersen, Kaituo Wang, and Pontus Gourdon. Diverse roles of the metal binding domains and transport mechanism of copper transporting p-type atpases. Nature Communications, Mar 2024. URL: https://doi.org/10.1038/s41467-024-47001-4, doi:10.1038/s41467-024-47001-4. This article has 20 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(petruzzelli2026copperinhuman pages 18-19): Raffaella Petruzzelli, Elena Polishchuk, and Roman Polishchuk. Copper in human health and disease: insights from inherited disorders. Physiology, Nov 2026. URL: https://doi.org/10.1152/physiol.00032.2025, doi:10.1152/physiol.00032.2025. This article has 6 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(petruzzelli2026copperinhuman pages 19-21): Raffaella Petruzzelli, Elena Polishchuk, and Roman Polishchuk. Copper in human health and disease: insights from inherited disorders. Physiology, Nov 2026. URL: https://doi.org/10.1152/physiol.00032.2025, doi:10.1152/physiol.00032.2025. This article has 6 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(chakraborty2023wilsondiseasecausing pages 1-2): Kaustav Chakraborty, Santanu Das, Anusree Pal, Saptarshi Maji, Bhawana Rai, Arnab Gupta, and Ashima Bhattacharjee. Wilson disease causing mutations in the carboxyl terminus of atp7b regulates its localization and golgi exit selectively in the unpolarized cells. Metallomics : integrated biometal science, Sep 2023. URL: https://doi.org/10.1093/mtomcs/mfad051, doi:10.1093/mtomcs/mfad051. This article has 3 citations.</p>
+</li>
+<li>
+<p>(ovchinnikova2024epidemiologyofwilson’s pages 2-3): Elena Vasilievna Ovchinnikova, Mikhail Maksimovich Garbuz, Anna Aleksandrovna Ovchinnikova, and Vadim Vladimirovich Kumeiko. Epidemiology of wilson’s disease and pathogenic variants of the atp7b gene leading to diversified protein disfunctions. International Journal of Molecular Sciences, 25:2402, Feb 2024. URL: https://doi.org/10.3390/ijms25042402, doi:10.3390/ijms25042402. This article has 51 citations.</p>
+</li>
+<li>
+<p>(choi2024navigatingthecrisprcas pages 16-17): Woong Choi, Seongkwang Cha, and Kyoungmi Kim. Navigating the crispr/cas landscape for enhanced diagnosis and treatment of wilson’s disease. Cells, 13:1214, Jul 2024. URL: https://doi.org/10.3390/cells13141214, doi:10.3390/cells13141214. This article has 12 citations.</p>
+</li>
+<li>
+<p>(ovchinnikova2024epidemiologyofwilson’s pages 1-2): Elena Vasilievna Ovchinnikova, Mikhail Maksimovich Garbuz, Anna Aleksandrovna Ovchinnikova, and Vadim Vladimirovich Kumeiko. Epidemiology of wilson’s disease and pathogenic variants of the atp7b gene leading to diversified protein disfunctions. International Journal of Molecular Sciences, 25:2402, Feb 2024. URL: https://doi.org/10.3390/ijms25042402, doi:10.3390/ijms25042402. This article has 51 citations.</p>
+</li>
+<li>
+<p>(marino2025wilsondiseasenovel pages 7-8): Zoe Mariño and Michael L. Schilsky. Wilson disease: novel diagnostic and therapeutic approaches. Seminars in Liver Disease, 45:221-235, Nov 2025. URL: https://doi.org/10.1055/a-2460-8999, doi:10.1055/a-2460-8999. This article has 18 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ivanenko2025therapeuticstrategiesfor pages 1-2): A.L. Ivanenko, VD Starodubova, and AG Shokhina. Therapeutic strategies for wilson’s disease: current state and prospects. Bulletin of Russian State Medical University, Apr 2025. URL: https://doi.org/10.24075/brsmu.2025.022, doi:10.24075/brsmu.2025.022. This article has 0 citations.</p>
+</li>
+<li>
+<p>(teschke2024wilsondiseasecoppermediated pages 19-21): Rolf Teschke and Axel Eickhoff. Wilson disease: copper-mediated cuproptosis, iron-related ferroptosis, and clinical highlights, with comprehensive and critical analysis update. International Journal of Molecular Sciences, 25:4753, Apr 2024. URL: https://doi.org/10.3390/ijms25094753, doi:10.3390/ijms25094753. This article has 116 citations.</p>
+</li>
+<li>
+<p>(NCT04884815 chunk 1):  A Phase 1/2/3 Study of UX701 Gene Therapy in Adults With Wilson Disease. Ultragenyx Pharmaceutical Inc. 2021. ClinicalTrials.gov Identifier: NCT04884815</p>
+</li>
+<li>
+<p>(NCT04884815 chunk 2):  A Phase 1/2/3 Study of UX701 Gene Therapy in Adults With Wilson Disease. Ultragenyx Pharmaceutical Inc. 2021. ClinicalTrials.gov Identifier: NCT04884815</p>
+</li>
+<li>
+<p>(NCT04537377 chunk 1):  A Phase I/II Study of VTX-801 in Adult Patients With Wilson's Disease. Vivet Therapeutics SAS. 2021. ClinicalTrials.gov Identifier: NCT04537377</p>
+</li>
+<li>
+<p>(NCT07240896 chunk 1):  A Clinical Study on the Treatment of Wilson Disease With ATP7B mRNA/LNP (DSL101). DSciLab Co., Ltd.. 2025. ClinicalTrials.gov Identifier: NCT07240896</p>
+</li>
+<li>
+<p>(NCT07173933 chunk 1):  Phase I/II Clinical Study to Evaluate the Safety, Tolerability, and Efficacy of GC310 Injection in Patients With Wilson's Disease (WD). GeneCradle Inc. 2025. ClinicalTrials.gov Identifier: NCT07173933</p>
+</li>
+<li>
+<p>(NCT07226622 chunk 1):  Prescreening Study to Identify Potential Wilson Disease Participants for Gene-Editing Clinical Trial. Prime Medicine, Inc.. 2025. ClinicalTrials.gov Identifier: NCT07226622</p>
+</li>
+<li>
+<p>(OpenTargets Search: Wilson disease-ATP7B): Open Targets Query (Wilson disease-ATP7B, 5 results). Buniello, A. et al. (2025). Open Targets Platform: facilitating therapeutic hypotheses building in drug discovery. Nucleic Acids Research.</p>
+</li>
+<li>
+<p>(marino2025wilsondiseasenovel pages 11-12): Zoe Mariño and Michael L. Schilsky. Wilson disease: novel diagnostic and therapeutic approaches. Seminars in Liver Disease, 45:221-235, Nov 2025. URL: https://doi.org/10.1055/a-2460-8999, doi:10.1055/a-2460-8999. This article has 18 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(zeng2025evaluationofefficacy pages 1-2): Chunhua Zeng, Yunting Lin, Xinshuo Lu, Shehong Chen, Yan Xia, Kangdi Zhang, Yongxian Shao, Zhihong Guan, Rong Du, Zongcai Liu, Mingqi Zhao, Xiaoling Jiang, Yanna Cai, Taolin Li, Xueying Su, Yaoyong Chen, Xiaoyan Dong, Wen Zhang, Li Liu, and Wenhao Zhou. Evaluation of efficacy and safety of aav8-δc4atp7b gene therapy in a mutant mouse model of wilson’s disease. Molecular Therapy Methods &amp; Clinical Development, 33:101435, Mar 2025. URL: https://doi.org/10.1016/j.omtm.2025.101435, doi:10.1016/j.omtm.2025.101435. This article has 1 citations.</p>
+</li>
+</ol>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>guo2024diverserolesof pages 1-2</li>
+<li>petruzzelli2026copperinhuman pages 18-19</li>
+<li>petruzzelli2026copperinhuman pages 19-21</li>
+<li>chakraborty2023wilsondiseasecausing pages 1-2</li>
+<li>choi2024navigatingthecrisprcas pages 16-17</li>
+<li>marino2025wilsondiseasenovel pages 7-8</li>
+<li>marino2025wilsondiseasenovel pages 11-12</li>
+<li>gourdon2012structuralmodelsof pages 1-4</li>
+<li>petruzzelli2026copperinhuman pages 3-4</li>
+<li>petruzzelli2026copperinhuman pages 30-35</li>
+<li>ivanenko2025therapeuticstrategiesfor pages 1-2</li>
+<li>teschke2024wilsondiseasecoppermediated pages 19-21</li>
+<li>zeng2025evaluationofefficacy pages 1-2</li>
+<li>https://doi.org/10.1093/mtomcs/mfad051;</li>
+<li>https://doi.org/10.1038/s41467-024-47001-4;</li>
+<li>https://doi.org/10.3390/ijms25042402;</li>
+<li>https://doi.org/10.3390/cells13141214;</li>
+<li>https://doi.org/10.1055/a-2460-8999;</li>
+<li>https://clinicaltrials.gov/study/NCT04884815;</li>
+<li>https://clinicaltrials.gov/study/NCT04537377;</li>
+<li>https://clinicaltrials.gov/study/NCT07240896;</li>
+<li>https://clinicaltrials.gov/study/NCT07173933;</li>
+<li>https://doi.org/10.3390/ijms25042402,</li>
+<li>https://doi.org/10.1038/s41467-024-47001-4,</li>
+<li>https://doi.org/10.1515/hsz-2011-0249,</li>
+<li>https://doi.org/10.1152/physiol.00032.2025,</li>
+<li>https://doi.org/10.1093/mtomcs/mfad051,</li>
+<li>https://doi.org/10.3390/cells13141214,</li>
+<li>https://doi.org/10.1055/a-2460-8999,</li>
+<li>https://doi.org/10.24075/brsmu.2025.022,</li>
+<li>https://doi.org/10.3390/ijms25094753,</li>
+<li>https://doi.org/10.1016/j.omtm.2025.101435,</li>
+</ol>
+            </div>
+        </details>
+
         <details class="markdown-section">
             <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
                 <div style="flex: 1;">
@@ -5489,9 +6165,9 @@
 </ul>
             </div>
         </details>
-        
+
     </div>
-    
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -5503,7 +6179,7 @@
                 <pre><code>id: P35670
 gene_symbol: ATP7B
 product_type: PROTEIN
-status: IN_PROGRESS
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
@@ -5576,6 +6252,12 @@ existing_annotations:
           catalytic and transport activity, whereas others lost transport
           activity but retained phosphor-intermediate formation or had
           partial losses of activity.
+      - reference_id: file:human/ATP7B/ATP7B-deep-research-falcon.md
+        supporting_text: &gt;-
+          ATP7B is the human Wilson disease protein, a P1B-1
+          copper-transporting P-type ATPase that transports Cu(I) and
+          functions in hepatocytes to lower cytosolic copper and support
+          cuproenzyme biosynthesis.
 
 - term:
     id: GO:0140581
@@ -6018,6 +6700,11 @@ existing_annotations:
           Wilson&#39;s disease protein (WNDP) is a copper-transporting P(1)-type
           ATPase which plays a key role in normal distribution of copper in
           a number of tissues, particularly in the liver and the brain.
+      - reference_id: file:human/ATP7B/ATP7B-deep-research-falcon.md
+        supporting_text: &gt;-
+          ATP7B has two principal hepatic functions: loading copper into the
+          secretory pathway for ceruloplasmin metallation and exporting excess
+          copper into bile.
 
 # --- Copper ion IMPORT (INCORRECT) ---
 - term:
@@ -6568,7 +7255,52 @@ existing_annotations:
       not mitochondria. This HTP finding is inconsistent with the
       extensive cell biology literature.
 
+core_functions:
+- molecular_function:
+    id: GO:0140581
+    label: P-type monovalent copper transporter activity
+  description: &gt;-
+    ATP7B is a P1B-type Cu(I)-transporting ATPase whose core molecular
+    function is ATP-coupled movement of copper out of the cytosol into the
+    secretory pathway and copper-responsive vesicular/apical routes in
+    hepatocytes. This activity supports both cuproenzyme metallation and
+    detoxifying copper excretion.
+  directly_involved_in:
+  - id: GO:0006825
+    label: copper ion transport
+  - id: GO:0060003
+    label: copper ion export
+  locations:
+  - id: GO:0032588
+    label: trans-Golgi network membrane
+  - id: GO:0031410
+    label: cytoplasmic vesicle
+- molecular_function:
+    id: GO:0005507
+    label: copper ion binding
+  description: &gt;-
+    ATP7B contains N-terminal metal-binding domains with CXXC motifs that bind
+    copper delivered by ATOX1 and regulate copper transfer to the P-type ATPase
+    core. Copper binding is mechanistically coupled to ATP7B transport and
+    trafficking, but the transporter activity is the primary core function.
+  directly_involved_in:
+  - id: GO:0006825
+    label: copper ion transport
+  locations:
+  - id: GO:0032588
+    label: trans-Golgi network membrane
 references:
+- id: file:human/ATP7B/ATP7B-deep-research-falcon.md
+  title: Falcon deep research report for ATP7B
+  findings:
+  - statement: &gt;-
+      Falcon corroborates ATP7B as a hepatocyte P1B-type Cu(I)-transporting
+      ATPase that loads copper into the secretory pathway and supports biliary
+      copper excretion through copper-responsive trafficking.
+    supporting_text: &gt;-
+      ATP7B has two principal hepatic functions: loading copper into the
+      secretory pathway for ceruloplasmin metallation and exporting excess
+      copper into bile.
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO terms
   findings: []
@@ -6909,7 +7641,7 @@ references:
     </div>
 
     <!-- Pathway Visualization Link -->
-    
+
 
     <style>
         /* Markdown Section Styles */

--- a/genes/human/ATP7B/ATP7B-ai-review.yaml
+++ b/genes/human/ATP7B/ATP7B-ai-review.yaml
@@ -1,7 +1,7 @@
 id: P35670
 gene_symbol: ATP7B
 product_type: PROTEIN
-status: IN_PROGRESS
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
@@ -74,6 +74,12 @@ existing_annotations:
           catalytic and transport activity, whereas others lost transport
           activity but retained phosphor-intermediate formation or had
           partial losses of activity.
+      - reference_id: file:human/ATP7B/ATP7B-deep-research-falcon.md
+        supporting_text: >-
+          ATP7B is the human Wilson disease protein, a P1B-1
+          copper-transporting P-type ATPase that transports Cu(I) and
+          functions in hepatocytes to lower cytosolic copper and support
+          cuproenzyme biosynthesis.
 
 - term:
     id: GO:0140581
@@ -516,6 +522,11 @@ existing_annotations:
           Wilson's disease protein (WNDP) is a copper-transporting P(1)-type
           ATPase which plays a key role in normal distribution of copper in
           a number of tissues, particularly in the liver and the brain.
+      - reference_id: file:human/ATP7B/ATP7B-deep-research-falcon.md
+        supporting_text: >-
+          ATP7B has two principal hepatic functions: loading copper into the
+          secretory pathway for ceruloplasmin metallation and exporting excess
+          copper into bile.
 
 # --- Copper ion IMPORT (INCORRECT) ---
 - term:
@@ -1066,7 +1077,52 @@ existing_annotations:
       not mitochondria. This HTP finding is inconsistent with the
       extensive cell biology literature.
 
+core_functions:
+- molecular_function:
+    id: GO:0140581
+    label: P-type monovalent copper transporter activity
+  description: >-
+    ATP7B is a P1B-type Cu(I)-transporting ATPase whose core molecular
+    function is ATP-coupled movement of copper out of the cytosol into the
+    secretory pathway and copper-responsive vesicular/apical routes in
+    hepatocytes. This activity supports both cuproenzyme metallation and
+    detoxifying copper excretion.
+  directly_involved_in:
+  - id: GO:0006825
+    label: copper ion transport
+  - id: GO:0060003
+    label: copper ion export
+  locations:
+  - id: GO:0032588
+    label: trans-Golgi network membrane
+  - id: GO:0031410
+    label: cytoplasmic vesicle
+- molecular_function:
+    id: GO:0005507
+    label: copper ion binding
+  description: >-
+    ATP7B contains N-terminal metal-binding domains with CXXC motifs that bind
+    copper delivered by ATOX1 and regulate copper transfer to the P-type ATPase
+    core. Copper binding is mechanistically coupled to ATP7B transport and
+    trafficking, but the transporter activity is the primary core function.
+  directly_involved_in:
+  - id: GO:0006825
+    label: copper ion transport
+  locations:
+  - id: GO:0032588
+    label: trans-Golgi network membrane
 references:
+- id: file:human/ATP7B/ATP7B-deep-research-falcon.md
+  title: Falcon deep research report for ATP7B
+  findings:
+  - statement: >-
+      Falcon corroborates ATP7B as a hepatocyte P1B-type Cu(I)-transporting
+      ATPase that loads copper into the secretory pathway and supports biliary
+      copper excretion through copper-responsive trafficking.
+    supporting_text: >-
+      ATP7B has two principal hepatic functions: loading copper into the
+      secretory pathway for ceruloplasmin metallation and exporting excess
+      copper into bile.
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO terms
   findings: []

--- a/genes/human/ATP7B/ATP7B-deep-research-falcon.md
+++ b/genes/human/ATP7B/ATP7B-deep-research-falcon.md
@@ -1,0 +1,388 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-11T02:08:36.993256'
+end_time: '2026-05-11T02:26:19.698530'
+duration_seconds: 1062.71
+template_file: templates/gene_research_go_focused.md
+template_variables:
+  organism: human
+  gene_id: ATP7B
+  gene_symbol: ATP7B
+  uniprot_accession: P35670
+  protein_description: 'RecName: Full=Copper-transporting ATPase 2; EC=7.2.2.8 {ECO:0000269|PubMed:22240481};
+    AltName: Full=Copper pump 2; AltName: Full=Wilson disease-associated protein;
+    Contains: RecName: Full=WND/140 kDa {ECO:0000303|PubMed:9600907};'
+  gene_info: Name=ATP7B; Synonyms=PWD, WC1, WND;
+  organism_full: Homo sapiens (Human).
+  protein_family: Belongs to the cation transport ATPase (P-type) (TC 3.A.3)
+  protein_domains: ATPase_P-typ_cyto_dom_N. (IPR023299); ATPase_P-typ_P_site. (IPR018303);
+    ATPase_P-typ_TM_dom_sf. (IPR023298); ATPase_P-typ_transduc_dom_A_sf. (IPR008250);
+    ATPase_P-type_domA. (IPR059000)
+provider_config:
+  timeout: 600
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 32
+---
+
+## Question
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** P35670
+- **Protein Description:** RecName: Full=Copper-transporting ATPase 2; EC=7.2.2.8 {ECO:0000269|PubMed:22240481}; AltName: Full=Copper pump 2; AltName: Full=Wilson disease-associated protein; Contains: RecName: Full=WND/140 kDa {ECO:0000303|PubMed:9600907};
+- **Gene Information:** Name=ATP7B; Synonyms=PWD, WC1, WND;
+- **Organism (full):** Homo sapiens (Human).
+- **Protein Family:** Belongs to the cation transport ATPase (P-type) (TC 3.A.3)
+- **Key Domains:** ATPase_P-typ_cyto_dom_N. (IPR023299); ATPase_P-typ_P_site. (IPR018303); ATPase_P-typ_TM_dom_sf. (IPR023298); ATPase_P-typ_transduc_dom_A_sf. (IPR008250); ATPase_P-type_domA. (IPR059000)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "ATP7B" matches the protein description above**
+2. **Verify the organism is correct:** Homo sapiens (Human).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'ATP7B' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **ATP7B** (gene ID: ATP7B, UniProt: P35670) in human.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** P35670
+- **Protein Description:** RecName: Full=Copper-transporting ATPase 2; EC=7.2.2.8 {ECO:0000269|PubMed:22240481}; AltName: Full=Copper pump 2; AltName: Full=Wilson disease-associated protein; Contains: RecName: Full=WND/140 kDa {ECO:0000303|PubMed:9600907};
+- **Gene Information:** Name=ATP7B; Synonyms=PWD, WC1, WND;
+- **Organism (full):** Homo sapiens (Human).
+- **Protein Family:** Belongs to the cation transport ATPase (P-type) (TC 3.A.3)
+- **Key Domains:** ATPase_P-typ_cyto_dom_N. (IPR023299); ATPase_P-typ_P_site. (IPR018303); ATPase_P-typ_TM_dom_sf. (IPR023298); ATPase_P-typ_transduc_dom_A_sf. (IPR008250); ATPase_P-type_domA. (IPR059000)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "ATP7B" matches the protein description above**
+2. **Verify the organism is correct:** Homo sapiens (Human).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'ATP7B' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **ATP7B** (gene ID: ATP7B, UniProt: P35670) in human.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Comprehensive Research Report: Human **ATP7B** (UniProt **P35670**) — Functional Annotation, Mechanism, Localization, and Translational Landscape
+
+### 1) Target verification (critical identity check)
+The UniProt accession **P35670** corresponds to **human ATP7B** (ATPase copper transporting beta), historically termed the **Wilson disease protein**. The literature reviewed here describes ATP7B as a **P1B-1 (Cu+) P-type ATPase** with canonical cytosolic **A/N/P** catalytic domains and multiple N-terminal **copper-binding metal-binding domains (MBDs)**, consistent with the UniProt entry and distinguishing it from the homolog **ATP7A** (Menkes disease protein). (ovchinnikova2024epidemiologyofwilson’s pages 3-6, guo2024diverserolesof pages 1-2, gourdon2012structuralmodelsof pages 1-4)
+
+### 2) Key concepts and definitions (current understanding)
+
+#### 2.1 What ATP7B is (protein class) and what it transports
+ATP7B is an **ATP-dependent primary active transporter** (P-type ATPase) that translocates **copper, predominantly Cu(I)** across membranes as part of mammalian copper homeostasis. It is particularly important in **hepatocytes**, where it supports both **copper incorporation into secretory cuproproteins** and **copper excretion into bile**. (ovchinnikova2024epidemiologyofwilson’s pages 3-6, guo2024diverserolesof pages 1-2, petruzzelli2026copperinhuman pages 3-4)
+
+#### 2.2 “Post-Albers cycle” and P-type ATPase catalysis (definition)
+ATP7B follows the **Post-Albers E1/E1P/E2P/E2** conformational cycle typical of P-type ATPases, coupling **ATP binding/hydrolysis** to **transient autophosphorylation** of a conserved Asp in the P-domain and subsequent dephosphorylation to drive ion transport. This framework is central to interpreting ATP7B variant effects (e.g., catalytic vs trafficking defects). (guo2024diverserolesof pages 1-2, gourdon2012structuralmodelsof pages 1-4)
+
+#### 2.3 ATP7B’s two principal hepatic functions (definition)
+A widely used functional partitioning (also reflected in modern reviews) is:
+1) **Biosynthetic role**: delivering Cu into the **trans-Golgi network (TGN)** lumen for **ceruloplasmin metallation**; and
+2) **Detox/excretory role**: exporting excess Cu into bile via **copper-responsive vesicles/lysosomes and apical (canalicular) routes**. (petruzzelli2026copperinhuman pages 30-35, ovchinnikova2024epidemiologyofwilson’s pages 3-6, petruzzelli2026copperinhuman pages 3-4)
+
+### 3) Molecular function: domains, motifs, and biochemical mechanism
+
+#### 3.1 Domain architecture and key motifs
+ATP7B is described as having:
+- **Six N-terminal MBDs** with surface-exposed **CXXC** motifs (Cu-binding);
+- Cytosolic catalytic **N domain** (nucleotide-binding), **P domain** (phosphorylation), and **A domain** (actuator);
+- A multi-pass **transmembrane core** (reviews describe eight TM segments for ATP7B), forming the copper-translocation pathway; and
+- A C-terminal region containing trafficking signals (e.g., **trileucine motif**) implicated in intracellular routing. (ovchinnikova2024epidemiologyofwilson’s pages 3-6, gourdon2012structuralmodelsof pages 1-4, guo2024diverserolesof media 2f81ca0e)
+
+Catalytic motifs emphasized across mechanistic sources include the **DKTGT** P-domain motif (phosphorylation loop) and **TGE** motif in the A-domain that mediates dephosphorylation. (guo2024diverserolesof pages 1-2, gourdon2012structuralmodelsof pages 1-4, guo2024diverserolesof media 2f81ca0e)
+
+A specific ATP7B residue highlighted in a 2024 review is the invariant phosphorylated Asp **Asp1027**, consistent with P-type ATPase chemistry. (ovchinnikova2024epidemiologyofwilson’s pages 3-6)
+
+#### 3.2 Copper delivery to ATP7B (substrate handling)
+Mechanistically, copper is thought to be delivered to ATP7B from the cytosol via chaperones such as **ATOX1** to the N-terminal MBDs and/or near-core sites, supporting vectorial copper transfer into the transport pathway. (guo2024diverserolesof pages 1-2, gourdon2012structuralmodelsof pages 1-4)
+
+#### 3.3 Recent mechanistic advances (2024): roles of near-core metal-binding domains
+A 2024 structural/mechanistic study (cryo-EM + MD) of a eukaryotic P1B-1 ATPase system provides an updated model in which the MBD immediately proximal to the ATPase core (**MBD−1**) can serve a **structural role** (remodeling the ion-uptake region), while an adjacent domain (**MBD−2**) more likely supports **copper delivery** to the core. While not exclusive to ATP7B, the authors explicitly connect these findings to the mechanistic interpretation of ATP7B/ATP7A-like Cu+-ATPases. (guo2024diverserolesof pages 1-2)
+
+A visual summary of this domain organization and the transport cycle is provided in **Figure 1** of Guo et al. 2024. (guo2024diverserolesof media 2f81ca0e, guo2024diverserolesof media 44828a63)
+
+### 4) Cellular localization and copper-dependent trafficking (where ATP7B functions)
+
+#### 4.1 Basal localization: TGN-centric biosynthetic role
+Under low/basal copper, ATP7B localizes predominantly to the **TGN**, consistent with its role in loading copper into newly synthesized secretory proteins such as ceruloplasmin. (petruzzelli2026copperinhuman pages 30-35, ovchinnikova2024epidemiologyofwilson’s pages 3-6, petruzzelli2026copperinhuman pages 3-4)
+
+#### 4.2 Copper-stimulated relocation to vesicular/lysosomal and apical compartments
+When cellular copper increases, ATP7B redistributes from the TGN to **endo-lysosomal / copper-responsive vesicular compartments** and ultimately toward the **apical (canalicular) domain** in hepatocytes. This trafficking enables copper detoxification and biliary elimination. (petruzzelli2026copperinhuman pages 30-35, petruzzelli2026copperinhuman pages 18-19, petruzzelli2026copperinhuman pages 3-4)
+
+A detailed trafficking model described in a recent physiology review proposes that ATP7B-positive lysosomes can reach the canalicular region and remove copper by two complementary mechanisms:
+- **Lysosomal exocytosis** (releasing stored copper into canalicular space), and
+- **Lysosomal fusion with the apical membrane** (delivering ATP7B to the canalicular membrane to export copper directly into bile). (petruzzelli2026copperinhuman pages 18-19)
+
+#### 4.3 Regulators of polarity and trafficking (adaptor complexes and cytoskeleton)
+Trafficking polarity of ATP7B involves adaptor machinery. In polarized epithelial models, **AP-1 complexes** influence TGN retention and apical delivery, with AP-1A implicated in TGN retention/directional trafficking and AP-1B in copper-independent apical delivery in MDCK systems; however, hepatocyte-specific rules may differ and remain an active area for clarification. (petruzzelli2026copperinhuman pages 19-21)
+
+A microtubule linkage mechanism is also described: a **copper-dependent interaction with p62/DNCT4** can connect ATP7B-positive lysosomes to microtubules and promote apical trafficking; p62 knockdown reduces ATP7B delivery/exocytosis in the cited model. (petruzzelli2026copperinhuman pages 18-19)
+
+### 5) Pathways and biological processes
+
+#### 5.1 Copper homeostasis pathway placement
+ATP7B sits at a key hepatic “node” integrating:
+- **Secretory pathway copper loading** (TGN lumen; ceruloplasmin maturation), and
+- **Systemic copper elimination** via **biliary excretion**.
+Loss of ATP7B disrupts both processes, leading to hepatic copper overload and downstream multi-organ toxicity (Wilson disease). (petruzzelli2026copperinhuman pages 30-35, ovchinnikova2024epidemiologyofwilson’s pages 3-6, petruzzelli2026copperinhuman pages 3-4)
+
+#### 5.2 Wilson disease (ATP7B loss-of-function) as a functional readout
+Wilson disease is caused by pathogenic ATP7B variants that can impair **enzymatic activity** and/or **trafficking**, preventing ceruloplasmin metallation and biliary copper excretion. A common European variant, **p.H1069Q**, is highlighted as causing misfolding with ER retention/degradation and low ceruloplasmin/high free copper, illustrating how variant class maps onto functional outcomes. (petruzzelli2026copperinhuman pages 30-35, ovchinnikova2024epidemiologyofwilson’s pages 3-6)
+
+### 6) Recent developments and latest research (prioritizing 2023–2024)
+
+#### 6.1 2023: C-terminal trafficking mutations and cell polarization effects
+A 2023 Metallomics study tested Wilson-disease–associated ATP7B mutations (including C-terminal variants **S1423N, S1426I, T1434M**) in polarized vs unpolarized/differentiation-state cell models. It concluded that the **distal C-terminus** dictates **cell-type/polarization-specific TGN retention and Golgi exit**, with some C-terminal mutants showing corrected localization/trafficking in differentiated cells—proposed as a mechanism for milder clinical phenotypes for certain variants. (Chakraborty et al., 2023, https://doi.org/10.1093/mtomcs/mfad051; published Sep 2023) (chakraborty2023wilsondiseasecausing pages 1-2)
+
+#### 6.2 2024: Cryo-EM/MD-driven refinement of Cu+-ATPase transport mechanism
+A 2024 Nature Communications paper provides cryo-EM structures and mechanistic interpretation for P1B-1 Cu+-ATPases, clarifying how near-core MBDs can contribute differently to structural remodeling vs copper delivery, and implicating conserved TM residues in copper handling. This supports more precise hypotheses about how ATP7B variants in MBDs/TMs alter copper uptake/release and conformational cycling. (Guo et al., 2024, https://doi.org/10.1038/s41467-024-47001-4; published Mar 2024) (guo2024diverserolesof pages 1-2, guo2024diverserolesof media 2f81ca0e)
+
+#### 6.3 2024: Updated epidemiology and variant landscape synthesis
+A 2024 review consolidates ATP7B structure/function and highlights that **>900 pathogenic ATP7B variants** have been described, with strong geographic variability and persistent gaps in experimental functional characterization for most variants. (Ovchinnikova et al., 2024, https://doi.org/10.3390/ijms25042402; published Feb 2024) (ovchinnikova2024epidemiologyofwilson’s pages 3-6, ovchinnikova2024epidemiologyofwilson’s pages 2-3)
+
+#### 6.4 2024: Translational emphasis on delivery constraints for genetic medicines
+A 2024 review on CRISPR/Cas for Wilson disease emphasizes that **in vivo delivery** is the key limiting factor, with AAV payload capacity driving strategies such as **mini-ATP7B**, split approaches, and compact regulatory elements; it also notes two AAV programs in clinical testing (UX701 and VTX-801). (Choi et al., 2024, https://doi.org/10.3390/cells13141214; published Jul 2024) (choi2024navigatingthecrisprcas pages 16-17)
+
+### 7) Current applications and real-world implementations
+
+#### 7.1 Diagnostics and monitoring
+**Epidemiologic/diagnostic shift with NGS:** historical clinical prevalence estimates cited in a 2024 review are ~**1:35,000–45,000**, whereas large molecular genetic studies cited there suggest a detected frequency around **1:7,026**, reflecting increased ascertainment using NGS and registries. (Ovchinnikova et al., 2024, https://doi.org/10.3390/ijms25042402; published Feb 2024) (ovchinnikova2024epidemiologyofwilson’s pages 1-2)
+
+**Copper speciation / non-ceruloplasmin copper metrics (diagnostic/monitoring):** a 2025 review describes a speciation method (SAX-ICP-MS-MS) to directly measure ceruloplasmin and its copper content and compute **ANCC** and **RelANCC**. In the cited cohort, **RelANCC** was higher in a naive WD patient (37.07%) and treated WD patients (median 30.64%) than non-WD (median 9.66%; p<0.05). (Mariño & Schilsky, 2025, https://doi.org/10.1055/a-2460-8999; published Nov 2025) (marino2025wilsondiseasenovel pages 7-8)
+
+**Newborn screening–adjacent approach (DBS ATP7B peptides):** the same 2025 review describes an immunoaffinity enrichment + SRM method to quantify **ATP7B peptides from dried blood spots**, reported across **206 WD patients**, positioning blood ATP7B as a surrogate for hepatic ATP7B and a candidate tool for screening/diagnosis. (Mariño & Schilsky, 2025, https://doi.org/10.1055/a-2460-8999; published Nov 2025) (marino2025wilsondiseasenovel pages 7-8)
+
+#### 7.2 Standard therapies in practice
+Recent reviews summarize standard-of-care as **chelators (D-penicillamine, trientine)** and **zinc salts**, with **liver transplantation** as definitive therapy for acute liver failure or refractory/end-stage disease. Zinc is described as better tolerated but slower acting and not suitable for acute presentations, whereas chelators can have significant adverse effects (including neurologic worsening in some contexts). (ivanenko2025therapeuticstrategiesfor pages 1-2, teschke2024wilsondiseasecoppermediated pages 19-21)
+
+#### 7.3 Emerging therapies and real-world clinical trials (gene/mRNA)
+Multiple **in-human trials** are active or initiating, targeting restoration of ATP7B function via AAV gene transfer or mRNA delivery.
+
+| Program/Intervention | Modality | Trial ID (NCT) | Phase | Status | Enrollment | Dosing/Regimen | Primary outcomes (brief) | Key notes |
+|---|---|---|---|---|---:|---|---|---|
+| UX701 (rivunatpagene miziparvovec) | AAV gene therapy | NCT04884815 | Phase 1/2/3 | Active, not recruiting | 82 | Single peripheral IV infusion; Stage 1 dose-finding across 4 dose levels, Stage 2 randomized open-label vs standard of care, Stage 3 long-term follow-up ≥5 years | Safety through Week 52 (TEAEs/TESAEs/AESIs) plus copper biomarkers including 24-hour urinary copper, total copper, ceruloplasmin-bound copper, NCC/free copper, ceruloplasmin activity | AAV9-based; requires biallelic ATP7B mutations; excludes detectable anti-AAV9 antibodies, prior liver transplant, MELD >13, prior gene transfer exposure (NCT04884815 chunk 1, NCT04884815 chunk 2) |
+| VTX-801 | AAV gene therapy | NCT04537377 | Phase 1/2 | Active, not recruiting | 4 | Single IV dose-escalation, up to 3 dose levels; 5-year follow-up | Safety/tolerability (including TEAEs) through ~1 year; secondary measures include free serum Cu, total serum Cu, 24-hour urinary Cu, ceruloplasmin activity, responder status using radiocopper PK and copper parameters | Replication-deficient rAAV carrying a shortened/mini ATP7B transgene; adult Wilson disease patients; multicenter, non-randomized, open-label GATEWAY study (NCT04537377 chunk 1, choi2024navigatingthecrisprcas pages 16-17) |
+| DSL101 (ATP7B mRNA/LNP) | mRNA-LNP replacement therapy | NCT07240896 | Early Phase 1 | Recruiting | 18 | IV infusion every 4 weeks; low-dose accelerated titration, medium/high-dose 3+3 with sentinel approach | Incidence of AEs/SAEs up to 56 weeks; secondary outcomes include 24-hour urine copper, serum free copper, ceruloplasmin and activity, liver tests, UWDRS score, PK, immunogenicity | Requires confirmed biallelic ATP7B mutations, Leipzig score ≥4, ceruloplasmin <0.1 g/L; participants may continue standard copper therapies (NCT07240896 chunk 1) |
+| GC310 injection | AAV gene therapy | NCT07173933 | Phase 1/2 | Not yet recruiting | 15 | Single IV administration; 2 dose cohorts (3.0E+13 and 6.0E+13 d.vg/kg); 52-week follow-up | Incidence of AEs (12 weeks), dose-limiting toxicities (4 weeks), change in serum ceruloplasmin and 24-hour urinary copper excretion (52 weeks) | AAV5 vector delivering truncated human ATP7B; secondary measures include ALT/AST, imaging, Kayser-Fleischer ring change, anti-AAV5/anti-ATP7B antibodies, vector genomes, shedding; excludes anti-AAV5 NAb titre >1:100 (NCT07173933 chunk 1) |
+| Prime Medicine prescreening study | Gene-editing trial prescreening / observational genomics | NCT07226622 | Observational | Recruiting | 30 | No therapeutic intervention; single blood draw, targeted ATP7B sequencing if needed, chart review, patient attitudes survey; ~90-day participation | Primary outcome is gene-editing interest/attitudes survey; secondary outcomes include serum ceruloplasmin distribution, ATP7B mutational landscape, aggregated WD-related health characteristics | Designed to identify candidates for future gene-editing trial; enriches for p.H1069Q and p.R778L carriers; excludes prior liver transplant or prior WD gene therapy (NCT07226622 chunk 1) |
+| LY-M003 injection | Gene therapy / advanced therapeutic candidate | NCT06650319 | Early Phase 1 | Recruiting | 18 | Regimen details not available in gathered evidence | Safety and efficacy study in Wilson disease | Listed in ClinicalTrials.gov search results as a recruiting early-phase study; detailed vector/platform and endpoints were not available in the gathered evidence, so specifics should be interpreted cautiously (OpenTargets Search: Wilson disease-ATP7B) |
+| TETA4 (trientine tetrahydrochloride) | Improved chelator formulation | NCT06128954 | Phase 1 | Completed/performed in healthy volunteers; results pending in review summary | 26 | Single-dose phase 1 study | Pharmacokinetics/safety supporting potential once-daily regimen | Not ATP7B replacement/editing, but a recent advanced therapeutic development in WD care pipeline; reviewed as a new formulation intended to improve maintenance treatment convenience (marino2025wilsondiseasenovel pages 11-12) |
+| miniATP7B hepatotropic AAV8 programs (preclinical/ongoing company programs referenced in review) | AAV gene therapy | Not specified in gathered evidence | Preclinical to clinical transition | Ongoing clinical development referenced | Not specified | Single-dose liver-directed AAV delivery in preclinical studies | Restoration of copper metabolism and physiologic copper excretion in rodent models | Full-length ATP7B is too large for standard AAV packaging, prompting truncated/miniATP7B constructs; Vivet and other companies referenced as pursuing clinical translation (marino2025wilsondiseasenovel pages 11-12, choi2024navigatingthecrisprcas pages 16-17, zeng2025evaluationofefficacy pages 1-2) |
+
+
+*Table: This table summarizes current clinical trials and advanced therapeutic programs targeting ATP7B/Wilson disease, including AAV gene therapies, mRNA-LNP replacement, and gene-editing prescreening. It is useful for quickly comparing modality, development stage, dosing, endpoints, and trial-specific design features from the gathered evidence.*
+
+Key examples from ClinicalTrials.gov include:
+- **UX701 (AAV9)**: operationally seamless Phase 1/2/3 trial with copper biomarkers as key endpoints (NCT04884815; started 2021-09-27). (https://clinicaltrials.gov/study/NCT04884815; posted/record 2021; see record for updates) (NCT04884815 chunk 1)
+- **VTX-801 (rAAV, miniATP7B)**: Phase 1/2, single-dose escalation, long-term follow-up, with copper measures and responder definitions including radiocopper PK elements (NCT04537377). (https://clinicaltrials.gov/study/NCT04537377; posted/record 2021; see record for updates) (NCT04537377 chunk 1)
+- **DSL101 (ATP7B mRNA/LNP)**: Early Phase 1, repeated IV infusions every 4 weeks with copper biochemistry and UWDRS as outcomes (NCT07240896). (https://clinicaltrials.gov/study/NCT07240896; posted/record 2025; see record for updates) (NCT07240896 chunk 1)
+- **GC310 (AAV5 truncated ATP7B)**: Phase 1/2, single-dose escalation; includes immunogenicity, vector shedding, and copper endpoints (NCT07173933). (https://clinicaltrials.gov/study/NCT07173933; posted/record 2025; see record for updates) (NCT07173933 chunk 1)
+
+### 8) Expert opinions and analysis (authoritative synthesis)
+
+1) **Mechanism-to-phenotype framing:** Contemporary reviews emphasize that Wilson disease mutations can impair ATP7B via **catalytic defects** or **trafficking defects**, and both mechanisms can converge on the same physiological outcomes (low ceruloplasmin metallation and reduced biliary copper excretion). This classification is essential for precision strategies (e.g., trafficking-correctors vs gene replacement). (petruzzelli2026copperinhuman pages 30-35, ovchinnikova2024epidemiologyofwilson’s pages 3-6)
+
+2) **Delivery is the bottleneck for curative genetic therapies:** The 2024 CRISPR/gene-therapy review emphasizes that vector payload limits and in vivo delivery constraints dominate translational feasibility, explaining why **miniATP7B** and other engineered constructs are prominent in clinical programs. (choi2024navigatingthecrisprcas pages 16-17)
+
+3) **Trafficking is cell-context dependent:** The 2023 mutation study provides experimental evidence that ATP7B localization and copper-responsive Golgi exit can depend on cellular differentiation/polarization state, implying that variant interpretation should consider tissue context and polarity-specific trafficking pathways. (chakraborty2023wilsondiseasecausing pages 1-2)
+
+### 9) Relevant statistics and recent data points
+
+#### 9.1 Prevalence and carrier frequency
+- Historical clinical prevalence estimates summarized in a 2024 review: **~1:35,000–45,000**. (ovchinnikova2024epidemiologyofwilson’s pages 1-2)
+- Carrier frequency estimate cited in the same review: **~1 in 90** heterozygous carriers of ATP7B pathogenic variants. (ovchinnikova2024epidemiologyofwilson’s pages 2-3)
+- Genetic-screening–based frequency reported by large molecular genetic studies cited in that review: **~1:7,026**. (ovchinnikova2024epidemiologyofwilson’s pages 1-2)
+- Regional prevalence values summarized in 2024 include (examples): **Sardinia 36.6/100,000**, **Great Britain 14.2/100,000**, **Korea 13/100,000**. (ovchinnikova2024epidemiologyofwilson’s pages 3-6)
+
+#### 9.2 Variant burden
+A 2024 review highlights that **>900 ATP7B pathogenic variants** have been identified and that variant spectra differ by geography/ethnicity; most variants still lack deep functional characterization. (ovchinnikova2024epidemiologyofwilson’s pages 2-3, ovchinnikova2024epidemiologyofwilson’s pages 3-6)
+
+#### 9.3 Biomarker performance data (recent)
+Copper-speciation monitoring: **RelANCC** discrimination (treated vs non-WD medians) is reported as above, supporting a quantitative monitoring/diagnostic approach based on copper speciation rather than indirect calculations. (marino2025wilsondiseasenovel pages 7-8)
+
+### 10) Visual evidence (domain architecture and transport cycle)
+Guo et al. 2024 provide a schematic of P1B-ATPase domain architecture and the Post-Albers transport cycle (including E1/E1P/E2P/E2 states) that is directly relevant to ATP7B’s mechanism and domain organization. (guo2024diverserolesof media 2f81ca0e, guo2024diverserolesof media 44828a63)
+
+### 11) Consolidated functional annotation summary
+The table below consolidates ATP7B’s primary function, mechanism, domain organization, localization/trafficking, and variant-driven dysfunction.
+
+| Aspect | Key points | Key evidence |
+|---|---|---|
+| Protein class / substrate | ATP7B (UniProt P35670) is the human Wilson disease protein, a P1B-1 copper-transporting P-type ATPase that transports Cu(I) and functions in hepatocytes to lower cytosolic copper and support cuproenzyme biosynthesis. It is distinct from ATP7A, the related Menkes protein. | (ovchinnikova2024epidemiologyofwilson’s pages 3-6, guo2024diverserolesof pages 1-2, gourdon2012structuralmodelsof pages 1-4) |
+| Catalytic mechanism | ATP7B uses the canonical P-type ATPase/Post-Albers cycle (E1-E1P-E2P-E2). ATP binding and hydrolysis drive transient phosphorylation of the invariant Asp in the P-domain (Asp1027 in ATP7B), while the A-domain TGE motif mediates dephosphorylation and interdomain rearrangements required for Cu translocation. | (ovchinnikova2024epidemiologyofwilson’s pages 3-6, guo2024diverserolesof pages 1-2, gourdon2012structuralmodelsof pages 1-4) |
+| Domain architecture / motifs | ATP7B contains six N-terminal metal-binding domains with CXXC motifs, cytosolic N, P, and A domains, and a transmembrane core with eight helices in ATP7B-specific descriptions; conserved catalytic motifs include DKTGT in the P-domain and TGE in the A-domain. Structural modeling/review literature also highlights the CPC motif in TM4 and a C-terminal trileucine motif important for trafficking regulation. | (ovchinnikova2024epidemiologyofwilson’s pages 3-6, gourdon2012structuralmodelsof pages 1-4, guo2024diverserolesof media 2f81ca0e) |
+| Copper chaperone delivery | Cytosolic copper is delivered to ATP7B primarily by the copper chaperone ATOX1; thermodynamic studies support vectorial transfer from ATOX1 to ATP7B metal-binding domains, and recent structural work suggests distinct roles for the two MBDs nearest the core in copper delivery versus structural remodeling. | (guo2024diverserolesof pages 1-2, gourdon2012structuralmodelsof pages 1-4) |
+| Baseline localization | Under low/basal copper, ATP7B localizes mainly to the trans-Golgi network (TGN); in hepatocytes it can also occupy a TGN-proximal lysosomal compartment. This positioning supports biosynthetic copper delivery to the secretory pathway. | (petruzzelli2026copperinhuman pages 30-35, petruzzelli2026copperinhuman pages 19-21, petruzzelli2026copperinhuman pages 18-19, petruzzelli2026copperinhuman pages 3-4) |
+| Copper-stimulated trafficking route(s) | As cellular copper rises, ATP7B exits the TGN and traffics to endo-lysosomal/copper-responsive vesicles and then toward apical/canalicular compartments. In hepatocytes, ATP7B-positive lysosomes can undergo lysosomal exocytosis into the canalicular space or fuse with the apical membrane, placing ATP7B at the canalicular surface for direct biliary copper export. AP-1 adaptors and microtubule-linked factors such as p62/DNCT4 regulate polarity and apical delivery. | (petruzzelli2026copperinhuman pages 30-35, petruzzelli2026copperinhuman pages 19-21, petruzzelli2026copperinhuman pages 18-19, petruzzelli2026copperinhuman pages 3-4) |
+| Physiological roles | ATP7B has two principal hepatic functions: loading copper into the secretory pathway for ceruloplasmin metallation and exporting excess copper into bile. These functions integrate ATP7B into systemic copper homeostasis by coupling copper storage, secretory maturation, and detoxifying excretion. | (petruzzelli2026copperinhuman pages 30-35, ovchinnikova2024epidemiologyofwilson’s pages 3-6, petruzzelli2026copperinhuman pages 3-4) |
+| Consequences of loss-of-function | Pathogenic ATP7B variants impair enzymatic activity and/or trafficking, blocking ceruloplasmin metallation and biliary copper excretion. The result is hepatic copper accumulation, elevated free copper, and subsequent injury to liver and extrahepatic organs; His1069Gln is specifically associated with folding defects, ER retention/degradation, low ceruloplasmin, and neuropsychiatric-predominant disease. | (petruzzelli2026copperinhuman pages 30-35, ovchinnikova2024epidemiologyofwilson’s pages 3-6) |
+| Example mutations affecting trafficking | C-terminal ATP7B variants S1423N, S1426I, and T1434M alter TGN retention and Cu-responsive Golgi exit in a cell-polarization-dependent manner; S1423N shows incomplete rescue of trafficking in differentiated cells, whereas S1426I and T1434M show corrected localization/trafficking in differentiated models. The study concludes that distal C-terminus helps govern cell-specific TGN localization and exit. | (chakraborty2023wilsondiseasecausing pages 1-2) |
+
+
+*Table: This table summarizes the core functional annotation of human ATP7B, including substrate, mechanism, domain features, localization, copper-dependent trafficking, and disease-relevant consequences. It condenses the most relevant evidence gathered for a functional annotation-focused research report.*
+
+### 12) Notes on evidence scope and recency
+This report prioritizes 2023–2024 sources for mechanistic and trafficking updates (e.g., Chakraborty 2023; Guo 2024; Ovchinnikova 2024; Choi 2024). For some clinically actionable diagnostic details (DBS ATP7B peptide quantification; copper speciation metrics), the most explicit data located in the retrieved corpus came from a 2025 hepatology review, which is included because it provides concrete quantitative performance details and describes ongoing trial directions. (marino2025wilsondiseasenovel pages 7-8)
+
+
+References
+
+1. (ovchinnikova2024epidemiologyofwilson’s pages 3-6): Elena Vasilievna Ovchinnikova, Mikhail Maksimovich Garbuz, Anna Aleksandrovna Ovchinnikova, and Vadim Vladimirovich Kumeiko. Epidemiology of wilson’s disease and pathogenic variants of the atp7b gene leading to diversified protein disfunctions. International Journal of Molecular Sciences, 25:2402, Feb 2024. URL: https://doi.org/10.3390/ijms25042402, doi:10.3390/ijms25042402. This article has 51 citations.
+
+2. (guo2024diverserolesof pages 1-2): Zongxin Guo, Fredrik Orädd, Viktoria Bågenholm, Christina Grønberg, Jian Feng Ma, Peter Ott, Yong Wang, Magnus Andersson, Per Amstrup Pedersen, Kaituo Wang, and Pontus Gourdon. Diverse roles of the metal binding domains and transport mechanism of copper transporting p-type atpases. Nature Communications, Mar 2024. URL: https://doi.org/10.1038/s41467-024-47001-4, doi:10.1038/s41467-024-47001-4. This article has 20 citations and is from a highest quality peer-reviewed journal.
+
+3. (gourdon2012structuralmodelsof pages 1-4): Pontus Gourdon, Oleg Sitsel, Jesper Lykkegaard Karlsen, Lisbeth Birk Møller, and Poul Nissen. Structural models of the human copper p-type atpases atp7a and atp7b. bchm, 393:205-216, Apr 2012. URL: https://doi.org/10.1515/hsz-2011-0249, doi:10.1515/hsz-2011-0249. This article has 74 citations.
+
+4. (petruzzelli2026copperinhuman pages 3-4): Raffaella Petruzzelli, Elena Polishchuk, and Roman Polishchuk. Copper in human health and disease: insights from inherited disorders. Physiology, Nov 2026. URL: https://doi.org/10.1152/physiol.00032.2025, doi:10.1152/physiol.00032.2025. This article has 6 citations and is from a peer-reviewed journal.
+
+5. (petruzzelli2026copperinhuman pages 30-35): Raffaella Petruzzelli, Elena Polishchuk, and Roman Polishchuk. Copper in human health and disease: insights from inherited disorders. Physiology, Nov 2026. URL: https://doi.org/10.1152/physiol.00032.2025, doi:10.1152/physiol.00032.2025. This article has 6 citations and is from a peer-reviewed journal.
+
+6. (guo2024diverserolesof media 2f81ca0e): Zongxin Guo, Fredrik Orädd, Viktoria Bågenholm, Christina Grønberg, Jian Feng Ma, Peter Ott, Yong Wang, Magnus Andersson, Per Amstrup Pedersen, Kaituo Wang, and Pontus Gourdon. Diverse roles of the metal binding domains and transport mechanism of copper transporting p-type atpases. Nature Communications, Mar 2024. URL: https://doi.org/10.1038/s41467-024-47001-4, doi:10.1038/s41467-024-47001-4. This article has 20 citations and is from a highest quality peer-reviewed journal.
+
+7. (guo2024diverserolesof media 44828a63): Zongxin Guo, Fredrik Orädd, Viktoria Bågenholm, Christina Grønberg, Jian Feng Ma, Peter Ott, Yong Wang, Magnus Andersson, Per Amstrup Pedersen, Kaituo Wang, and Pontus Gourdon. Diverse roles of the metal binding domains and transport mechanism of copper transporting p-type atpases. Nature Communications, Mar 2024. URL: https://doi.org/10.1038/s41467-024-47001-4, doi:10.1038/s41467-024-47001-4. This article has 20 citations and is from a highest quality peer-reviewed journal.
+
+8. (petruzzelli2026copperinhuman pages 18-19): Raffaella Petruzzelli, Elena Polishchuk, and Roman Polishchuk. Copper in human health and disease: insights from inherited disorders. Physiology, Nov 2026. URL: https://doi.org/10.1152/physiol.00032.2025, doi:10.1152/physiol.00032.2025. This article has 6 citations and is from a peer-reviewed journal.
+
+9. (petruzzelli2026copperinhuman pages 19-21): Raffaella Petruzzelli, Elena Polishchuk, and Roman Polishchuk. Copper in human health and disease: insights from inherited disorders. Physiology, Nov 2026. URL: https://doi.org/10.1152/physiol.00032.2025, doi:10.1152/physiol.00032.2025. This article has 6 citations and is from a peer-reviewed journal.
+
+10. (chakraborty2023wilsondiseasecausing pages 1-2): Kaustav Chakraborty, Santanu Das, Anusree Pal, Saptarshi Maji, Bhawana Rai, Arnab Gupta, and Ashima Bhattacharjee. Wilson disease causing mutations in the carboxyl terminus of atp7b regulates its localization and golgi exit selectively in the unpolarized cells. Metallomics : integrated biometal science, Sep 2023. URL: https://doi.org/10.1093/mtomcs/mfad051, doi:10.1093/mtomcs/mfad051. This article has 3 citations.
+
+11. (ovchinnikova2024epidemiologyofwilson’s pages 2-3): Elena Vasilievna Ovchinnikova, Mikhail Maksimovich Garbuz, Anna Aleksandrovna Ovchinnikova, and Vadim Vladimirovich Kumeiko. Epidemiology of wilson’s disease and pathogenic variants of the atp7b gene leading to diversified protein disfunctions. International Journal of Molecular Sciences, 25:2402, Feb 2024. URL: https://doi.org/10.3390/ijms25042402, doi:10.3390/ijms25042402. This article has 51 citations.
+
+12. (choi2024navigatingthecrisprcas pages 16-17): Woong Choi, Seongkwang Cha, and Kyoungmi Kim. Navigating the crispr/cas landscape for enhanced diagnosis and treatment of wilson’s disease. Cells, 13:1214, Jul 2024. URL: https://doi.org/10.3390/cells13141214, doi:10.3390/cells13141214. This article has 12 citations.
+
+13. (ovchinnikova2024epidemiologyofwilson’s pages 1-2): Elena Vasilievna Ovchinnikova, Mikhail Maksimovich Garbuz, Anna Aleksandrovna Ovchinnikova, and Vadim Vladimirovich Kumeiko. Epidemiology of wilson’s disease and pathogenic variants of the atp7b gene leading to diversified protein disfunctions. International Journal of Molecular Sciences, 25:2402, Feb 2024. URL: https://doi.org/10.3390/ijms25042402, doi:10.3390/ijms25042402. This article has 51 citations.
+
+14. (marino2025wilsondiseasenovel pages 7-8): Zoe Mariño and Michael L. Schilsky. Wilson disease: novel diagnostic and therapeutic approaches. Seminars in Liver Disease, 45:221-235, Nov 2025. URL: https://doi.org/10.1055/a-2460-8999, doi:10.1055/a-2460-8999. This article has 18 citations and is from a peer-reviewed journal.
+
+15. (ivanenko2025therapeuticstrategiesfor pages 1-2): A.L. Ivanenko, VD Starodubova, and AG Shokhina. Therapeutic strategies for wilson’s disease: current state and prospects. Bulletin of Russian State Medical University, Apr 2025. URL: https://doi.org/10.24075/brsmu.2025.022, doi:10.24075/brsmu.2025.022. This article has 0 citations.
+
+16. (teschke2024wilsondiseasecoppermediated pages 19-21): Rolf Teschke and Axel Eickhoff. Wilson disease: copper-mediated cuproptosis, iron-related ferroptosis, and clinical highlights, with comprehensive and critical analysis update. International Journal of Molecular Sciences, 25:4753, Apr 2024. URL: https://doi.org/10.3390/ijms25094753, doi:10.3390/ijms25094753. This article has 116 citations.
+
+17. (NCT04884815 chunk 1):  A Phase 1/2/3 Study of UX701 Gene Therapy in Adults With Wilson Disease. Ultragenyx Pharmaceutical Inc. 2021. ClinicalTrials.gov Identifier: NCT04884815
+
+18. (NCT04884815 chunk 2):  A Phase 1/2/3 Study of UX701 Gene Therapy in Adults With Wilson Disease. Ultragenyx Pharmaceutical Inc. 2021. ClinicalTrials.gov Identifier: NCT04884815
+
+19. (NCT04537377 chunk 1):  A Phase I/II Study of VTX-801 in Adult Patients With Wilson's Disease. Vivet Therapeutics SAS. 2021. ClinicalTrials.gov Identifier: NCT04537377
+
+20. (NCT07240896 chunk 1):  A Clinical Study on the Treatment of Wilson Disease With ATP7B mRNA/LNP (DSL101). DSciLab Co., Ltd.. 2025. ClinicalTrials.gov Identifier: NCT07240896
+
+21. (NCT07173933 chunk 1):  Phase I/II Clinical Study to Evaluate the Safety, Tolerability, and Efficacy of GC310 Injection in Patients With Wilson's Disease (WD). GeneCradle Inc. 2025. ClinicalTrials.gov Identifier: NCT07173933
+
+22. (NCT07226622 chunk 1):  Prescreening Study to Identify Potential Wilson Disease Participants for Gene-Editing Clinical Trial. Prime Medicine, Inc.. 2025. ClinicalTrials.gov Identifier: NCT07226622
+
+23. (OpenTargets Search: Wilson disease-ATP7B): Open Targets Query (Wilson disease-ATP7B, 5 results). Buniello, A. et al. (2025). Open Targets Platform: facilitating therapeutic hypotheses building in drug discovery. Nucleic Acids Research.
+
+24. (marino2025wilsondiseasenovel pages 11-12): Zoe Mariño and Michael L. Schilsky. Wilson disease: novel diagnostic and therapeutic approaches. Seminars in Liver Disease, 45:221-235, Nov 2025. URL: https://doi.org/10.1055/a-2460-8999, doi:10.1055/a-2460-8999. This article has 18 citations and is from a peer-reviewed journal.
+
+25. (zeng2025evaluationofefficacy pages 1-2): Chunhua Zeng, Yunting Lin, Xinshuo Lu, Shehong Chen, Yan Xia, Kangdi Zhang, Yongxian Shao, Zhihong Guan, Rong Du, Zongcai Liu, Mingqi Zhao, Xiaoling Jiang, Yanna Cai, Taolin Li, Xueying Su, Yaoyong Chen, Xiaoyan Dong, Wen Zhang, Li Liu, and Wenhao Zhou. Evaluation of efficacy and safety of aav8-δc4atp7b gene therapy in a mutant mouse model of wilson’s disease. Molecular Therapy Methods &amp; Clinical Development, 33:101435, Mar 2025. URL: https://doi.org/10.1016/j.omtm.2025.101435, doi:10.1016/j.omtm.2025.101435. This article has 1 citations.
+
+## Citations
+
+1. guo2024diverserolesof pages 1-2
+2. petruzzelli2026copperinhuman pages 18-19
+3. petruzzelli2026copperinhuman pages 19-21
+4. chakraborty2023wilsondiseasecausing pages 1-2
+5. choi2024navigatingthecrisprcas pages 16-17
+6. marino2025wilsondiseasenovel pages 7-8
+7. marino2025wilsondiseasenovel pages 11-12
+8. gourdon2012structuralmodelsof pages 1-4
+9. petruzzelli2026copperinhuman pages 3-4
+10. petruzzelli2026copperinhuman pages 30-35
+11. ivanenko2025therapeuticstrategiesfor pages 1-2
+12. teschke2024wilsondiseasecoppermediated pages 19-21
+13. zeng2025evaluationofefficacy pages 1-2
+14. https://doi.org/10.1093/mtomcs/mfad051;
+15. https://doi.org/10.1038/s41467-024-47001-4;
+16. https://doi.org/10.3390/ijms25042402;
+17. https://doi.org/10.3390/cells13141214;
+18. https://doi.org/10.1055/a-2460-8999;
+19. https://clinicaltrials.gov/study/NCT04884815;
+20. https://clinicaltrials.gov/study/NCT04537377;
+21. https://clinicaltrials.gov/study/NCT07240896;
+22. https://clinicaltrials.gov/study/NCT07173933;
+23. https://doi.org/10.3390/ijms25042402,
+24. https://doi.org/10.1038/s41467-024-47001-4,
+25. https://doi.org/10.1515/hsz-2011-0249,
+26. https://doi.org/10.1152/physiol.00032.2025,
+27. https://doi.org/10.1093/mtomcs/mfad051,
+28. https://doi.org/10.3390/cells13141214,
+29. https://doi.org/10.1055/a-2460-8999,
+30. https://doi.org/10.24075/brsmu.2025.022,
+31. https://doi.org/10.3390/ijms25094753,
+32. https://doi.org/10.1016/j.omtm.2025.101435,

--- a/genes/human/TPM1/TPM1-ai-review.html
+++ b/genes/human/TPM1/TPM1-ai-review.html
@@ -671,33 +671,33 @@
     <div class="header">
         <h1>TPM1</h1>
         <div class="gene-info">
-            
+
             <div class="info-item">
-                
+
                 <span class="info-label">UniProt ID:</span>
                 <span>
                     <a href="https://www.uniprot.org/uniprotkb/P09493" target="_blank" class="term-link">
                         P09493
                     </a>
                 </span>
-                
+
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Organism:</span>
                 <span>Homo sapiens</span>
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
-                <span class="status-badge status-initialized">
-                    INITIALIZED
+                <span class="status-badge status-complete">
+                    COMPLETE
                 </span>
             </div>
-            
-            
+
+
         </div>
         <div style="margin-top: 1rem; text-align: center;">
             <a id="feedback-form-link"
@@ -728,7 +728,7 @@
         </div>
     </div>
 
-    
+
     <div class="description-card">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <h2>Gene Description</h2>
@@ -739,13 +739,13 @@
         </div>
         <p>TPM1 (Tropomyosin 1) is a coiled-coil actin-binding protein with 10 tissue-specific isoforms. ISOFORM BIOLOGY: (1) Isoform 1 (TPM1alpha, P09493-1) is expressed in SKELETAL MUSCLE; (2) Isoform 2 is SMOOTH MUSCLE-specific; (3) Isoform 3 (TM3) is the FIBROBLAST/cytoskeletal form; (4) Isoform 6 (TPM1kappa) is CARDIAC-specific. UniProt states &#34;Isoform 1 is expressed in adult and fetal skeletal muscle and cardiac tissues. Isoform 10 is expressed in adult and fetal cardiac tissues, but not in skeletal muscle.&#34; Muscle isoforms regulate actin-myosin interaction in sarcomeres; cytoskeletal isoforms organize non-muscle actin. DISEASE: Mutations cause cardiomyopathy (CMH3, CMD1Y) affecting sarcomere function. Annotations for &#34;muscle contraction&#34; and &#34;sarcomere&#34; apply primarily to muscle isoforms, while &#34;cytoskeleton organization&#34; applies more to non-muscle isoforms.</p>
     </div>
-    
 
-    
 
-    
 
-    
+
+
+
+
     <div class="section">
         <h2 class="section-title">Existing Annotations Review</h2>
         <table class="annotations-table">
@@ -758,32 +758,32 @@
                 </tr>
             </thead>
             <tbody>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051015" target="_blank" class="term-link">
                                     GO:0051015
                                 </a>
                             </span>
                             <span class="term-label">actin filament binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -795,77 +795,88 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Core function of all TPM1 isoforms. Tropomyosin binds along the length of actin filaments in both muscle and non-muscle cells. UniProt states that TPM1 binds to actin filaments. This function is conserved across all isoforms - muscle isoforms bind thin filament actin while cytoskeletal isoforms bind stress fiber actin.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Actin filament binding is the fundamental molecular function of all tropomyosins. IBA annotation is appropriate as this function is phylogenetically conserved. Supported by functional studies showing TPM1 binds actin filaments in both muscle and non-muscle contexts [PMID:12686598].
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/12686598" target="_blank" class="term-link">
                                         PMID:12686598
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">tropomyosin-1 was found diffuse in the cells, whereas it quickly colocalized with actin and stress fibers upon stimulation</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/8205619" target="_blank" class="term-link">
                                         PMID:8205619
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">alpha-tropomyosin and cardiac troponin T as well as beta myosin heavy chain mutations cause the same phenotype, we conclude that FHC is a disease of the sarcomere</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TPM1/TPM1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The target gene TPM1 in Homo sapiens encodes tropomyosin alpha-1 chain, a coiled-coil protein of the tropomyosin family that binds F-actin and specifies functional properties of actin filaments in both sarcomeric thin filaments and specialized non-muscle actin networks.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007015" target="_blank" class="term-link">
                                     GO:0007015
                                 </a>
                             </span>
                             <span class="term-label">actin filament organization</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -877,77 +888,77 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TPM1 plays a role in actin filament organization in both muscle and non-muscle cells. In muscle, it organizes thin filaments; in non-muscle cells, it contributes to stress fiber formation and cytoskeletal organization [PMID:12686598].
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Actin filament organization is a core function of tropomyosins across all isoforms. Muscle isoforms organize thin filaments in sarcomeres; cytoskeletal isoforms stabilize stress fibers in non-muscle cells. IBA annotation is appropriate.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/12686598" target="_blank" class="term-link">
                                         PMID:12686598
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">phosphorylation of tropomyosin-1 downstream of ERK by contributing to formation of actin filaments increases cellular contractility and promotes the formation of focal adhesions</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/15897890" target="_blank" class="term-link">
                                         PMID:15897890
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">TGF-beta induction of stress fibers in epithelial cells requires high molecular weight tropomyosins encoded by TPM1 and TPM2 genes</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005884" target="_blank" class="term-link">
                                     GO:0005884
                                 </a>
                             </span>
                             <span class="term-label">actin filament</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -959,64 +970,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TPM1 localizes to actin filaments in both muscle and non-muscle cells. This cellular component annotation reflects the physical location of tropomyosin bound along actin filaments.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Tropomyosin is an integral component of actin filaments. In muscle cells it forms the thin filament regulatory complex; in non-muscle cells it associates with stress fibers and other actin structures. IBA annotation is appropriate.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/12686598" target="_blank" class="term-link">
                                         PMID:12686598
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">tropomyosin-1 was found diffuse in the cells, whereas it quickly colocalized with actin and stress fibers upon stimulation</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0060048" target="_blank" class="term-link">
                                     GO:0060048
                                 </a>
                             </span>
                             <span class="term-label">cardiac muscle contraction</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1028,77 +1039,77 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> ISOFORM-SPECIFIC: Cardiac muscle contraction is a function of the striated muscle isoforms (Isoform 1/TPM1alpha and Isoform 6/TPM1kappa). UniProt states Isoform 1 is expressed in cardiac tissues and Isoform 6 is cardiac-specific. Mutations cause cardiomyopathy (CMH3, CMD1Y) [PMID:8205619, PMID:11273725].
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This is a core function for cardiac isoforms. TPM1 plays a central role in calcium-dependent regulation of cardiac muscle contraction via the troponin complex. Mutations affecting this function cause hypertrophic and dilated cardiomyopathy, demonstrating its importance [PMID:8205619]. IBA annotation is appropriate as this function is conserved in striated muscle isoforms.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/8205619" target="_blank" class="term-link">
                                         PMID:8205619
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">We demonstrate that missense mutations (Asp175Asn; Glu180Gly) in the alpha-tropomyosin gene cause familial hypertrophic cardiomyopathy (FHC)</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/11136687" target="_blank" class="term-link">
                                         PMID:11136687
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">HCM was linked to the TPM1 gene... The mutation caused a 40% to 50% increase in calcium affinity in regulated thin filament-myosin subfragment-1 (S1) MgATPase assays</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003779" target="_blank" class="term-link">
                                     GO:0003779
                                 </a>
                             </span>
                             <span class="term-label">actin binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1110,64 +1121,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Actin binding is the fundamental molecular function of all tropomyosins. This IEA annotation based on UniProt keyword mapping is correct but less specific than GO:0051015 (actin filament binding) which is already annotated via IBA.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> While this is a broader parent term of actin filament binding, it is still correct. IEA annotations at a broader level are acceptable alongside more specific experimental annotations. No action needed as the more specific IBA annotation (GO:0051015) captures the precise function.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/12686598" target="_blank" class="term-link">
                                         PMID:12686598
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">tropomyosin-1 was found diffuse in the cells, whereas it quickly colocalized with actin and stress fibers upon stimulation</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005856" target="_blank" class="term-link">
                                     GO:0005856
                                 </a>
                             </span>
                             <span class="term-label">cytoskeleton</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1179,64 +1190,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TPM1 is a cytoskeletal protein. UniProt subcellular location indicates &#34;Cytoplasm, cytoskeleton&#34; and notes it &#34;Associates with F-actin stress fibers.&#34; This is a broad cellular component annotation appropriate for all isoforms.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This is a valid broad localization term. All TPM1 isoforms are components of the cytoskeleton, whether in sarcomeres (muscle isoforms) or stress fibers (non-muscle isoforms). IEA based on UniProt subcellular location is appropriate.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/12686598" target="_blank" class="term-link">
                                         PMID:12686598
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">tropomyosin-1 was found diffuse in the cells, whereas it quickly colocalized with actin and stress fibers upon stimulation</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005862" target="_blank" class="term-link">
                                     GO:0005862
                                 </a>
                             </span>
                             <span class="term-label">muscle thin filament tropomyosin</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1248,88 +1259,88 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> ISOFORM-SPECIFIC: This cellular component term is specifically for muscle isoforms (Isoform 1/skeletal, Isoform 2/smooth, Isoform 6/cardiac). The muscle thin filament tropomyosin complex contains tropomyosin bound to actin filaments in sarcomeres. Non-muscle isoforms (e.g., Isoform 3/fibroblast) do not form this specific complex.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This is a core localization for muscle isoforms of TPM1. The annotation is correct for the muscle-expressed isoforms that are integral to the thin filament regulatory complex in sarcomeres [PMID:8205619].
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/8205619" target="_blank" class="term-link">
                                         PMID:8205619
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">FHC is a disease of the sarcomere</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/11136687" target="_blank" class="term-link">
                                         PMID:11136687
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">regulated thin filament-myosin subfragment-1 (S1) MgATPase assays</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16189514" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16189514
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Towards a proteome-scale map of the human protein-protein in...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1341,75 +1352,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> High-throughput Y2H interactome study. The term &#34;protein binding&#34; is uninformative and does not indicate specific binding partners or functional context. TPM1 binds actin, troponins, and other muscle/cytoskeletal proteins, but this generic term does not capture those specific interactions.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> &#34;Protein binding&#34; (GO:0005515) is an uninformative annotation that does not convey the specific molecular interactions of TPM1 (e.g., actin binding, troponin complex binding). High-throughput interactome studies often generate these generic annotations. More specific MF terms are preferred [PMID:16189514].
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/16189514" target="_blank" class="term-link">
                                         PMID:16189514
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Using a stringent, high-throughput yeast two-hybrid system, we tested pairwise interactions among the products of approximately 8,100 currently available Gateway-cloned open reading frames and detected approximately 2,800 interactions</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21516116" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21516116
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Next-generation sequencing to generate interactome datasets.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1421,75 +1432,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> High-throughput Stitch-seq Y2H interactome study. The generic term &#34;protein binding&#34; is uninformative for this well-characterized actin-binding protein.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> &#34;Protein binding&#34; (GO:0005515) from high-throughput interactome studies is too generic. TPM1 has specific, well-characterized binding partners (actin, troponins, LMOD2, TMOD1) that are more informative [PMID:21516116].
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21516116" target="_blank" class="term-link">
                                         PMID:21516116
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">We describe a massively parallel interactome-mapping pipeline, Stitch-seq, that combines PCR stitching with next-generation sequencing and used it to generate a new human interactome dataset</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/25416956" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:25416956
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A proteome-scale map of the human interactome network.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1501,75 +1512,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Large-scale proteome-scale human interactome map study. Generic &#34;protein binding&#34; term is uninformative for TPM1 which has well-characterized specific interactions.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> &#34;Protein binding&#34; (GO:0005515) from systematic interactome mapping is too generic. TPM1 has specific, functionally important binding partners that should be annotated instead [PMID:25416956].
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/25416956" target="_blank" class="term-link">
                                         PMID:25416956
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Here, we describe a systematic map of ?14,000 high-quality human binary protein-protein interactions</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/26871637" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:26871637
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Widespread Expansion of Protein Interaction Capabilities by ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1581,75 +1592,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Study on alternative splicing and protein interaction capabilities. Notably relevant for TPM1 which has 10 isoforms with different interaction profiles. However &#34;protein binding&#34; remains uninformative.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> While this study is highly relevant to TPM1 isoform biology, showing that alternative isoforms exhibit different interaction profiles, the generic &#34;protein binding&#34; term does not capture the specific binding partners or isoform-specific interactions [PMID:26871637].
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/26871637" target="_blank" class="term-link">
                                         PMID:26871637
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The majority of isoform pairs share less than 50% of their interactions. In the global context of interactome network maps, alternative isoforms tend to behave like distinct proteins rather than minor variants of each other</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/30021884" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:30021884
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Histone Interaction Landscapes Visualized by Crosslinking Ma...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1661,75 +1672,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Crosslinking mass spectrometry study of histone interactions in nuclei. TPM1 is a cytoplasmic/cytoskeletal protein; its detection here may be incidental. Generic &#34;protein binding&#34; term is uninformative.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> &#34;Protein binding&#34; from crosslinking MS study of nuclear proteins is not informative for TPM1, which is primarily a cytoskeletal protein. The generic term provides no functional insight [PMID:30021884].
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/30021884" target="_blank" class="term-link">
                                         PMID:30021884
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Here we use crosslinking mass spectrometry (XL-MS) to chart the protein-protein interactions in intact human nuclei</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:33961781
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Dual proteome-scale networks reveal cell-specific remodeling...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1741,75 +1752,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> BioPlex 3.0 dual proteome-scale network study in 293T and HCT116 cells. While this reveals cell-specific interactome remodeling relevant to TPM1 isoforms, the generic &#34;protein binding&#34; term is uninformative.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> &#34;Protein binding&#34; from large-scale AP-MS interactome study does not provide specific information about TPM1&#39;s functional binding partners. More specific terms for actin binding, troponin binding etc. are preferred [PMID:33961781].
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
                                         PMID:33961781
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Thousands of interactions assemble proteins into modules that impart spatial and functional organization to the cellular proteome</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:40205054
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Multimodal cell maps as a foundation for structural and func...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1821,82 +1832,82 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Multimodal cell maps study integrating multiple data types for structural and functional genomics. Generic &#34;protein binding&#34; term is uninformative.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> &#34;Protein binding&#34; from multimodal cell mapping study does not convey specific information about TPM1&#39;s well-characterized binding partners [PMID:40205054].
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link">
                                         PMID:40205054
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Multimodal cell maps as a foundation for structural and functional genomics</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
+
+
                         <br>
                         <span class="isoform-badge" title="This annotation was made on a specific isoform">
                             <a href="https://www.uniprot.org/uniprotkb/P09493-10" target="_blank" class="term-link" style="font-size: 0.7rem;">
                                 P09493-10
                             </a>
                         </span>
-                        
-                        
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/25910212" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:25910212
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Widespread macromolecular interaction perturbations in human...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1908,82 +1919,82 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> ISOFORM-SPECIFIC ANNOTATION (P09493-10). Study on macromolecular interaction perturbations in genetic disorders. While highly relevant to understanding how TPM1 mutations affect interactions, &#34;protein binding&#34; is uninformative.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> &#34;Protein binding&#34; from edgetic mutation studies is too generic. This study shows disease mutations can perturb specific interactions, but the annotation lacks specificity about which interactions [PMID:25910212].
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/25910212" target="_blank" class="term-link">
                                         PMID:25910212
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">While common variants from healthy individuals rarely affect interactions, two-thirds of disease-associated alleles perturb protein-protein interactions, with half corresponding to &#34;edgetic&#34; alleles affecting only a subset of interactions while leaving most other interactions unperturbed</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
+
+
                         <br>
                         <span class="isoform-badge" title="This annotation was made on a specific isoform">
                             <a href="https://www.uniprot.org/uniprotkb/P09493-10" target="_blank" class="term-link" style="font-size: 0.7rem;">
                                 P09493-10
                             </a>
                         </span>
-                        
-                        
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:32296183
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A reference map of the human binary protein interactome.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1995,64 +2006,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> ISOFORM-SPECIFIC ANNOTATION (P09493-10). HuRI reference human binary protein interactome map. While highly valuable for mapping interactions, the generic &#34;protein binding&#34; term is uninformative for TPM1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> &#34;Protein binding&#34; from the comprehensive HuRI interactome map does not convey specific binding partners. TPM1 has well-characterized interactions with actin, troponins, and other thin filament proteins that are more informative [PMID:32296183].
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
                                         PMID:32296183
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Here we present a human &#39;all-by-all&#39; reference interactome map of human binary protein interactions, or &#39;HuRI&#39;</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
                                     GO:0042802
                                 </a>
                             </span>
                             <span class="term-label">identical protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">ISS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000024
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2064,46 +2075,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Tropomyosins form coiled-coil dimers (homo- or heterodimers) as their functional unit. UniProt indicates TPM1 forms dimers with itself or other tropomyosin isoforms. This ISS annotation from sequence similarity is consistent with the coiled-coil structure of tropomyosins.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> TPM1 forms parallel coiled-coil dimers that bind along actin filaments. This is a fundamental structural property of all tropomyosins. Self-association (homodimerization) is documented in UniProt. ISS annotation based on sequence similarity to characterized orthologs is appropriate.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042803" target="_blank" class="term-link">
                                     GO:0042803
                                 </a>
                             </span>
                             <span class="term-label">protein homodimerization activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">ISS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000024
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2115,46 +2126,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Tropomyosins function as coiled-coil dimers. TPM1 homodimerizes to form the functional unit that binds along actin filaments. This is a core structural property of tropomyosins.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Homodimerization is fundamental to tropomyosin function. Two TPM1 chains form a parallel coiled-coil dimer that spans seven actin subunits. ISS annotation based on sequence similarity is appropriate for this conserved structural property.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046982" target="_blank" class="term-link">
                                     GO:0046982
                                 </a>
                             </span>
                             <span class="term-label">protein heterodimerization activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">ISS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000024
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2166,46 +2177,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TPM1 can form heterodimers with other tropomyosin isoforms (e.g., TPM2, TPM3). UniProt indicates it interacts with self or TPM2. Heterodimer formation provides functional diversity in different tissue contexts.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Heterodimerization with other tropomyosin isoforms is a documented property that provides functional diversity. TPM1 can form dimers with TPM2 and potentially other isoforms. ISS annotation based on sequence similarity is appropriate.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051015" target="_blank" class="term-link">
                                     GO:0051015
                                 </a>
                             </span>
                             <span class="term-label">actin filament binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">ISS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000024
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2217,57 +2228,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Duplicate of the IBA annotation for actin filament binding. This ISS annotation provides additional evidence for this core function from sequence similarity.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Actin filament binding is the fundamental molecular function of TPM1 across all isoforms. This ISS annotation supplements the IBA annotation and is consistent with the conserved function of tropomyosins.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008360" target="_blank" class="term-link">
                                     GO:0008360
                                 </a>
                             </span>
                             <span class="term-label">regulation of cell shape</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21817107" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21817107
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     MicroRNA-21 regulates vascular smooth muscle cell function v...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -2279,75 +2290,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> ISOFORM-SPECIFIC: This annotation relates to the cytoskeletal (non-muscle) function of TPM1 isoforms. The study shows TPM1 affects vascular smooth muscle cell morphology via cytoskeletal remodeling [PMID:21817107].
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Regulation of cell shape is a function of cytoskeletal TPM1 isoforms in non-muscle cells. While important, it is not the core function of the striated muscle isoforms. This is a valid annotation for cytoskeletal isoforms [PMID:21817107].
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21817107" target="_blank" class="term-link">
                                         PMID:21817107
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">cell proliferation and migration were significantly decreased by</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1904706" target="_blank" class="term-link">
                                     GO:1904706
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of vascular associated smooth muscle cell proliferation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21817107" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21817107
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     MicroRNA-21 regulates vascular smooth muscle cell function v...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -2359,75 +2370,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> ISOFORM-SPECIFIC: TPM1 overexpression inhibits vascular smooth muscle cell (VSMC) proliferation. This relates to the cytoskeletal function of TPM1 in regulating cell behavior [PMID:21817107].
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This is a valid functional annotation for cytoskeletal TPM1 isoforms in smooth muscle cells. While biologically relevant, it represents a peripheral function rather than the core sarcomeric function of TPM1 [PMID:21817107].
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21817107" target="_blank" class="term-link">
                                         PMID:21817107
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">cell proliferation and migration were significantly decreased by</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1904753" target="_blank" class="term-link">
                                     GO:1904753
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of vascular associated smooth muscle cell migration</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21817107" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21817107
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     MicroRNA-21 regulates vascular smooth muscle cell function v...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -2439,64 +2450,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> ISOFORM-SPECIFIC: TPM1 overexpression inhibits vascular smooth muscle cell (VSMC) migration. This relates to the cytoskeletal function of TPM1 in regulating cell motility [PMID:21817107].
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This is a valid functional annotation for cytoskeletal TPM1 isoforms in smooth muscle cells. While biologically relevant, it represents a peripheral function rather than the core sarcomeric function of TPM1 [PMID:21817107].
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21817107" target="_blank" class="term-link">
                                         PMID:21817107
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">cell proliferation and migration were significantly decreased by</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-390593
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2508,46 +2519,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Reactome pathway annotation for muscle contraction. TPM1 is a cytosolic/ cytoskeletal protein that associates with actin filaments. Cytosol localization is valid for soluble tropomyosin before assembly.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytosol is an appropriate cellular component for TPM1. Prior to incorporation into actin filaments, tropomyosin exists in the cytosol. Reactome pathway annotations for muscle contraction support this localization.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-390595
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2559,46 +2570,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Duplicate Reactome pathway annotation for cytosol localization in muscle contraction pathway.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Valid cellular component annotation from Reactome muscle contraction pathway. Cytosol localization is appropriate for soluble tropomyosin.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-390597
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2610,46 +2621,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Duplicate Reactome pathway annotation for cytosol localization.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Valid cellular component annotation from Reactome pathway. Cytosol localization is appropriate for soluble tropomyosin.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-390598
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2661,46 +2672,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Duplicate Reactome pathway annotation for cytosol localization.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Valid cellular component annotation from Reactome pathway. Cytosol localization is appropriate for soluble tropomyosin.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-445699
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2712,46 +2723,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Duplicate Reactome pathway annotation for cytosol localization.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Valid cellular component annotation from Reactome pathway. Cytosol localization is appropriate for soluble tropomyosin.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-445700
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2763,46 +2774,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Duplicate Reactome pathway annotation for cytosol localization.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Valid cellular component annotation from Reactome pathway. Cytosol localization is appropriate for soluble tropomyosin.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-445704
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2814,46 +2825,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Duplicate Reactome pathway annotation for cytosol localization.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Valid cellular component annotation from Reactome pathway. Cytosol localization is appropriate for soluble tropomyosin.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-445705
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2865,57 +2876,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Duplicate Reactome pathway annotation for cytosol localization.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Valid cellular component annotation from Reactome pathway. Cytosol localization is appropriate for soluble tropomyosin.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008092" target="_blank" class="term-link">
                                     GO:0008092
                                 </a>
                             </span>
                             <span class="term-label">cytoskeletal protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17987659" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:17987659
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Nebulette interacts with filamin C.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2927,75 +2938,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TPM1 binds cytoskeletal proteins including nebulette. The study identified tropomyosin-1 as a binding partner of nebulette in a yeast two-hybrid screen [PMID:17987659].
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytoskeletal protein binding accurately describes TPM1&#39;s interactions with actin filaments and associated regulatory proteins. This is a valid molecular function annotation that is more specific than &#34;protein binding&#34;.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/17987659" target="_blank" class="term-link">
                                         PMID:17987659
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Nebulette interacts with filamin C.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045214" target="_blank" class="term-link">
                                     GO:0045214
                                 </a>
                             </span>
                             <span class="term-label">sarcomere organization</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/11273725" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:11273725
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Mutations that alter the surface charge of alpha-tropomyosin...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3007,75 +3018,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> ISOFORM-SPECIFIC: Sarcomere organization is a function of muscle isoforms. TPM1 mutations cause disorganized sarcomere structure in cardiomyopathy [PMID:11273725].
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Sarcomere organization is a core function of striated muscle TPM1 isoforms. Mutations affecting this function cause hypertrophic and dilated cardiomyopathy. This is a well-supported experimental annotation [PMID:11273725].
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/11273725" target="_blank" class="term-link">
                                         PMID:11273725
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Proteins in cardiac myocytes assemble into contractile units known as sarcomeres</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001725" target="_blank" class="term-link">
                                     GO:0001725
                                 </a>
                             </span>
                             <span class="term-label">stress fiber</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/12686598" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:12686598
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Extracellular signal-regulated kinase mediates phosphorylati...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3087,75 +3098,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> ISOFORM-SPECIFIC: TPM1 localizes to stress fibers in non-muscle cells. The study shows TPM1 colocalizes with actin stress fibers upon stimulation [PMID:12686598].
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Stress fiber localization is a valid cellular component annotation for cytoskeletal TPM1 isoforms (e.g., Isoform 3/TM3). IDA evidence from direct observation of colocalization with stress fibers [PMID:12686598].
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/12686598" target="_blank" class="term-link">
                                         PMID:12686598
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">tropomyosin-1 was found diffuse in the cells, whereas it quickly colocalized with actin and stress fibers upon stimulation</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003065" target="_blank" class="term-link">
                                     GO:0003065
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of heart rate by epinephrine</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">ISS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17556658" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:17556658
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Dilated cardiomyopathy mutant tropomyosin mice develop cardi...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -3167,75 +3178,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> ISOFORM-SPECIFIC: This relates to cardiac isoforms (TPM1alpha, TPM1kappa) and their role in beta-adrenergic signaling in the heart. Tropomyosin phosphorylation modulates cardiac contractility.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> While TPM1 is involved in cardiac muscle contraction, the specific role in epinephrine-mediated heart rate regulation is indirect via modulation of thin filament Ca2+ sensitivity. This is a secondary function rather than a core molecular function.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/17556658" target="_blank" class="term-link">
                                         PMID:17556658
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">2007 Jun 7. Dilated cardiomyopathy mutant tropomyosin mice develop cardiac dysfunction with significantly decreased fractional shortening and myofilament calcium sensitivity.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003779" target="_blank" class="term-link">
                                     GO:0003779
                                 </a>
                             </span>
                             <span class="term-label">actin binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/12686598" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:12686598
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Extracellular signal-regulated kinase mediates phosphorylati...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3247,75 +3258,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Core function of TPM1. Actin binding is fundamental to all TPM1 isoforms. This TAS annotation based on literature review is consistent with the well-established role of tropomyosin [PMID:12686598].
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Actin binding is the fundamental molecular function of tropomyosin. This annotation supplements the more specific &#34;actin filament binding&#34; term already annotated via IBA [PMID:12686598].
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/12686598" target="_blank" class="term-link">
                                         PMID:12686598
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">tropomyosin-1 was found diffuse in the cells, whereas it quickly colocalized with actin and stress fibers upon stimulation</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005200" target="_blank" class="term-link">
                                     GO:0005200
                                 </a>
                             </span>
                             <span class="term-label">structural constituent of cytoskeleton</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/12686598" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:12686598
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Extracellular signal-regulated kinase mediates phosphorylati...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3327,75 +3338,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TPM1 is a structural component of the actin cytoskeleton in both muscle and non-muscle cells. In muscle cells it forms thin filaments; in non-muscle cells it stabilizes stress fibers [PMID:12686598].
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Structural constituent of cytoskeleton is an accurate molecular function for TPM1. Tropomyosin provides structural stability to actin filaments and is integral to cytoskeletal architecture [PMID:12686598].
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/12686598" target="_blank" class="term-link">
                                         PMID:12686598
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">phosphorylation of tropomyosin-1 downstream of ERK by contributing to formation of actin filaments increases cellular contractility and promotes the formation of focal adhesions</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007010" target="_blank" class="term-link">
                                     GO:0007010
                                 </a>
                             </span>
                             <span class="term-label">cytoskeleton organization</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/12686598" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:12686598
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Extracellular signal-regulated kinase mediates phosphorylati...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3407,75 +3418,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TPM1 contributes to cytoskeleton organization in both muscle and non-muscle cells. This is closely related to actin filament organization [PMID:12686598].
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytoskeleton organization is a core function of TPM1 across all isoforms. In muscle, it organizes sarcomere thin filaments; in non-muscle cells, it contributes to stress fiber organization [PMID:12686598].
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/12686598" target="_blank" class="term-link">
                                         PMID:12686598
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">phosphorylation of tropomyosin-1 downstream of ERK by contributing to formation of actin filaments increases cellular contractility and promotes the formation of focal adhesions</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030049" target="_blank" class="term-link">
                                     GO:0030049
                                 </a>
                             </span>
                             <span class="term-label">muscle filament sliding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">ISS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/11136687" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:11136687
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Hypertrophic cardiomyopathy caused by a novel alpha-tropomyo...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3487,75 +3498,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> ISOFORM-SPECIFIC: Muscle filament sliding is a function of striated muscle isoforms. TPM1 regulates the interaction between thin and thick filaments during muscle contraction [PMID:11136687].
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Muscle filament sliding is a core function of muscle TPM1 isoforms. Tropomyosin regulates the actin-myosin interaction that drives filament sliding during contraction. Mutations affecting this cause cardiomyopathy [PMID:11136687].
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/11136687" target="_blank" class="term-link">
                                         PMID:11136687
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The mutation caused a 40% to 50% increase in calcium affinity in regulated thin filament-myosin subfragment-1 (S1) MgATPase assays</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030336" target="_blank" class="term-link">
                                     GO:0030336
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of cell migration</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">ISS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/15897890" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:15897890
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Silencing of the Tropomyosin-1 gene by DNA methylation alter...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -3567,75 +3578,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> ISOFORM-SPECIFIC: Cytoskeletal TPM1 isoforms regulate cell migration. High molecular weight tropomyosins stabilize stress fibers and inhibit cell motility [PMID:15897890].
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Regulation of cell migration is a function of cytoskeletal TPM1 isoforms in non-muscle cells. While valid, this is a peripheral function related to the core actin-binding activity [PMID:15897890].
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/15897890" target="_blank" class="term-link">
                                         PMID:15897890
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">TGF-beta induction of stress fibers in epithelial cells requires high molecular weight tropomyosins encoded by TPM1 and TPM2 genes</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031529" target="_blank" class="term-link">
                                     GO:0031529
                                 </a>
                             </span>
                             <span class="term-label">ruffle organization</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">ISS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/15897890" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:15897890
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Silencing of the Tropomyosin-1 gene by DNA methylation alter...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -3647,75 +3658,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> ISOFORM-SPECIFIC: TPM1 affects membrane ruffle organization in non-muscle cells. This relates to cytoskeletal actin dynamics [PMID:15897890].
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Ruffle organization is a function of cytoskeletal TPM1 isoforms in non-muscle cells. This is a peripheral function related to the core actin-organizing activity [PMID:15897890].
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/15897890" target="_blank" class="term-link">
                                         PMID:15897890
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">TGF-beta induction of stress fibers in epithelial cells requires high molecular weight tropomyosins encoded by TPM1 and TPM2 genes</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032059" target="_blank" class="term-link">
                                     GO:0032059
                                 </a>
                             </span>
                             <span class="term-label">bleb</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/12686598" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:12686598
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Extracellular signal-regulated kinase mediates phosphorylati...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -3727,75 +3738,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TPM1 localizes to membrane blebs in response to oxidative stress. This relates to cytoskeletal reorganization during stress responses [PMID:12686598].
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Bleb localization is a peripheral cellular component annotation related to stress responses rather than core TPM1 function [PMID:12686598].
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/12686598" target="_blank" class="term-link">
                                         PMID:12686598
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">presence of H(2)O(2) resulted in a quick and intense membrane blebbing</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032587" target="_blank" class="term-link">
                                     GO:0032587
                                 </a>
                             </span>
                             <span class="term-label">ruffle membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/12686598" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:12686598
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Extracellular signal-regulated kinase mediates phosphorylati...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -3807,75 +3818,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> ISOFORM-SPECIFIC: TPM1 localizes to ruffle membranes in non-muscle cells. This relates to cytoskeletal actin dynamics at the cell periphery [PMID:12686598].
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Ruffle membrane localization is a cellular component for cytoskeletal TPM1 isoforms in non-muscle cells. This is a peripheral localization related to actin dynamics [PMID:12686598].
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/12686598" target="_blank" class="term-link">
                                         PMID:12686598
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">tropomyosin-1 was found diffuse in the cells, whereas it quickly colocalized with actin and stress fibers upon stimulation</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034614" target="_blank" class="term-link">
                                     GO:0034614
                                 </a>
                             </span>
                             <span class="term-label">cellular response to reactive oxygen species</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/12686598" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:12686598
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Extracellular signal-regulated kinase mediates phosphorylati...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -3887,75 +3898,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TPM1 is phosphorylated in response to oxidative stress via ERK signaling. This leads to cytoskeletal remodeling and affects membrane dynamics [PMID:12686598].
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Response to ROS is a peripheral function related to stress-induced cytoskeletal remodeling. TPM1 phosphorylation downstream of ERK modulates stress fiber formation during oxidative stress [PMID:12686598].
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/12686598" target="_blank" class="term-link">
                                         PMID:12686598
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">phosphorylation of tropomyosin-1 downstream of ERK by contributing to formation of actin filaments increases cellular contractility and promotes the formation of focal adhesions</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042060" target="_blank" class="term-link">
                                     GO:0042060
                                 </a>
                             </span>
                             <span class="term-label">wound healing</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">ISS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17721995" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:17721995
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Role of high-molecular weight tropomyosins in TGF-beta-media...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -3967,75 +3978,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> ISOFORM-SPECIFIC: TPM1 is involved in wound healing through its role in cytoskeletal remodeling and cell migration during tissue repair [PMID:17721995].
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Wound healing is a peripheral function of cytoskeletal TPM1 isoforms related to cell migration and tissue remodeling. While biologically relevant, this is not a core molecular function [PMID:17721995].
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/17721995" target="_blank" class="term-link">
                                         PMID:17721995
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">HMW-tropomyosins are important for TGF-beta-mediated control of cell</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045785" target="_blank" class="term-link">
                                     GO:0045785
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of cell adhesion</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">ISS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17721995" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:17721995
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Role of high-molecular weight tropomyosins in TGF-beta-media...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -4047,75 +4058,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> ISOFORM-SPECIFIC: TPM1 promotes cell adhesion by enhancing actin stress fibers and focal adhesions in non-muscle cells [PMID:17721995].
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Regulation of cell adhesion is a peripheral function of cytoskeletal TPM1 isoforms related to stress fiber stabilization [PMID:17721995].
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/17721995" target="_blank" class="term-link">
                                         PMID:17721995
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Tropomyosin increased cell adhesion to matrix by enhancing actin fibers and focal adhesions</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051496" target="_blank" class="term-link">
                                     GO:0051496
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of stress fiber assembly</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">ISS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/15897890" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:15897890
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Silencing of the Tropomyosin-1 gene by DNA methylation alter...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -4127,75 +4138,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> ISOFORM-SPECIFIC: TPM1 (HMW tropomyosins) are required for TGF-beta-induced stress fiber assembly in epithelial cells [PMID:15897890].
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Positive regulation of stress fiber assembly is a well-documented function of cytoskeletal TPM1 isoforms. HMW tropomyosins stabilize and promote stress fiber formation [PMID:15897890].
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/15897890" target="_blank" class="term-link">
                                         PMID:15897890
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">TGF-beta induction of stress fibers in epithelial cells requires high molecular weight tropomyosins encoded by TPM1 and TPM2 genes</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0055010" target="_blank" class="term-link">
                                     GO:0055010
                                 </a>
                             </span>
                             <span class="term-label">ventricular cardiac muscle tissue morphogenesis</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/11136687" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:11136687
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Hypertrophic cardiomyopathy caused by a novel alpha-tropomyo...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -4207,75 +4218,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> ISOFORM-SPECIFIC: Cardiac TPM1 isoforms are essential for ventricular morphogenesis. Mutations cause hypertrophic cardiomyopathy with ventricular hypertrophy [PMID:11136687].
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Ventricular morphogenesis is a developmental process that TPM1 mutations affect. While important, this is a downstream consequence of TPM1&#39;s role in cardiac muscle function rather than a core molecular function [PMID:11136687].
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/11136687" target="_blank" class="term-link">
                                         PMID:11136687
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The mutation caused a 40% to 50% increase in calcium affinity in regulated thin filament-myosin subfragment-1 (S1) MgATPase assays</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0060048" target="_blank" class="term-link">
                                     GO:0060048
                                 </a>
                             </span>
                             <span class="term-label">cardiac muscle contraction</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/11136687" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:11136687
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Hypertrophic cardiomyopathy caused by a novel alpha-tropomyo...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -4287,75 +4298,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> ISOFORM-SPECIFIC: This IMP annotation with experimental evidence complements the IBA annotation for cardiac muscle contraction. TPM1 mutations affect Ca2+ sensitivity and muscle contraction [PMID:11136687].
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cardiac muscle contraction is a core function of cardiac TPM1 isoforms. This experimental annotation provides direct evidence that TPM1 mutations affect cardiac contractile function [PMID:11136687].
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/11136687" target="_blank" class="term-link">
                                         PMID:11136687
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The mutation caused a 40% to 50% increase in calcium affinity in regulated thin filament-myosin subfragment-1 (S1) MgATPase assays</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030017" target="_blank" class="term-link">
                                     GO:0030017
                                 </a>
                             </span>
                             <span class="term-label">sarcomere</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16754800" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16754800
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Single-gene mutations and increased left ventricular wall th...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -4367,75 +4378,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> ISOFORM-SPECIFIC: Sarcomere localization is specific to striated muscle TPM1 isoforms. TPM1 is an integral component of thin filaments in sarcomeres.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Sarcomere is a core cellular component for muscle TPM1 isoforms. Tropomyosin is an integral part of the thin filament in sarcomeric structures. TAS annotation from literature supports this well-established localization.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/16754800" target="_blank" class="term-link">
                                         PMID:16754800
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Single-gene mutations and increased left ventricular wall thickness in the community: the Framingham Heart Study.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005856" target="_blank" class="term-link">
                                     GO:0005856
                                 </a>
                             </span>
                             <span class="term-label">cytoskeleton</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16130169" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16130169
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Proteomics of human umbilical vein endothelial cells applied...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -4447,75 +4458,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TPM1 is a cytoskeletal protein identified in proteomic studies of endothelial cells. This annotation complements the IEA cytoskeleton annotation.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytoskeleton is a valid cellular component for TPM1. All isoforms are components of the cytoskeleton, whether in sarcomeres or stress fibers. TAS annotation is appropriate.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/16130169" target="_blank" class="term-link">
                                         PMID:16130169
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Proteomics of human umbilical vein endothelial cells applied to etoposide-induced apoptosis.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005862" target="_blank" class="term-link">
                                     GO:0005862
                                 </a>
                             </span>
                             <span class="term-label">muscle thin filament tropomyosin</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/8205619" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:8205619
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Alpha-tropomyosin and cardiac troponin T mutations cause fam...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -4527,75 +4538,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> ISOFORM-SPECIFIC: This TAS annotation complements the IEA annotation for muscle thin filament tropomyosin. TPM1 mutations in this complex cause familial hypertrophic cardiomyopathy [PMID:8205619].
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Muscle thin filament tropomyosin is a core cellular component for muscle TPM1 isoforms. The cited study demonstrates TPM1&#39;s role in the thin filament complex and disease consequences of mutations [PMID:8205619].
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/8205619" target="_blank" class="term-link">
                                         PMID:8205619
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">alpha-tropomyosin and cardiac troponin T as well as beta myosin heavy chain mutations cause the same phenotype, we conclude that FHC is a disease of the sarcomere</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006937" target="_blank" class="term-link">
                                     GO:0006937
                                 </a>
                             </span>
                             <span class="term-label">regulation of muscle contraction</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/3336363" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:3336363
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Human hTM alpha gene: expression in muscle and nonmuscle tis...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -4607,75 +4618,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> ISOFORM-SPECIFIC: Regulation of muscle contraction is a core function of muscle TPM1 isoforms. The study describes expression of alpha-tropomyosin in muscle and non-muscle tissues.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Regulation of muscle contraction is a core biological process for muscle TPM1 isoforms. Tropomyosin regulates actin-myosin interaction in a Ca2+-dependent manner via the troponin complex. TAS annotation is appropriate.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/3336363" target="_blank" class="term-link">
                                         PMID:3336363
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Human hTM alpha gene: expression in muscle and nonmuscle tissue.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008016" target="_blank" class="term-link">
                                     GO:0008016
                                 </a>
                             </span>
                             <span class="term-label">regulation of heart contraction</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/8205619" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:8205619
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Alpha-tropomyosin and cardiac troponin T mutations cause fam...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -4687,75 +4698,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> ISOFORM-SPECIFIC: Cardiac TPM1 isoforms regulate heart contraction. Mutations cause familial hypertrophic cardiomyopathy, demonstrating the essential role of TPM1 in cardiac function [PMID:8205619].
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Regulation of heart contraction is a core function of cardiac TPM1 isoforms. Mutations affecting this function cause cardiomyopathy [PMID:8205619].
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/8205619" target="_blank" class="term-link">
                                         PMID:8205619
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">We demonstrate that missense mutations (Asp175Asn; Glu180Gly) in the alpha-tropomyosin gene cause familial hypertrophic cardiomyopathy (FHC)</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008307" target="_blank" class="term-link">
                                     GO:0008307
                                 </a>
                             </span>
                             <span class="term-label">structural constituent of muscle</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/8205619" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:8205619
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Alpha-tropomyosin and cardiac troponin T mutations cause fam...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -4767,50 +4778,50 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> ISOFORM-SPECIFIC: Muscle TPM1 isoforms are structural constituents of muscle thin filaments in sarcomeres [PMID:8205619].
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Structural constituent of muscle is a core molecular function for muscle TPM1 isoforms. TPM1 is an integral structural component of thin filaments in sarcomeres [PMID:8205619].
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/8205619" target="_blank" class="term-link">
                                         PMID:8205619
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">alpha-tropomyosin and cardiac troponin T as well as beta myosin heavy chain mutations cause the same phenotype, we conclude that FHC is a disease of the sarcomere</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
             </tbody>
         </table>
     </div>
-    
 
-    
+
+
     <div class="section">
         <h2 class="section-title">Core Functions</h2>
-        
+
         <div class="core-function-card">
-            
+
             <div style="display: flex; justify-content: space-between; align-items: center;">
                 <h3>Actin filament binding is the fundamental molecular function of all TPM1 isoforms. Tropomyosin dimers bind along the length of actin filaments in both muscle (thin filaments) and non-muscle (stress fibers) cells, stabilizing actin filaments and regulating their interactions with other proteins.</h3>
                 <span class="vote-buttons" data-g="P09493" data-a="FUNCTION: Actin filament binding is the fundamental molecula..." data-r="" data-act="CORE_FUNCTION">
@@ -4818,10 +4829,10 @@
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
             </div>
-            
+
 
             <div class="core-function-terms">
-                
+
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
@@ -4830,48 +4841,48 @@
                         </a>
                     </span>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Directly Involved In:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007015" target="_blank" class="term-link">
                                 actin filament organization
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Cellular Locations:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005884" target="_blank" class="term-link">
                                 actin filament
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
 
-                
+
+
+
             </div>
 
-            
+
         </div>
-        
+
         <div class="core-function-card">
-            
+
             <div style="display: flex; justify-content: space-between; align-items: center;">
                 <h3>ISOFORM-SPECIFIC (Cardiac isoforms): Cardiac muscle contraction is a core function of striated muscle isoforms (TPM1alpha, TPM1kappa). TPM1 regulates calcium-dependent actin-myosin interaction via the troponin complex. Mutations cause cardiomyopathy (CMH3, CMD1Y).</h3>
                 <span class="vote-buttons" data-g="P09493" data-a="FUNCTION: ISOFORM-SPECIFIC (Cardiac isoforms): Cardiac muscl..." data-r="" data-act="CORE_FUNCTION">
@@ -4879,10 +4890,10 @@
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
             </div>
-            
+
 
             <div class="core-function-terms">
-                
+
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
@@ -4891,45 +4902,45 @@
                         </a>
                     </span>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Directly Involved In:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0060048" target="_blank" class="term-link">
                                 cardiac muscle contraction
                             </a>
                         </span>
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006937" target="_blank" class="term-link">
                                 regulation of muscle contraction
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Cellular Locations:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030017" target="_blank" class="term-link">
                                 sarcomere
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">In Complex:</div>
                     <span class="badge">
@@ -4938,16 +4949,16 @@
                         </a>
                     </span>
                 </div>
-                
 
-                
+
+
             </div>
 
-            
+
         </div>
-        
+
         <div class="core-function-card">
-            
+
             <div style="display: flex; justify-content: space-between; align-items: center;">
                 <h3>ISOFORM-SPECIFIC (Cytoskeletal isoforms): Non-muscle TPM1 isoforms (e.g., TM3) bind actin filaments in stress fibers and contribute to cytoskeletal organization, cell shape regulation, and cell motility.</h3>
                 <span class="vote-buttons" data-g="P09493" data-a="FUNCTION: ISOFORM-SPECIFIC (Cytoskeletal isoforms): Non-musc..." data-r="" data-act="CORE_FUNCTION">
@@ -4955,10 +4966,10 @@
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
             </div>
-            
+
 
             <div class="core-function-terms">
-                
+
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
@@ -4967,607 +4978,1012 @@
                         </a>
                     </span>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Directly Involved In:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007015" target="_blank" class="term-link">
                                 actin filament organization
                             </a>
                         </span>
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051496" target="_blank" class="term-link">
                                 positive regulation of stress fiber assembly
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Cellular Locations:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001725" target="_blank" class="term-link">
                                 stress fiber
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
 
-                
+
+
+
             </div>
 
-            
-        </div>
-        
-    </div>
-    
 
-    
+        </div>
+
+    </div>
+
+
+
     <div class="section">
         <h2 class="section-title collapsible">References</h2>
         <div class="collapse-content">
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
+                        file:human/TPM1/TPM1-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research report for TPM1</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Falcon corroborates TPM1 as an actin-filament tropomyosin whose core roles are sarcomeric thin-filament regulation in muscle isoforms and stress-fiber/focal-adhesion actin network specification in non-muscle isoforms.</div>
+
+                        <div class="finding-text">"TPM1 encodes alpha-tropomyosin, a coiled-coil actin-binding thin-filament protein that regulates actin-myosin interaction in a Ca2+/troponin-dependent manner in cardiac muscle."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000024.md" target="_blank" class="term-link">
                             GO_REF:0000024
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment of sequence similarity</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
                             GO_REF:0000033
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Annotation inferences using phylogenetic trees</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000043.md" target="_blank" class="term-link">
                             GO_REF:0000043
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
                             GO_REF:0000044
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
                             GO_REF:0000117
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/11136687" target="_blank" class="term-link">
                             PMID:11136687
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Hypertrophic cardiomyopathy caused by a novel alpha-tropomyosin mutation (V95A) is associated with mild cardiac phenotype, abnormal calcium binding to troponin, abnormal myosin cycling, and poor prognosis.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/11273725" target="_blank" class="term-link">
                             PMID:11273725
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Mutations that alter the surface charge of alpha-tropomyosin are associated with dilated cardiomyopathy.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/12686598" target="_blank" class="term-link">
                             PMID:12686598
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Extracellular signal-regulated kinase mediates phosphorylation of tropomyosin-1 to promote cytoskeleton remodeling in response to oxidative stress: impact on membrane blebbing.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/15897890" target="_blank" class="term-link">
                             PMID:15897890
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Silencing of the Tropomyosin-1 gene by DNA methylation alters tumor suppressor function of TGF-beta.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/16130169" target="_blank" class="term-link">
                             PMID:16130169
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Proteomics of human umbilical vein endothelial cells applied to etoposide-induced apoptosis.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/16189514" target="_blank" class="term-link">
                             PMID:16189514
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Towards a proteome-scale map of the human protein-protein interaction network.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/16754800" target="_blank" class="term-link">
                             PMID:16754800
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Single-gene mutations and increased left ventricular wall thickness in the community: the Framingham Heart Study.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/17556658" target="_blank" class="term-link">
                             PMID:17556658
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Dilated cardiomyopathy mutant tropomyosin mice develop cardiac dysfunction with significantly decreased fractional shortening and myofilament calcium sensitivity.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/17721995" target="_blank" class="term-link">
                             PMID:17721995
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Role of high-molecular weight tropomyosins in TGF-beta-mediated control of cell motility.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/17987659" target="_blank" class="term-link">
                             PMID:17987659
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Nebulette interacts with filamin C.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/21516116" target="_blank" class="term-link">
                             PMID:21516116
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Next-generation sequencing to generate interactome datasets.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/21817107" target="_blank" class="term-link">
                             PMID:21817107
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">MicroRNA-21 regulates vascular smooth muscle cell function via targeting tropomyosin 1 in arteriosclerosis obliterans of lower extremities.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/25416956" target="_blank" class="term-link">
                             PMID:25416956
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A proteome-scale map of the human interactome network.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/25910212" target="_blank" class="term-link">
                             PMID:25910212
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Widespread macromolecular interaction perturbations in human genetic disorders.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/26871637" target="_blank" class="term-link">
                             PMID:26871637
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Widespread Expansion of Protein Interaction Capabilities by Alternative Splicing.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/30021884" target="_blank" class="term-link">
                             PMID:30021884
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Histone Interaction Landscapes Visualized by Crosslinking Mass Spectrometry in Intact Cell Nuclei.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
                             PMID:32296183
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A reference map of the human binary protein interactome.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/3336363" target="_blank" class="term-link">
                             PMID:3336363
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Human hTM alpha gene: expression in muscle and nonmuscle tissue.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
                             PMID:33961781
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link">
                             PMID:40205054
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Multimodal cell maps as a foundation for structural and functional genomics.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/8205619" target="_blank" class="term-link">
                             PMID:8205619
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Alpha-tropomyosin and cardiac troponin T mutations cause familial hypertrophic cardiomyopathy: a disease of the sarcomere.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-390593
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">ATP Hydrolysis By Myosin</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-390595
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Calcium Binds Troponin-C</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-390597
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Release Of ADP From Myosin</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-390598
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Myosin Binds ATP</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-445699
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">ATP Hydrolysis By Myosin</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-445700
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Myosin Binds ATP</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-445704
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Calcium Binds Caldesmon</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-445705
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Release Of ADP From Myosin</div>
-                
-                
+
+
             </div>
-            
+
         </div>
     </div>
-    
 
 
-    
 
-    
 
-    
+
+
+
+
 
     <!-- Computational Predictions Section -->
-    
+
 
     <!-- Additional Documentation Sections -->
-    
+
     <div class="section">
         <h2 class="section-title">📚 Additional Documentation</h2>
-        
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Deep Research Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(TPM1-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P09493" data-a="DOC: Deep Research Falcon" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <hr />
+<p>provider: falcon<br />
+model: Edison Scientific Literature<br />
+cached: false<br />
+start_time: '2026-05-11T02:34:53.569140'<br />
+end_time: '2026-05-11T02:52:28.929760'<br />
+duration_seconds: 1055.36<br />
+template_file: templates/gene_research_go_focused.md<br />
+template_variables:<br />
+  organism: human<br />
+  gene_id: TPM1<br />
+  gene_symbol: TPM1<br />
+  uniprot_accession: P09493<br />
+  protein_description: 'RecName: Full=Tropomyosin alpha-1 chain; AltName: Full=Alpha-tropomyosin;<br />
+    AltName: Full=Tropomyosin-1;'<br />
+  gene_info: Name=TPM1; Synonyms=C15orf13, TMSA;<br />
+  organism_full: Homo sapiens (Human).<br />
+  protein_family: Belongs to the tropomyosin family. .<br />
+  protein_domains: Tropomyosin. (IPR000533); Tropomyosin (PF00261)<br />
+provider_config:<br />
+  timeout: 600<br />
+  max_retries: 3<br />
+  parameters:<br />
+    allowed_domains: []<br />
+    temperature: 0.1<br />
+citation_count: 41</p>
+<hr />
+<h2 id="question">Question</h2>
+<h1 id="gene-research-for-functional-annotation">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> P09493</li>
+<li><strong>Protein Description:</strong> RecName: Full=Tropomyosin alpha-1 chain; AltName: Full=Alpha-tropomyosin; AltName: Full=Tropomyosin-1;</li>
+<li><strong>Gene Information:</strong> Name=TPM1; Synonyms=C15orf13, TMSA;</li>
+<li><strong>Organism (full):</strong> Homo sapiens (Human).</li>
+<li><strong>Protein Family:</strong> Belongs to the tropomyosin family. .</li>
+<li><strong>Key Domains:</strong> Tropomyosin. (IPR000533); Tropomyosin (PF00261)</li>
+</ul>
+<h3 id="mandatory-verification-steps">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "TPM1" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Homo sapiens (Human).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'TPM1' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>TPM1</strong> (gene ID: TPM1, UniProt: P09493) in human.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="output">Output</h2>
+<p>Question: You are an expert researcher providing comprehensive, well-cited information.</p>
+<p>Provide detailed information focusing on:<br />
+1. Key concepts and definitions with current understanding<br />
+2. Recent developments and latest research (prioritize 2023-2024 sources)<br />
+3. Current applications and real-world implementations<br />
+4. Expert opinions and analysis from authoritative sources<br />
+5. Relevant statistics and data from recent studies</p>
+<p>Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.<br />
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.</p>
+<h1 id="gene-research-for-functional-annotation_1">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context_1">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot_1">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> P09493</li>
+<li><strong>Protein Description:</strong> RecName: Full=Tropomyosin alpha-1 chain; AltName: Full=Alpha-tropomyosin; AltName: Full=Tropomyosin-1;</li>
+<li><strong>Gene Information:</strong> Name=TPM1; Synonyms=C15orf13, TMSA;</li>
+<li><strong>Organism (full):</strong> Homo sapiens (Human).</li>
+<li><strong>Protein Family:</strong> Belongs to the tropomyosin family. .</li>
+<li><strong>Key Domains:</strong> Tropomyosin. (IPR000533); Tropomyosin (PF00261)</li>
+</ul>
+<h3 id="mandatory-verification-steps_1">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "TPM1" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Homo sapiens (Human).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature_1">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'TPM1' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target_1">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>TPM1</strong> (gene ID: TPM1, UniProt: P09493) in human.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="research-report-human-tpm1-uniprot-p09493-functional-annotation-of-tropomyosin-alpha-1-chain">Research report: Human <strong>TPM1</strong> (UniProt <strong>P09493</strong>) — functional annotation of tropomyosin alpha-1 chain</h2>
+<h3 id="0-geneprotein-identity-verification-critical-disambiguation">0) Gene/protein identity verification (critical disambiguation)</h3>
+<p>The target gene <strong>TPM1</strong> in <em>Homo sapiens</em> encodes <strong>tropomyosin alpha-1 chain</strong> (α‑tropomyosin), a coiled‑coil protein of the tropomyosin family that binds <strong>F‑actin</strong> and specifies functional properties of actin filaments in both <strong>sarcomeric thin filaments</strong> and specialized <strong>non‑muscle actin networks</strong>. This identity matches the UniProt description provided (P09493) and is consistent with recent human studies explicitly analyzing TPM1 isoforms (e.g., cardiomyocyte differentiation, focal adhesion nanoscale layers, and ovarian cancer isoform functions). In particular, a 2024 cardiomyocyte differentiation study maps <strong>TPM1μ</strong> to a SwissProt/UniProt isoform <strong>P09493‑4</strong>, directly linking the experimental literature to the UniProt accession provided. (dube2024sarcomerictropomyosinexpression pages 2-4)</p>
+<h3 id="1-key-concepts-and-definitions-current-understanding">1) Key concepts and definitions (current understanding)</h3>
+<h4 id="11-tropomyosin-as-an-actin-filament-specifier">1.1 Tropomyosin as an actin “filament specifier”</h4>
+<p>Tropomyosins are <strong>head‑to‑tail polymers</strong> that decorate the major groove of actin filaments and regulate which actin-binding proteins can productively interact with those filaments. A practical current definition is that <strong>tropomyosin isoforms “specify” actin filament identity</strong>—altering filament stability and the access/behavior of myosins and severing factors such as ADF/cofilin in an isoform‑dependent manner. (kumari2024focaladhesionscontain pages 2-3)</p>
+<h4 id="12-tpm1s-primary-function-in-striated-muscle-thinfilament-regulation">1.2 TPM1’s primary function in striated muscle: thin‑filament regulation</h4>
+<p>In the sarcomere, tropomyosin is a core thin‑filament component that mediates Ca2+-dependent contractile regulation: Ca2+ binding to troponin changes thin‑filament state, and tropomyosin movement along actin helps expose or occlude myosin-binding sites, thereby tuning actin–myosin interaction. This describes the <strong>primary biochemical role</strong> of TPM1 in cardiomyocytes as an actin-binding regulatory protein rather than an enzyme or transporter. (haas2026sarcomericremodellingin pages 1-4)</p>
+<h4 id="13-alternative-splicing-and-isoform-logic-in-tpm1">1.3 Alternative splicing and “isoform logic” in TPM1</h4>
+<p>A central TPM1 concept is that <strong>alternative promoters/splicing generate multiple TPM1 proteoforms</strong> with distinct N‑termini and exon compositions, which correlate with distinct actin networks and cell phenotypes.</p>
+<p>A high‑impact 2024 ovarian cancer study provides a clear isoform-defining rule set for non‑muscle TPM1 isoforms: <strong>Tpm1.6/1.7</strong> are associated with <strong>exons 1a and 2b</strong>, while <strong>Tpm1.8/1.9</strong> are defined by <strong>exon 1b</strong>. (xu2024tropomyosin1isoformsunderlie pages 6-8, xu2024tropomyosin1isoformsunderlie media 181dbb5d, xu2024tropomyosin1isoformsunderlie media f45ab9b5)</p>
+<h3 id="2-molecular-function-mechanisms-and-subcellular-localization">2) Molecular function, mechanisms, and subcellular localization</h3>
+<h4 id="21-subcellular-localization-sarcomere-cardiac-muscle">2.1 Subcellular localization: sarcomere (cardiac muscle)</h4>
+<p>TPM1 is a canonical <strong>sarcomeric thin filament</strong> gene/protein in heart, and recent cardiomyopathy literature continues to place TPM1 within the sarcomere gene set used for genetic testing and penetrance estimation in hypertrophic cardiomyopathy. (topriceanu2024metaanalysisofpenetrance pages 6-7, jaouadi2024exomesequencingdata pages 1-2)</p>
+<h4 id="22-subcellular-localization-focal-adhesions-and-stress-fibers-nonmuscle">2.2 Subcellular localization: focal adhesions and stress fibers (non‑muscle)</h4>
+<p>A 2024 <em>Nature Communications</em> study resolved focal adhesions (FAs) into multiple nanoscale actin layers and identified a distinct FA actin layer decorated by the <strong>TPM1-derived isoform Tpm1.6</strong>. Tpm1.6-localized actin filaments are positioned <strong>beneath</strong> the previously described α‑actinin–cross-linked actin layer and extend from adhesions onto <strong>dorsal stress fibers</strong>, linking adhesion architecture to the contractile actin cytoskeleton. (Publication: Mar 2024; https://doi.org/10.1038/s41467-024-46868-7) (kumari2024focaladhesionscontain pages 1-2, kumari2024focaladhesionscontain pages 2-3)</p>
+<p>Functionally, the same work supports that Tpm1.6‑actin filaments are <strong>critical for adhesion maturation and controlled cell motility</strong> and that loss of Tpm1 yields <strong>smaller adhesions</strong>, altered adhesion distribution (e.g., ~70% within 5 μm of the leading edge), reduced traction forces, and changes in migration behavior. (kumari2024focaladhesionscontain pages 3-4, kumari2024focaladhesionscontain pages 4-6)</p>
+<h4 id="23-mechanistic-specificity-by-isoform-competition-on-actin">2.3 Mechanistic specificity by isoform competition on actin</h4>
+<p>The FA study also emphasizes a mechanistic basis for layered actin organization: Tpm1.6 and Tpm3.2 decorate <strong>distinct filament arrays</strong> and cannot co‑polymerize on the same filament; additionally, both appear to <strong>compete with α‑actinin</strong> for actin binding, supporting segregation of distinct actin filament layers. (kumari2024focaladhesionscontain pages 1-2, kumari2024focaladhesionscontain pages 10-12)</p>
+<p>A complementary structural/biochemical preprint (May 2023) provides mechanism-level support: cryo‑EM shows Tpm1.6 and Tpm3.2 follow different trajectories on actin, explaining mutual exclusivity; functionally, Tpm1.6 has a slow off‑rate and can protect actin filaments from ADF/cofilin severing, whereas Tpm3.2 more strongly activates non-muscle myosin II ATPase activity—illustrating isoform‑dependent tuning of actin filament dynamics and motor engagement. (https://doi.org/10.1101/2022.05.12.491677; May 2023) (selvaraj2023structuralbasisunderlying pages 1-3)</p>
+<h3 id="3-isoforms-developmental-programs-and-regulation-20232024">3) Isoforms, developmental programs, and regulation (2023–2024)</h3>
+<h4 id="31-quantitative-tpm1-isoform-expression-during-human-ipsc-cardiomyocyte-differentiation">3.1 Quantitative TPM1 isoform expression during human iPSC cardiomyocyte differentiation</h4>
+<p>A 2024 <em>Cytoskeleton</em> study quantified sarcomeric TPM isoforms during differentiation of human iPSCs into cardiomyocytes and found strong temporal dynamics:</p>
+<ul>
+<li><strong>TPM1α</strong>: 6.88×10^8 copies (hiPSCs) increasing ~100‑fold by day 5 (~5.6×10^10 copies/mg total RNA), dipping at days 10–15, then rising again (~5.98×10^10 by day 20).</li>
+<li><strong>TPM1μ</strong>: detected early, peaks around day 5 then declines; importantly, TPM1μ sequence matched a SwissProt isoform <strong>P09493‑4</strong> (connecting to UniProt P09493).</li>
+<li><strong>TPM1κ</strong>: rises from day 5 onward and peaks by day 20.</li>
+</ul>
+<p>By day 20, transcript rank order was <strong>TPM1α &gt; TPM1κ &gt; TPM2α &gt; TPM1μ &gt; TPM3α &gt; TPM4α</strong>, and protein-level assays showed increased high‑molecular‑weight TPM proteins during differentiation. (Publication: Mar 2024; https://doi.org/10.1002/cm.21850) (dube2024sarcomerictropomyosinexpression pages 2-4)</p>
+<h4 id="32-regulatory-framing-from-expert-synthesis">3.2 Regulatory framing from expert synthesis</h4>
+<p>A large 2024 meta-analysis in <em>Circulation</em> underscores that sarcomeric variant penetrance is <strong>age dependent</strong> and context dependent (family/clinic vs population ascertainment), and positions TPM1 among “definitive” sarcomere genes used in clinical genetics and cascade screening, establishing TPM1 as part of the clinically actionable sarcomere gene set. (Publication: Jan 2024; https://doi.org/10.1161/circulationaha.123.065987) (topriceanu2024metaanalysisofpenetrance pages 2-3, topriceanu2024metaanalysisofpenetrance pages 6-7)</p>
+<h3 id="4-disease-relevance-applications-and-real-world-implementations">4) Disease relevance, applications, and real-world implementations</h3>
+<h4 id="41-hypertrophic-cardiomyopathy-hcm-penetrance-and-clinical-genetics">4.1 Hypertrophic cardiomyopathy (HCM): penetrance and clinical genetics</h4>
+<p><strong>Penetrance statistics (authoritative 2024 meta-analysis):</strong> In genotype-positive relatives carrying pathogenic/likely pathogenic (P/LP) sarcomere variants, the pooled penetrance across genes was ~57.4%. For <strong>TPM1 specifically</strong>, pooled penetrance in relatives was <strong>48.6% (95% CI 25.7–72.2)</strong> with pooled <strong>age at diagnosis 40.3 years (36.9–43.8)</strong>. (topriceanu2024metaanalysisofpenetrance pages 6-7)</p>
+<p><strong>Population context:</strong> In large population cohorts (combined n≈213,911), P/LP sarcomere variants were present in ~0.7% overall, and penetrance in incidentally identified carriers was much lower (~11% overall at mean age ~56), emphasizing why TPM1 testing is most impactful in phenotype/family-based settings. (topriceanu2024metaanalysisofpenetrance pages 9-10)</p>
+<p><strong>Real-world implementation:</strong> These data support current clinical practice where TPM1 is included in cardiomyopathy gene panels for diagnosis and cascade screening, but with careful counseling on variable penetrance and age effects. (topriceanu2024metaanalysisofpenetrance pages 6-7)</p>
+<h4 id="42-hcm-cohorts-variant-yield-is-context-dependent">4.2 HCM cohorts: variant yield is context dependent</h4>
+<p>A 2024 reanalysis of exome data from <strong>200 HCM</strong> patients (HYPERGEN French cohort) reported that most variants were in MYBPC3 (26%, n=51) and MYH7 (8%, n=16), and <strong>explicitly found no variants in TPM1</strong> (as well as ACTC1, TNNI3) in this cohort. This illustrates that although TPM1 is a definitive sarcomere gene, <strong>its contribution can be low in specific cohorts</strong> and that yield depends on population structure, ascertainment, and panel composition. (Publication: Oct 2024; https://doi.org/10.3389/fmed.2024.1480947) (jaouadi2024exomesequencingdata pages 1-2)</p>
+<h4 id="43-familial-hcm-with-sudden-cardiac-death-scd-example-of-variant-interpretation-workflow-2024">4.3 Familial HCM with sudden cardiac death (SCD): example of variant interpretation workflow (2024)</h4>
+<p>A 2024 <em>ESC Heart Failure</em> family study reported a novel TPM1 missense variant <strong>c.761A&gt;G (p.Asp254Gly; p.D254G)</strong>, absent from population databases, predicted deleterious (e.g., CADD phred score 32), and classified as likely pathogenic under ACMG criteria. The variant segregated with disease in available family members. Clinical pedigree context included relatives with SCD at ages 16 and 28 and pacemaker implantation in paternal uncles; the proband presented in early childhood with mild LV diastolic dysfunction. (Publication: Jun 2024; https://doi.org/10.1002/ehf2.14906) (azimi2024identificationofa pages 7-7, azimi2024identificationofa pages 2-2)</p>
+<p>This is a representative real-world example of how TPM1 variants are used in <strong>cascade screening and clinical monitoring</strong> for inherited cardiomyopathy families, while also highlighting the frequent need for <strong>functional validation</strong> beyond in silico evidence. (azimi2024identificationofa pages 7-8)</p>
+<h4 id="44-non-compaction-cardiomyopathy-nccmlvnc-tpm1-n-terminus-as-a-potential-mechanistic-hotspot">4.4 Non-compaction cardiomyopathy (NCCM/LVNC): TPM1 N-terminus as a potential mechanistic hotspot</h4>
+<p>A 2024 case report identified TPM1 <strong>p.Lys7del</strong> (in-frame deletion; absent from gnomAD) co‑segregating with familial NCCM/LVNC and classified it as likely pathogenic (ACMG class 4). The authors propose mechanistic impact via disrupted interactions with thin-filament pointed-end regulators <strong>tropomodulin‑1 (Tmod1)</strong> and <strong>leiomodin‑2 (Lmod2)</strong>, consistent with the N‑terminal role in thin-filament end regulation. The paper also notes TPM1 variants are uncommon in LVNC/NCCM cohorts (reported as <strong>&lt;2%</strong>). (Publication: Apr 2024; https://doi.org/10.1007/s00392-023-02190-8) (hanel2024casereportcosegregation pages 3-4)</p>
+<h4 id="45-cancer-tpm1-isoforms-as-functional-drivers-of-emtplasticity-and-therapy-resistance-2024">4.5 Cancer: TPM1 isoforms as functional drivers of EMT/plasticity and therapy resistance (2024)</h4>
+<p>A major 2024 primary study in high-grade serous ovarian cancer (HGSOC) demonstrated that TPM1 isoform balance is not merely correlative but can be <strong>causal</strong> for epithelial–mesenchymal plasticity (EMP), metastatic dissemination, and chemotherapy response.</p>
+<ul>
+<li><strong>Isoform definitions (actionable):</strong> Tpm1.6/1.7 (exon 1a/2b) vs Tpm1.8/1.9 (exon 1b). (xu2024tropomyosin1isoformsunderlie pages 6-8, xu2024tropomyosin1isoformsunderlie media 181dbb5d)</li>
+<li><strong>Chemo-resistance statistics (OV90 cells):</strong> Tpm1.8/9 overexpression increased cisplatin IC50 to ~<strong>3.266–3.414 μM</strong> vs ~<strong>0.043–0.078 μM</strong> for Tpm1.6/7 overexpression (~40‑fold difference). Paclitaxel IC50 similarly increased to ~<strong>1.28–1.66 μM</strong> vs ~<strong>0.015–0.017 μM</strong>. Knockdown of Tpm1.8/9 reduced IC50, supporting a functional role. (Publication: Feb 2024; https://doi.org/10.1038/s41418-024-01267-9) (xu2024tropomyosin1isoformsunderlie pages 6-8)</li>
+</ul>
+<p>The authors further link these isoforms to <strong>Wnt pathway activation</strong> and propose Tpm1.8/9 as therapeutic targets, including the concept of small molecules directed at tropomyosin N‑termini as an isoform-selective strategy. (xu2024tropomyosin1isoformsunderlie pages 10-12)</p>
+<p>A 2023 review of tropomyosin family roles in cancer provides expert synthesis that TPM1 often shows tumor-suppressive associations and that TPM1 can be regulated by microRNAs in multiple cancers, supporting the broader plausibility of TPM1 as a biomarker or functional modulator in malignancy contexts. (Publication: Aug 2023; https://doi.org/10.3390/ijms241713295) (meng2023researchadvancesin pages 3-5)</p>
+<h3 id="5-current-applications-and-implementations">5) Current applications and implementations</h3>
+<h4 id="51-clinical-genetics-cardiomyopathy">5.1 Clinical genetics (cardiomyopathy)</h4>
+<ul>
+<li><strong>Gene panels and cascade screening:</strong> The 2024 penetrance meta-analysis provides quantitative risk framing for counseling carriers, and the 2024 family HCM/NCCM case reports illustrate gene discovery/segregation workflows in practice. (topriceanu2024metaanalysisofpenetrance pages 6-7, azimi2024identificationofa pages 7-7, hanel2024casereportcosegregation pages 3-4)</li>
+<li><strong>Variant yield and reanalysis:</strong> The 2024 HYPERGEN cohort shows why periodic reanalysis and gene-validity prioritization are needed; TPM1 can be clinically important yet rare in particular cohorts. (jaouadi2024exomesequencingdata pages 1-2)</li>
+</ul>
+<h4 id="52-disease-modeling-and-translational-biology">5.2 Disease modeling and translational biology</h4>
+<ul>
+<li><strong>hiPSC-cardiomyocyte systems:</strong> Quantitative TPM1 isoform dynamics in iPSC-to-cardiomyocyte differentiation support TPM1 isoforms as biomarkers of maturation state and as readouts for perturbation experiments targeting sarcomere assembly/regulation. (dube2024sarcomerictropomyosinexpression pages 2-4)</li>
+</ul>
+<h4 id="53-cancer-stratification-and-therapy-development">5.3 Cancer stratification and therapy development</h4>
+<ul>
+<li><strong>Isoform-resolved biomarkers and targeting:</strong> The ovarian cancer work indicates that TPM1 isoform identification (Tpm1.6/7 vs Tpm1.8/9) may inform EMP state, metastatic potential, and chemotherapy response, and supports development of <strong>isoform-selective inhibitors</strong> as a potential therapeutic avenue. (xu2024tropomyosin1isoformsunderlie pages 6-8, xu2024tropomyosin1isoformsunderlie pages 10-12)</li>
+</ul>
+<h3 id="6-visual-evidence-tpm1-isoform-structure-and-chemo-resistance">6) Visual evidence: TPM1 isoform structure and chemo-resistance</h3>
+<p>The following figure panels from the 2024 HGSOC study visually summarize TPM1 exon-defined isoforms and chemotherapy dose–response/IC50 effects:</p>
+<ul>
+<li>TPM1 isoform exon structures and RT-qPCR stratification (Tpm1.6/7 vs Tpm1.8/9): (xu2024tropomyosin1isoformsunderlie media 181dbb5d)</li>
+<li>Chemotherapy dose–response curves/IC50 values for paclitaxel and cisplatin showing resistance conferred by Tpm1.8/9: (xu2024tropomyosin1isoformsunderlie media f45ab9b5)</li>
+</ul>
+<h3 id="7-concise-functional-annotation-summary-evidence-table">7) Concise functional annotation summary (evidence table)</h3>
+<p>The table below consolidates TPM1’s functional roles, localization, isoform logic, disease links, and key quantitative findings from 2023–2024 sources.</p>
+<table>
+<thead>
+<tr>
+<th>Aspect</th>
+<th>Evidence-backed summary</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Molecular function</td>
+<td>• TPM1 encodes α-tropomyosin, a coiled-coil actin-binding thin-filament protein that regulates actin–myosin interaction in a Ca²⁺/troponin-dependent manner in cardiac muscle. • Recent heart studies also describe TPM1 as the predominant cardiac tropomyosin and a sarcomeric regulator of contractility (haas2026sarcomericremodellingin pages 1-4, haas2026sarcomericremodellingin pages 7-10, azimi2024identificationofa pages 1-2)</td>
+</tr>
+<tr>
+<td>Mechanism</td>
+<td>• In sarcomeres, tropomyosin shifts on actin in response to troponin/Ca²⁺ signaling to expose myosin-binding sites; TPM1 isoforms therefore tune thin-filament activation and motility. • In non-muscle cells, TPM1-derived Tpm1.6 follows a distinct path on actin, cannot co-polymerize with Tpm3.2 on the same filament, and competes with α-actinin for actin binding, helping specify functionally distinct actin networks (haas2026sarcomericremodellingin pages 1-4, kumari2024focaladhesionscontain pages 1-2, kumari2024focaladhesionscontain pages 10-12, selvaraj2023structuralbasisunderlying pages 1-3)</td>
+</tr>
+<tr>
+<td>Isoforms / splicing</td>
+<td>• TPM1 undergoes extensive alternative splicing, generating multiple muscle and non-muscle isoforms; 2024 hiPSC-cardiomyocyte work detected TPM1α, TPM1κ, and TPM1μ, with TPM1μ matching UniProt/SwissProt isoform P09493-4. • Ovarian-cancer work distinguished Tpm1.6/1.7 from Tpm1.8/1.9 by exon usage: exons 1a/2b mark Tpm1.6/7, whereas exon 1b marks Tpm1.8/9 (dube2024sarcomerictropomyosinexpression pages 2-4, xu2024tropomyosin1isoformsunderlie media 181dbb5d, xu2024tropomyosin1isoformsunderlie pages 6-8)</td>
+</tr>
+<tr>
+<td>Subcellular localization</td>
+<td>• In muscle, TPM1 is localized to the sarcomeric thin filament of cardiomyocytes. • In non-muscle cells, TPM1-derived Tpm1.6 forms a distinct focal-adhesion actin layer beneath the α-actinin layer and extends along associated dorsal stress fibers, linking adhesion architecture to motility control (haas2026sarcomericremodellingin pages 1-4, kumari2024focaladhesionscontain pages 1-2, kumari2024focaladhesionscontain pages 9-10, kumari2024focaladhesionscontain pages 2-3)</td>
+</tr>
+<tr>
+<td>Key binding partners / complexes</td>
+<td>• Core TPM1 complexes/functions involve F-actin, troponin, and myosin in thin-filament regulation. • Additional evidence links TPM1 biology to α-actinin competition in focal adhesions and suggests disease-relevant interactions with leiomodin-2 and tropomodulin-1 for N-terminal variants (haas2026sarcomericremodellingin pages 1-4, haas2026sarcomericremodellingin pages 7-10, kumari2024focaladhesionscontain pages 10-12, hanel2024casereportcosegregation pages 3-4)</td>
+</tr>
+<tr>
+<td>Regulation</td>
+<td>• Cardiac TPM1 isoform expression is regulated by alternative splicing programs involving RBM20 and other RNA-binding/splicing factors; heart-failure studies report isoform remodeling across sarcomere genes including TPM1. • In ovarian cancer, TPM1 isoform balance is linked to epithelial–mesenchymal plasticity and Wnt/inflammatory pathway activation, indicating context-dependent post-transcriptional regulation with functional consequences (haas2026sarcomericremodellingin pages 23-26, haas2026sarcomericremodellingin pages 1-4, xu2024tropomyosin1isoformsunderlie pages 10-12)</td>
+</tr>
+<tr>
+<td>Disease relevance</td>
+<td>• Cardiomyopathy: TPM1 variants are implicated in HCM and NCCM/LVNC; recent reports include p.D254G linked to familial HCM/SCD and p.Lys7del co-segregating with familial NCCM. • Cancer: TPM1 isoforms are functionally linked to EMT/plasticity, metastatic dissemination, and chemotherapy resistance in high-grade serous ovarian cancer; broader cancer review literature supports tumor-suppressive and stress-fiber-stabilizing roles for TPM1 in several malignancies (azimi2024identificationofa pages 7-7, azimi2024identificationofa pages 2-2, hanel2024casereportcosegregation pages 3-4, xu2024tropomyosin1isoformsunderlie pages 10-12, meng2023researchadvancesin pages 3-5)</td>
+</tr>
+<tr>
+<td>Recent key studies (2023–2024)</td>
+<td>• 2023 structural work defined isoform-specific actin engagement of non-muscle Tpm1.6 and explained differential effects on cofilin/myosin interactions. • 2024 studies mapped Tpm1.6 into focal-adhesion nanoscale layers, profiled TPM1 isoforms during hiPSC-cardiomyocyte differentiation, linked TPM1 isoforms to ovarian-cancer EMT/chemoresistance, and quantified TPM1-associated penetrance in HCM meta-analysis (selvaraj2023structuralbasisunderlying pages 1-3, kumari2024focaladhesionscontain pages 1-2, dube2024sarcomerictropomyosinexpression pages 2-4, xu2024tropomyosin1isoformsunderlie pages 10-12, topriceanu2024metaanalysisofpenetrance pages 6-7)</td>
+</tr>
+<tr>
+<td>Quantitative data</td>
+<td>• hiPSC-cardiomyocyte differentiation: TPM1α mRNA rose from 6.88×10^8 copies in hiPSCs to ~5.6×10^10 by day 5 and ~5.98×10^10 by day 20; day-20 transcript rank was TPM1α &gt; TPM1κ &gt; TPM2α &gt; TPM1μ &gt; TPM3α &gt; TPM4α (dube2024sarcomerictropomyosinexpression pages 2-4). • HCM meta-analysis: TPM1 penetrance in relatives carrying P/LP variants was 48.6% (95% CI 25.7–72.2), pooled age at diagnosis 40.3 years; in HYPERGEN reanalysis of 200 HCM cases, no TPM1 variants were found; NCCM report notes TPM1 variants account for &lt;2% of LVNC/NCCM cohorts (topriceanu2024metaanalysisofpenetrance pages 6-7, jaouadi2024exomesequencingdata pages 1-2, hanel2024casereportcosegregation pages 3-4). • Ovarian cancer: OV90 cisplatin IC50 was ~3.266/3.414 μM for Tpm1.8/9-OE versus ~0.078/0.043 μM for Tpm1.6/7-OE; paclitaxel IC50 was ~1.28/1.66 μM versus 0.017/0.015 μM, respectively (xu2024tropomyosin1isoformsunderlie pages 6-8)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the functional annotation of human TPM1 (UniProt P09493) using only gathered evidence, covering molecular function, localization, splicing, regulation, disease links, and recent quantitative findings from 2023–2024 studies.</em></p>
+<h3 id="8-notes-on-evidence-quality-and-gaps">8) Notes on evidence quality and gaps</h3>
+<ul>
+<li>The strongest TPM1 functional isoform evidence in 2023–2024 comes from high-impact primary studies in <strong>focal adhesion nanoscale architecture</strong> and <strong>ovarian cancer EMP/chemoresistance</strong>, plus quantitative iPSC cardiomyocyte maturation profiling (kumari2024focaladhesionscontain pages 1-2, xu2024tropomyosin1isoformsunderlie pages 6-8, dube2024sarcomerictropomyosinexpression pages 2-4).</li>
+<li>Some mechanistic structure-function evidence for non-muscle isoforms is currently in preprint form (bioRxiv 2023) and should be interpreted accordingly, though it is consistent with the high-resolution FA study’s mutual-exclusivity/competition model. (selvaraj2023structuralbasisunderlying pages 1-3, kumari2024focaladhesionscontain pages 10-12)</li>
+</ul>
+<h3 id="key-sources-20232024-prioritized-urls-and-dates">Key sources (2023–2024 prioritized; URLs and dates)</h3>
+<ul>
+<li>Kumari R. et al. <strong>Focal adhesions contain three specialized actin nanoscale layers</strong>. <em>Nature Communications</em>. <strong>Mar 2024</strong>. https://doi.org/10.1038/s41467-024-46868-7 (kumari2024focaladhesionscontain pages 1-2)</li>
+<li>Xu T. et al. <strong>Tropomyosin1 isoforms underlie epithelial to mesenchymal plasticity, metastatic dissemination, and resistance to chemotherapy in high-grade serous ovarian cancer</strong>. <em>Cell Death &amp; Differentiation</em>. <strong>Feb 2024</strong>. https://doi.org/10.1038/s41418-024-01267-9 (xu2024tropomyosin1isoformsunderlie pages 6-8)</li>
+<li>Dube D.K. et al. <strong>Sarcomeric tropomyosin expression during human iPSC differentiation into cardiomyocytes</strong>. <em>Cytoskeleton</em>. <strong>Mar 2024</strong>. https://doi.org/10.1002/cm.21850 (dube2024sarcomerictropomyosinexpression pages 2-4)</li>
+<li>Topriceanu C.-C. et al. <strong>Meta-analysis of penetrance and systematic review on transition to disease in genetic hypertrophic cardiomyopathy</strong>. <em>Circulation</em>. <strong>Jan 2024</strong>. https://doi.org/10.1161/circulationaha.123.065987 (topriceanu2024metaanalysisofpenetrance pages 6-7)</li>
+<li>Jaouadi H. et al. <strong>Exome sequencing data reanalysis of 200 hypertrophic cardiomyopathy patients: the HYPERGEN French cohort</strong>. <em>Frontiers in Medicine</em>. <strong>Oct 2024</strong>. https://doi.org/10.3389/fmed.2024.1480947 (jaouadi2024exomesequencingdata pages 1-2)</li>
+<li>Azimi A. et al. <strong>Identification of a novel likely pathogenic TPM1 variant linked to hypertrophic cardiomyopathy in a family with sudden cardiac death</strong>. <em>ESC Heart Failure</em>. <strong>Jun 2024</strong>. https://doi.org/10.1002/ehf2.14906 (azimi2024identificationofa pages 7-7)</li>
+<li>Hanel Y. et al. <strong>Cosegregation of a TPM1 in-frame deletion (p.Lys7del) with familial non-compaction cardiomyopathy</strong>. <em>Clinical Research in Cardiology</em>. <strong>Apr 2024</strong>. https://doi.org/10.1007/s00392-023-02190-8 (hanel2024casereportcosegregation pages 3-4)</li>
+<li>Meng Y. et al. <strong>Research advances in the role of the tropomyosin family in cancer</strong>. <em>International Journal of Molecular Sciences</em>. <strong>Aug 2023</strong>. https://doi.org/10.3390/ijms241713295 (meng2023researchadvancesin pages 3-5)</li>
+<li>Selvaraj M. et al. <strong>Structural basis underlying specific biochemical activities of non-muscle tropomyosin isoforms</strong>. <em>bioRxiv</em>. <strong>May 2023</strong>. https://doi.org/10.1101/2022.05.12.491677 (selvaraj2023structuralbasisunderlying pages 1-3)</li>
+</ul>
+<p>References</p>
+<ol>
+<li>
+<p>(dube2024sarcomerictropomyosinexpression pages 2-4): Dipak K. Dube, Syamalima Dube, Huaiyu Shi, Patricia Benz, Samender Randhawa, Yingli Fan, Jusuo Wang, Zhen Ma, Joseph W. Sanger, Jean M. Sanger, and Bernard J. Poiesz. Sarcomeric tropomyosin expression during human ipsc differentiation into cardiomyocytes. Cytoskeleton, 81:448-472, Mar 2024. URL: https://doi.org/10.1002/cm.21850, doi:10.1002/cm.21850. This article has 1 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(kumari2024focaladhesionscontain pages 2-3): Reena Kumari, Katharina Ven, Megan Chastney, Shrikant B. Kokate, Johan Peränen, Jesse Aaron, Konstantin Kogan, Leonardo Almeida-Souza, Elena Kremneva, Renaud Poincloux, Teng-Leong Chew, Peter W. Gunning, Johanna Ivaska, and Pekka Lappalainen. Focal adhesions contain three specialized actin nanoscale layers. Nature Communications, Mar 2024. URL: https://doi.org/10.1038/s41467-024-46868-7, doi:10.1038/s41467-024-46868-7. This article has 57 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(haas2026sarcomericremodellingin pages 1-4): Jan Haas, Sarah Schudy, Benedikt Rauscher, Ana Munoz, Steffen Roßkopf, Christoph Reich, Gizem Donmez Yalcin, Abdullah Yalcin, Timon Seeger, Manuel H. Taft, Marc Freichel, Dirk Grimm, Dietmar Manstein, Johannes Backs, Norbert Frey, Lars Steinmetz, and Benjamin Meder. Sarcomeric remodelling in human heart failure unraveled by single molecule long read sequencing. BioRxiv, Mar 2026. URL: https://doi.org/10.1101/2025.02.28.640805, doi:10.1101/2025.02.28.640805. This article has 2 citations.</p>
+</li>
+<li>
+<p>(xu2024tropomyosin1isoformsunderlie pages 6-8): Tong Xu, Mathijs P. Verhagen, Miriam Teeuwssen, Wenjie Sun, Rosalie Joosten, Andrea Sacchetti, Patricia C. Ewing-Graham, Maurice P. H. M. Jansen, Ingrid A. Boere, Nicole S. Bryce, Jun Zeng, Herbert R. Treutlein, Jeff Hook, Edna C. Hardeman, Peter W. Gunning, and Riccardo Fodde. Tropomyosin1 isoforms underlie epithelial to mesenchymal plasticity, metastatic dissemination, and resistance to chemotherapy in high-grade serous ovarian cancer. Cell Death and Differentiation, 31:360-377, Feb 2024. URL: https://doi.org/10.1038/s41418-024-01267-9, doi:10.1038/s41418-024-01267-9. This article has 22 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(xu2024tropomyosin1isoformsunderlie media 181dbb5d): Tong Xu, Mathijs P. Verhagen, Miriam Teeuwssen, Wenjie Sun, Rosalie Joosten, Andrea Sacchetti, Patricia C. Ewing-Graham, Maurice P. H. M. Jansen, Ingrid A. Boere, Nicole S. Bryce, Jun Zeng, Herbert R. Treutlein, Jeff Hook, Edna C. Hardeman, Peter W. Gunning, and Riccardo Fodde. Tropomyosin1 isoforms underlie epithelial to mesenchymal plasticity, metastatic dissemination, and resistance to chemotherapy in high-grade serous ovarian cancer. Cell Death and Differentiation, 31:360-377, Feb 2024. URL: https://doi.org/10.1038/s41418-024-01267-9, doi:10.1038/s41418-024-01267-9. This article has 22 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(xu2024tropomyosin1isoformsunderlie media f45ab9b5): Tong Xu, Mathijs P. Verhagen, Miriam Teeuwssen, Wenjie Sun, Rosalie Joosten, Andrea Sacchetti, Patricia C. Ewing-Graham, Maurice P. H. M. Jansen, Ingrid A. Boere, Nicole S. Bryce, Jun Zeng, Herbert R. Treutlein, Jeff Hook, Edna C. Hardeman, Peter W. Gunning, and Riccardo Fodde. Tropomyosin1 isoforms underlie epithelial to mesenchymal plasticity, metastatic dissemination, and resistance to chemotherapy in high-grade serous ovarian cancer. Cell Death and Differentiation, 31:360-377, Feb 2024. URL: https://doi.org/10.1038/s41418-024-01267-9, doi:10.1038/s41418-024-01267-9. This article has 22 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(topriceanu2024metaanalysisofpenetrance pages 6-7): Constantin-Cristian Topriceanu, Alexandre C. Pereira, James C. Moon, Gabriella Captur, and Carolyn Y. Ho. Meta-analysis of penetrance and systematic review on transition to disease in genetic hypertrophic cardiomyopathy. Circulation, 149:107-123, Jan 2024. URL: https://doi.org/10.1161/circulationaha.123.065987, doi:10.1161/circulationaha.123.065987. This article has 86 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(jaouadi2024exomesequencingdata pages 1-2): Hager Jaouadi, Victor Morel, Helene Martel, Pierre Lindenbaum, Lorcan Lamy de la Chapelle, Marine Herbane, Claire Lucas, Frédérique Magdinier, Habib Gilbert, Jean-Jacques Schott, Stéphane Zaffran, and Karine Nguyen. Exome sequencing data reanalysis of 200 hypertrophic cardiomyopathy patients: the hypergen french cohort 5 years after the initial analysis. Frontiers in Medicine, Oct 2024. URL: https://doi.org/10.3389/fmed.2024.1480947, doi:10.3389/fmed.2024.1480947. This article has 1 citations.</p>
+</li>
+<li>
+<p>(kumari2024focaladhesionscontain pages 1-2): Reena Kumari, Katharina Ven, Megan Chastney, Shrikant B. Kokate, Johan Peränen, Jesse Aaron, Konstantin Kogan, Leonardo Almeida-Souza, Elena Kremneva, Renaud Poincloux, Teng-Leong Chew, Peter W. Gunning, Johanna Ivaska, and Pekka Lappalainen. Focal adhesions contain three specialized actin nanoscale layers. Nature Communications, Mar 2024. URL: https://doi.org/10.1038/s41467-024-46868-7, doi:10.1038/s41467-024-46868-7. This article has 57 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(kumari2024focaladhesionscontain pages 3-4): Reena Kumari, Katharina Ven, Megan Chastney, Shrikant B. Kokate, Johan Peränen, Jesse Aaron, Konstantin Kogan, Leonardo Almeida-Souza, Elena Kremneva, Renaud Poincloux, Teng-Leong Chew, Peter W. Gunning, Johanna Ivaska, and Pekka Lappalainen. Focal adhesions contain three specialized actin nanoscale layers. Nature Communications, Mar 2024. URL: https://doi.org/10.1038/s41467-024-46868-7, doi:10.1038/s41467-024-46868-7. This article has 57 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(kumari2024focaladhesionscontain pages 4-6): Reena Kumari, Katharina Ven, Megan Chastney, Shrikant B. Kokate, Johan Peränen, Jesse Aaron, Konstantin Kogan, Leonardo Almeida-Souza, Elena Kremneva, Renaud Poincloux, Teng-Leong Chew, Peter W. Gunning, Johanna Ivaska, and Pekka Lappalainen. Focal adhesions contain three specialized actin nanoscale layers. Nature Communications, Mar 2024. URL: https://doi.org/10.1038/s41467-024-46868-7, doi:10.1038/s41467-024-46868-7. This article has 57 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(kumari2024focaladhesionscontain pages 10-12): Reena Kumari, Katharina Ven, Megan Chastney, Shrikant B. Kokate, Johan Peränen, Jesse Aaron, Konstantin Kogan, Leonardo Almeida-Souza, Elena Kremneva, Renaud Poincloux, Teng-Leong Chew, Peter W. Gunning, Johanna Ivaska, and Pekka Lappalainen. Focal adhesions contain three specialized actin nanoscale layers. Nature Communications, Mar 2024. URL: https://doi.org/10.1038/s41467-024-46868-7, doi:10.1038/s41467-024-46868-7. This article has 57 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(selvaraj2023structuralbasisunderlying pages 1-3): Muniyandi Selvaraj, Shrikant Kokate, Gabriella Reggiano, Konstantin Kogan, Tommi Kotila, Elena Kremneva, Frank DiMaio, Pekka Lappalainen, and Juha T. Huiskonen. Structural basis underlying specific biochemical activities of non-muscle tropomyosin isoforms. bioRxiv, May 2023. URL: https://doi.org/10.1101/2022.05.12.491677, doi:10.1101/2022.05.12.491677. This article has 23 citations.</p>
+</li>
+<li>
+<p>(topriceanu2024metaanalysisofpenetrance pages 2-3): Constantin-Cristian Topriceanu, Alexandre C. Pereira, James C. Moon, Gabriella Captur, and Carolyn Y. Ho. Meta-analysis of penetrance and systematic review on transition to disease in genetic hypertrophic cardiomyopathy. Circulation, 149:107-123, Jan 2024. URL: https://doi.org/10.1161/circulationaha.123.065987, doi:10.1161/circulationaha.123.065987. This article has 86 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(topriceanu2024metaanalysisofpenetrance pages 9-10): Constantin-Cristian Topriceanu, Alexandre C. Pereira, James C. Moon, Gabriella Captur, and Carolyn Y. Ho. Meta-analysis of penetrance and systematic review on transition to disease in genetic hypertrophic cardiomyopathy. Circulation, 149:107-123, Jan 2024. URL: https://doi.org/10.1161/circulationaha.123.065987, doi:10.1161/circulationaha.123.065987. This article has 86 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(azimi2024identificationofa pages 7-7): Amir Azimi, Mahdieh Soveizi, Alireza Salmanipour, Mohammadhossein Mozafarybazargany, Amir Ghaffari Jolfayi, Majid Maleki, and Samira Kalayinia. Identification of a novel likely pathogenic tpm1 variant linked to hypertrophic cardiomyopathy in a family with sudden cardiac death. ESC Heart Failure, 11:3180-3190, Jun 2024. URL: https://doi.org/10.1002/ehf2.14906, doi:10.1002/ehf2.14906. This article has 3 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(azimi2024identificationofa pages 2-2): Amir Azimi, Mahdieh Soveizi, Alireza Salmanipour, Mohammadhossein Mozafarybazargany, Amir Ghaffari Jolfayi, Majid Maleki, and Samira Kalayinia. Identification of a novel likely pathogenic tpm1 variant linked to hypertrophic cardiomyopathy in a family with sudden cardiac death. ESC Heart Failure, 11:3180-3190, Jun 2024. URL: https://doi.org/10.1002/ehf2.14906, doi:10.1002/ehf2.14906. This article has 3 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(azimi2024identificationofa pages 7-8): Amir Azimi, Mahdieh Soveizi, Alireza Salmanipour, Mohammadhossein Mozafarybazargany, Amir Ghaffari Jolfayi, Majid Maleki, and Samira Kalayinia. Identification of a novel likely pathogenic tpm1 variant linked to hypertrophic cardiomyopathy in a family with sudden cardiac death. ESC Heart Failure, 11:3180-3190, Jun 2024. URL: https://doi.org/10.1002/ehf2.14906, doi:10.1002/ehf2.14906. This article has 3 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(hanel2024casereportcosegregation pages 3-4): Yvonne Hanel, Sven Dittmann, Klara Müller, Monica Elena Ioannou, and Eric Schulze-Bahr. Case report: cosegregation of a tpm1 in-frame deletion (p.lys7del) with familial non-compaction cardiomyopathy (nccm). Clinical Research in Cardiology, 113:656-660, Apr 2024. URL: https://doi.org/10.1007/s00392-023-02190-8, doi:10.1007/s00392-023-02190-8. This article has 1 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(xu2024tropomyosin1isoformsunderlie pages 10-12): Tong Xu, Mathijs P. Verhagen, Miriam Teeuwssen, Wenjie Sun, Rosalie Joosten, Andrea Sacchetti, Patricia C. Ewing-Graham, Maurice P. H. M. Jansen, Ingrid A. Boere, Nicole S. Bryce, Jun Zeng, Herbert R. Treutlein, Jeff Hook, Edna C. Hardeman, Peter W. Gunning, and Riccardo Fodde. Tropomyosin1 isoforms underlie epithelial to mesenchymal plasticity, metastatic dissemination, and resistance to chemotherapy in high-grade serous ovarian cancer. Cell Death and Differentiation, 31:360-377, Feb 2024. URL: https://doi.org/10.1038/s41418-024-01267-9, doi:10.1038/s41418-024-01267-9. This article has 22 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(meng2023researchadvancesin pages 3-5): Yucheng Meng, Kemin Huang*, Mingxuan Shi, Yifei Huo, L. Han, Bin Liu, and Yi Li. Research advances in the role of the tropomyosin family in cancer. International Journal of Molecular Sciences, 24:13295, Aug 2023. URL: https://doi.org/10.3390/ijms241713295, doi:10.3390/ijms241713295. This article has 25 citations.</p>
+</li>
+<li>
+<p>(haas2026sarcomericremodellingin pages 7-10): Jan Haas, Sarah Schudy, Benedikt Rauscher, Ana Munoz, Steffen Roßkopf, Christoph Reich, Gizem Donmez Yalcin, Abdullah Yalcin, Timon Seeger, Manuel H. Taft, Marc Freichel, Dirk Grimm, Dietmar Manstein, Johannes Backs, Norbert Frey, Lars Steinmetz, and Benjamin Meder. Sarcomeric remodelling in human heart failure unraveled by single molecule long read sequencing. BioRxiv, Mar 2026. URL: https://doi.org/10.1101/2025.02.28.640805, doi:10.1101/2025.02.28.640805. This article has 2 citations.</p>
+</li>
+<li>
+<p>(azimi2024identificationofa pages 1-2): Amir Azimi, Mahdieh Soveizi, Alireza Salmanipour, Mohammadhossein Mozafarybazargany, Amir Ghaffari Jolfayi, Majid Maleki, and Samira Kalayinia. Identification of a novel likely pathogenic tpm1 variant linked to hypertrophic cardiomyopathy in a family with sudden cardiac death. ESC Heart Failure, 11:3180-3190, Jun 2024. URL: https://doi.org/10.1002/ehf2.14906, doi:10.1002/ehf2.14906. This article has 3 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(kumari2024focaladhesionscontain pages 9-10): Reena Kumari, Katharina Ven, Megan Chastney, Shrikant B. Kokate, Johan Peränen, Jesse Aaron, Konstantin Kogan, Leonardo Almeida-Souza, Elena Kremneva, Renaud Poincloux, Teng-Leong Chew, Peter W. Gunning, Johanna Ivaska, and Pekka Lappalainen. Focal adhesions contain three specialized actin nanoscale layers. Nature Communications, Mar 2024. URL: https://doi.org/10.1038/s41467-024-46868-7, doi:10.1038/s41467-024-46868-7. This article has 57 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(haas2026sarcomericremodellingin pages 23-26): Jan Haas, Sarah Schudy, Benedikt Rauscher, Ana Munoz, Steffen Roßkopf, Christoph Reich, Gizem Donmez Yalcin, Abdullah Yalcin, Timon Seeger, Manuel H. Taft, Marc Freichel, Dirk Grimm, Dietmar Manstein, Johannes Backs, Norbert Frey, Lars Steinmetz, and Benjamin Meder. Sarcomeric remodelling in human heart failure unraveled by single molecule long read sequencing. BioRxiv, Mar 2026. URL: https://doi.org/10.1101/2025.02.28.640805, doi:10.1101/2025.02.28.640805. This article has 2 citations.</p>
+</li>
+</ol>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>dube2024sarcomerictropomyosinexpression pages 2-4</li>
+<li>kumari2024focaladhesionscontain pages 2-3</li>
+<li>haas2026sarcomericremodellingin pages 1-4</li>
+<li>selvaraj2023structuralbasisunderlying pages 1-3</li>
+<li>topriceanu2024metaanalysisofpenetrance pages 6-7</li>
+<li>topriceanu2024metaanalysisofpenetrance pages 9-10</li>
+<li>jaouadi2024exomesequencingdata pages 1-2</li>
+<li>azimi2024identificationofa pages 7-8</li>
+<li>hanel2024casereportcosegregation pages 3-4</li>
+<li>meng2023researchadvancesin pages 3-5</li>
+<li>kumari2024focaladhesionscontain pages 1-2</li>
+<li>azimi2024identificationofa pages 7-7</li>
+<li>kumari2024focaladhesionscontain pages 3-4</li>
+<li>kumari2024focaladhesionscontain pages 4-6</li>
+<li>kumari2024focaladhesionscontain pages 10-12</li>
+<li>topriceanu2024metaanalysisofpenetrance pages 2-3</li>
+<li>azimi2024identificationofa pages 2-2</li>
+<li>haas2026sarcomericremodellingin pages 7-10</li>
+<li>azimi2024identificationofa pages 1-2</li>
+<li>kumari2024focaladhesionscontain pages 9-10</li>
+<li>haas2026sarcomericremodellingin pages 23-26</li>
+<li>https://doi.org/10.1038/s41467-024-46868-7</li>
+<li>https://doi.org/10.1101/2022.05.12.491677;</li>
+<li>https://doi.org/10.1002/cm.21850</li>
+<li>https://doi.org/10.1161/circulationaha.123.065987</li>
+<li>https://doi.org/10.3389/fmed.2024.1480947</li>
+<li>https://doi.org/10.1002/ehf2.14906</li>
+<li>https://doi.org/10.1007/s00392-023-02190-8</li>
+<li>https://doi.org/10.1038/s41418-024-01267-9</li>
+<li>https://doi.org/10.3390/ijms241713295</li>
+<li>https://doi.org/10.1101/2022.05.12.491677</li>
+<li>https://doi.org/10.1002/cm.21850,</li>
+<li>https://doi.org/10.1038/s41467-024-46868-7,</li>
+<li>https://doi.org/10.1101/2025.02.28.640805,</li>
+<li>https://doi.org/10.1038/s41418-024-01267-9,</li>
+<li>https://doi.org/10.1161/circulationaha.123.065987,</li>
+<li>https://doi.org/10.3389/fmed.2024.1480947,</li>
+<li>https://doi.org/10.1101/2022.05.12.491677,</li>
+<li>https://doi.org/10.1002/ehf2.14906,</li>
+<li>https://doi.org/10.1007/s00392-023-02190-8,</li>
+<li>https://doi.org/10.3390/ijms241713295,</li>
+</ol>
+            </div>
+        </details>
+
         <details class="markdown-section">
             <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
                 <div style="flex: 1;">
@@ -5657,9 +6073,9 @@
 <h2 id="goa-annotation-count-55">GOA Annotation Count: 55</h2>
             </div>
         </details>
-        
+
     </div>
-    
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -5671,7 +6087,7 @@
                 <pre><code>id: P09493
 gene_symbol: TPM1
 product_type: PROTEIN
-status: INITIALIZED
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
@@ -5693,48 +6109,55 @@ existing_annotations:
     evidence_type: IBA
     original_reference_id: GO_REF:0000033
     review:
-      summary: Core function of all TPM1 isoforms. Tropomyosin binds along the 
-        length of actin filaments in both muscle and non-muscle cells. UniProt 
-        states that TPM1 binds to actin filaments. This function is conserved 
-        across all isoforms - muscle isoforms bind thin filament actin while 
+      summary: Core function of all TPM1 isoforms. Tropomyosin binds along the
+        length of actin filaments in both muscle and non-muscle cells. UniProt
+        states that TPM1 binds to actin filaments. This function is conserved
+        across all isoforms - muscle isoforms bind thin filament actin while
         cytoskeletal isoforms bind stress fiber actin.
       action: ACCEPT
-      reason: Actin filament binding is the fundamental molecular function of 
-        all tropomyosins. IBA annotation is appropriate as this function is 
+      reason: Actin filament binding is the fundamental molecular function of
+        all tropomyosins. IBA annotation is appropriate as this function is
         phylogenetically conserved. Supported by functional studies showing TPM1
-        binds actin filaments in both muscle and non-muscle contexts 
+        binds actin filaments in both muscle and non-muscle contexts
         [PMID:12686598].
       supported_by:
         - reference_id: PMID:12686598
           supporting_text: tropomyosin-1 was found diffuse in the cells, whereas
             it quickly colocalized with actin and stress fibers upon stimulation
         - reference_id: PMID:8205619
-          supporting_text: alpha-tropomyosin and cardiac troponin T as well as 
-            beta myosin heavy chain mutations cause the same phenotype, we 
+          supporting_text: alpha-tropomyosin and cardiac troponin T as well as
+            beta myosin heavy chain mutations cause the same phenotype, we
             conclude that FHC is a disease of the sarcomere
+        - reference_id: file:human/TPM1/TPM1-deep-research-falcon.md
+          supporting_text: &gt;-
+            The target gene TPM1 in Homo sapiens encodes tropomyosin alpha-1
+            chain, a coiled-coil protein of the tropomyosin family that binds
+            F-actin and specifies functional properties of actin filaments in
+            both sarcomeric thin filaments and specialized non-muscle actin
+            networks.
   - term:
       id: GO:0007015
       label: actin filament organization
     evidence_type: IBA
     original_reference_id: GO_REF:0000033
     review:
-      summary: TPM1 plays a role in actin filament organization in both muscle 
-        and non-muscle cells. In muscle, it organizes thin filaments; in 
-        non-muscle cells, it contributes to stress fiber formation and 
+      summary: TPM1 plays a role in actin filament organization in both muscle
+        and non-muscle cells. In muscle, it organizes thin filaments; in
+        non-muscle cells, it contributes to stress fiber formation and
         cytoskeletal organization [PMID:12686598].
       action: ACCEPT
-      reason: Actin filament organization is a core function of tropomyosins 
-        across all isoforms. Muscle isoforms organize thin filaments in 
-        sarcomeres; cytoskeletal isoforms stabilize stress fibers in non-muscle 
+      reason: Actin filament organization is a core function of tropomyosins
+        across all isoforms. Muscle isoforms organize thin filaments in
+        sarcomeres; cytoskeletal isoforms stabilize stress fibers in non-muscle
         cells. IBA annotation is appropriate.
       supported_by:
         - reference_id: PMID:12686598
           supporting_text: phosphorylation of tropomyosin-1 downstream of ERK by
-            contributing to formation of actin filaments increases cellular 
+            contributing to formation of actin filaments increases cellular
             contractility and promotes the formation of focal adhesions
         - reference_id: PMID:15897890
-          supporting_text: TGF-beta induction of stress fibers in epithelial 
-            cells requires high molecular weight tropomyosins encoded by TPM1 
+          supporting_text: TGF-beta induction of stress fibers in epithelial
+            cells requires high molecular weight tropomyosins encoded by TPM1
             and TPM2 genes
   - term:
       id: GO:0005884
@@ -5742,13 +6165,13 @@ existing_annotations:
     evidence_type: IBA
     original_reference_id: GO_REF:0000033
     review:
-      summary: TPM1 localizes to actin filaments in both muscle and non-muscle 
+      summary: TPM1 localizes to actin filaments in both muscle and non-muscle
         cells. This cellular component annotation reflects the physical location
         of tropomyosin bound along actin filaments.
       action: ACCEPT
       reason: Tropomyosin is an integral component of actin filaments. In muscle
         cells it forms the thin filament regulatory complex; in non-muscle cells
-        it associates with stress fibers and other actin structures. IBA 
+        it associates with stress fibers and other actin structures. IBA
         annotation is appropriate.
       supported_by:
         - reference_id: PMID:12686598
@@ -5766,19 +6189,19 @@ existing_annotations:
         Mutations cause cardiomyopathy (CMH3, CMD1Y) [PMID:8205619, PMID:11273725].&#39;
       action: ACCEPT
       reason: This is a core function for cardiac isoforms. TPM1 plays a central
-        role in calcium-dependent regulation of cardiac muscle contraction via 
-        the troponin complex. Mutations affecting this function cause 
-        hypertrophic and dilated cardiomyopathy, demonstrating its importance 
-        [PMID:8205619]. IBA annotation is appropriate as this function is 
+        role in calcium-dependent regulation of cardiac muscle contraction via
+        the troponin complex. Mutations affecting this function cause
+        hypertrophic and dilated cardiomyopathy, demonstrating its importance
+        [PMID:8205619]. IBA annotation is appropriate as this function is
         conserved in striated muscle isoforms.
       supported_by:
         - reference_id: PMID:8205619
-          supporting_text: We demonstrate that missense mutations (Asp175Asn; 
+          supporting_text: We demonstrate that missense mutations (Asp175Asn;
             Glu180Gly) in the alpha-tropomyosin gene cause familial hypertrophic
             cardiomyopathy (FHC)
         - reference_id: PMID:11136687
-          supporting_text: HCM was linked to the TPM1 gene... The mutation 
-            caused a 40% to 50% increase in calcium affinity in regulated thin 
+          supporting_text: HCM was linked to the TPM1 gene... The mutation
+            caused a 40% to 50% increase in calcium affinity in regulated thin
             filament-myosin subfragment-1 (S1) MgATPase assays
   - term:
       id: GO:0003779
@@ -5786,15 +6209,15 @@ existing_annotations:
     evidence_type: IEA
     original_reference_id: GO_REF:0000043
     review:
-      summary: Actin binding is the fundamental molecular function of all 
-        tropomyosins. This IEA annotation based on UniProt keyword mapping is 
+      summary: Actin binding is the fundamental molecular function of all
+        tropomyosins. This IEA annotation based on UniProt keyword mapping is
         correct but less specific than GO:0051015 (actin filament binding) which
         is already annotated via IBA.
       action: ACCEPT
-      reason: While this is a broader parent term of actin filament binding, it 
-        is still correct. IEA annotations at a broader level are acceptable 
-        alongside more specific experimental annotations. No action needed as 
-        the more specific IBA annotation (GO:0051015) captures the precise 
+      reason: While this is a broader parent term of actin filament binding, it
+        is still correct. IEA annotations at a broader level are acceptable
+        alongside more specific experimental annotations. No action needed as
+        the more specific IBA annotation (GO:0051015) captures the precise
         function.
       supported_by:
         - reference_id: PMID:12686598
@@ -5806,13 +6229,13 @@ existing_annotations:
     evidence_type: IEA
     original_reference_id: GO_REF:0000044
     review:
-      summary: TPM1 is a cytoskeletal protein. UniProt subcellular location 
-        indicates &#34;Cytoplasm, cytoskeleton&#34; and notes it &#34;Associates with 
-        F-actin stress fibers.&#34; This is a broad cellular component annotation 
+      summary: TPM1 is a cytoskeletal protein. UniProt subcellular location
+        indicates &#34;Cytoplasm, cytoskeleton&#34; and notes it &#34;Associates with
+        F-actin stress fibers.&#34; This is a broad cellular component annotation
         appropriate for all isoforms.
       action: ACCEPT
-      reason: This is a valid broad localization term. All TPM1 isoforms are 
-        components of the cytoskeleton, whether in sarcomeres (muscle isoforms) 
+      reason: This is a valid broad localization term. All TPM1 isoforms are
+        components of the cytoskeleton, whether in sarcomeres (muscle isoforms)
         or stress fibers (non-muscle isoforms). IEA based on UniProt subcellular
         location is appropriate.
       supported_by:
@@ -5831,15 +6254,15 @@ existing_annotations:
         actin filaments in sarcomeres. Non-muscle isoforms (e.g., Isoform 3/fibroblast)
         do not form this specific complex.&#39;
       action: ACCEPT
-      reason: This is a core localization for muscle isoforms of TPM1. The 
-        annotation is correct for the muscle-expressed isoforms that are 
-        integral to the thin filament regulatory complex in sarcomeres 
+      reason: This is a core localization for muscle isoforms of TPM1. The
+        annotation is correct for the muscle-expressed isoforms that are
+        integral to the thin filament regulatory complex in sarcomeres
         [PMID:8205619].
       supported_by:
         - reference_id: PMID:8205619
           supporting_text: FHC is a disease of the sarcomere
         - reference_id: PMID:11136687
-          supporting_text: regulated thin filament-myosin subfragment-1 (S1) 
+          supporting_text: regulated thin filament-myosin subfragment-1 (S1)
             MgATPase assays
   - term:
       id: GO:0005515
@@ -5848,9 +6271,9 @@ existing_annotations:
     original_reference_id: PMID:16189514
     review:
       summary: High-throughput Y2H interactome study. The term &#34;protein binding&#34;
-        is uninformative and does not indicate specific binding partners or 
-        functional context. TPM1 binds actin, troponins, and other 
-        muscle/cytoskeletal proteins, but this generic term does not capture 
+        is uninformative and does not indicate specific binding partners or
+        functional context. TPM1 binds actin, troponins, and other
+        muscle/cytoskeletal proteins, but this generic term does not capture
         those specific interactions.
       action: MARK_AS_OVER_ANNOTATED
       reason: &#39;&#34;Protein binding&#34; (GO:0005515) is an uninformative annotation that
@@ -5859,9 +6282,9 @@ existing_annotations:
         these generic annotations. More specific MF terms are preferred [PMID:16189514].&#39;
       supported_by:
         - reference_id: PMID:16189514
-          supporting_text: Using a stringent, high-throughput yeast two-hybrid 
-            system, we tested pairwise interactions among the products of 
-            approximately 8,100 currently available Gateway-cloned open reading 
+          supporting_text: Using a stringent, high-throughput yeast two-hybrid
+            system, we tested pairwise interactions among the products of
+            approximately 8,100 currently available Gateway-cloned open reading
             frames and detected approximately 2,800 interactions
   - term:
       id: GO:0005515
@@ -5869,8 +6292,8 @@ existing_annotations:
     evidence_type: IPI
     original_reference_id: PMID:21516116
     review:
-      summary: High-throughput Stitch-seq Y2H interactome study. The generic 
-        term &#34;protein binding&#34; is uninformative for this well-characterized 
+      summary: High-throughput Stitch-seq Y2H interactome study. The generic
+        term &#34;protein binding&#34; is uninformative for this well-characterized
         actin-binding protein.
       action: MARK_AS_OVER_ANNOTATED
       reason: &#39;&#34;Protein binding&#34; (GO:0005515) from high-throughput interactome studies
@@ -5878,9 +6301,9 @@ existing_annotations:
         troponins, LMOD2, TMOD1) that are more informative [PMID:21516116].&#39;
       supported_by:
         - reference_id: PMID:21516116
-          supporting_text: We describe a massively parallel interactome-mapping 
-            pipeline, Stitch-seq, that combines PCR stitching with 
-            next-generation sequencing and used it to generate a new human 
+          supporting_text: We describe a massively parallel interactome-mapping
+            pipeline, Stitch-seq, that combines PCR stitching with
+            next-generation sequencing and used it to generate a new human
             interactome dataset
   - term:
       id: GO:0005515
@@ -5888,8 +6311,8 @@ existing_annotations:
     evidence_type: IPI
     original_reference_id: PMID:25416956
     review:
-      summary: Large-scale proteome-scale human interactome map study. Generic 
-        &#34;protein binding&#34; term is uninformative for TPM1 which has 
+      summary: Large-scale proteome-scale human interactome map study. Generic
+        &#34;protein binding&#34; term is uninformative for TPM1 which has
         well-characterized specific interactions.
       action: MARK_AS_OVER_ANNOTATED
       reason: &#39;&#34;Protein binding&#34; (GO:0005515) from systematic interactome mapping
@@ -5897,7 +6320,7 @@ existing_annotations:
         that should be annotated instead [PMID:25416956].&#39;
       supported_by:
         - reference_id: PMID:25416956
-          supporting_text: Here, we describe a systematic map of ?14,000 
+          supporting_text: Here, we describe a systematic map of ?14,000
             high-quality human binary protein-protein interactions
   - term:
       id: GO:0005515
@@ -5905,21 +6328,21 @@ existing_annotations:
     evidence_type: IPI
     original_reference_id: PMID:26871637
     review:
-      summary: Study on alternative splicing and protein interaction 
-        capabilities. Notably relevant for TPM1 which has 10 isoforms with 
-        different interaction profiles. However &#34;protein binding&#34; remains 
+      summary: Study on alternative splicing and protein interaction
+        capabilities. Notably relevant for TPM1 which has 10 isoforms with
+        different interaction profiles. However &#34;protein binding&#34; remains
         uninformative.
       action: MARK_AS_OVER_ANNOTATED
-      reason: While this study is highly relevant to TPM1 isoform biology, 
-        showing that alternative isoforms exhibit different interaction 
-        profiles, the generic &#34;protein binding&#34; term does not capture the 
-        specific binding partners or isoform-specific interactions 
+      reason: While this study is highly relevant to TPM1 isoform biology,
+        showing that alternative isoforms exhibit different interaction
+        profiles, the generic &#34;protein binding&#34; term does not capture the
+        specific binding partners or isoform-specific interactions
         [PMID:26871637].
       supported_by:
         - reference_id: PMID:26871637
-          supporting_text: The majority of isoform pairs share less than 50% of 
-            their interactions. In the global context of interactome network 
-            maps, alternative isoforms tend to behave like distinct proteins 
+          supporting_text: The majority of isoform pairs share less than 50% of
+            their interactions. In the global context of interactome network
+            maps, alternative isoforms tend to behave like distinct proteins
             rather than minor variants of each other
   - term:
       id: GO:0005515
@@ -5927,8 +6350,8 @@ existing_annotations:
     evidence_type: IPI
     original_reference_id: PMID:30021884
     review:
-      summary: Crosslinking mass spectrometry study of histone interactions in 
-        nuclei. TPM1 is a cytoplasmic/cytoskeletal protein; its detection here 
+      summary: Crosslinking mass spectrometry study of histone interactions in
+        nuclei. TPM1 is a cytoplasmic/cytoskeletal protein; its detection here
         may be incidental. Generic &#34;protein binding&#34; term is uninformative.
       action: MARK_AS_OVER_ANNOTATED
       reason: &#39;&#34;Protein binding&#34; from crosslinking MS study of nuclear proteins is
@@ -5944,8 +6367,8 @@ existing_annotations:
     evidence_type: IPI
     original_reference_id: PMID:33961781
     review:
-      summary: BioPlex 3.0 dual proteome-scale network study in 293T and HCT116 
-        cells. While this reveals cell-specific interactome remodeling relevant 
+      summary: BioPlex 3.0 dual proteome-scale network study in 293T and HCT116
+        cells. While this reveals cell-specific interactome remodeling relevant
         to TPM1 isoforms, the generic &#34;protein binding&#34; term is uninformative.
       action: MARK_AS_OVER_ANNOTATED
       reason: &#39;&#34;Protein binding&#34; from large-scale AP-MS interactome study does not
@@ -5953,8 +6376,8 @@ existing_annotations:
         specific terms for actin binding, troponin binding etc. are preferred [PMID:33961781].&#39;
       supported_by:
         - reference_id: PMID:33961781
-          supporting_text: Thousands of interactions assemble proteins into 
-            modules that impart spatial and functional organization to the 
+          supporting_text: Thousands of interactions assemble proteins into
+            modules that impart spatial and functional organization to the
             cellular proteome
   - term:
       id: GO:0005515
@@ -5962,15 +6385,15 @@ existing_annotations:
     evidence_type: IPI
     original_reference_id: PMID:40205054
     review:
-      summary: Multimodal cell maps study integrating multiple data types for 
-        structural and functional genomics. Generic &#34;protein binding&#34; term is 
+      summary: Multimodal cell maps study integrating multiple data types for
+        structural and functional genomics. Generic &#34;protein binding&#34; term is
         uninformative.
       action: MARK_AS_OVER_ANNOTATED
       reason: &#39;&#34;Protein binding&#34; from multimodal cell mapping study does not convey
         specific information about TPM1&#39;&#39;s well-characterized binding partners [PMID:40205054].&#39;
       supported_by:
         - reference_id: PMID:40205054
-          supporting_text: Multimodal cell maps as a foundation for structural 
+          supporting_text: Multimodal cell maps as a foundation for structural
             and functional genomics
   - term:
       id: GO:0005515
@@ -5979,9 +6402,9 @@ existing_annotations:
     original_reference_id: PMID:25910212
     isoform: P09493-10
     review:
-      summary: ISOFORM-SPECIFIC ANNOTATION (P09493-10). Study on macromolecular 
+      summary: ISOFORM-SPECIFIC ANNOTATION (P09493-10). Study on macromolecular
         interaction perturbations in genetic disorders. While highly relevant to
-        understanding how TPM1 mutations affect interactions, &#34;protein binding&#34; 
+        understanding how TPM1 mutations affect interactions, &#34;protein binding&#34;
         is uninformative.
       action: MARK_AS_OVER_ANNOTATED
       reason: &#39;&#34;Protein binding&#34; from edgetic mutation studies is too generic. This
@@ -5990,9 +6413,9 @@ existing_annotations:
       supported_by:
         - reference_id: PMID:25910212
           supporting_text: While common variants from healthy individuals rarely
-            affect interactions, two-thirds of disease-associated alleles 
-            perturb protein-protein interactions, with half corresponding to 
-            &#34;edgetic&#34; alleles affecting only a subset of interactions while 
+            affect interactions, two-thirds of disease-associated alleles
+            perturb protein-protein interactions, with half corresponding to
+            &#34;edgetic&#34; alleles affecting only a subset of interactions while
             leaving most other interactions unperturbed
   - term:
       id: GO:0005515
@@ -6001,9 +6424,9 @@ existing_annotations:
     original_reference_id: PMID:32296183
     isoform: P09493-10
     review:
-      summary: ISOFORM-SPECIFIC ANNOTATION (P09493-10). HuRI reference human 
-        binary protein interactome map. While highly valuable for mapping 
-        interactions, the generic &#34;protein binding&#34; term is uninformative for 
+      summary: ISOFORM-SPECIFIC ANNOTATION (P09493-10). HuRI reference human
+        binary protein interactome map. While highly valuable for mapping
+        interactions, the generic &#34;protein binding&#34; term is uninformative for
         TPM1.
       action: MARK_AS_OVER_ANNOTATED
       reason: &#39;&#34;Protein binding&#34; from the comprehensive HuRI interactome map does
@@ -6012,7 +6435,7 @@ existing_annotations:
         [PMID:32296183].&#39;
       supported_by:
         - reference_id: PMID:32296183
-          supporting_text: Here we present a human &#39;all-by-all&#39; reference 
+          supporting_text: Here we present a human &#39;all-by-all&#39; reference
             interactome map of human binary protein interactions, or &#39;HuRI&#39;
   - term:
       id: GO:0042802
@@ -6020,15 +6443,15 @@ existing_annotations:
     evidence_type: ISS
     original_reference_id: GO_REF:0000024
     review:
-      summary: Tropomyosins form coiled-coil dimers (homo- or heterodimers) as 
-        their functional unit. UniProt indicates TPM1 forms dimers with itself 
-        or other tropomyosin isoforms. This ISS annotation from sequence 
+      summary: Tropomyosins form coiled-coil dimers (homo- or heterodimers) as
+        their functional unit. UniProt indicates TPM1 forms dimers with itself
+        or other tropomyosin isoforms. This ISS annotation from sequence
         similarity is consistent with the coiled-coil structure of tropomyosins.
       action: ACCEPT
-      reason: TPM1 forms parallel coiled-coil dimers that bind along actin 
-        filaments. This is a fundamental structural property of all 
-        tropomyosins. Self-association (homodimerization) is documented in 
-        UniProt. ISS annotation based on sequence similarity to characterized 
+      reason: TPM1 forms parallel coiled-coil dimers that bind along actin
+        filaments. This is a fundamental structural property of all
+        tropomyosins. Self-association (homodimerization) is documented in
+        UniProt. ISS annotation based on sequence similarity to characterized
         orthologs is appropriate.
   - term:
       id: GO:0042803
@@ -6036,12 +6459,12 @@ existing_annotations:
     evidence_type: ISS
     original_reference_id: GO_REF:0000024
     review:
-      summary: Tropomyosins function as coiled-coil dimers. TPM1 homodimerizes 
-        to form the functional unit that binds along actin filaments. This is a 
+      summary: Tropomyosins function as coiled-coil dimers. TPM1 homodimerizes
+        to form the functional unit that binds along actin filaments. This is a
         core structural property of tropomyosins.
       action: ACCEPT
-      reason: Homodimerization is fundamental to tropomyosin function. Two TPM1 
-        chains form a parallel coiled-coil dimer that spans seven actin 
+      reason: Homodimerization is fundamental to tropomyosin function. Two TPM1
+        chains form a parallel coiled-coil dimer that spans seven actin
         subunits. ISS annotation based on sequence similarity is appropriate for
         this conserved structural property.
   - term:
@@ -6051,13 +6474,13 @@ existing_annotations:
     original_reference_id: GO_REF:0000024
     review:
       summary: TPM1 can form heterodimers with other tropomyosin isoforms (e.g.,
-        TPM2, TPM3). UniProt indicates it interacts with self or TPM2. 
-        Heterodimer formation provides functional diversity in different tissue 
+        TPM2, TPM3). UniProt indicates it interacts with self or TPM2.
+        Heterodimer formation provides functional diversity in different tissue
         contexts.
       action: ACCEPT
       reason: Heterodimerization with other tropomyosin isoforms is a documented
-        property that provides functional diversity. TPM1 can form dimers with 
-        TPM2 and potentially other isoforms. ISS annotation based on sequence 
+        property that provides functional diversity. TPM1 can form dimers with
+        TPM2 and potentially other isoforms. ISS annotation based on sequence
         similarity is appropriate.
   - term:
       id: GO:0051015
@@ -6065,13 +6488,13 @@ existing_annotations:
     evidence_type: ISS
     original_reference_id: GO_REF:0000024
     review:
-      summary: Duplicate of the IBA annotation for actin filament binding. This 
-        ISS annotation provides additional evidence for this core function from 
+      summary: Duplicate of the IBA annotation for actin filament binding. This
+        ISS annotation provides additional evidence for this core function from
         sequence similarity.
       action: ACCEPT
-      reason: Actin filament binding is the fundamental molecular function of 
-        TPM1 across all isoforms. This ISS annotation supplements the IBA 
-        annotation and is consistent with the conserved function of 
+      reason: Actin filament binding is the fundamental molecular function of
+        TPM1 across all isoforms. This ISS annotation supplements the IBA
+        annotation and is consistent with the conserved function of
         tropomyosins.
   - term:
       id: GO:0008360
@@ -6083,17 +6506,17 @@ existing_annotations:
         function of TPM1 isoforms. The study shows TPM1 affects vascular smooth muscle
         cell morphology via cytoskeletal remodeling [PMID:21817107].&#39;
       action: KEEP_AS_NON_CORE
-      reason: Regulation of cell shape is a function of cytoskeletal TPM1 
-        isoforms in non-muscle cells. While important, it is not the core 
+      reason: Regulation of cell shape is a function of cytoskeletal TPM1
+        isoforms in non-muscle cells. While important, it is not the core
         function of the striated muscle isoforms. This is a valid annotation for
         cytoskeletal isoforms [PMID:21817107].
       supported_by:
         - reference_id: PMID:21817107
-          supporting_text: cell proliferation and migration were significantly 
+          supporting_text: cell proliferation and migration were significantly
             decreased by
   - term:
       id: GO:1904706
-      label: negative regulation of vascular associated smooth muscle cell 
+      label: negative regulation of vascular associated smooth muscle cell
         proliferation
     evidence_type: IMP
     original_reference_id: PMID:21817107
@@ -6102,17 +6525,17 @@ existing_annotations:
         cell (VSMC) proliferation. This relates to the cytoskeletal function of TPM1
         in regulating cell behavior [PMID:21817107].&#39;
       action: KEEP_AS_NON_CORE
-      reason: This is a valid functional annotation for cytoskeletal TPM1 
-        isoforms in smooth muscle cells. While biologically relevant, it 
-        represents a peripheral function rather than the core sarcomeric 
+      reason: This is a valid functional annotation for cytoskeletal TPM1
+        isoforms in smooth muscle cells. While biologically relevant, it
+        represents a peripheral function rather than the core sarcomeric
         function of TPM1 [PMID:21817107].
       supported_by:
         - reference_id: PMID:21817107
-          supporting_text: cell proliferation and migration were significantly 
+          supporting_text: cell proliferation and migration were significantly
             decreased by
   - term:
       id: GO:1904753
-      label: negative regulation of vascular associated smooth muscle cell 
+      label: negative regulation of vascular associated smooth muscle cell
         migration
     evidence_type: IMP
     original_reference_id: PMID:21817107
@@ -6121,13 +6544,13 @@ existing_annotations:
         cell (VSMC) migration. This relates to the cytoskeletal function of TPM1 in
         regulating cell motility [PMID:21817107].&#39;
       action: KEEP_AS_NON_CORE
-      reason: This is a valid functional annotation for cytoskeletal TPM1 
-        isoforms in smooth muscle cells. While biologically relevant, it 
-        represents a peripheral function rather than the core sarcomeric 
+      reason: This is a valid functional annotation for cytoskeletal TPM1
+        isoforms in smooth muscle cells. While biologically relevant, it
+        represents a peripheral function rather than the core sarcomeric
         function of TPM1 [PMID:21817107].
       supported_by:
         - reference_id: PMID:21817107
-          supporting_text: cell proliferation and migration were significantly 
+          supporting_text: cell proliferation and migration were significantly
             decreased by
   - term:
       id: GO:0005829
@@ -6135,13 +6558,13 @@ existing_annotations:
     evidence_type: TAS
     original_reference_id: Reactome:R-HSA-390593
     review:
-      summary: Reactome pathway annotation for muscle contraction. TPM1 is a 
-        cytosolic/ cytoskeletal protein that associates with actin filaments. 
+      summary: Reactome pathway annotation for muscle contraction. TPM1 is a
+        cytosolic/ cytoskeletal protein that associates with actin filaments.
         Cytosol localization is valid for soluble tropomyosin before assembly.
       action: ACCEPT
-      reason: Cytosol is an appropriate cellular component for TPM1. Prior to 
-        incorporation into actin filaments, tropomyosin exists in the cytosol. 
-        Reactome pathway annotations for muscle contraction support this 
+      reason: Cytosol is an appropriate cellular component for TPM1. Prior to
+        incorporation into actin filaments, tropomyosin exists in the cytosol.
+        Reactome pathway annotations for muscle contraction support this
         localization.
   - term:
       id: GO:0005829
@@ -6152,8 +6575,8 @@ existing_annotations:
       summary: Duplicate Reactome pathway annotation for cytosol localization in
         muscle contraction pathway.
       action: ACCEPT
-      reason: Valid cellular component annotation from Reactome muscle 
-        contraction pathway. Cytosol localization is appropriate for soluble 
+      reason: Valid cellular component annotation from Reactome muscle
+        contraction pathway. Cytosol localization is appropriate for soluble
         tropomyosin.
   - term:
       id: GO:0005829
@@ -6221,12 +6644,12 @@ existing_annotations:
     evidence_type: IPI
     original_reference_id: PMID:17987659
     review:
-      summary: TPM1 binds cytoskeletal proteins including nebulette. The study 
-        identified tropomyosin-1 as a binding partner of nebulette in a yeast 
+      summary: TPM1 binds cytoskeletal proteins including nebulette. The study
+        identified tropomyosin-1 as a binding partner of nebulette in a yeast
         two-hybrid screen [PMID:17987659].
       action: ACCEPT
-      reason: Cytoskeletal protein binding accurately describes TPM1&#39;s 
-        interactions with actin filaments and associated regulatory proteins. 
+      reason: Cytoskeletal protein binding accurately describes TPM1&#39;s
+        interactions with actin filaments and associated regulatory proteins.
         This is a valid molecular function annotation that is more specific than
         &#34;protein binding&#34;.
       supported_by:
@@ -6241,13 +6664,13 @@ existing_annotations:
       summary: &#39;ISOFORM-SPECIFIC: Sarcomere organization is a function of muscle isoforms.
         TPM1 mutations cause disorganized sarcomere structure in cardiomyopathy [PMID:11273725].&#39;
       action: ACCEPT
-      reason: Sarcomere organization is a core function of striated muscle TPM1 
-        isoforms. Mutations affecting this function cause hypertrophic and 
+      reason: Sarcomere organization is a core function of striated muscle TPM1
+        isoforms. Mutations affecting this function cause hypertrophic and
         dilated cardiomyopathy. This is a well-supported experimental annotation
         [PMID:11273725].
       supported_by:
         - reference_id: PMID:11273725
-          supporting_text: Proteins in cardiac myocytes assemble into 
+          supporting_text: Proteins in cardiac myocytes assemble into
             contractile units known as sarcomeres
   - term:
       id: GO:0001725
@@ -6260,7 +6683,7 @@ existing_annotations:
         [PMID:12686598].&#39;
       action: ACCEPT
       reason: Stress fiber localization is a valid cellular component annotation
-        for cytoskeletal TPM1 isoforms (e.g., Isoform 3/TM3). IDA evidence from 
+        for cytoskeletal TPM1 isoforms (e.g., Isoform 3/TM3). IDA evidence from
         direct observation of colocalization with stress fibers [PMID:12686598].
       supported_by:
         - reference_id: PMID:12686598
@@ -6277,13 +6700,13 @@ existing_annotations:
         modulates cardiac contractility.&#39;
       action: KEEP_AS_NON_CORE
       reason: While TPM1 is involved in cardiac muscle contraction, the specific
-        role in epinephrine-mediated heart rate regulation is indirect via 
-        modulation of thin filament Ca2+ sensitivity. This is a secondary 
+        role in epinephrine-mediated heart rate regulation is indirect via
+        modulation of thin filament Ca2+ sensitivity. This is a secondary
         function rather than a core molecular function.
       supported_by:
         - reference_id: PMID:17556658
           supporting_text: 2007 Jun 7. Dilated cardiomyopathy mutant tropomyosin
-            mice develop cardiac dysfunction with significantly decreased 
+            mice develop cardiac dysfunction with significantly decreased
             fractional shortening and myofilament calcium sensitivity.
   - term:
       id: GO:0003779
@@ -6291,12 +6714,12 @@ existing_annotations:
     evidence_type: TAS
     original_reference_id: PMID:12686598
     review:
-      summary: Core function of TPM1. Actin binding is fundamental to all TPM1 
-        isoforms. This TAS annotation based on literature review is consistent 
+      summary: Core function of TPM1. Actin binding is fundamental to all TPM1
+        isoforms. This TAS annotation based on literature review is consistent
         with the well-established role of tropomyosin [PMID:12686598].
       action: ACCEPT
-      reason: Actin binding is the fundamental molecular function of 
-        tropomyosin. This annotation supplements the more specific &#34;actin 
+      reason: Actin binding is the fundamental molecular function of
+        tropomyosin. This annotation supplements the more specific &#34;actin
         filament binding&#34; term already annotated via IBA [PMID:12686598].
       supported_by:
         - reference_id: PMID:12686598
@@ -6308,17 +6731,17 @@ existing_annotations:
     evidence_type: TAS
     original_reference_id: PMID:12686598
     review:
-      summary: TPM1 is a structural component of the actin cytoskeleton in both 
+      summary: TPM1 is a structural component of the actin cytoskeleton in both
         muscle and non-muscle cells. In muscle cells it forms thin filaments; in
         non-muscle cells it stabilizes stress fibers [PMID:12686598].
       action: ACCEPT
-      reason: Structural constituent of cytoskeleton is an accurate molecular 
-        function for TPM1. Tropomyosin provides structural stability to actin 
+      reason: Structural constituent of cytoskeleton is an accurate molecular
+        function for TPM1. Tropomyosin provides structural stability to actin
         filaments and is integral to cytoskeletal architecture [PMID:12686598].
       supported_by:
         - reference_id: PMID:12686598
           supporting_text: phosphorylation of tropomyosin-1 downstream of ERK by
-            contributing to formation of actin filaments increases cellular 
+            contributing to formation of actin filaments increases cellular
             contractility and promotes the formation of focal adhesions
   - term:
       id: GO:0007010
@@ -6326,18 +6749,18 @@ existing_annotations:
     evidence_type: TAS
     original_reference_id: PMID:12686598
     review:
-      summary: TPM1 contributes to cytoskeleton organization in both muscle and 
+      summary: TPM1 contributes to cytoskeleton organization in both muscle and
         non-muscle cells. This is closely related to actin filament organization
         [PMID:12686598].
       action: ACCEPT
-      reason: Cytoskeleton organization is a core function of TPM1 across all 
-        isoforms. In muscle, it organizes sarcomere thin filaments; in 
-        non-muscle cells, it contributes to stress fiber organization 
+      reason: Cytoskeleton organization is a core function of TPM1 across all
+        isoforms. In muscle, it organizes sarcomere thin filaments; in
+        non-muscle cells, it contributes to stress fiber organization
         [PMID:12686598].
       supported_by:
         - reference_id: PMID:12686598
           supporting_text: phosphorylation of tropomyosin-1 downstream of ERK by
-            contributing to formation of actin filaments increases cellular 
+            contributing to formation of actin filaments increases cellular
             contractility and promotes the formation of focal adhesions
   - term:
       id: GO:0030049
@@ -6349,14 +6772,14 @@ existing_annotations:
         muscle isoforms. TPM1 regulates the interaction between thin and thick filaments
         during muscle contraction [PMID:11136687].&#39;
       action: ACCEPT
-      reason: Muscle filament sliding is a core function of muscle TPM1 
+      reason: Muscle filament sliding is a core function of muscle TPM1
         isoforms. Tropomyosin regulates the actin-myosin interaction that drives
-        filament sliding during contraction. Mutations affecting this cause 
+        filament sliding during contraction. Mutations affecting this cause
         cardiomyopathy [PMID:11136687].
       supported_by:
         - reference_id: PMID:11136687
-          supporting_text: The mutation caused a 40% to 50% increase in calcium 
-            affinity in regulated thin filament-myosin subfragment-1 (S1) 
+          supporting_text: The mutation caused a 40% to 50% increase in calcium
+            affinity in regulated thin filament-myosin subfragment-1 (S1)
             MgATPase assays
   - term:
       id: GO:0030336
@@ -6368,13 +6791,13 @@ existing_annotations:
         High molecular weight tropomyosins stabilize stress fibers and inhibit cell
         motility [PMID:15897890].&#39;
       action: KEEP_AS_NON_CORE
-      reason: Regulation of cell migration is a function of cytoskeletal TPM1 
+      reason: Regulation of cell migration is a function of cytoskeletal TPM1
         isoforms in non-muscle cells. While valid, this is a peripheral function
         related to the core actin-binding activity [PMID:15897890].
       supported_by:
         - reference_id: PMID:15897890
-          supporting_text: TGF-beta induction of stress fibers in epithelial 
-            cells requires high molecular weight tropomyosins encoded by TPM1 
+          supporting_text: TGF-beta induction of stress fibers in epithelial
+            cells requires high molecular weight tropomyosins encoded by TPM1
             and TPM2 genes
   - term:
       id: GO:0031529
@@ -6386,12 +6809,12 @@ existing_annotations:
         cells. This relates to cytoskeletal actin dynamics [PMID:15897890].&#39;
       action: KEEP_AS_NON_CORE
       reason: Ruffle organization is a function of cytoskeletal TPM1 isoforms in
-        non-muscle cells. This is a peripheral function related to the core 
+        non-muscle cells. This is a peripheral function related to the core
         actin-organizing activity [PMID:15897890].
       supported_by:
         - reference_id: PMID:15897890
-          supporting_text: TGF-beta induction of stress fibers in epithelial 
-            cells requires high molecular weight tropomyosins encoded by TPM1 
+          supporting_text: TGF-beta induction of stress fibers in epithelial
+            cells requires high molecular weight tropomyosins encoded by TPM1
             and TPM2 genes
   - term:
       id: GO:0032059
@@ -6400,15 +6823,15 @@ existing_annotations:
     original_reference_id: PMID:12686598
     review:
       summary: TPM1 localizes to membrane blebs in response to oxidative stress.
-        This relates to cytoskeletal reorganization during stress responses 
+        This relates to cytoskeletal reorganization during stress responses
         [PMID:12686598].
       action: KEEP_AS_NON_CORE
-      reason: Bleb localization is a peripheral cellular component annotation 
-        related to stress responses rather than core TPM1 function 
+      reason: Bleb localization is a peripheral cellular component annotation
+        related to stress responses rather than core TPM1 function
         [PMID:12686598].
       supported_by:
         - reference_id: PMID:12686598
-          supporting_text: presence of H(2)O(2) resulted in a quick and intense 
+          supporting_text: presence of H(2)O(2) resulted in a quick and intense
             membrane blebbing
   - term:
       id: GO:0032587
@@ -6419,8 +6842,8 @@ existing_annotations:
       summary: &#39;ISOFORM-SPECIFIC: TPM1 localizes to ruffle membranes in non-muscle
         cells. This relates to cytoskeletal actin dynamics at the cell periphery [PMID:12686598].&#39;
       action: KEEP_AS_NON_CORE
-      reason: Ruffle membrane localization is a cellular component for 
-        cytoskeletal TPM1 isoforms in non-muscle cells. This is a peripheral 
+      reason: Ruffle membrane localization is a cellular component for
+        cytoskeletal TPM1 isoforms in non-muscle cells. This is a peripheral
         localization related to actin dynamics [PMID:12686598].
       supported_by:
         - reference_id: PMID:12686598
@@ -6432,18 +6855,18 @@ existing_annotations:
     evidence_type: IEP
     original_reference_id: PMID:12686598
     review:
-      summary: TPM1 is phosphorylated in response to oxidative stress via ERK 
-        signaling. This leads to cytoskeletal remodeling and affects membrane 
+      summary: TPM1 is phosphorylated in response to oxidative stress via ERK
+        signaling. This leads to cytoskeletal remodeling and affects membrane
         dynamics [PMID:12686598].
       action: KEEP_AS_NON_CORE
       reason: Response to ROS is a peripheral function related to stress-induced
-        cytoskeletal remodeling. TPM1 phosphorylation downstream of ERK 
-        modulates stress fiber formation during oxidative stress 
+        cytoskeletal remodeling. TPM1 phosphorylation downstream of ERK
+        modulates stress fiber formation during oxidative stress
         [PMID:12686598].
       supported_by:
         - reference_id: PMID:12686598
           supporting_text: phosphorylation of tropomyosin-1 downstream of ERK by
-            contributing to formation of actin filaments increases cellular 
+            contributing to formation of actin filaments increases cellular
             contractility and promotes the formation of focal adhesions
   - term:
       id: GO:0042060
@@ -6454,13 +6877,13 @@ existing_annotations:
       summary: &#39;ISOFORM-SPECIFIC: TPM1 is involved in wound healing through its role
         in cytoskeletal remodeling and cell migration during tissue repair [PMID:17721995].&#39;
       action: KEEP_AS_NON_CORE
-      reason: Wound healing is a peripheral function of cytoskeletal TPM1 
-        isoforms related to cell migration and tissue remodeling. While 
-        biologically relevant, this is not a core molecular function 
+      reason: Wound healing is a peripheral function of cytoskeletal TPM1
+        isoforms related to cell migration and tissue remodeling. While
+        biologically relevant, this is not a core molecular function
         [PMID:17721995].
       supported_by:
         - reference_id: PMID:17721995
-          supporting_text: HMW-tropomyosins are important for TGF-beta-mediated 
+          supporting_text: HMW-tropomyosins are important for TGF-beta-mediated
             control of cell
   - term:
       id: GO:0045785
@@ -6471,12 +6894,12 @@ existing_annotations:
       summary: &#39;ISOFORM-SPECIFIC: TPM1 promotes cell adhesion by enhancing actin stress
         fibers and focal adhesions in non-muscle cells [PMID:17721995].&#39;
       action: KEEP_AS_NON_CORE
-      reason: Regulation of cell adhesion is a peripheral function of 
-        cytoskeletal TPM1 isoforms related to stress fiber stabilization 
+      reason: Regulation of cell adhesion is a peripheral function of
+        cytoskeletal TPM1 isoforms related to stress fiber stabilization
         [PMID:17721995].
       supported_by:
         - reference_id: PMID:17721995
-          supporting_text: Tropomyosin increased cell adhesion to matrix by 
+          supporting_text: Tropomyosin increased cell adhesion to matrix by
             enhancing actin fibers and focal adhesions
   - term:
       id: GO:0051496
@@ -6487,13 +6910,13 @@ existing_annotations:
       summary: &#39;ISOFORM-SPECIFIC: TPM1 (HMW tropomyosins) are required for TGF-beta-induced
         stress fiber assembly in epithelial cells [PMID:15897890].&#39;
       action: ACCEPT
-      reason: Positive regulation of stress fiber assembly is a well-documented 
-        function of cytoskeletal TPM1 isoforms. HMW tropomyosins stabilize and 
+      reason: Positive regulation of stress fiber assembly is a well-documented
+        function of cytoskeletal TPM1 isoforms. HMW tropomyosins stabilize and
         promote stress fiber formation [PMID:15897890].
       supported_by:
         - reference_id: PMID:15897890
-          supporting_text: TGF-beta induction of stress fibers in epithelial 
-            cells requires high molecular weight tropomyosins encoded by TPM1 
+          supporting_text: TGF-beta induction of stress fibers in epithelial
+            cells requires high molecular weight tropomyosins encoded by TPM1
             and TPM2 genes
   - term:
       id: GO:0055010
@@ -6505,14 +6928,14 @@ existing_annotations:
         morphogenesis. Mutations cause hypertrophic cardiomyopathy with ventricular
         hypertrophy [PMID:11136687].&#39;
       action: KEEP_AS_NON_CORE
-      reason: Ventricular morphogenesis is a developmental process that TPM1 
-        mutations affect. While important, this is a downstream consequence of 
-        TPM1&#39;s role in cardiac muscle function rather than a core molecular 
+      reason: Ventricular morphogenesis is a developmental process that TPM1
+        mutations affect. While important, this is a downstream consequence of
+        TPM1&#39;s role in cardiac muscle function rather than a core molecular
         function [PMID:11136687].
       supported_by:
         - reference_id: PMID:11136687
-          supporting_text: The mutation caused a 40% to 50% increase in calcium 
-            affinity in regulated thin filament-myosin subfragment-1 (S1) 
+          supporting_text: The mutation caused a 40% to 50% increase in calcium
+            affinity in regulated thin filament-myosin subfragment-1 (S1)
             MgATPase assays
   - term:
       id: GO:0060048
@@ -6524,13 +6947,13 @@ existing_annotations:
         the IBA annotation for cardiac muscle contraction. TPM1 mutations affect Ca2+
         sensitivity and muscle contraction [PMID:11136687].&#39;
       action: ACCEPT
-      reason: Cardiac muscle contraction is a core function of cardiac TPM1 
-        isoforms. This experimental annotation provides direct evidence that 
+      reason: Cardiac muscle contraction is a core function of cardiac TPM1
+        isoforms. This experimental annotation provides direct evidence that
         TPM1 mutations affect cardiac contractile function [PMID:11136687].
       supported_by:
         - reference_id: PMID:11136687
-          supporting_text: The mutation caused a 40% to 50% increase in calcium 
-            affinity in regulated thin filament-myosin subfragment-1 (S1) 
+          supporting_text: The mutation caused a 40% to 50% increase in calcium
+            affinity in regulated thin filament-myosin subfragment-1 (S1)
             MgATPase assays
   - term:
       id: GO:0030017
@@ -6541,9 +6964,9 @@ existing_annotations:
       summary: &#39;ISOFORM-SPECIFIC: Sarcomere localization is specific to striated muscle
         TPM1 isoforms. TPM1 is an integral component of thin filaments in sarcomeres.&#39;
       action: ACCEPT
-      reason: Sarcomere is a core cellular component for muscle TPM1 isoforms. 
-        Tropomyosin is an integral part of the thin filament in sarcomeric 
-        structures. TAS annotation from literature supports this 
+      reason: Sarcomere is a core cellular component for muscle TPM1 isoforms.
+        Tropomyosin is an integral part of the thin filament in sarcomeric
+        structures. TAS annotation from literature supports this
         well-established localization.
       supported_by:
         - reference_id: PMID:16754800
@@ -6556,15 +6979,15 @@ existing_annotations:
     original_reference_id: PMID:16130169
     review:
       summary: TPM1 is a cytoskeletal protein identified in proteomic studies of
-        endothelial cells. This annotation complements the IEA cytoskeleton 
+        endothelial cells. This annotation complements the IEA cytoskeleton
         annotation.
       action: ACCEPT
-      reason: Cytoskeleton is a valid cellular component for TPM1. All isoforms 
-        are components of the cytoskeleton, whether in sarcomeres or stress 
+      reason: Cytoskeleton is a valid cellular component for TPM1. All isoforms
+        are components of the cytoskeleton, whether in sarcomeres or stress
         fibers. TAS annotation is appropriate.
       supported_by:
         - reference_id: PMID:16130169
-          supporting_text: Proteomics of human umbilical vein endothelial cells 
+          supporting_text: Proteomics of human umbilical vein endothelial cells
             applied to etoposide-induced apoptosis.
   - term:
       id: GO:0005862
@@ -6576,14 +6999,14 @@ existing_annotations:
         for muscle thin filament tropomyosin. TPM1 mutations in this complex cause
         familial hypertrophic cardiomyopathy [PMID:8205619].&#39;
       action: ACCEPT
-      reason: Muscle thin filament tropomyosin is a core cellular component for 
-        muscle TPM1 isoforms. The cited study demonstrates TPM1&#39;s role in the 
-        thin filament complex and disease consequences of mutations 
+      reason: Muscle thin filament tropomyosin is a core cellular component for
+        muscle TPM1 isoforms. The cited study demonstrates TPM1&#39;s role in the
+        thin filament complex and disease consequences of mutations
         [PMID:8205619].
       supported_by:
         - reference_id: PMID:8205619
-          supporting_text: alpha-tropomyosin and cardiac troponin T as well as 
-            beta myosin heavy chain mutations cause the same phenotype, we 
+          supporting_text: alpha-tropomyosin and cardiac troponin T as well as
+            beta myosin heavy chain mutations cause the same phenotype, we
             conclude that FHC is a disease of the sarcomere
   - term:
       id: GO:0006937
@@ -6595,9 +7018,9 @@ existing_annotations:
         of muscle TPM1 isoforms. The study describes expression of alpha-tropomyosin
         in muscle and non-muscle tissues.&#39;
       action: ACCEPT
-      reason: Regulation of muscle contraction is a core biological process for 
-        muscle TPM1 isoforms. Tropomyosin regulates actin-myosin interaction in 
-        a Ca2+-dependent manner via the troponin complex. TAS annotation is 
+      reason: Regulation of muscle contraction is a core biological process for
+        muscle TPM1 isoforms. Tropomyosin regulates actin-myosin interaction in
+        a Ca2+-dependent manner via the troponin complex. TAS annotation is
         appropriate.
       supported_by:
         - reference_id: PMID:3336363
@@ -6614,11 +7037,11 @@ existing_annotations:
         role of TPM1 in cardiac function [PMID:8205619].&#39;
       action: ACCEPT
       reason: Regulation of heart contraction is a core function of cardiac TPM1
-        isoforms. Mutations affecting this function cause cardiomyopathy 
+        isoforms. Mutations affecting this function cause cardiomyopathy
         [PMID:8205619].
       supported_by:
         - reference_id: PMID:8205619
-          supporting_text: We demonstrate that missense mutations (Asp175Asn; 
+          supporting_text: We demonstrate that missense mutations (Asp175Asn;
             Glu180Gly) in the alpha-tropomyosin gene cause familial hypertrophic
             cardiomyopathy (FHC)
   - term:
@@ -6630,22 +7053,22 @@ existing_annotations:
       summary: &#39;ISOFORM-SPECIFIC: Muscle TPM1 isoforms are structural constituents
         of muscle thin filaments in sarcomeres [PMID:8205619].&#39;
       action: ACCEPT
-      reason: Structural constituent of muscle is a core molecular function for 
-        muscle TPM1 isoforms. TPM1 is an integral structural component of thin 
+      reason: Structural constituent of muscle is a core molecular function for
+        muscle TPM1 isoforms. TPM1 is an integral structural component of thin
         filaments in sarcomeres [PMID:8205619].
       supported_by:
         - reference_id: PMID:8205619
-          supporting_text: alpha-tropomyosin and cardiac troponin T as well as 
-            beta myosin heavy chain mutations cause the same phenotype, we 
+          supporting_text: alpha-tropomyosin and cardiac troponin T as well as
+            beta myosin heavy chain mutations cause the same phenotype, we
             conclude that FHC is a disease of the sarcomere
 core_functions:
   - molecular_function:
       id: GO:0051015
       label: actin filament binding
     description: Actin filament binding is the fundamental molecular function of
-      all TPM1 isoforms. Tropomyosin dimers bind along the length of actin 
-      filaments in both muscle (thin filaments) and non-muscle (stress fibers) 
-      cells, stabilizing actin filaments and regulating their interactions with 
+      all TPM1 isoforms. Tropomyosin dimers bind along the length of actin
+      filaments in both muscle (thin filaments) and non-muscle (stress fibers)
+      cells, stabilizing actin filaments and regulating their interactions with
       other proteins.
     directly_involved_in:
       - id: GO:0007015
@@ -6686,20 +7109,32 @@ core_functions:
       - id: GO:0001725
         label: stress fiber
 references:
+  - id: file:human/TPM1/TPM1-deep-research-falcon.md
+    title: Falcon deep research report for TPM1
+    findings:
+      - statement: &gt;-
+          Falcon corroborates TPM1 as an actin-filament tropomyosin whose core
+          roles are sarcomeric thin-filament regulation in muscle isoforms and
+          stress-fiber/focal-adhesion actin network specification in non-muscle
+          isoforms.
+        supporting_text: &gt;-
+          TPM1 encodes alpha-tropomyosin, a coiled-coil actin-binding
+          thin-filament protein that regulates actin-myosin interaction in a
+          Ca2+/troponin-dependent manner in cardiac muscle.
   - id: GO_REF:0000024
-    title: Manual transfer of experimentally-verified manual GO annotation data 
+    title: Manual transfer of experimentally-verified manual GO annotation data
       to orthologs by curator judgment of sequence similarity
     findings: []
   - id: GO_REF:0000033
     title: Annotation inferences using phylogenetic trees
     findings: []
   - id: GO_REF:0000043
-    title: Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword 
+    title: Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword
       mapping
     findings: []
   - id: GO_REF:0000044
-    title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular 
-      Location vocabulary mapping, accompanied by conservative changes to GO 
+    title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular
+      Location vocabulary mapping, accompanied by conservative changes to GO
       terms applied by UniProt
     findings: []
   - id: GO_REF:0000117
@@ -6707,12 +7142,12 @@ references:
       models
     findings: []
   - id: PMID:11136687
-    title: Hypertrophic cardiomyopathy caused by a novel alpha-tropomyosin 
-      mutation (V95A) is associated with mild cardiac phenotype, abnormal 
+    title: Hypertrophic cardiomyopathy caused by a novel alpha-tropomyosin
+      mutation (V95A) is associated with mild cardiac phenotype, abnormal
       calcium binding to troponin, abnormal myosin cycling, and poor prognosis.
     findings: []
   - id: PMID:11273725
-    title: Mutations that alter the surface charge of alpha-tropomyosin are 
+    title: Mutations that alter the surface charge of alpha-tropomyosin are
       associated with dilated cardiomyopathy.
     findings: []
   - id: PMID:12686598
@@ -6721,11 +7156,11 @@ references:
       membrane blebbing.&#39;
     findings: []
   - id: PMID:15897890
-    title: Silencing of the Tropomyosin-1 gene by DNA methylation alters tumor 
+    title: Silencing of the Tropomyosin-1 gene by DNA methylation alters tumor
       suppressor function of TGF-beta.
     findings: []
   - id: PMID:16130169
-    title: Proteomics of human umbilical vein endothelial cells applied to 
+    title: Proteomics of human umbilical vein endothelial cells applied to
       etoposide-induced apoptosis.
     findings: []
   - id: PMID:16189514
@@ -6737,12 +7172,12 @@ references:
       the community: the Framingham Heart Study.&#39;
     findings: []
   - id: PMID:17556658
-    title: Dilated cardiomyopathy mutant tropomyosin mice develop cardiac 
-      dysfunction with significantly decreased fractional shortening and 
+    title: Dilated cardiomyopathy mutant tropomyosin mice develop cardiac
+      dysfunction with significantly decreased fractional shortening and
       myofilament calcium sensitivity.
     findings: []
   - id: PMID:17721995
-    title: Role of high-molecular weight tropomyosins in TGF-beta-mediated 
+    title: Role of high-molecular weight tropomyosins in TGF-beta-mediated
       control of cell motility.
     findings: []
   - id: PMID:17987659
@@ -6752,23 +7187,23 @@ references:
     title: Next-generation sequencing to generate interactome datasets.
     findings: []
   - id: PMID:21817107
-    title: MicroRNA-21 regulates vascular smooth muscle cell function via 
-      targeting tropomyosin 1 in arteriosclerosis obliterans of lower 
+    title: MicroRNA-21 regulates vascular smooth muscle cell function via
+      targeting tropomyosin 1 in arteriosclerosis obliterans of lower
       extremities.
     findings: []
   - id: PMID:25416956
     title: A proteome-scale map of the human interactome network.
     findings: []
   - id: PMID:25910212
-    title: Widespread macromolecular interaction perturbations in human genetic 
+    title: Widespread macromolecular interaction perturbations in human genetic
       disorders.
     findings: []
   - id: PMID:26871637
-    title: Widespread Expansion of Protein Interaction Capabilities by 
+    title: Widespread Expansion of Protein Interaction Capabilities by
       Alternative Splicing.
     findings: []
   - id: PMID:30021884
-    title: Histone Interaction Landscapes Visualized by Crosslinking Mass 
+    title: Histone Interaction Landscapes Visualized by Crosslinking Mass
       Spectrometry in Intact Cell Nuclei.
     findings: []
   - id: PMID:32296183
@@ -6778,11 +7213,11 @@ references:
     title: &#39;Human hTM alpha gene: expression in muscle and nonmuscle tissue.&#39;
     findings: []
   - id: PMID:33961781
-    title: Dual proteome-scale networks reveal cell-specific remodeling of the 
+    title: Dual proteome-scale networks reveal cell-specific remodeling of the
       human interactome.
     findings: []
   - id: PMID:40205054
-    title: Multimodal cell maps as a foundation for structural and functional 
+    title: Multimodal cell maps as a foundation for structural and functional
       genomics.
     findings: []
   - id: PMID:8205619
@@ -6889,7 +7324,7 @@ alternative_products:
     </div>
 
     <!-- Pathway Visualization Link -->
-    
+
 
     <style>
         /* Markdown Section Styles */

--- a/genes/human/TPM1/TPM1-ai-review.yaml
+++ b/genes/human/TPM1/TPM1-ai-review.yaml
@@ -1,7 +1,7 @@
 id: P09493
 gene_symbol: TPM1
 product_type: PROTEIN
-status: INITIALIZED
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
@@ -42,6 +42,13 @@ existing_annotations:
           supporting_text: alpha-tropomyosin and cardiac troponin T as well as 
             beta myosin heavy chain mutations cause the same phenotype, we 
             conclude that FHC is a disease of the sarcomere
+        - reference_id: file:human/TPM1/TPM1-deep-research-falcon.md
+          supporting_text: >-
+            The target gene TPM1 in Homo sapiens encodes tropomyosin alpha-1
+            chain, a coiled-coil protein of the tropomyosin family that binds
+            F-actin and specifies functional properties of actin filaments in
+            both sarcomeric thin filaments and specialized non-muscle actin
+            networks.
   - term:
       id: GO:0007015
       label: actin filament organization
@@ -1016,6 +1023,18 @@ core_functions:
       - id: GO:0001725
         label: stress fiber
 references:
+  - id: file:human/TPM1/TPM1-deep-research-falcon.md
+    title: Falcon deep research report for TPM1
+    findings:
+      - statement: >-
+          Falcon corroborates TPM1 as an actin-filament tropomyosin whose core
+          roles are sarcomeric thin-filament regulation in muscle isoforms and
+          stress-fiber/focal-adhesion actin network specification in non-muscle
+          isoforms.
+        supporting_text: >-
+          TPM1 encodes alpha-tropomyosin, a coiled-coil actin-binding
+          thin-filament protein that regulates actin-myosin interaction in a
+          Ca2+/troponin-dependent manner in cardiac muscle.
   - id: GO_REF:0000024
     title: Manual transfer of experimentally-verified manual GO annotation data 
       to orthologs by curator judgment of sequence similarity

--- a/genes/human/TPM1/TPM1-deep-research-falcon.md
+++ b/genes/human/TPM1/TPM1-deep-research-falcon.md
@@ -1,0 +1,359 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-11T02:34:53.569140'
+end_time: '2026-05-11T02:52:28.929760'
+duration_seconds: 1055.36
+template_file: templates/gene_research_go_focused.md
+template_variables:
+  organism: human
+  gene_id: TPM1
+  gene_symbol: TPM1
+  uniprot_accession: P09493
+  protein_description: 'RecName: Full=Tropomyosin alpha-1 chain; AltName: Full=Alpha-tropomyosin;
+    AltName: Full=Tropomyosin-1;'
+  gene_info: Name=TPM1; Synonyms=C15orf13, TMSA;
+  organism_full: Homo sapiens (Human).
+  protein_family: Belongs to the tropomyosin family. .
+  protein_domains: Tropomyosin. (IPR000533); Tropomyosin (PF00261)
+provider_config:
+  timeout: 600
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 41
+---
+
+## Question
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** P09493
+- **Protein Description:** RecName: Full=Tropomyosin alpha-1 chain; AltName: Full=Alpha-tropomyosin; AltName: Full=Tropomyosin-1;
+- **Gene Information:** Name=TPM1; Synonyms=C15orf13, TMSA;
+- **Organism (full):** Homo sapiens (Human).
+- **Protein Family:** Belongs to the tropomyosin family. .
+- **Key Domains:** Tropomyosin. (IPR000533); Tropomyosin (PF00261)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "TPM1" matches the protein description above**
+2. **Verify the organism is correct:** Homo sapiens (Human).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'TPM1' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **TPM1** (gene ID: TPM1, UniProt: P09493) in human.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** P09493
+- **Protein Description:** RecName: Full=Tropomyosin alpha-1 chain; AltName: Full=Alpha-tropomyosin; AltName: Full=Tropomyosin-1;
+- **Gene Information:** Name=TPM1; Synonyms=C15orf13, TMSA;
+- **Organism (full):** Homo sapiens (Human).
+- **Protein Family:** Belongs to the tropomyosin family. .
+- **Key Domains:** Tropomyosin. (IPR000533); Tropomyosin (PF00261)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "TPM1" matches the protein description above**
+2. **Verify the organism is correct:** Homo sapiens (Human).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'TPM1' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **TPM1** (gene ID: TPM1, UniProt: P09493) in human.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Research report: Human **TPM1** (UniProt **P09493**) — functional annotation of tropomyosin alpha-1 chain
+
+### 0) Gene/protein identity verification (critical disambiguation)
+The target gene **TPM1** in *Homo sapiens* encodes **tropomyosin alpha-1 chain** (α‑tropomyosin), a coiled‑coil protein of the tropomyosin family that binds **F‑actin** and specifies functional properties of actin filaments in both **sarcomeric thin filaments** and specialized **non‑muscle actin networks**. This identity matches the UniProt description provided (P09493) and is consistent with recent human studies explicitly analyzing TPM1 isoforms (e.g., cardiomyocyte differentiation, focal adhesion nanoscale layers, and ovarian cancer isoform functions). In particular, a 2024 cardiomyocyte differentiation study maps **TPM1μ** to a SwissProt/UniProt isoform **P09493‑4**, directly linking the experimental literature to the UniProt accession provided. (dube2024sarcomerictropomyosinexpression pages 2-4)
+
+### 1) Key concepts and definitions (current understanding)
+
+#### 1.1 Tropomyosin as an actin “filament specifier”
+Tropomyosins are **head‑to‑tail polymers** that decorate the major groove of actin filaments and regulate which actin-binding proteins can productively interact with those filaments. A practical current definition is that **tropomyosin isoforms “specify” actin filament identity**—altering filament stability and the access/behavior of myosins and severing factors such as ADF/cofilin in an isoform‑dependent manner. (kumari2024focaladhesionscontain pages 2-3)
+
+#### 1.2 TPM1’s primary function in striated muscle: thin‑filament regulation
+In the sarcomere, tropomyosin is a core thin‑filament component that mediates Ca2+-dependent contractile regulation: Ca2+ binding to troponin changes thin‑filament state, and tropomyosin movement along actin helps expose or occlude myosin-binding sites, thereby tuning actin–myosin interaction. This describes the **primary biochemical role** of TPM1 in cardiomyocytes as an actin-binding regulatory protein rather than an enzyme or transporter. (haas2026sarcomericremodellingin pages 1-4)
+
+#### 1.3 Alternative splicing and “isoform logic” in TPM1
+A central TPM1 concept is that **alternative promoters/splicing generate multiple TPM1 proteoforms** with distinct N‑termini and exon compositions, which correlate with distinct actin networks and cell phenotypes.
+
+A high‑impact 2024 ovarian cancer study provides a clear isoform-defining rule set for non‑muscle TPM1 isoforms: **Tpm1.6/1.7** are associated with **exons 1a and 2b**, while **Tpm1.8/1.9** are defined by **exon 1b**. (xu2024tropomyosin1isoformsunderlie pages 6-8, xu2024tropomyosin1isoformsunderlie media 181dbb5d, xu2024tropomyosin1isoformsunderlie media f45ab9b5)
+
+### 2) Molecular function, mechanisms, and subcellular localization
+
+#### 2.1 Subcellular localization: sarcomere (cardiac muscle)
+TPM1 is a canonical **sarcomeric thin filament** gene/protein in heart, and recent cardiomyopathy literature continues to place TPM1 within the sarcomere gene set used for genetic testing and penetrance estimation in hypertrophic cardiomyopathy. (topriceanu2024metaanalysisofpenetrance pages 6-7, jaouadi2024exomesequencingdata pages 1-2)
+
+#### 2.2 Subcellular localization: focal adhesions and stress fibers (non‑muscle)
+A 2024 *Nature Communications* study resolved focal adhesions (FAs) into multiple nanoscale actin layers and identified a distinct FA actin layer decorated by the **TPM1-derived isoform Tpm1.6**. Tpm1.6-localized actin filaments are positioned **beneath** the previously described α‑actinin–cross-linked actin layer and extend from adhesions onto **dorsal stress fibers**, linking adhesion architecture to the contractile actin cytoskeleton. (Publication: Mar 2024; https://doi.org/10.1038/s41467-024-46868-7) (kumari2024focaladhesionscontain pages 1-2, kumari2024focaladhesionscontain pages 2-3)
+
+Functionally, the same work supports that Tpm1.6‑actin filaments are **critical for adhesion maturation and controlled cell motility** and that loss of Tpm1 yields **smaller adhesions**, altered adhesion distribution (e.g., ~70% within 5 μm of the leading edge), reduced traction forces, and changes in migration behavior. (kumari2024focaladhesionscontain pages 3-4, kumari2024focaladhesionscontain pages 4-6)
+
+#### 2.3 Mechanistic specificity by isoform competition on actin
+The FA study also emphasizes a mechanistic basis for layered actin organization: Tpm1.6 and Tpm3.2 decorate **distinct filament arrays** and cannot co‑polymerize on the same filament; additionally, both appear to **compete with α‑actinin** for actin binding, supporting segregation of distinct actin filament layers. (kumari2024focaladhesionscontain pages 1-2, kumari2024focaladhesionscontain pages 10-12)
+
+A complementary structural/biochemical preprint (May 2023) provides mechanism-level support: cryo‑EM shows Tpm1.6 and Tpm3.2 follow different trajectories on actin, explaining mutual exclusivity; functionally, Tpm1.6 has a slow off‑rate and can protect actin filaments from ADF/cofilin severing, whereas Tpm3.2 more strongly activates non-muscle myosin II ATPase activity—illustrating isoform‑dependent tuning of actin filament dynamics and motor engagement. (https://doi.org/10.1101/2022.05.12.491677; May 2023) (selvaraj2023structuralbasisunderlying pages 1-3)
+
+### 3) Isoforms, developmental programs, and regulation (2023–2024)
+
+#### 3.1 Quantitative TPM1 isoform expression during human iPSC cardiomyocyte differentiation
+A 2024 *Cytoskeleton* study quantified sarcomeric TPM isoforms during differentiation of human iPSCs into cardiomyocytes and found strong temporal dynamics:
+
+* **TPM1α**: 6.88×10^8 copies (hiPSCs) increasing ~100‑fold by day 5 (~5.6×10^10 copies/mg total RNA), dipping at days 10–15, then rising again (~5.98×10^10 by day 20).
+* **TPM1μ**: detected early, peaks around day 5 then declines; importantly, TPM1μ sequence matched a SwissProt isoform **P09493‑4** (connecting to UniProt P09493).
+* **TPM1κ**: rises from day 5 onward and peaks by day 20.
+
+By day 20, transcript rank order was **TPM1α > TPM1κ > TPM2α > TPM1μ > TPM3α > TPM4α**, and protein-level assays showed increased high‑molecular‑weight TPM proteins during differentiation. (Publication: Mar 2024; https://doi.org/10.1002/cm.21850) (dube2024sarcomerictropomyosinexpression pages 2-4)
+
+#### 3.2 Regulatory framing from expert synthesis
+A large 2024 meta-analysis in *Circulation* underscores that sarcomeric variant penetrance is **age dependent** and context dependent (family/clinic vs population ascertainment), and positions TPM1 among “definitive” sarcomere genes used in clinical genetics and cascade screening, establishing TPM1 as part of the clinically actionable sarcomere gene set. (Publication: Jan 2024; https://doi.org/10.1161/circulationaha.123.065987) (topriceanu2024metaanalysisofpenetrance pages 2-3, topriceanu2024metaanalysisofpenetrance pages 6-7)
+
+### 4) Disease relevance, applications, and real-world implementations
+
+#### 4.1 Hypertrophic cardiomyopathy (HCM): penetrance and clinical genetics
+**Penetrance statistics (authoritative 2024 meta-analysis):** In genotype-positive relatives carrying pathogenic/likely pathogenic (P/LP) sarcomere variants, the pooled penetrance across genes was ~57.4%. For **TPM1 specifically**, pooled penetrance in relatives was **48.6% (95% CI 25.7–72.2)** with pooled **age at diagnosis 40.3 years (36.9–43.8)**. (topriceanu2024metaanalysisofpenetrance pages 6-7)
+
+**Population context:** In large population cohorts (combined n≈213,911), P/LP sarcomere variants were present in ~0.7% overall, and penetrance in incidentally identified carriers was much lower (~11% overall at mean age ~56), emphasizing why TPM1 testing is most impactful in phenotype/family-based settings. (topriceanu2024metaanalysisofpenetrance pages 9-10)
+
+**Real-world implementation:** These data support current clinical practice where TPM1 is included in cardiomyopathy gene panels for diagnosis and cascade screening, but with careful counseling on variable penetrance and age effects. (topriceanu2024metaanalysisofpenetrance pages 6-7)
+
+#### 4.2 HCM cohorts: variant yield is context dependent
+A 2024 reanalysis of exome data from **200 HCM** patients (HYPERGEN French cohort) reported that most variants were in MYBPC3 (26%, n=51) and MYH7 (8%, n=16), and **explicitly found no variants in TPM1** (as well as ACTC1, TNNI3) in this cohort. This illustrates that although TPM1 is a definitive sarcomere gene, **its contribution can be low in specific cohorts** and that yield depends on population structure, ascertainment, and panel composition. (Publication: Oct 2024; https://doi.org/10.3389/fmed.2024.1480947) (jaouadi2024exomesequencingdata pages 1-2)
+
+#### 4.3 Familial HCM with sudden cardiac death (SCD): example of variant interpretation workflow (2024)
+A 2024 *ESC Heart Failure* family study reported a novel TPM1 missense variant **c.761A>G (p.Asp254Gly; p.D254G)**, absent from population databases, predicted deleterious (e.g., CADD phred score 32), and classified as likely pathogenic under ACMG criteria. The variant segregated with disease in available family members. Clinical pedigree context included relatives with SCD at ages 16 and 28 and pacemaker implantation in paternal uncles; the proband presented in early childhood with mild LV diastolic dysfunction. (Publication: Jun 2024; https://doi.org/10.1002/ehf2.14906) (azimi2024identificationofa pages 7-7, azimi2024identificationofa pages 2-2)
+
+This is a representative real-world example of how TPM1 variants are used in **cascade screening and clinical monitoring** for inherited cardiomyopathy families, while also highlighting the frequent need for **functional validation** beyond in silico evidence. (azimi2024identificationofa pages 7-8)
+
+#### 4.4 Non-compaction cardiomyopathy (NCCM/LVNC): TPM1 N-terminus as a potential mechanistic hotspot
+A 2024 case report identified TPM1 **p.Lys7del** (in-frame deletion; absent from gnomAD) co‑segregating with familial NCCM/LVNC and classified it as likely pathogenic (ACMG class 4). The authors propose mechanistic impact via disrupted interactions with thin-filament pointed-end regulators **tropomodulin‑1 (Tmod1)** and **leiomodin‑2 (Lmod2)**, consistent with the N‑terminal role in thin-filament end regulation. The paper also notes TPM1 variants are uncommon in LVNC/NCCM cohorts (reported as **<2%**). (Publication: Apr 2024; https://doi.org/10.1007/s00392-023-02190-8) (hanel2024casereportcosegregation pages 3-4)
+
+#### 4.5 Cancer: TPM1 isoforms as functional drivers of EMT/plasticity and therapy resistance (2024)
+A major 2024 primary study in high-grade serous ovarian cancer (HGSOC) demonstrated that TPM1 isoform balance is not merely correlative but can be **causal** for epithelial–mesenchymal plasticity (EMP), metastatic dissemination, and chemotherapy response.
+
+* **Isoform definitions (actionable):** Tpm1.6/1.7 (exon 1a/2b) vs Tpm1.8/1.9 (exon 1b). (xu2024tropomyosin1isoformsunderlie pages 6-8, xu2024tropomyosin1isoformsunderlie media 181dbb5d)
+* **Chemo-resistance statistics (OV90 cells):** Tpm1.8/9 overexpression increased cisplatin IC50 to ~**3.266–3.414 μM** vs ~**0.043–0.078 μM** for Tpm1.6/7 overexpression (~40‑fold difference). Paclitaxel IC50 similarly increased to ~**1.28–1.66 μM** vs ~**0.015–0.017 μM**. Knockdown of Tpm1.8/9 reduced IC50, supporting a functional role. (Publication: Feb 2024; https://doi.org/10.1038/s41418-024-01267-9) (xu2024tropomyosin1isoformsunderlie pages 6-8)
+
+The authors further link these isoforms to **Wnt pathway activation** and propose Tpm1.8/9 as therapeutic targets, including the concept of small molecules directed at tropomyosin N‑termini as an isoform-selective strategy. (xu2024tropomyosin1isoformsunderlie pages 10-12)
+
+A 2023 review of tropomyosin family roles in cancer provides expert synthesis that TPM1 often shows tumor-suppressive associations and that TPM1 can be regulated by microRNAs in multiple cancers, supporting the broader plausibility of TPM1 as a biomarker or functional modulator in malignancy contexts. (Publication: Aug 2023; https://doi.org/10.3390/ijms241713295) (meng2023researchadvancesin pages 3-5)
+
+### 5) Current applications and implementations
+
+#### 5.1 Clinical genetics (cardiomyopathy)
+* **Gene panels and cascade screening:** The 2024 penetrance meta-analysis provides quantitative risk framing for counseling carriers, and the 2024 family HCM/NCCM case reports illustrate gene discovery/segregation workflows in practice. (topriceanu2024metaanalysisofpenetrance pages 6-7, azimi2024identificationofa pages 7-7, hanel2024casereportcosegregation pages 3-4)
+* **Variant yield and reanalysis:** The 2024 HYPERGEN cohort shows why periodic reanalysis and gene-validity prioritization are needed; TPM1 can be clinically important yet rare in particular cohorts. (jaouadi2024exomesequencingdata pages 1-2)
+
+#### 5.2 Disease modeling and translational biology
+* **hiPSC-cardiomyocyte systems:** Quantitative TPM1 isoform dynamics in iPSC-to-cardiomyocyte differentiation support TPM1 isoforms as biomarkers of maturation state and as readouts for perturbation experiments targeting sarcomere assembly/regulation. (dube2024sarcomerictropomyosinexpression pages 2-4)
+
+#### 5.3 Cancer stratification and therapy development
+* **Isoform-resolved biomarkers and targeting:** The ovarian cancer work indicates that TPM1 isoform identification (Tpm1.6/7 vs Tpm1.8/9) may inform EMP state, metastatic potential, and chemotherapy response, and supports development of **isoform-selective inhibitors** as a potential therapeutic avenue. (xu2024tropomyosin1isoformsunderlie pages 6-8, xu2024tropomyosin1isoformsunderlie pages 10-12)
+
+### 6) Visual evidence: TPM1 isoform structure and chemo-resistance
+The following figure panels from the 2024 HGSOC study visually summarize TPM1 exon-defined isoforms and chemotherapy dose–response/IC50 effects:
+
+* TPM1 isoform exon structures and RT-qPCR stratification (Tpm1.6/7 vs Tpm1.8/9): (xu2024tropomyosin1isoformsunderlie media 181dbb5d)
+* Chemotherapy dose–response curves/IC50 values for paclitaxel and cisplatin showing resistance conferred by Tpm1.8/9: (xu2024tropomyosin1isoformsunderlie media f45ab9b5)
+
+### 7) Concise functional annotation summary (evidence table)
+The table below consolidates TPM1’s functional roles, localization, isoform logic, disease links, and key quantitative findings from 2023–2024 sources.
+
+| Aspect | Evidence-backed summary |
+|---|---|
+| Molecular function | • TPM1 encodes α-tropomyosin, a coiled-coil actin-binding thin-filament protein that regulates actin–myosin interaction in a Ca²⁺/troponin-dependent manner in cardiac muscle. • Recent heart studies also describe TPM1 as the predominant cardiac tropomyosin and a sarcomeric regulator of contractility (haas2026sarcomericremodellingin pages 1-4, haas2026sarcomericremodellingin pages 7-10, azimi2024identificationofa pages 1-2) |
+| Mechanism | • In sarcomeres, tropomyosin shifts on actin in response to troponin/Ca²⁺ signaling to expose myosin-binding sites; TPM1 isoforms therefore tune thin-filament activation and motility. • In non-muscle cells, TPM1-derived Tpm1.6 follows a distinct path on actin, cannot co-polymerize with Tpm3.2 on the same filament, and competes with α-actinin for actin binding, helping specify functionally distinct actin networks (haas2026sarcomericremodellingin pages 1-4, kumari2024focaladhesionscontain pages 1-2, kumari2024focaladhesionscontain pages 10-12, selvaraj2023structuralbasisunderlying pages 1-3) |
+| Isoforms / splicing | • TPM1 undergoes extensive alternative splicing, generating multiple muscle and non-muscle isoforms; 2024 hiPSC-cardiomyocyte work detected TPM1α, TPM1κ, and TPM1μ, with TPM1μ matching UniProt/SwissProt isoform P09493-4. • Ovarian-cancer work distinguished Tpm1.6/1.7 from Tpm1.8/1.9 by exon usage: exons 1a/2b mark Tpm1.6/7, whereas exon 1b marks Tpm1.8/9 (dube2024sarcomerictropomyosinexpression pages 2-4, xu2024tropomyosin1isoformsunderlie media 181dbb5d, xu2024tropomyosin1isoformsunderlie pages 6-8) |
+| Subcellular localization | • In muscle, TPM1 is localized to the sarcomeric thin filament of cardiomyocytes. • In non-muscle cells, TPM1-derived Tpm1.6 forms a distinct focal-adhesion actin layer beneath the α-actinin layer and extends along associated dorsal stress fibers, linking adhesion architecture to motility control (haas2026sarcomericremodellingin pages 1-4, kumari2024focaladhesionscontain pages 1-2, kumari2024focaladhesionscontain pages 9-10, kumari2024focaladhesionscontain pages 2-3) |
+| Key binding partners / complexes | • Core TPM1 complexes/functions involve F-actin, troponin, and myosin in thin-filament regulation. • Additional evidence links TPM1 biology to α-actinin competition in focal adhesions and suggests disease-relevant interactions with leiomodin-2 and tropomodulin-1 for N-terminal variants (haas2026sarcomericremodellingin pages 1-4, haas2026sarcomericremodellingin pages 7-10, kumari2024focaladhesionscontain pages 10-12, hanel2024casereportcosegregation pages 3-4) |
+| Regulation | • Cardiac TPM1 isoform expression is regulated by alternative splicing programs involving RBM20 and other RNA-binding/splicing factors; heart-failure studies report isoform remodeling across sarcomere genes including TPM1. • In ovarian cancer, TPM1 isoform balance is linked to epithelial–mesenchymal plasticity and Wnt/inflammatory pathway activation, indicating context-dependent post-transcriptional regulation with functional consequences (haas2026sarcomericremodellingin pages 23-26, haas2026sarcomericremodellingin pages 1-4, xu2024tropomyosin1isoformsunderlie pages 10-12) |
+| Disease relevance | • Cardiomyopathy: TPM1 variants are implicated in HCM and NCCM/LVNC; recent reports include p.D254G linked to familial HCM/SCD and p.Lys7del co-segregating with familial NCCM. • Cancer: TPM1 isoforms are functionally linked to EMT/plasticity, metastatic dissemination, and chemotherapy resistance in high-grade serous ovarian cancer; broader cancer review literature supports tumor-suppressive and stress-fiber-stabilizing roles for TPM1 in several malignancies (azimi2024identificationofa pages 7-7, azimi2024identificationofa pages 2-2, hanel2024casereportcosegregation pages 3-4, xu2024tropomyosin1isoformsunderlie pages 10-12, meng2023researchadvancesin pages 3-5) |
+| Recent key studies (2023–2024) | • 2023 structural work defined isoform-specific actin engagement of non-muscle Tpm1.6 and explained differential effects on cofilin/myosin interactions. • 2024 studies mapped Tpm1.6 into focal-adhesion nanoscale layers, profiled TPM1 isoforms during hiPSC-cardiomyocyte differentiation, linked TPM1 isoforms to ovarian-cancer EMT/chemoresistance, and quantified TPM1-associated penetrance in HCM meta-analysis (selvaraj2023structuralbasisunderlying pages 1-3, kumari2024focaladhesionscontain pages 1-2, dube2024sarcomerictropomyosinexpression pages 2-4, xu2024tropomyosin1isoformsunderlie pages 10-12, topriceanu2024metaanalysisofpenetrance pages 6-7) |
+| Quantitative data | • hiPSC-cardiomyocyte differentiation: TPM1α mRNA rose from 6.88×10^8 copies in hiPSCs to ~5.6×10^10 by day 5 and ~5.98×10^10 by day 20; day-20 transcript rank was TPM1α > TPM1κ > TPM2α > TPM1μ > TPM3α > TPM4α (dube2024sarcomerictropomyosinexpression pages 2-4). • HCM meta-analysis: TPM1 penetrance in relatives carrying P/LP variants was 48.6% (95% CI 25.7–72.2), pooled age at diagnosis 40.3 years; in HYPERGEN reanalysis of 200 HCM cases, no TPM1 variants were found; NCCM report notes TPM1 variants account for <2% of LVNC/NCCM cohorts (topriceanu2024metaanalysisofpenetrance pages 6-7, jaouadi2024exomesequencingdata pages 1-2, hanel2024casereportcosegregation pages 3-4). • Ovarian cancer: OV90 cisplatin IC50 was ~3.266/3.414 μM for Tpm1.8/9-OE versus ~0.078/0.043 μM for Tpm1.6/7-OE; paclitaxel IC50 was ~1.28/1.66 μM versus 0.017/0.015 μM, respectively (xu2024tropomyosin1isoformsunderlie pages 6-8) |
+
+
+*Table: This table summarizes the functional annotation of human TPM1 (UniProt P09493) using only gathered evidence, covering molecular function, localization, splicing, regulation, disease links, and recent quantitative findings from 2023–2024 studies.*
+
+### 8) Notes on evidence quality and gaps
+* The strongest TPM1 functional isoform evidence in 2023–2024 comes from high-impact primary studies in **focal adhesion nanoscale architecture** and **ovarian cancer EMP/chemoresistance**, plus quantitative iPSC cardiomyocyte maturation profiling (kumari2024focaladhesionscontain pages 1-2, xu2024tropomyosin1isoformsunderlie pages 6-8, dube2024sarcomerictropomyosinexpression pages 2-4).
+* Some mechanistic structure-function evidence for non-muscle isoforms is currently in preprint form (bioRxiv 2023) and should be interpreted accordingly, though it is consistent with the high-resolution FA study’s mutual-exclusivity/competition model. (selvaraj2023structuralbasisunderlying pages 1-3, kumari2024focaladhesionscontain pages 10-12)
+
+### Key sources (2023–2024 prioritized; URLs and dates)
+* Kumari R. et al. **Focal adhesions contain three specialized actin nanoscale layers**. *Nature Communications*. **Mar 2024**. https://doi.org/10.1038/s41467-024-46868-7 (kumari2024focaladhesionscontain pages 1-2)
+* Xu T. et al. **Tropomyosin1 isoforms underlie epithelial to mesenchymal plasticity, metastatic dissemination, and resistance to chemotherapy in high-grade serous ovarian cancer**. *Cell Death & Differentiation*. **Feb 2024**. https://doi.org/10.1038/s41418-024-01267-9 (xu2024tropomyosin1isoformsunderlie pages 6-8)
+* Dube D.K. et al. **Sarcomeric tropomyosin expression during human iPSC differentiation into cardiomyocytes**. *Cytoskeleton*. **Mar 2024**. https://doi.org/10.1002/cm.21850 (dube2024sarcomerictropomyosinexpression pages 2-4)
+* Topriceanu C.-C. et al. **Meta-analysis of penetrance and systematic review on transition to disease in genetic hypertrophic cardiomyopathy**. *Circulation*. **Jan 2024**. https://doi.org/10.1161/circulationaha.123.065987 (topriceanu2024metaanalysisofpenetrance pages 6-7)
+* Jaouadi H. et al. **Exome sequencing data reanalysis of 200 hypertrophic cardiomyopathy patients: the HYPERGEN French cohort**. *Frontiers in Medicine*. **Oct 2024**. https://doi.org/10.3389/fmed.2024.1480947 (jaouadi2024exomesequencingdata pages 1-2)
+* Azimi A. et al. **Identification of a novel likely pathogenic TPM1 variant linked to hypertrophic cardiomyopathy in a family with sudden cardiac death**. *ESC Heart Failure*. **Jun 2024**. https://doi.org/10.1002/ehf2.14906 (azimi2024identificationofa pages 7-7)
+* Hanel Y. et al. **Cosegregation of a TPM1 in-frame deletion (p.Lys7del) with familial non-compaction cardiomyopathy**. *Clinical Research in Cardiology*. **Apr 2024**. https://doi.org/10.1007/s00392-023-02190-8 (hanel2024casereportcosegregation pages 3-4)
+* Meng Y. et al. **Research advances in the role of the tropomyosin family in cancer**. *International Journal of Molecular Sciences*. **Aug 2023**. https://doi.org/10.3390/ijms241713295 (meng2023researchadvancesin pages 3-5)
+* Selvaraj M. et al. **Structural basis underlying specific biochemical activities of non-muscle tropomyosin isoforms**. *bioRxiv*. **May 2023**. https://doi.org/10.1101/2022.05.12.491677 (selvaraj2023structuralbasisunderlying pages 1-3)
+
+References
+
+1. (dube2024sarcomerictropomyosinexpression pages 2-4): Dipak K. Dube, Syamalima Dube, Huaiyu Shi, Patricia Benz, Samender Randhawa, Yingli Fan, Jusuo Wang, Zhen Ma, Joseph W. Sanger, Jean M. Sanger, and Bernard J. Poiesz. Sarcomeric tropomyosin expression during human ipsc differentiation into cardiomyocytes. Cytoskeleton, 81:448-472, Mar 2024. URL: https://doi.org/10.1002/cm.21850, doi:10.1002/cm.21850. This article has 1 citations and is from a peer-reviewed journal.
+
+2. (kumari2024focaladhesionscontain pages 2-3): Reena Kumari, Katharina Ven, Megan Chastney, Shrikant B. Kokate, Johan Peränen, Jesse Aaron, Konstantin Kogan, Leonardo Almeida-Souza, Elena Kremneva, Renaud Poincloux, Teng-Leong Chew, Peter W. Gunning, Johanna Ivaska, and Pekka Lappalainen. Focal adhesions contain three specialized actin nanoscale layers. Nature Communications, Mar 2024. URL: https://doi.org/10.1038/s41467-024-46868-7, doi:10.1038/s41467-024-46868-7. This article has 57 citations and is from a highest quality peer-reviewed journal.
+
+3. (haas2026sarcomericremodellingin pages 1-4): Jan Haas, Sarah Schudy, Benedikt Rauscher, Ana Munoz, Steffen Roßkopf, Christoph Reich, Gizem Donmez Yalcin, Abdullah Yalcin, Timon Seeger, Manuel H. Taft, Marc Freichel, Dirk Grimm, Dietmar Manstein, Johannes Backs, Norbert Frey, Lars Steinmetz, and Benjamin Meder. Sarcomeric remodelling in human heart failure unraveled by single molecule long read sequencing. BioRxiv, Mar 2026. URL: https://doi.org/10.1101/2025.02.28.640805, doi:10.1101/2025.02.28.640805. This article has 2 citations.
+
+4. (xu2024tropomyosin1isoformsunderlie pages 6-8): Tong Xu, Mathijs P. Verhagen, Miriam Teeuwssen, Wenjie Sun, Rosalie Joosten, Andrea Sacchetti, Patricia C. Ewing-Graham, Maurice P. H. M. Jansen, Ingrid A. Boere, Nicole S. Bryce, Jun Zeng, Herbert R. Treutlein, Jeff Hook, Edna C. Hardeman, Peter W. Gunning, and Riccardo Fodde. Tropomyosin1 isoforms underlie epithelial to mesenchymal plasticity, metastatic dissemination, and resistance to chemotherapy in high-grade serous ovarian cancer. Cell Death and Differentiation, 31:360-377, Feb 2024. URL: https://doi.org/10.1038/s41418-024-01267-9, doi:10.1038/s41418-024-01267-9. This article has 22 citations and is from a domain leading peer-reviewed journal.
+
+5. (xu2024tropomyosin1isoformsunderlie media 181dbb5d): Tong Xu, Mathijs P. Verhagen, Miriam Teeuwssen, Wenjie Sun, Rosalie Joosten, Andrea Sacchetti, Patricia C. Ewing-Graham, Maurice P. H. M. Jansen, Ingrid A. Boere, Nicole S. Bryce, Jun Zeng, Herbert R. Treutlein, Jeff Hook, Edna C. Hardeman, Peter W. Gunning, and Riccardo Fodde. Tropomyosin1 isoforms underlie epithelial to mesenchymal plasticity, metastatic dissemination, and resistance to chemotherapy in high-grade serous ovarian cancer. Cell Death and Differentiation, 31:360-377, Feb 2024. URL: https://doi.org/10.1038/s41418-024-01267-9, doi:10.1038/s41418-024-01267-9. This article has 22 citations and is from a domain leading peer-reviewed journal.
+
+6. (xu2024tropomyosin1isoformsunderlie media f45ab9b5): Tong Xu, Mathijs P. Verhagen, Miriam Teeuwssen, Wenjie Sun, Rosalie Joosten, Andrea Sacchetti, Patricia C. Ewing-Graham, Maurice P. H. M. Jansen, Ingrid A. Boere, Nicole S. Bryce, Jun Zeng, Herbert R. Treutlein, Jeff Hook, Edna C. Hardeman, Peter W. Gunning, and Riccardo Fodde. Tropomyosin1 isoforms underlie epithelial to mesenchymal plasticity, metastatic dissemination, and resistance to chemotherapy in high-grade serous ovarian cancer. Cell Death and Differentiation, 31:360-377, Feb 2024. URL: https://doi.org/10.1038/s41418-024-01267-9, doi:10.1038/s41418-024-01267-9. This article has 22 citations and is from a domain leading peer-reviewed journal.
+
+7. (topriceanu2024metaanalysisofpenetrance pages 6-7): Constantin-Cristian Topriceanu, Alexandre C. Pereira, James C. Moon, Gabriella Captur, and Carolyn Y. Ho. Meta-analysis of penetrance and systematic review on transition to disease in genetic hypertrophic cardiomyopathy. Circulation, 149:107-123, Jan 2024. URL: https://doi.org/10.1161/circulationaha.123.065987, doi:10.1161/circulationaha.123.065987. This article has 86 citations and is from a highest quality peer-reviewed journal.
+
+8. (jaouadi2024exomesequencingdata pages 1-2): Hager Jaouadi, Victor Morel, Helene Martel, Pierre Lindenbaum, Lorcan Lamy de la Chapelle, Marine Herbane, Claire Lucas, Frédérique Magdinier, Habib Gilbert, Jean-Jacques Schott, Stéphane Zaffran, and Karine Nguyen. Exome sequencing data reanalysis of 200 hypertrophic cardiomyopathy patients: the hypergen french cohort 5 years after the initial analysis. Frontiers in Medicine, Oct 2024. URL: https://doi.org/10.3389/fmed.2024.1480947, doi:10.3389/fmed.2024.1480947. This article has 1 citations.
+
+9. (kumari2024focaladhesionscontain pages 1-2): Reena Kumari, Katharina Ven, Megan Chastney, Shrikant B. Kokate, Johan Peränen, Jesse Aaron, Konstantin Kogan, Leonardo Almeida-Souza, Elena Kremneva, Renaud Poincloux, Teng-Leong Chew, Peter W. Gunning, Johanna Ivaska, and Pekka Lappalainen. Focal adhesions contain three specialized actin nanoscale layers. Nature Communications, Mar 2024. URL: https://doi.org/10.1038/s41467-024-46868-7, doi:10.1038/s41467-024-46868-7. This article has 57 citations and is from a highest quality peer-reviewed journal.
+
+10. (kumari2024focaladhesionscontain pages 3-4): Reena Kumari, Katharina Ven, Megan Chastney, Shrikant B. Kokate, Johan Peränen, Jesse Aaron, Konstantin Kogan, Leonardo Almeida-Souza, Elena Kremneva, Renaud Poincloux, Teng-Leong Chew, Peter W. Gunning, Johanna Ivaska, and Pekka Lappalainen. Focal adhesions contain three specialized actin nanoscale layers. Nature Communications, Mar 2024. URL: https://doi.org/10.1038/s41467-024-46868-7, doi:10.1038/s41467-024-46868-7. This article has 57 citations and is from a highest quality peer-reviewed journal.
+
+11. (kumari2024focaladhesionscontain pages 4-6): Reena Kumari, Katharina Ven, Megan Chastney, Shrikant B. Kokate, Johan Peränen, Jesse Aaron, Konstantin Kogan, Leonardo Almeida-Souza, Elena Kremneva, Renaud Poincloux, Teng-Leong Chew, Peter W. Gunning, Johanna Ivaska, and Pekka Lappalainen. Focal adhesions contain three specialized actin nanoscale layers. Nature Communications, Mar 2024. URL: https://doi.org/10.1038/s41467-024-46868-7, doi:10.1038/s41467-024-46868-7. This article has 57 citations and is from a highest quality peer-reviewed journal.
+
+12. (kumari2024focaladhesionscontain pages 10-12): Reena Kumari, Katharina Ven, Megan Chastney, Shrikant B. Kokate, Johan Peränen, Jesse Aaron, Konstantin Kogan, Leonardo Almeida-Souza, Elena Kremneva, Renaud Poincloux, Teng-Leong Chew, Peter W. Gunning, Johanna Ivaska, and Pekka Lappalainen. Focal adhesions contain three specialized actin nanoscale layers. Nature Communications, Mar 2024. URL: https://doi.org/10.1038/s41467-024-46868-7, doi:10.1038/s41467-024-46868-7. This article has 57 citations and is from a highest quality peer-reviewed journal.
+
+13. (selvaraj2023structuralbasisunderlying pages 1-3): Muniyandi Selvaraj, Shrikant Kokate, Gabriella Reggiano, Konstantin Kogan, Tommi Kotila, Elena Kremneva, Frank DiMaio, Pekka Lappalainen, and Juha T. Huiskonen. Structural basis underlying specific biochemical activities of non-muscle tropomyosin isoforms. bioRxiv, May 2023. URL: https://doi.org/10.1101/2022.05.12.491677, doi:10.1101/2022.05.12.491677. This article has 23 citations.
+
+14. (topriceanu2024metaanalysisofpenetrance pages 2-3): Constantin-Cristian Topriceanu, Alexandre C. Pereira, James C. Moon, Gabriella Captur, and Carolyn Y. Ho. Meta-analysis of penetrance and systematic review on transition to disease in genetic hypertrophic cardiomyopathy. Circulation, 149:107-123, Jan 2024. URL: https://doi.org/10.1161/circulationaha.123.065987, doi:10.1161/circulationaha.123.065987. This article has 86 citations and is from a highest quality peer-reviewed journal.
+
+15. (topriceanu2024metaanalysisofpenetrance pages 9-10): Constantin-Cristian Topriceanu, Alexandre C. Pereira, James C. Moon, Gabriella Captur, and Carolyn Y. Ho. Meta-analysis of penetrance and systematic review on transition to disease in genetic hypertrophic cardiomyopathy. Circulation, 149:107-123, Jan 2024. URL: https://doi.org/10.1161/circulationaha.123.065987, doi:10.1161/circulationaha.123.065987. This article has 86 citations and is from a highest quality peer-reviewed journal.
+
+16. (azimi2024identificationofa pages 7-7): Amir Azimi, Mahdieh Soveizi, Alireza Salmanipour, Mohammadhossein Mozafarybazargany, Amir Ghaffari Jolfayi, Majid Maleki, and Samira Kalayinia. Identification of a novel likely pathogenic tpm1 variant linked to hypertrophic cardiomyopathy in a family with sudden cardiac death. ESC Heart Failure, 11:3180-3190, Jun 2024. URL: https://doi.org/10.1002/ehf2.14906, doi:10.1002/ehf2.14906. This article has 3 citations and is from a peer-reviewed journal.
+
+17. (azimi2024identificationofa pages 2-2): Amir Azimi, Mahdieh Soveizi, Alireza Salmanipour, Mohammadhossein Mozafarybazargany, Amir Ghaffari Jolfayi, Majid Maleki, and Samira Kalayinia. Identification of a novel likely pathogenic tpm1 variant linked to hypertrophic cardiomyopathy in a family with sudden cardiac death. ESC Heart Failure, 11:3180-3190, Jun 2024. URL: https://doi.org/10.1002/ehf2.14906, doi:10.1002/ehf2.14906. This article has 3 citations and is from a peer-reviewed journal.
+
+18. (azimi2024identificationofa pages 7-8): Amir Azimi, Mahdieh Soveizi, Alireza Salmanipour, Mohammadhossein Mozafarybazargany, Amir Ghaffari Jolfayi, Majid Maleki, and Samira Kalayinia. Identification of a novel likely pathogenic tpm1 variant linked to hypertrophic cardiomyopathy in a family with sudden cardiac death. ESC Heart Failure, 11:3180-3190, Jun 2024. URL: https://doi.org/10.1002/ehf2.14906, doi:10.1002/ehf2.14906. This article has 3 citations and is from a peer-reviewed journal.
+
+19. (hanel2024casereportcosegregation pages 3-4): Yvonne Hanel, Sven Dittmann, Klara Müller, Monica Elena Ioannou, and Eric Schulze-Bahr. Case report: cosegregation of a tpm1 in-frame deletion (p.lys7del) with familial non-compaction cardiomyopathy (nccm). Clinical Research in Cardiology, 113:656-660, Apr 2024. URL: https://doi.org/10.1007/s00392-023-02190-8, doi:10.1007/s00392-023-02190-8. This article has 1 citations and is from a peer-reviewed journal.
+
+20. (xu2024tropomyosin1isoformsunderlie pages 10-12): Tong Xu, Mathijs P. Verhagen, Miriam Teeuwssen, Wenjie Sun, Rosalie Joosten, Andrea Sacchetti, Patricia C. Ewing-Graham, Maurice P. H. M. Jansen, Ingrid A. Boere, Nicole S. Bryce, Jun Zeng, Herbert R. Treutlein, Jeff Hook, Edna C. Hardeman, Peter W. Gunning, and Riccardo Fodde. Tropomyosin1 isoforms underlie epithelial to mesenchymal plasticity, metastatic dissemination, and resistance to chemotherapy in high-grade serous ovarian cancer. Cell Death and Differentiation, 31:360-377, Feb 2024. URL: https://doi.org/10.1038/s41418-024-01267-9, doi:10.1038/s41418-024-01267-9. This article has 22 citations and is from a domain leading peer-reviewed journal.
+
+21. (meng2023researchadvancesin pages 3-5): Yucheng Meng, Kemin Huang*, Mingxuan Shi, Yifei Huo, L. Han, Bin Liu, and Yi Li. Research advances in the role of the tropomyosin family in cancer. International Journal of Molecular Sciences, 24:13295, Aug 2023. URL: https://doi.org/10.3390/ijms241713295, doi:10.3390/ijms241713295. This article has 25 citations.
+
+22. (haas2026sarcomericremodellingin pages 7-10): Jan Haas, Sarah Schudy, Benedikt Rauscher, Ana Munoz, Steffen Roßkopf, Christoph Reich, Gizem Donmez Yalcin, Abdullah Yalcin, Timon Seeger, Manuel H. Taft, Marc Freichel, Dirk Grimm, Dietmar Manstein, Johannes Backs, Norbert Frey, Lars Steinmetz, and Benjamin Meder. Sarcomeric remodelling in human heart failure unraveled by single molecule long read sequencing. BioRxiv, Mar 2026. URL: https://doi.org/10.1101/2025.02.28.640805, doi:10.1101/2025.02.28.640805. This article has 2 citations.
+
+23. (azimi2024identificationofa pages 1-2): Amir Azimi, Mahdieh Soveizi, Alireza Salmanipour, Mohammadhossein Mozafarybazargany, Amir Ghaffari Jolfayi, Majid Maleki, and Samira Kalayinia. Identification of a novel likely pathogenic tpm1 variant linked to hypertrophic cardiomyopathy in a family with sudden cardiac death. ESC Heart Failure, 11:3180-3190, Jun 2024. URL: https://doi.org/10.1002/ehf2.14906, doi:10.1002/ehf2.14906. This article has 3 citations and is from a peer-reviewed journal.
+
+24. (kumari2024focaladhesionscontain pages 9-10): Reena Kumari, Katharina Ven, Megan Chastney, Shrikant B. Kokate, Johan Peränen, Jesse Aaron, Konstantin Kogan, Leonardo Almeida-Souza, Elena Kremneva, Renaud Poincloux, Teng-Leong Chew, Peter W. Gunning, Johanna Ivaska, and Pekka Lappalainen. Focal adhesions contain three specialized actin nanoscale layers. Nature Communications, Mar 2024. URL: https://doi.org/10.1038/s41467-024-46868-7, doi:10.1038/s41467-024-46868-7. This article has 57 citations and is from a highest quality peer-reviewed journal.
+
+25. (haas2026sarcomericremodellingin pages 23-26): Jan Haas, Sarah Schudy, Benedikt Rauscher, Ana Munoz, Steffen Roßkopf, Christoph Reich, Gizem Donmez Yalcin, Abdullah Yalcin, Timon Seeger, Manuel H. Taft, Marc Freichel, Dirk Grimm, Dietmar Manstein, Johannes Backs, Norbert Frey, Lars Steinmetz, and Benjamin Meder. Sarcomeric remodelling in human heart failure unraveled by single molecule long read sequencing. BioRxiv, Mar 2026. URL: https://doi.org/10.1101/2025.02.28.640805, doi:10.1101/2025.02.28.640805. This article has 2 citations.
+
+## Citations
+
+1. dube2024sarcomerictropomyosinexpression pages 2-4
+2. kumari2024focaladhesionscontain pages 2-3
+3. haas2026sarcomericremodellingin pages 1-4
+4. selvaraj2023structuralbasisunderlying pages 1-3
+5. topriceanu2024metaanalysisofpenetrance pages 6-7
+6. topriceanu2024metaanalysisofpenetrance pages 9-10
+7. jaouadi2024exomesequencingdata pages 1-2
+8. azimi2024identificationofa pages 7-8
+9. hanel2024casereportcosegregation pages 3-4
+10. meng2023researchadvancesin pages 3-5
+11. kumari2024focaladhesionscontain pages 1-2
+12. azimi2024identificationofa pages 7-7
+13. kumari2024focaladhesionscontain pages 3-4
+14. kumari2024focaladhesionscontain pages 4-6
+15. kumari2024focaladhesionscontain pages 10-12
+16. topriceanu2024metaanalysisofpenetrance pages 2-3
+17. azimi2024identificationofa pages 2-2
+18. haas2026sarcomericremodellingin pages 7-10
+19. azimi2024identificationofa pages 1-2
+20. kumari2024focaladhesionscontain pages 9-10
+21. haas2026sarcomericremodellingin pages 23-26
+22. https://doi.org/10.1038/s41467-024-46868-7
+23. https://doi.org/10.1101/2022.05.12.491677;
+24. https://doi.org/10.1002/cm.21850
+25. https://doi.org/10.1161/circulationaha.123.065987
+26. https://doi.org/10.3389/fmed.2024.1480947
+27. https://doi.org/10.1002/ehf2.14906
+28. https://doi.org/10.1007/s00392-023-02190-8
+29. https://doi.org/10.1038/s41418-024-01267-9
+30. https://doi.org/10.3390/ijms241713295
+31. https://doi.org/10.1101/2022.05.12.491677
+32. https://doi.org/10.1002/cm.21850,
+33. https://doi.org/10.1038/s41467-024-46868-7,
+34. https://doi.org/10.1101/2025.02.28.640805,
+35. https://doi.org/10.1038/s41418-024-01267-9,
+36. https://doi.org/10.1161/circulationaha.123.065987,
+37. https://doi.org/10.3389/fmed.2024.1480947,
+38. https://doi.org/10.1101/2022.05.12.491677,
+39. https://doi.org/10.1002/ehf2.14906,
+40. https://doi.org/10.1007/s00392-023-02190-8,
+41. https://doi.org/10.3390/ijms241713295,


### PR DESCRIPTION
## Summary

Adds Falcon deep research for two reviewed human genes that lacked deep research files:

- `ATP7B`
- `TPM1`

The reports are incorporated into the review YAML as file references and supporting evidence. `ATP7B` also now has core function entries for P-type Cu(I) transporter activity and copper binding, and both gene review pages were re-rendered.

## Validation

- `uv run python scripts/validate_deep_research.py genes/human/ATP7B/ATP7B-deep-research-falcon.md genes/human/TPM1/TPM1-deep-research-falcon.md`
- `just validate human ATP7B`
- `just validate human TPM1`
- `just render human ATP7B`
- `just render human TPM1`
- `git diff --check origin/main..HEAD`

`ATP7B` validation passes with seven pre-existing best-practice warnings about inconsistent actions across duplicate GO terms; no schema, term, reference, or deep-research validation failures remain.