### PR TITLE
[codex] Add falcon deep research batch 7

### DIFF
--- a/genes/human/KCNQ1OT1/KCNQ1OT1-ai-review.html
+++ b/genes/human/KCNQ1OT1/KCNQ1OT1-ai-review.html
@@ -671,33 +671,33 @@
     <div class="header">
         <h1>KCNQ1OT1</h1>
         <div class="gene-info">
-            
+
             <div class="info-item">
-                
+
                 <span class="info-label">UniProt ID:</span>
                 <span>
                     <a href="https://www.uniprot.org/uniprotkb/URS0000759CF4_9606" target="_blank" class="term-link">
                         URS0000759CF4_9606
                     </a>
                 </span>
-                
+
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Organism:</span>
                 <span>Homo sapiens</span>
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
                 <span class="status-badge status-complete">
                     COMPLETE
                 </span>
             </div>
-            
-            
+
+
         </div>
         <div style="margin-top: 1rem; text-align: center;">
             <a id="feedback-form-link"
@@ -728,7 +728,7 @@
         </div>
     </div>
 
-    
+
     <div class="description-card">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <h2>Gene Description</h2>
@@ -739,13 +739,13 @@
         </div>
         <p>KCNQ1OT1 is a 91kb paternally-expressed imprinted long non-coding RNA that regulates genomic imprinting at the KCNQ1 locus on chromosome 11p15.5. It silences genes in the KCNQ1 imprinted domain by recruiting Polycomb Repressive Complex 2 (PRC2) and establishing heterochromatin. Loss of imprinting leads to Beckwith-Wiedemann syndrome.</p>
     </div>
-    
 
-    
 
-    
 
-    
+
+
+
+
     <div class="section">
         <h2 class="section-title">Existing Annotations Review</h2>
         <table class="annotations-table">
@@ -758,32 +758,32 @@
                 </tr>
             </thead>
             <tbody>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031507" target="_blank" class="term-link">
                                     GO:0031507
                                 </a>
                             </span>
                             <span class="term-label">heterochromatin formation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000115
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -795,53 +795,69 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This is the core function of KCNQ1OT1 - it mediates heterochromatin formation at the KCNQ1 imprinted locus by recruiting Polycomb Repressive Complex 2 (PRC2) to silence genes in the imprinted domain. This is consistent with its role in genomic imprinting.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/KCNQ1OT1/KCNQ1OT1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">At the KCNQ1/KCNQ1OT1 domain, imprinting yields monoallelic expression of a cluster of genes, controlled by a differentially methylated region.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000512" target="_blank" class="term-link">
                                     GO:0000512
                                 </a>
                             </span>
                             <span class="term-label">lncRNA-mediated post-transcriptional gene silencing</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/32271402" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:32271402
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     KCNQ1OT1 regulates osteogenic differentiation of hBMSC by mi...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -853,71 +869,71 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This annotation is based on KCNQ1OT1 acting as a ceRNA/miRNA sponge in an osteogenic differentiation study using hBMSCs. While the miRNA sponging activity may be real, this represents an over-annotation of KCNQ1OT1 beyond its core genomic imprinting function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/32271402" target="_blank" class="term-link">
                                         PMID:32271402
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">KCNQ1OT1 regulates osteogenic differentiation of hBMSC by miR-320a/Smad5 axis.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045669" target="_blank" class="term-link">
                                     GO:0045669
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of osteoblast differentiation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/32271402" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:32271402
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     KCNQ1OT1 regulates osteogenic differentiation of hBMSC by mi...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -929,71 +945,71 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Based on in vitro osteogenic differentiation study. This is not the core function of KCNQ1OT1 which is genomic imprinting at the KCNQ1 locus. This represents a non-physiological over-annotation.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/32271402" target="_blank" class="term-link">
                                         PMID:32271402
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">KCNQ1OT1 regulates osteogenic differentiation of hBMSC by miR-320a/Smad5 axis.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140869" target="_blank" class="term-link">
                                     GO:0140869
                                 </a>
                             </span>
                             <span class="term-label">miRNA inhibitor activity via base-pairing</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/32271402" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:32271402
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     KCNQ1OT1 regulates osteogenic differentiation of hBMSC by mi...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1005,71 +1021,71 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Based on KCNQ1OT1 sponging miR-320a in osteogenic differentiation model. This is an over-annotation beyond the core genomic imprinting function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/32271402" target="_blank" class="term-link">
                                         PMID:32271402
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">KCNQ1OT1 regulates osteogenic differentiation of hBMSC by miR-320a/Smad5 axis.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:2000627" target="_blank" class="term-link">
                                     GO:2000627
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of miRNA catabolic process</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/32271402" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:32271402
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     KCNQ1OT1 regulates osteogenic differentiation of hBMSC by mi...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1081,71 +1097,71 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Based on miRNA sponging activity in osteogenic model. Over-annotation of KCNQ1OT1&#39;s core function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/32271402" target="_blank" class="term-link">
                                         PMID:32271402
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">KCNQ1OT1 regulates osteogenic differentiation of hBMSC by miR-320a/Smad5 axis.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001819" target="_blank" class="term-link">
                                     GO:0001819
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of cytokine production</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/30703347" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:30703347
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     LncRNA KCNQ1OT1 promoted BMP2 expression to regulate osteoge...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1157,71 +1173,71 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Based on osteogenic differentiation study. This is an over-annotation unrelated to KCNQ1OT1&#39;s core imprinting function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/30703347" target="_blank" class="term-link">
                                         PMID:30703347
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">2019 Jan 28. LncRNA KCNQ1OT1 promoted BMP2 expression to regulate osteogenic differentiation by sponging miRNA-214.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140869" target="_blank" class="term-link">
                                     GO:0140869
                                 </a>
                             </span>
                             <span class="term-label">miRNA inhibitor activity via base-pairing</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/30241939" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:30241939
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     YY1-induced upregulation of lncRNA KCNQ1OT1 regulates angiot...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1233,71 +1249,71 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Based on atrial fibrillation study showing KCNQ1OT1 sponging miR-384b. This is an over-annotation beyond the core genomic imprinting function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/30241939" target="_blank" class="term-link">
                                         PMID:30241939
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">YY1-induced upregulation of lncRNA KCNQ1OT1 regulates angiotensin II-induced atrial fibrillation by modulating miR-384b/CACNA1C axis.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000512" target="_blank" class="term-link">
                                     GO:0000512
                                 </a>
                             </span>
                             <span class="term-label">lncRNA-mediated post-transcriptional gene silencing</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/30703347" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:30703347
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     LncRNA KCNQ1OT1 promoted BMP2 expression to regulate osteoge...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1309,71 +1325,71 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Based on ceRNA/miRNA sponging in osteogenic model. Over-annotation of core function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/30703347" target="_blank" class="term-link">
                                         PMID:30703347
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">2019 Jan 28. LncRNA KCNQ1OT1 promoted BMP2 expression to regulate osteogenic differentiation by sponging miRNA-214.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001649" target="_blank" class="term-link">
                                     GO:0001649
                                 </a>
                             </span>
                             <span class="term-label">osteoblast differentiation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/30703347" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:30703347
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     LncRNA KCNQ1OT1 promoted BMP2 expression to regulate osteoge...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1385,71 +1401,71 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Based on in vitro osteogenic model. Over-annotation unrelated to core genomic imprinting function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/30703347" target="_blank" class="term-link">
                                         PMID:30703347
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">2019 Jan 28. LncRNA KCNQ1OT1 promoted BMP2 expression to regulate osteogenic differentiation by sponging miRNA-214.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0010628" target="_blank" class="term-link">
                                     GO:0010628
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of gene expression</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/30703347" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:30703347
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     LncRNA KCNQ1OT1 promoted BMP2 expression to regulate osteoge...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1461,71 +1477,71 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> While KCNQ1OT1 does regulate gene expression through imprinting, this annotation is from an osteogenic study focused on BMP2 regulation via miRNA sponging, not the core imprinting mechanism.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/30703347" target="_blank" class="term-link">
                                         PMID:30703347
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">2019 Jan 28. LncRNA KCNQ1OT1 promoted BMP2 expression to regulate osteogenic differentiation by sponging miRNA-214.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030513" target="_blank" class="term-link">
                                     GO:0030513
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of BMP signaling pathway</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/30703347" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:30703347
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     LncRNA KCNQ1OT1 promoted BMP2 expression to regulate osteoge...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1537,71 +1553,71 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Based on osteogenic differentiation study. Over-annotation unrelated to core imprinting function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/30703347" target="_blank" class="term-link">
                                         PMID:30703347
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">2019 Jan 28. LncRNA KCNQ1OT1 promoted BMP2 expression to regulate osteogenic differentiation by sponging miRNA-214.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035198" target="_blank" class="term-link">
                                     GO:0035198
                                 </a>
                             </span>
                             <span class="term-label">miRNA binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/30703347" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:30703347
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     LncRNA KCNQ1OT1 promoted BMP2 expression to regulate osteoge...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1613,71 +1629,71 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Based on ceRNA activity in osteogenic model. Over-annotation of core function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/30703347" target="_blank" class="term-link">
                                         PMID:30703347
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">2019 Jan 28. LncRNA KCNQ1OT1 promoted BMP2 expression to regulate osteogenic differentiation by sponging miRNA-214.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140869" target="_blank" class="term-link">
                                     GO:0140869
                                 </a>
                             </span>
                             <span class="term-label">miRNA inhibitor activity via base-pairing</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/30703347" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:30703347
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     LncRNA KCNQ1OT1 promoted BMP2 expression to regulate osteoge...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1689,71 +1705,71 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Based on miRNA sponging in osteogenic model. Over-annotation beyond core imprinting function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/30703347" target="_blank" class="term-link">
                                         PMID:30703347
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">2019 Jan 28. LncRNA KCNQ1OT1 promoted BMP2 expression to regulate osteogenic differentiation by sponging miRNA-214.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:2000627" target="_blank" class="term-link">
                                     GO:2000627
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of miRNA catabolic process</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/30703347" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:30703347
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     LncRNA KCNQ1OT1 promoted BMP2 expression to regulate osteoge...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1765,71 +1781,71 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Based on ceRNA activity in osteogenic model. Over-annotation of core function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/30703347" target="_blank" class="term-link">
                                         PMID:30703347
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">2019 Jan 28. LncRNA KCNQ1OT1 promoted BMP2 expression to regulate osteogenic differentiation by sponging miRNA-214.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0010628" target="_blank" class="term-link">
                                     GO:0010628
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of gene expression</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IGI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/30241939" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:30241939
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     YY1-induced upregulation of lncRNA KCNQ1OT1 regulates angiot...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1841,71 +1857,71 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Based on atrial fibrillation model. Over-annotation unrelated to core imprinting function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/30241939" target="_blank" class="term-link">
                                         PMID:30241939
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">YY1-induced upregulation of lncRNA KCNQ1OT1 regulates angiotensin II-induced atrial fibrillation by modulating miR-384b/CACNA1C axis.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035198" target="_blank" class="term-link">
                                     GO:0035198
                                 </a>
                             </span>
                             <span class="term-label">miRNA binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/30241939" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:30241939
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     YY1-induced upregulation of lncRNA KCNQ1OT1 regulates angiot...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1917,60 +1933,60 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Based on ceRNA activity in atrial fibrillation model. Over-annotation of core function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/30241939" target="_blank" class="term-link">
                                         PMID:30241939
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">YY1-induced upregulation of lncRNA KCNQ1OT1 regulates angiotensin II-induced atrial fibrillation by modulating miR-384b/CACNA1C axis.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005730" target="_blank" class="term-link">
                                     GO:0005730
                                 </a>
                             </span>
                             <span class="term-label">nucleolus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000115
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -1982,53 +1998,53 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> While some lncRNAs localize to the nucleolus, KCNQ1OT1&#39;s primary localization is to the KCNQ1 imprinted domain on chromosome 11p15.5 where it establishes heterochromatin. Without experimental evidence for nucleolar localization, this annotation should be questioned.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:2000627" target="_blank" class="term-link">
                                     GO:2000627
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of miRNA catabolic process</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IGI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/30241939" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:30241939
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     YY1-induced upregulation of lncRNA KCNQ1OT1 regulates angiot...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2040,106 +2056,106 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Based on ceRNA activity in disease model. Over-annotation of core function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/30241939" target="_blank" class="term-link">
                                         PMID:30241939
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">YY1-induced upregulation of lncRNA KCNQ1OT1 regulates angiotensin II-induced atrial fibrillation by modulating miR-384b/CACNA1C axis.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003676" target="_blank" class="term-link">
-                                    GO:0003676
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003682" target="_blank" class="term-link">
+                                    GO:0003682
                                 </a>
                             </span>
-                            <span class="term-label">nucleic acid binding</span>
-                            
+                            <span class="term-label">chromatin binding</span>
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">NAS</span>
-                        
-                        
-                        
+
+
+
                     </td>
                     <td>
                         <span class="action-badge action-new">
                             NEW
                         </span>
-                        <span class="vote-buttons" data-g="URS0000759CF4_9606" data-a="GO:0003676" data-r="" data-act="NEW">
+                        <span class="vote-buttons" data-g="URS0000759CF4_9606" data-a="GO:0003682" data-r="" data-act="NEW">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Added to align core_functions with existing annotations.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core function term not present in existing_annotations.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    GO_REF:0000115
-                                    
+
+                                    file:human/KCNQ1OT1/KCNQ1OT1-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">KCNQ1OT1 is a paternally-expressed lncRNA that recruits chromatin-modifying complexes to establish heterochromatin and silence genes in the KCNQ1 imprinted domain on chromosome 11p15.5</div>
-                                
+
+                                <div class="support-text">KCNQ1OT1 is best annotated to cis-regulatory chromatin functions at the imprinted KCNQ1/KCNQ1OT1 domain, with disease-associated miRNA-sponging studies treated cautiously as context-specific evidence.</div>
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
             </tbody>
         </table>
     </div>
-    
 
-    
+
+
     <div class="section">
         <h2 class="section-title">Core Functions</h2>
-        
+
         <div class="core-function-card">
-            
+
             <div style="display: flex; justify-content: space-between; align-items: center;">
                 <h3>Genomic imprinting regulation through heterochromatin establishment at KCNQ1 locus</h3>
                 <span class="vote-buttons" data-g="URS0000759CF4_9606" data-a="FUNCTION: Genomic imprinting regulation through heterochroma..." data-r="" data-act="CORE_FUNCTION">
@@ -2147,138 +2163,569 @@
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
             </div>
-            
+
 
             <div class="core-function-terms">
-                
+
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
-                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003676" target="_blank" class="term-link">
-                            nucleic acid binding
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003682" target="_blank" class="term-link">
+                            chromatin binding
                         </a>
                     </span>
                 </div>
-                
 
-                
 
-                
 
-                
 
-                
+
+
+
+
+
             </div>
 
-            
+
             <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
                 <strong>Supporting Evidence:</strong>
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
-                            GO_REF:0000115
-                            
+
+                            file:human/KCNQ1OT1/KCNQ1OT1-deep-research-falcon.md
+
                         </span>
-                        
-                        <div class="finding-text">KCNQ1OT1 is a paternally-expressed lncRNA that recruits chromatin-modifying complexes to establish heterochromatin and silence genes in the KCNQ1 imprinted domain on chromosome 11p15.5</div>
-                        
+
+                        <div class="finding-text">KCNQ1OT1 is best annotated to cis-regulatory chromatin functions at the imprinted KCNQ1/KCNQ1OT1 domain, with disease-associated miRNA-sponging studies treated cautiously as context-specific evidence.</div>
+
                     </li>
-                    
+
                 </ul>
             </div>
-            
-        </div>
-        
-    </div>
-    
 
-    
+        </div>
+
+    </div>
+
+
+
     <div class="section">
         <h2 class="section-title collapsible">References</h2>
         <div class="collapse-content">
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
+                        file:human/KCNQ1OT1/KCNQ1OT1-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research report for KCNQ1OT1</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Falcon supports KCNQ1OT1&#39;s core role as a cis-acting imprinted lncRNA that associates with the KCNQ1/KCNQ1OT1 domain and promotes local repressive chromatin, while treating miRNA-sponge disease models as non-core context-specific evidence.</div>
+
+                        <div class="finding-text">"This report focuses on primary molecular roles of KCNQ1OT1 as a long non-coding RNA involved in genomic imprinting and chromatin regulation at the KCNQ1/KCNQ1OT1 imprinted domain."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000115.md" target="_blank" class="term-link">
                             GO_REF:0000115
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Automatic Gene Ontology annotation of non-coding RNA sequences through association of Rfam records with GO terms</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/30241939" target="_blank" class="term-link">
                             PMID:30241939
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">YY1-induced upregulation of lncRNA KCNQ1OT1 regulates angiotensin II-induced atrial fibrillation by modulating miR-384b/CACNA1C axis.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/30703347" target="_blank" class="term-link">
                             PMID:30703347
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">LncRNA KCNQ1OT1 promoted BMP2 expression to regulate osteogenic differentiation by sponging miRNA-214.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/32271402" target="_blank" class="term-link">
                             PMID:32271402
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">KCNQ1OT1 regulates osteogenic differentiation of hBMSC by miR-320a/Smad5 axis.</div>
-                
-                
+
+
             </div>
-            
+
         </div>
     </div>
-    
 
 
-    
 
-    
 
-    
+
+
+
+
 
     <!-- Computational Predictions Section -->
-    
+
 
     <!-- Additional Documentation Sections -->
-    
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Deep Research Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(KCNQ1OT1-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="URS0000759CF4_9606" data-a="DOC: Deep Research Falcon" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <hr />
+<p>provider: falcon<br />
+model: Edison Scientific Literature<br />
+cached: false<br />
+start_time: '2026-05-11T03:29:14.829659'<br />
+end_time: '2026-05-11T04:03:01.113999'<br />
+duration_seconds: 2026.28<br />
+provider_config:<br />
+  timeout: 600<br />
+  max_retries: 3<br />
+  parameters:<br />
+    allowed_domains: []<br />
+    temperature: 0.1<br />
+citation_count: 37</p>
+<hr />
+<h2 id="question">Question</h2>
+<p>Research the human long non-coding RNA gene KCNQ1OT1 (KCNQ1 opposite strand/antisense transcript 1; RNAcentral URS0000759CF4_9606) for Gene Ontology functional annotation. This is a non-coding RNA, not a protein; do not infer protein domains or enzyme activity. Focus on its primary molecular role in imprinting and chromatin regulation at the KCNQ1 locus, lncRNA-mediated gene silencing, interactions with chromatin modifiers or microRNAs only where supported, cellular localization, and which GO molecular function, biological process, and cellular component terms are directly supported by primary literature. Distinguish core function from disease- or context-specific downstream phenotypes, and provide citations for each major claim.</p>
+<h2 id="output">Output</h2>
+<p>Question: You are an expert researcher providing comprehensive, well-cited information.</p>
+<p>Provide detailed information focusing on:<br />
+1. Key concepts and definitions with current understanding<br />
+2. Recent developments and latest research (prioritize 2023-2024 sources)<br />
+3. Current applications and real-world implementations<br />
+4. Expert opinions and analysis from authoritative sources<br />
+5. Relevant statistics and data from recent studies</p>
+<p>Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.<br />
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.</p>
+<p>Research the human long non-coding RNA gene KCNQ1OT1 (KCNQ1 opposite strand/antisense transcript 1; RNAcentral URS0000759CF4_9606) for Gene Ontology functional annotation. This is a non-coding RNA, not a protein; do not infer protein domains or enzyme activity. Focus on its primary molecular role in imprinting and chromatin regulation at the KCNQ1 locus, lncRNA-mediated gene silencing, interactions with chromatin modifiers or microRNAs only where supported, cellular localization, and which GO molecular function, biological process, and cellular component terms are directly supported by primary literature. Distinguish core function from disease- or context-specific downstream phenotypes, and provide citations for each major claim.</p>
+<h2 id="research-report-gene-ontology-go-functional-annotation-for-human-lncrna-kcnq1ot1-kcnq1-opposite-strandantisense-transcript-1-rnacentral-urs0000759cf4_9606">Research report: Gene Ontology (GO) functional annotation for human lncRNA <strong>KCNQ1OT1</strong> (KCNQ1 opposite strand/antisense transcript 1; RNAcentral URS0000759CF4_9606)</h2>
+<h3 id="scope-and-constraints">Scope and constraints</h3>
+<p>This report focuses on <strong>primary molecular roles</strong> of KCNQ1OT1 as a <strong>long non-coding RNA (lncRNA)</strong> involved in <strong>genomic imprinting and chromatin regulation</strong> at the KCNQ1/KCNQ1OT1 (IC2/KvDMR1) imprinted domain, emphasizing <strong>cis</strong> gene silencing, chromatin association, chromatin-modifier interactions where directly supported, and cellular localization. It <strong>does not</strong> infer protein-like activities (domains/enzymatic functions). Disease associations are treated as downstream phenotypes and are separated from core mechanistic annotation.</p>
+<hr />
+<h2 id="1-key-concepts-and-definitions-current-understanding">1) Key concepts and definitions (current understanding)</h2>
+<h3 id="11-what-kcnq1ot1-is">1.1 What KCNQ1OT1 is</h3>
+<p>KCNQ1OT1 is an <strong>imprinted antisense lncRNA</strong> expressed from the <strong>paternal allele</strong> at the KCNQ1 domain (human 11p15.5; mouse syntenic region), with its promoter embedded in the imprinting control region IC2/KvDMR1. Functional experiments in the mouse system (Kcnq1ot1) demonstrate that expression of this lncRNA (and/or its transcriptional process) is required for parent-of-origin-specific repression of multiple genes in the domain in cis. (pandey2008kcnq1ot1antisensenoncoding pages 6-8, autuoro2014longnoncodingrnas pages 6-9, landschoot2014regulationofthe pages 38-43)</p>
+<h3 id="12-what-imprinting-and-cis-silencing-mean-here">1.2 What “imprinting” and “cis silencing” mean here</h3>
+<p>At the KCNQ1/KCNQ1OT1 domain, imprinting yields <strong>monoallelic expression</strong> of a cluster of genes, controlled by a differentially methylated region (ICR/DMR). In this domain, paternal Kcnq1ot1 expression correlates with broad <strong>cis</strong> repression of neighboring genes and the establishment of repressive chromatin features. (redrup2009thelongnoncoding pages 1-2, pandey2008kcnq1ot1antisensenoncoding pages 6-8)</p>
+<h3 id="13-mechanistic-models-rna-product-vs-transcription">1.3 Mechanistic models (RNA product vs transcription)</h3>
+<p>Multiple mechanisms can contribute to KCNQ1OT1/Kcnq1ot1-mediated repression:<br />
+* <strong>RNA-dependent chromatin repression</strong>, in which the lncRNA accumulates locally and associates with chromatin regulators to promote repressive chromatin states. (pandey2008kcnq1ot1antisensenoncoding pages 6-8, michele2023imprintedlongnoncoding pages 10-11)<br />
+* <strong>Transcription-dependent interference</strong>, in which the act of lncRNA transcription across downstream loci contributes to repression. (korostowski2012thekcnq1ot1long pages 1-2, ferrer2024transcriptionregulationby pages 11-13)<br />
+Recent authoritative reviews emphasize that <strong>both</strong> transcription-dependent and RNA-dependent mechanisms may operate, and that locus- and lineage-specific differences remain unresolved. (ferrer2024transcriptionregulationby pages 11-13, moindrot2024differential3dgenome pages 7-9)</p>
+<hr />
+<h2 id="2-primary-literature-evidence-supporting-go-relevant-functions">2) Primary literature evidence supporting GO-relevant functions</h2>
+<h3 id="21-cellular-localization-and-chromatin-association-cellular-component">2.1 Cellular localization and chromatin association (Cellular Component)</h3>
+<p><strong>Nuclear localization:</strong> Primary fractionation and RNA-FISH data show Kcnq1ot1 is predominantly nuclear. (pandey2008kcnq1ot1antisensenoncoding pages 2-4, redrup2009thelongnoncoding pages 2-3)</p>
+<p><strong>Chromatin-associated nuclear domain (“RNA territory”):</strong> RNA/DNA FISH demonstrates that Kcnq1ot1 forms a <strong>local nuclear domain</strong> and that <strong>silenced target genes</strong> are frequently positioned within or adjacent to this domain, whereas nearby non-target loci are outside it. (redrup2009thelongnoncoding pages 1-2, redrup2009thelongnoncoding pages 4-5)</p>
+<p><strong>Quantitative evidence:</strong> In Redrup et al. (2009), 3D RNA-FISH volume distributions differed significantly across RNAs (P&lt;0.0001, χ2), with <strong>34.4%</strong> of Kcnq1ot1 signals exceeding <strong>0.4 μm³</strong> (vs <strong>5.6%</strong> for a typical mRNA signal, Kcnq1), and Kcnq1ot1 RNA volumes being <strong>significantly larger in placenta than embryo</strong> (P&lt;0.0001). (redrup2009thelongnoncoding pages 4-5, redrup2009thelongnoncoding media 5a86e8a0)</p>
+<p><strong>Perinucleolar/nucleolar-periphery association (lineage/context supported):</strong> In trophoblast stem cells, nucleolar association of the Kcnq1 locus increases with differentiation and depends on Kcnq1ot1; Fedoriw et al. report sample sizes (day 0 n=120; day 2 n=136) and a highly significant increase in perinucleolar association after differentiation (P&lt;0.0001). (fedoriw2012differentiationdrivennucleolarassociation pages 3-4, fedoriw2012differentiationdrivennucleolarassociation pages 2-3)</p>
+<h3 id="22-core-cis-silencing-and-imprinting-biological-process">2.2 Core cis silencing and imprinting (Biological Process)</h3>
+<p><strong>Cis silencing across a large domain:</strong> Genetic perturbations (promoter deletion, truncation, suppression) show that disrupting Kcnq1ot1 leads to derepression (loss of imprinting / biallelic expression) of multiple genes across the domain. (pandey2008kcnq1ot1antisensenoncoding pages 6-8, autuoro2014longnoncodingrnas pages 6-9, landschoot2014regulationofthe pages 38-43)</p>
+<p><strong>Lineage specificity:</strong> Primary studies and reviews report that the silenced span and the number of affected genes are greater in placenta than embryo (e.g., silenced region ~780 kb in placenta vs ~400 kb in embryo in Redrup et al.). (redrup2009thelongnoncoding pages 1-2, redrup2009thelongnoncoding pages 4-5)</p>
+<h3 id="23-interaction-with-chromatin-modifiers-and-repressive-chromatin-marks-molecular-function-biological-process">2.3 Interaction with chromatin modifiers and repressive chromatin marks (Molecular Function; Biological Process)</h3>
+<p><strong>Association with PRC2 and G9a (EHMT2):</strong> Pandey et al. (2008) used RNA immunoprecipitation with antibodies against <strong>G9a</strong>, <strong>EZH2</strong>, and <strong>SUZ12</strong> and detected Kcnq1ot1 RNA in these complexes in placenta but not fetal liver, supporting physical association with these chromatin modifiers in a lineage-dependent manner. (pandey2008kcnq1ot1antisensenoncoding pages 12-13, pandey2008kcnq1ot1antisensenoncoding pages 6-8)</p>
+<p><strong>RNA–chromatin contacts at specific promoters:</strong> Chromatin oligo-affinity purification (ChOP) shows Kcnq1ot1 associates with promoters/regions of multiple imprinted genes (Kcnq1, Cdkn1c, Cd81, Ascl2, Osbpl5), supporting a direct chromatin-binding/tethering role in cis. (pandey2008kcnq1ot1antisensenoncoding pages 6-8, pandey2008kcnq1ot1antisensenoncoding pages 12-13)</p>
+<p><strong>Kcnq1ot1-dependent H3K27me3 patterns:</strong> In Pandey et al., deletion of the Kcnq1ot1 promoter (DKcnq1ot1) causes substantial loss of placental H3K27me3 over parts of the domain, supporting a role for Kcnq1ot1 in establishing/maintaining PRC2-associated repression at many loci (with locus-specific exceptions). (pandey2008kcnq1ot1antisensenoncoding pages 12-13, pandey2008kcnq1ot1antisensenoncoding pages 6-8)</p>
+<p><strong>Chromatin architecture (intrachromosomal looping):</strong> Zhang et al. (2014) report that targeted suppression of Kcnq1ot1 prevents formation of a long-range intrachromosomal loop between KvDMR1 and the Kcnq1 promoter and causes loss of Kcnq1 imprinting, linking the lncRNA to imprint maintenance via chromatin topology. (zhang2014longnoncodingrnamediated pages 1-2)</p>
+<p><strong>Important limitation for GO:</strong> The provided primary evidence directly supports PRC2 (EZH2/SUZ12) and G9a association (pandey2008kcnq1ot1antisensenoncoding pages 12-13, pandey2008kcnq1ot1antisensenoncoding pages 6-8). Direct primary-evidence support in this retrieved corpus for PRC1/RING1B binding by KCNQ1OT1 in vivo is limited (PRC1 is more strongly supported via reviews here), so PRC1-related GO molecular-function assertions should be curated conservatively unless additional primary data are added. (pandey2008kcnq1ot1antisensenoncoding pages 6-8, feil2016noncodingrnasand pages 11-14)</p>
+<hr />
+<h2 id="3-recent-developments-and-latest-research-prioritizing-20232024">3) Recent developments and latest research (prioritizing 2023–2024)</h2>
+<h3 id="31-2023-review-synthesis-imprinted-lncrnas-as-cis-chromatin-repressors">3.1 2023 review synthesis: imprinted lncRNAs as cis chromatin repressors</h3>
+<p>Di Michele et al. (Sep 2023) synthesize that Kcnq1ot1 is strictly nuclear, accumulates in cis, and associates with EHMT2/G9A and Polycomb complexes, with repression broader in extra-embryonic tissues; they highlight open questions about cofactors (e.g., trophoblast-enriched factors) and which RNA regions mediate protein interactions. URL: https://doi.org/10.3390/ijms241713647 (published 2023-09). (michele2023imprintedlongnoncoding pages 10-11, michele2023imprintedlongnoncoding pages 11-13)</p>
+<h3 id="32-2024-authoritative-mechanistic-framing-lncrnas-and-cis-repression">3.2 2024 authoritative mechanistic framing: lncRNAs and cis repression</h3>
+<p>Ferrer &amp; Dimitrova (Jan 2024, Nature Reviews Molecular Cell Biology) frame imprinted lncRNAs (including Kcnq1ot1) as paradigms: they accumulate on chromatin at their loci, often silence bidirectionally over long ranges in cis, and can act via transcription-dependent and RNA-mediated chromatin recruitment mechanisms. URL: https://doi.org/10.1038/s41580-023-00694-9 (published 2024-01). (ferrer2024transcriptionregulationby pages 11-13, ferrer2024transcriptionregulationby pages 27-28)</p>
+<h3 id="33-2024-developments-imprinting-and-3d-genome-architecture">3.3 2024 developments: imprinting and 3D genome architecture</h3>
+<p>Moindrot et al. (May 2024) review how allele-specific DNA methylation and CTCF/cohesin shape imprinted-domain architecture and discuss imprinted lncRNAs (including Kcnq1ot1) as potential contributors to higher-order chromatin organization while emphasizing that the generality and causal direction (architecture → expression vs expression → architecture) remain incompletely resolved. URL: https://doi.org/10.1042/bst20230143 (published 2024-05). (moindrot2024differential3dgenome pages 1-2, moindrot2024differential3dgenome pages 7-9)</p>
+<h3 id="34-2024-clinical-genetics-context-mechanism-level-not-phenotype-claims">3.4 2024 clinical-genetics context (mechanism-level, not phenotype claims)</h3>
+<p>Eggermann (Genes, Jan 2024) summarizes that the KCNQ1OT1/IC2 locus is a cis-acting imprinting control region and that imprinting disturbances can involve cis variants and broader imprinting-defect mechanisms; detailed mechanistic steps specific to KCNQ1OT1 are limited in the excerpt. URL: https://doi.org/10.3390/genes15020163 (published 2024-01). (eggermann2024humanreproductionand pages 5-7, eggermann2024humanreproductionanda pages 7-8)</p>
+<hr />
+<h2 id="4-go-functional-annotation-recommendations-supported-terms-only">4) GO functional annotation recommendations (supported terms only)</h2>
+<p>The following table consolidates <strong>GO Molecular Function (MF)</strong>, <strong>Biological Process (BP)</strong>, and <strong>Cellular Component (CC)</strong> terms that are directly supportable from primary literature in this corpus, with explicit assays and citations.</p>
+<table>
+<thead>
+<tr>
+<th>GO aspect (MF/BP/CC)</th>
+<th>Proposed GO term (name; exact GO ID if known)</th>
+<th>Evidence type/assay</th>
+<th>Key finding (1 sentence)</th>
+<th>Primary citation context IDs</th>
+<th>Notes/limits</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>MF</td>
+<td>chromatin binding</td>
+<td>ChOP; RNA-guided chromatin conformation capture (R3C); chromatin-associated RNA IP</td>
+<td>Kcnq1ot1/KCNQ1OT1 physically associates with chromatin at the Kcnq1 domain, including Kcnq1, Cdkn1c, Cd81, Ascl2 and Osbpl5 promoters/regions in cis.</td>
+<td>(pandey2008kcnq1ot1antisensenoncoding pages 12-13, pandey2008kcnq1ot1antisensenoncoding pages 6-8, zhang2014longnoncodingrnamediated pages 1-2)</td>
+<td>Strongly supportable as a core chromatin-associated lncRNA function; evidence is mostly from mouse Kcnq1ot1, used here as conserved mechanistic support for human KCNQ1OT1.</td>
+</tr>
+<tr>
+<td>MF</td>
+<td>protein binding</td>
+<td>RIP</td>
+<td>Kcnq1ot1 RNA was recovered with G9a/EHMT2 and PRC2 components EZH2 and SUZ12 in placenta, indicating physical association with chromatin modifiers.</td>
+<td>(pandey2008kcnq1ot1antisensenoncoding pages 12-13, pandey2008kcnq1ot1antisensenoncoding pages 2-4, pandey2008kcnq1ot1antisensenoncoding pages 6-8, pandey2008kcnq1ot1antisensenoncoding pages 8-12)</td>
+<td>Support is direct for association with these proteins/complexes, but whether binding is direct versus bridged by other factors remains unresolved.</td>
+</tr>
+<tr>
+<td>MF</td>
+<td>histone methyltransferase complex binding</td>
+<td>RIP; functional perturbation with mutant/deletion analysis</td>
+<td>Association of Kcnq1ot1 with PRC2 and G9a correlates with Kcnq1ot1-dependent repressive chromatin at silenced loci.</td>
+<td>(pandey2008kcnq1ot1antisensenoncoding pages 12-13, pandey2008kcnq1ot1antisensenoncoding pages 6-8, pandey2008kcnq1ot1antisensenoncoding pages 8-12)</td>
+<td>More specific than generic protein binding, but still safest to phrase as complex association/binding rather than catalytic regulation.</td>
+</tr>
+<tr>
+<td>MF</td>
+<td>cis-regulatory region sequence-specific chromatin tethering/scaffolding</td>
+<td>R3C; ChOP; RNA/DNA FISH</td>
+<td>The 5′ region of Kcnq1ot1 helps organize intrachromosomal looping between KvDMR1 and the Kcnq1 promoter and tether silenced genes within a local RNA-defined nuclear compartment.</td>
+<td>(zhang2014longnoncodingrnamediated pages 1-2, redrup2009thelongnoncoding pages 4-5)</td>
+<td>Mechanistically central, but no exact GO term may currently capture “lncRNA scaffold for cis chromatin looping”; term may need curator judgment.</td>
+</tr>
+<tr>
+<td>BP</td>
+<td>genomic imprinting</td>
+<td>promoter/ICR deletion; transcript truncation; allele-specific expression assays</td>
+<td>Paternal Kcnq1ot1/KCNQ1OT1 expression is required for parent-of-origin-specific silencing of multiple genes in the Kcnq1 domain, while maternal methylation at the ICR suppresses its expression.</td>
+<td>(landschoot2014regulationofthea pages 43-49, redrup2009thelongnoncoding pages 1-2, pandey2008kcnq1ot1antisensenoncoding pages 6-8, autuoro2014longnoncodingrnas pages 6-9, landschoot2014regulationofthe pages 38-43)</td>
+<td>This is the clearest core biological process for GO annotation.</td>
+</tr>
+<tr>
+<td>BP</td>
+<td>gene silencing by RNA</td>
+<td>truncation mutants; ChOP; RIP; RNA/DNA FISH</td>
+<td>Full-length Kcnq1ot1 mediates cis repression of nearby and more distant imprinted genes, with loss of silencing after truncation or promoter deletion.</td>
+<td>(pandey2008kcnq1ot1antisensenoncoding pages 12-13, redrup2009thelongnoncoding pages 1-2, pandey2008kcnq1ot1antisensenoncoding pages 6-8, autuoro2014longnoncodingrnas pages 6-9)</td>
+<td>Strong evidence for RNA-mediated silencing in cis; some reviews note ongoing debate over RNA product versus transcriptional interference for subsets of genes, but primary data still support RNA-dependent silencing at multiple targets.</td>
+</tr>
+<tr>
+<td>BP</td>
+<td>negative regulation of transcription by RNA polymerase II in cis</td>
+<td>allele-specific expression assays; truncation mutants; chromatin conformation studies</td>
+<td>Kcnq1ot1 represses transcription of genes across the paternal Kcnq1 domain, although for some targets/tissues the act of transcription may contribute in addition to the RNA product itself.</td>
+<td>(landschoot2014regulationofthea pages 43-49, landschoot2014regulationofthe pages 43-49, korostowski2012thekcnq1ot1long pages 1-2)</td>
+<td>Use cautiously: supported as a domain-level regulatory outcome, but gene- and tissue-specific exceptions exist (e.g., Kcnq1 in developing heart).</td>
+</tr>
+<tr>
+<td>BP</td>
+<td>chromatin organization</td>
+<td>RNA/DNA FISH; R3C; chromosome conformation studies</td>
+<td>Kcnq1ot1 organizes a lineage-specific nuclear domain and promotes long-range intrachromosomal interactions associated with imprint maintenance.</td>
+<td>(redrup2009thelongnoncoding pages 1-2, redrup2009thelongnoncoding pages 4-5, zhang2014longnoncodingrnamediated pages 1-2, korostowski2012thekcnq1ot1long pages 1-2)</td>
+<td>Strongly supportable as a core process linked to imprinting; avoid overextending to general genome-wide chromatin architecture.</td>
+</tr>
+<tr>
+<td>BP</td>
+<td>establishment of repressive chromatin</td>
+<td>ChIP-on-chip; ChIP-qPCR; mutant/deletion analysis</td>
+<td>Kcnq1ot1-dependent silencing correlates with H3K27me3 and H3K9me3/H3K9me2 enrichment over the paternal domain and loss of these marks after Kcnq1ot1 perturbation at many loci.</td>
+<td>(pandey2008kcnq1ot1antisensenoncoding pages 6-8, pandey2008kcnq1ot1antisensenoncoding pages 12-13, redrup2009thelongnoncoding pages 1-2)</td>
+<td>Well supported for chromatin-level repression; mark dependence can vary by locus and lineage.</td>
+</tr>
+<tr>
+<td>BP</td>
+<td>regulation of histone H3-K27 methylation</td>
+<td>ChIP-on-chip; ChIP-qPCR; EZH2/PRC2 association assays</td>
+<td>Kcnq1ot1 associates with PRC2 and is required for H3K27me3 enrichment across substantial parts of the imprinted domain.</td>
+<td>(pandey2008kcnq1ot1antisensenoncoding pages 12-13, pandey2008kcnq1ot1antisensenoncoding pages 6-8, zhang2014longnoncodingrnamediated pages 1-2)</td>
+<td>Supported more directly than H2AK119ub/PRC1 in the provided primary evidence.</td>
+</tr>
+<tr>
+<td>BP</td>
+<td>regulation of histone H3-K9 methylation</td>
+<td>RIP; ChIP profiling; genetic perturbation</td>
+<td>Kcnq1ot1 associates with G9a/EHMT2 and silencing correlates with H3K9 methylation in the domain, particularly in placenta.</td>
+<td>(pandey2008kcnq1ot1antisensenoncoding pages 2-4, pandey2008kcnq1ot1antisensenoncoding pages 6-8, redrup2009thelongnoncoding pages 1-2)</td>
+<td>Supported, though direct Kcnq1ot1 dependence is strongest for some lineages/loci rather than universally across the domain.</td>
+</tr>
+<tr>
+<td>CC</td>
+<td>nucleus</td>
+<td>nuclear/cytoplasmic fractionation; RNA-FISH</td>
+<td>Kcnq1ot1/KCNQ1OT1 is predominantly or exclusively nuclear.</td>
+<td>(pandey2008kcnq1ot1antisensenoncoding pages 2-4, redrup2009thelongnoncoding pages 1-2, redrup2009thelongnoncoding pages 2-3)</td>
+<td>Very strong and directly observed; appropriate core cellular component annotation.</td>
+</tr>
+<tr>
+<td>CC</td>
+<td>chromatin</td>
+<td>ChOP; chromatin-associated RNA IP; R3C</td>
+<td>Kcnq1ot1 is retained on/with chromatin at the Kcnq1 locus and associated target regions.</td>
+<td>(pandey2008kcnq1ot1antisensenoncoding pages 12-13, pandey2008kcnq1ot1antisensenoncoding pages 6-8, zhang2014longnoncodingrnamediated pages 1-2)</td>
+<td>Best supported subcellular localization beyond generic nucleus.</td>
+</tr>
+<tr>
+<td>CC</td>
+<td>nuclear chromosome</td>
+<td>RNA/DNA FISH</td>
+<td>Silenced loci within the Kcnq1 imprinted domain frequently localize within the Kcnq1ot1 RNA-coated chromosomal territory.</td>
+<td>(redrup2009thelongnoncoding pages 1-2, redrup2009thelongnoncoding pages 4-5)</td>
+<td>Suitable if curators prefer chromosome-associated localization over broader chromatin term.</td>
+</tr>
+<tr>
+<td>CC</td>
+<td>nucleolar periphery / perinucleolar region</td>
+<td>immuno-DNA FISH; RNA/DNA FISH</td>
+<td>The paternal Kcnq1/Kcnq1ot1 domain frequently localizes at the nucleolar periphery, especially in trophoblast/placental contexts, in a Kcnq1ot1-dependent manner.</td>
+<td>(pandey2008kcnq1ot1antisensenoncoding pages 12-13, fedoriw2012differentiationdrivennucleolarassociation pages 1-2, fedoriw2012differentiationdrivennucleolarassociation pages 2-3, fedoriw2012differentiationdrivennucleolarassociation pages 3-4)</td>
+<td>Useful as a context-supported localization term, but likely lineage-specific rather than universal; annotate cautiously.</td>
+</tr>
+<tr>
+<td>CC</td>
+<td>nuclear periphery</td>
+<td>3D RNA/DNA FISH in XEN/extraembryonic cells</td>
+<td>Kcnq1ot1 domain displacement from the nuclear periphery after nucleoporin depletion indicates peripheral localization contributes to extraembryonic domain regulation.</td>
+<td>(fedoriw2012differentiationdrivennucleolarassociation pages 1-2)</td>
+<td>More context-specific and indirect than nucleus/chromatin; best treated as conditional localization, not the primary CC term.</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table maps KCNQ1OT1/Kcnq1ot1 to Gene Ontology-relevant molecular functions, biological processes, and cellular components using only directly supportable primary evidence from the provided context IDs. It separates core imprinting/chromatin-regulatory roles from more conditional localization or context-specific interpretations.</em></p>
+<hr />
+<h2 id="5-relevant-statistics-and-data-from-primary-studies">5) Relevant statistics and data (from primary studies)</h2>
+<h3 id="51-nuclear-domain-size-and-lineage-specificity-redrup-et-al-2009">5.1 Nuclear-domain size and lineage specificity (Redrup et al., 2009)</h3>
+<ul>
+<li>Silenced genomic span: ~<strong>400 kb</strong> in embryo vs ~<strong>780 kb</strong> in placenta. (redrup2009thelongnoncoding pages 4-5)</li>
+<li>RNA-FISH 3D volume distributions: Kcnq1ot1 signals were frequently large (e.g., <strong>34.4%</strong> &gt;0.4 μm³), similar to Xist at that threshold (35.7%), while typical mRNA (Kcnq1) rarely exceeded that size (5.6%). (redrup2009thelongnoncoding pages 4-5)</li>
+<li>Kcnq1ot1 RNA volumes were significantly larger in placenta than embryo (<strong>P&lt;0.0001</strong>, χ2), consistent with a larger silencing domain in extra-embryonic tissue. (redrup2009thelongnoncoding pages 4-5)<br />
+A representative figure panel showing the RNA-FISH nuclear domain and the quantitative placenta-versus-embryo comparison is available. (redrup2009thelongnoncoding media 5a86e8a0)</li>
+</ul>
+<h3 id="52-nucleolar-association-during-differentiation-fedoriw-et-al-2012">5.2 Nucleolar association during differentiation (Fedoriw et al., 2012)</h3>
+<ul>
+<li>RNA/DNA FISH sampling: day 0 <strong>n=120</strong> and day 2 <strong>n=136</strong>; undifferentiated CDX2+ <strong>n=175</strong>; differentiated CDX2− <strong>n=67</strong>. (fedoriw2012differentiationdrivennucleolarassociation pages 2-3)</li>
+<li>Increased perinucleolar association after 2 days differentiation with strong significance (<strong>P&lt;0.0001</strong>). (fedoriw2012differentiationdrivennucleolarassociation pages 3-4)</li>
+</ul>
+<h3 id="53-rna-length-and-stability-pandey-et-al-2008">5.3 RNA length and stability (Pandey et al., 2008)</h3>
+<ul>
+<li>Transcript length mapping supports a very long transcript with 3′ end ~<strong>91.5 kb</strong> from TSS. (pandey2008kcnq1ot1antisensenoncoding pages 2-4)</li>
+<li>RNA half-life in MEFs ~<strong>3.5 h</strong>. (pandey2008kcnq1ot1antisensenoncoding pages 2-4)</li>
+</ul>
+<hr />
+<h2 id="6-current-applications-and-real-world-implementations-mechanism-linked">6) Current applications and real-world implementations (mechanism-linked)</h2>
+<h3 id="61-imprinting-control-region-ic2kvdmr1-as-a-diagnosticinterpretive-target">6.1 Imprinting control region (IC2/KvDMR1) as a diagnostic/interpretive target</h3>
+<p>In human genetics, the IC2 region that includes the KCNQ1OT1 promoter is a locus where methylation or cis sequence changes can underlie imprinting disturbances; current clinical implementation is largely in <strong>methylation/variant testing and interpretation</strong> for imprinting disorders rather than direct therapeutic manipulation of KCNQ1OT1. (eggermann2024humanreproductionand pages 5-7)</p>
+<h3 id="62-experimental-systems-for-imprinting-modulation-preclinical-tools">6.2 Experimental systems for imprinting modulation (preclinical tools)</h3>
+<p>Mechanism-focused experimental studies use genetic and epigenetic perturbations (e.g., truncations, promoter deletions, targeted suppression) to probe imprint maintenance and chromatin folding controlled by Kcnq1ot1. These approaches operationalize Kcnq1ot1 as a tractable model for <strong>lncRNA-mediated chromatin repression</strong> and allele-specific regulation. (zhang2014longnoncodingrnamediated pages 1-2, pandey2008kcnq1ot1antisensenoncoding pages 6-8)</p>
+<hr />
+<h2 id="7-expert-opinion-and-analysis-authoritative-sources">7) Expert opinion and analysis (authoritative sources)</h2>
+<p>Across 2023–2024 reviews, Kcnq1ot1/KCNQ1OT1 is consistently treated as a canonical example of an imprinted lncRNA that (i) is nuclear/chromatin-associated, (ii) mediates long-range cis repression, and (iii) is linked to Polycomb/G9a-associated chromatin repression, while maintaining that the field still has active uncertainty about the balance between RNA-product versus transcriptional mechanisms and the identity of lineage-specific cofactors. (michele2023imprintedlongnoncoding pages 10-11, ferrer2024transcriptionregulationby pages 11-13, moindrot2024differential3dgenome pages 7-9)</p>
+<hr />
+<h2 id="8-core-function-vs-downstream-phenotypes-curation-guidance">8) Core function vs downstream phenotypes (curation guidance)</h2>
+<h3 id="core-molecular-role-appropriate-for-go-functional-annotation">Core molecular role (appropriate for GO functional annotation)</h3>
+<ul>
+<li><strong>Genomic imprinting / parent-of-origin-dependent cis repression</strong> at the KCNQ1 domain, mediated by nuclear/chromatin-localized lncRNA accumulation, promoter contacts, and chromatin-modifier association with repressive chromatin features. (pandey2008kcnq1ot1antisensenoncoding pages 6-8, redrup2009thelongnoncoding pages 4-5)</li>
+</ul>
+<h3 id="context-specific-downstream-phenotypes-should-not-be-used-as-core-go-function">Context-specific downstream phenotypes (should not be used as core GO function)</h3>
+<p>Many publications (not emphasized here) link KCNQ1OT1 expression changes to diverse diseases (e.g., cancers, metabolic and cardiovascular phenotypes). These associations are generally downstream and context-dependent and should not be conflated with the locus’s core imprinting/chromatin role unless direct mechanistic evidence connects KCNQ1OT1 activity to the phenotype in a causally supported chain.</p>
+<hr />
+<h2 id="key-primary-references-urls-and-publication-dates">Key primary references (URLs and publication dates)</h2>
+<ul>
+<li>Pandey RR et al. <strong>Molecular Cell</strong> (2008-10). https://doi.org/10.1016/j.molcel.2008.08.022 (pandey2008kcnq1ot1antisensenoncoding pages 6-8, pandey2008kcnq1ot1antisensenoncoding pages 2-4)</li>
+<li>Redrup L et al. <strong>Development</strong> (2009-02). https://doi.org/10.1242/dev.031328 (redrup2009thelongnoncoding pages 4-5, redrup2009thelongnoncoding media 5a86e8a0)</li>
+<li>Fedoriw AM et al. <strong>G3 (Genes|Genomes|Genetics)</strong> (2012-12). https://doi.org/10.1534/g3.112.004226 (fedoriw2012differentiationdrivennucleolarassociation pages 3-4, fedoriw2012differentiationdrivennucleolarassociation pages 2-3)</li>
+<li>Zhang H et al. <strong>Journal of Cell Biology</strong> (2014-01). https://doi.org/10.1083/jcb.201304152 (zhang2014longnoncodingrnamediated pages 1-2)</li>
+</ul>
+<h2 id="key-20232024-reviews-urls-and-publication-dates">Key 2023–2024 reviews (URLs and publication dates)</h2>
+<ul>
+<li>Di Michele F et al. <strong>Int. J. Mol. Sci.</strong> (2023-09). https://doi.org/10.3390/ijms241713647 (michele2023imprintedlongnoncoding pages 10-11, michele2023imprintedlongnoncoding pages 11-13)</li>
+<li>Ferrer J, Dimitrova N. <strong>Nat Rev Mol Cell Biol</strong> (2024-01). https://doi.org/10.1038/s41580-023-00694-9 (ferrer2024transcriptionregulationby pages 11-13, ferrer2024transcriptionregulationby pages 27-28)</li>
+<li>Moindrot B et al. <strong>Biochem Soc Trans</strong> (2024-05). https://doi.org/10.1042/bst20230143 (moindrot2024differential3dgenome pages 1-2, moindrot2024differential3dgenome pages 7-9)</li>
+<li>Eggermann T. <strong>Genes</strong> (2024-01). https://doi.org/10.3390/genes15020163 (eggermann2024humanreproductionand pages 5-7, eggermann2024humanreproductionanda pages 7-8)</li>
+</ul>
+<p>References</p>
+<ol>
+<li>
+<p>(pandey2008kcnq1ot1antisensenoncoding pages 6-8): Radha Raman Pandey, Tanmoy Mondal, Faizaan Mohammad, Stefan Enroth, Lisa Redrup, Jan Komorowski, Takashi Nagano, Debora Mancini-DiNardo, and Chandrasekhar Kanduri. Kcnq1ot1 antisense noncoding rna mediates lineage-specific transcriptional silencing through chromatin-level regulation. Molecular cell, 32 2:232-46, Oct 2008. URL: https://doi.org/10.1016/j.molcel.2008.08.022, doi:10.1016/j.molcel.2008.08.022. This article has 1463 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(autuoro2014longnoncodingrnas pages 6-9): Joseph M. Autuoro, Stephan P. Pirnie, and G. Carmichael. Long noncoding rnas in imprinting and x chromosome inactivation. Biomolecules, 4:76-100, Jan 2014. URL: https://doi.org/10.3390/biom4010076, doi:10.3390/biom4010076. This article has 87 citations.</p>
+</li>
+<li>
+<p>(landschoot2014regulationofthe pages 38-43): LSM Landschoot. Regulation of the kcnq1ot1 imprinting domain in mouse. Unknown journal, 2014.</p>
+</li>
+<li>
+<p>(redrup2009thelongnoncoding pages 1-2): Lisa Redrup, Miguel R. Branco, Elizabeth R. Perdeaux, Christel Krueger, Annabelle Lewis, Fátima Santos, Takashi Nagano, Bradley S. Cobb, Peter Fraser, and Wolf Reik. The long noncoding rna kcnq1ot1 organises a lineage-specific nuclear domain for epigenetic gene silencing. Development, 136:525-530, Feb 2009. URL: https://doi.org/10.1242/dev.031328, doi:10.1242/dev.031328. This article has 256 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(michele2023imprintedlongnoncoding pages 10-11): Flavio Di Michele, Isabel Chillón, and Robert Feil. Imprinted long non-coding rnas in mammalian development and disease. International Journal of Molecular Sciences, 24:13647, Sep 2023. URL: https://doi.org/10.3390/ijms241713647, doi:10.3390/ijms241713647. This article has 16 citations.</p>
+</li>
+<li>
+<p>(korostowski2012thekcnq1ot1long pages 1-2): Lisa Korostowski, Natalie Sedlak, and Nora Engel. The kcnq1ot1 long non-coding rna affects chromatin conformation and expression of kcnq1, but does not regulate its imprinting in the developing heart. PLoS Genetics, 8:e1002956, Sep 2012. URL: https://doi.org/10.1371/journal.pgen.1002956, doi:10.1371/journal.pgen.1002956. This article has 182 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ferrer2024transcriptionregulationby pages 11-13): Jorge Ferrer and Nadya Dimitrova. Transcription regulation by long non-coding rnas: mechanisms and disease relevance. Nature Reviews Molecular Cell Biology, 25:396-415, Jan 2024. URL: https://doi.org/10.1038/s41580-023-00694-9, doi:10.1038/s41580-023-00694-9. This article has 323 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(moindrot2024differential3dgenome pages 7-9): Benoit Moindrot, Yui Imaizumi, and Robert Feil. Differential 3d genome architecture and imprinted gene expression: cause or consequence? Biochemical Society Transactions, 52:973-986, May 2024. URL: https://doi.org/10.1042/bst20230143, doi:10.1042/bst20230143. This article has 9 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(pandey2008kcnq1ot1antisensenoncoding pages 2-4): Radha Raman Pandey, Tanmoy Mondal, Faizaan Mohammad, Stefan Enroth, Lisa Redrup, Jan Komorowski, Takashi Nagano, Debora Mancini-DiNardo, and Chandrasekhar Kanduri. Kcnq1ot1 antisense noncoding rna mediates lineage-specific transcriptional silencing through chromatin-level regulation. Molecular cell, 32 2:232-46, Oct 2008. URL: https://doi.org/10.1016/j.molcel.2008.08.022, doi:10.1016/j.molcel.2008.08.022. This article has 1463 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(redrup2009thelongnoncoding pages 2-3): Lisa Redrup, Miguel R. Branco, Elizabeth R. Perdeaux, Christel Krueger, Annabelle Lewis, Fátima Santos, Takashi Nagano, Bradley S. Cobb, Peter Fraser, and Wolf Reik. The long noncoding rna kcnq1ot1 organises a lineage-specific nuclear domain for epigenetic gene silencing. Development, 136:525-530, Feb 2009. URL: https://doi.org/10.1242/dev.031328, doi:10.1242/dev.031328. This article has 256 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(redrup2009thelongnoncoding pages 4-5): Lisa Redrup, Miguel R. Branco, Elizabeth R. Perdeaux, Christel Krueger, Annabelle Lewis, Fátima Santos, Takashi Nagano, Bradley S. Cobb, Peter Fraser, and Wolf Reik. The long noncoding rna kcnq1ot1 organises a lineage-specific nuclear domain for epigenetic gene silencing. Development, 136:525-530, Feb 2009. URL: https://doi.org/10.1242/dev.031328, doi:10.1242/dev.031328. This article has 256 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(redrup2009thelongnoncoding media 5a86e8a0): Lisa Redrup, Miguel R. Branco, Elizabeth R. Perdeaux, Christel Krueger, Annabelle Lewis, Fátima Santos, Takashi Nagano, Bradley S. Cobb, Peter Fraser, and Wolf Reik. The long noncoding rna kcnq1ot1 organises a lineage-specific nuclear domain for epigenetic gene silencing. Development, 136:525-530, Feb 2009. URL: https://doi.org/10.1242/dev.031328, doi:10.1242/dev.031328. This article has 256 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(fedoriw2012differentiationdrivennucleolarassociation pages 3-4): Andrew M Fedoriw, J Mauro Calabrese, Weipeng Mu, Della Yee, and Terry Magnuson. Differentiation-driven nucleolar association of the mouse imprinted kcnq1 locus. G3: Genes|Genomes|Genetics, 2:1521-1528, Dec 2012. URL: https://doi.org/10.1534/g3.112.004226, doi:10.1534/g3.112.004226. This article has 29 citations.</p>
+</li>
+<li>
+<p>(fedoriw2012differentiationdrivennucleolarassociation pages 2-3): Andrew M Fedoriw, J Mauro Calabrese, Weipeng Mu, Della Yee, and Terry Magnuson. Differentiation-driven nucleolar association of the mouse imprinted kcnq1 locus. G3: Genes|Genomes|Genetics, 2:1521-1528, Dec 2012. URL: https://doi.org/10.1534/g3.112.004226, doi:10.1534/g3.112.004226. This article has 29 citations.</p>
+</li>
+<li>
+<p>(pandey2008kcnq1ot1antisensenoncoding pages 12-13): Radha Raman Pandey, Tanmoy Mondal, Faizaan Mohammad, Stefan Enroth, Lisa Redrup, Jan Komorowski, Takashi Nagano, Debora Mancini-DiNardo, and Chandrasekhar Kanduri. Kcnq1ot1 antisense noncoding rna mediates lineage-specific transcriptional silencing through chromatin-level regulation. Molecular cell, 32 2:232-46, Oct 2008. URL: https://doi.org/10.1016/j.molcel.2008.08.022, doi:10.1016/j.molcel.2008.08.022. This article has 1463 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(zhang2014longnoncodingrnamediated pages 1-2): He Zhang, Michael J. Zeitz, Hong Wang, Beibei Niu, Shengfang Ge, Wei Li, Jiuwei Cui, Guanjun Wang, Guanxiang Qian, Michael J. Higgins, Xianqun Fan, Andrew R. Hoffman, and Ji-Fan Hu. Long noncoding rna-mediated intrachromosomal interactions promote imprinting at the kcnq1 locus. The Journal of Cell Biology, 204:61-75, Jan 2014. URL: https://doi.org/10.1083/jcb.201304152, doi:10.1083/jcb.201304152. This article has 152 citations.</p>
+</li>
+<li>
+<p>(feil2016noncodingrnasand pages 11-14): Robert Feil. Noncoding rnas and chromatin modifications in the developmental control of imprinted genes. ArXiv, pages 19-40, Mar 2016. URL: https://doi.org/10.1007/978-3-319-27186-6_2, doi:10.1007/978-3-319-27186-6_2. This article has 1 citations.</p>
+</li>
+<li>
+<p>(michele2023imprintedlongnoncoding pages 11-13): Flavio Di Michele, Isabel Chillón, and Robert Feil. Imprinted long non-coding rnas in mammalian development and disease. International Journal of Molecular Sciences, 24:13647, Sep 2023. URL: https://doi.org/10.3390/ijms241713647, doi:10.3390/ijms241713647. This article has 16 citations.</p>
+</li>
+<li>
+<p>(ferrer2024transcriptionregulationby pages 27-28): Jorge Ferrer and Nadya Dimitrova. Transcription regulation by long non-coding rnas: mechanisms and disease relevance. Nature Reviews Molecular Cell Biology, 25:396-415, Jan 2024. URL: https://doi.org/10.1038/s41580-023-00694-9, doi:10.1038/s41580-023-00694-9. This article has 323 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(moindrot2024differential3dgenome pages 1-2): Benoit Moindrot, Yui Imaizumi, and Robert Feil. Differential 3d genome architecture and imprinted gene expression: cause or consequence? Biochemical Society Transactions, 52:973-986, May 2024. URL: https://doi.org/10.1042/bst20230143, doi:10.1042/bst20230143. This article has 9 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(eggermann2024humanreproductionand pages 5-7): Thomas Eggermann. Human reproduction and disturbed genomic imprinting. Genes, 15:163, Jan 2024. URL: https://doi.org/10.3390/genes15020163, doi:10.3390/genes15020163. This article has 15 citations.</p>
+</li>
+<li>
+<p>(eggermann2024humanreproductionanda pages 7-8): T Eggermann. Human reproduction and disturbed genomic imprinting. genes 2024, 15, 163. Unknown journal, 2024.</p>
+</li>
+<li>
+<p>(pandey2008kcnq1ot1antisensenoncoding pages 8-12): Radha Raman Pandey, Tanmoy Mondal, Faizaan Mohammad, Stefan Enroth, Lisa Redrup, Jan Komorowski, Takashi Nagano, Debora Mancini-DiNardo, and Chandrasekhar Kanduri. Kcnq1ot1 antisense noncoding rna mediates lineage-specific transcriptional silencing through chromatin-level regulation. Molecular cell, 32 2:232-46, Oct 2008. URL: https://doi.org/10.1016/j.molcel.2008.08.022, doi:10.1016/j.molcel.2008.08.022. This article has 1463 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(landschoot2014regulationofthea pages 43-49): LSM Landschoot. Regulation of the kcnq1ot1 imprinting domain in mouse. Unknown journal, 2014.</p>
+</li>
+<li>
+<p>(landschoot2014regulationofthe pages 43-49): LSM Landschoot. Regulation of the kcnq1ot1 imprinting domain in mouse. Unknown journal, 2014.</p>
+</li>
+<li>
+<p>(fedoriw2012differentiationdrivennucleolarassociation pages 1-2): Andrew M Fedoriw, J Mauro Calabrese, Weipeng Mu, Della Yee, and Terry Magnuson. Differentiation-driven nucleolar association of the mouse imprinted kcnq1 locus. G3: Genes|Genomes|Genetics, 2:1521-1528, Dec 2012. URL: https://doi.org/10.1534/g3.112.004226, doi:10.1534/g3.112.004226. This article has 29 citations.</p>
+</li>
+</ol>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>zhang2014longnoncodingrnamediated pages 1-2</li>
+<li>fedoriw2012differentiationdrivennucleolarassociation pages 1-2</li>
+<li>redrup2009thelongnoncoding pages 4-5</li>
+<li>fedoriw2012differentiationdrivennucleolarassociation pages 2-3</li>
+<li>fedoriw2012differentiationdrivennucleolarassociation pages 3-4</li>
+<li>eggermann2024humanreproductionand pages 5-7</li>
+<li>autuoro2014longnoncodingrnas pages 6-9</li>
+<li>landschoot2014regulationofthe pages 38-43</li>
+<li>redrup2009thelongnoncoding pages 1-2</li>
+<li>michele2023imprintedlongnoncoding pages 10-11</li>
+<li>ferrer2024transcriptionregulationby pages 11-13</li>
+<li>redrup2009thelongnoncoding pages 2-3</li>
+<li>feil2016noncodingrnasand pages 11-14</li>
+<li>michele2023imprintedlongnoncoding pages 11-13</li>
+<li>ferrer2024transcriptionregulationby pages 27-28</li>
+<li>eggermann2024humanreproductionanda pages 7-8</li>
+<li>landschoot2014regulationofthea pages 43-49</li>
+<li>landschoot2014regulationofthe pages 43-49</li>
+<li>https://doi.org/10.3390/ijms241713647</li>
+<li>https://doi.org/10.1038/s41580-023-00694-9</li>
+<li>https://doi.org/10.1042/bst20230143</li>
+<li>https://doi.org/10.3390/genes15020163</li>
+<li>https://doi.org/10.1016/j.molcel.2008.08.022</li>
+<li>https://doi.org/10.1242/dev.031328</li>
+<li>https://doi.org/10.1534/g3.112.004226</li>
+<li>https://doi.org/10.1083/jcb.201304152</li>
+<li>https://doi.org/10.1016/j.molcel.2008.08.022,</li>
+<li>https://doi.org/10.3390/biom4010076,</li>
+<li>https://doi.org/10.1242/dev.031328,</li>
+<li>https://doi.org/10.3390/ijms241713647,</li>
+<li>https://doi.org/10.1371/journal.pgen.1002956,</li>
+<li>https://doi.org/10.1038/s41580-023-00694-9,</li>
+<li>https://doi.org/10.1042/bst20230143,</li>
+<li>https://doi.org/10.1534/g3.112.004226,</li>
+<li>https://doi.org/10.1083/jcb.201304152,</li>
+<li>https://doi.org/10.1007/978-3-319-27186-6_2,</li>
+<li>https://doi.org/10.3390/genes15020163,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -2293,26 +2740,38 @@ product_type: OTHER_NCRNA
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
-description: KCNQ1OT1 is a 91kb paternally-expressed imprinted long non-coding 
-  RNA that regulates genomic imprinting at the KCNQ1 locus on chromosome 
-  11p15.5. It silences genes in the KCNQ1 imprinted domain by recruiting 
+description: KCNQ1OT1 is a 91kb paternally-expressed imprinted long non-coding
+  RNA that regulates genomic imprinting at the KCNQ1 locus on chromosome
+  11p15.5. It silences genes in the KCNQ1 imprinted domain by recruiting
   Polycomb Repressive Complex 2 (PRC2) and establishing heterochromatin. Loss of
   imprinting leads to Beckwith-Wiedemann syndrome.
 references:
+- id: file:human/KCNQ1OT1/KCNQ1OT1-deep-research-falcon.md
+  title: Falcon deep research report for KCNQ1OT1
+  findings:
+  - statement: &gt;-
+      Falcon supports KCNQ1OT1&#39;s core role as a cis-acting imprinted lncRNA
+      that associates with the KCNQ1/KCNQ1OT1 domain and promotes local
+      repressive chromatin, while treating miRNA-sponge disease models as
+      non-core context-specific evidence.
+    supporting_text: &gt;-
+      This report focuses on primary molecular roles of KCNQ1OT1 as a long
+      non-coding RNA involved in genomic imprinting and chromatin regulation at
+      the KCNQ1/KCNQ1OT1 imprinted domain.
 - id: GO_REF:0000115
-  title: Automatic Gene Ontology annotation of non-coding RNA sequences through 
+  title: Automatic Gene Ontology annotation of non-coding RNA sequences through
     association of Rfam records with GO terms
   findings: []
 - id: PMID:30241939
-  title: YY1-induced upregulation of lncRNA KCNQ1OT1 regulates angiotensin 
+  title: YY1-induced upregulation of lncRNA KCNQ1OT1 regulates angiotensin
     II-induced atrial fibrillation by modulating miR-384b/CACNA1C axis.
   findings: []
 - id: PMID:30703347
-  title: LncRNA KCNQ1OT1 promoted BMP2 expression to regulate osteogenic 
+  title: LncRNA KCNQ1OT1 promoted BMP2 expression to regulate osteogenic
     differentiation by sponging miRNA-214.
   findings: []
 - id: PMID:32271402
-  title: KCNQ1OT1 regulates osteogenic differentiation of hBMSC by 
+  title: KCNQ1OT1 regulates osteogenic differentiation of hBMSC by
     miR-320a/Smad5 axis.
   findings: []
 existing_annotations:
@@ -2323,10 +2782,15 @@ existing_annotations:
   original_reference_id: GO_REF:0000115
   review:
     summary: This is the core function of KCNQ1OT1 - it mediates heterochromatin
-      formation at the KCNQ1 imprinted locus by recruiting Polycomb Repressive 
-      Complex 2 (PRC2) to silence genes in the imprinted domain. This is 
+      formation at the KCNQ1 imprinted locus by recruiting Polycomb Repressive
+      Complex 2 (PRC2) to silence genes in the imprinted domain. This is
       consistent with its role in genomic imprinting.
     action: ACCEPT
+    supported_by:
+    - reference_id: file:human/KCNQ1OT1/KCNQ1OT1-deep-research-falcon.md
+      supporting_text: &gt;-
+        At the KCNQ1/KCNQ1OT1 domain, imprinting yields monoallelic expression
+        of a cluster of genes, controlled by a differentially methylated region.
 - term:
     id: GO:0000512
     label: lncRNA-mediated post-transcriptional gene silencing
@@ -2334,8 +2798,8 @@ existing_annotations:
   original_reference_id: PMID:32271402
   review:
     summary: This annotation is based on KCNQ1OT1 acting as a ceRNA/miRNA sponge
-      in an osteogenic differentiation study using hBMSCs. While the miRNA 
-      sponging activity may be real, this represents an over-annotation of 
+      in an osteogenic differentiation study using hBMSCs. While the miRNA
+      sponging activity may be real, this represents an over-annotation of
       KCNQ1OT1 beyond its core genomic imprinting function.
     action: MARK_AS_OVER_ANNOTATED
     supported_by:
@@ -2349,7 +2813,7 @@ existing_annotations:
   original_reference_id: PMID:32271402
   review:
     summary: Based on in vitro osteogenic differentiation study. This is not the
-      core function of KCNQ1OT1 which is genomic imprinting at the KCNQ1 locus. 
+      core function of KCNQ1OT1 which is genomic imprinting at the KCNQ1 locus.
       This represents a non-physiological over-annotation.
     action: MARK_AS_OVER_ANNOTATED
     supported_by:
@@ -2362,8 +2826,8 @@ existing_annotations:
   evidence_type: IDA
   original_reference_id: PMID:32271402
   review:
-    summary: Based on KCNQ1OT1 sponging miR-320a in osteogenic differentiation 
-      model. This is an over-annotation beyond the core genomic imprinting 
+    summary: Based on KCNQ1OT1 sponging miR-320a in osteogenic differentiation
+      model. This is an over-annotation beyond the core genomic imprinting
       function.
     action: MARK_AS_OVER_ANNOTATED
     supported_by:
@@ -2376,7 +2840,7 @@ existing_annotations:
   evidence_type: IDA
   original_reference_id: PMID:32271402
   review:
-    summary: Based on miRNA sponging activity in osteogenic model. 
+    summary: Based on miRNA sponging activity in osteogenic model.
       Over-annotation of KCNQ1OT1&#39;s core function.
     action: MARK_AS_OVER_ANNOTATED
     supported_by:
@@ -2389,12 +2853,12 @@ existing_annotations:
   evidence_type: IMP
   original_reference_id: PMID:30703347
   review:
-    summary: Based on osteogenic differentiation study. This is an 
+    summary: Based on osteogenic differentiation study. This is an
       over-annotation unrelated to KCNQ1OT1&#39;s core imprinting function.
     action: MARK_AS_OVER_ANNOTATED
     supported_by:
     - reference_id: PMID:30703347
-      supporting_text: 2019 Jan 28. LncRNA KCNQ1OT1 promoted BMP2 expression to 
+      supporting_text: 2019 Jan 28. LncRNA KCNQ1OT1 promoted BMP2 expression to
         regulate osteogenic differentiation by sponging miRNA-214.
 - term:
     id: GO:0140869
@@ -2402,14 +2866,14 @@ existing_annotations:
   evidence_type: IDA
   original_reference_id: PMID:30241939
   review:
-    summary: Based on atrial fibrillation study showing KCNQ1OT1 sponging 
-      miR-384b. This is an over-annotation beyond the core genomic imprinting 
+    summary: Based on atrial fibrillation study showing KCNQ1OT1 sponging
+      miR-384b. This is an over-annotation beyond the core genomic imprinting
       function.
     action: MARK_AS_OVER_ANNOTATED
     supported_by:
     - reference_id: PMID:30241939
-      supporting_text: YY1-induced upregulation of lncRNA KCNQ1OT1 regulates 
-        angiotensin II-induced atrial fibrillation by modulating 
+      supporting_text: YY1-induced upregulation of lncRNA KCNQ1OT1 regulates
+        angiotensin II-induced atrial fibrillation by modulating
         miR-384b/CACNA1C axis.
 - term:
     id: GO:0000512
@@ -2417,12 +2881,12 @@ existing_annotations:
   evidence_type: IMP
   original_reference_id: PMID:30703347
   review:
-    summary: Based on ceRNA/miRNA sponging in osteogenic model. Over-annotation 
+    summary: Based on ceRNA/miRNA sponging in osteogenic model. Over-annotation
       of core function.
     action: MARK_AS_OVER_ANNOTATED
     supported_by:
     - reference_id: PMID:30703347
-      supporting_text: 2019 Jan 28. LncRNA KCNQ1OT1 promoted BMP2 expression to 
+      supporting_text: 2019 Jan 28. LncRNA KCNQ1OT1 promoted BMP2 expression to
         regulate osteogenic differentiation by sponging miRNA-214.
 - term:
     id: GO:0001649
@@ -2430,12 +2894,12 @@ existing_annotations:
   evidence_type: IMP
   original_reference_id: PMID:30703347
   review:
-    summary: Based on in vitro osteogenic model. Over-annotation unrelated to 
+    summary: Based on in vitro osteogenic model. Over-annotation unrelated to
       core genomic imprinting function.
     action: MARK_AS_OVER_ANNOTATED
     supported_by:
     - reference_id: PMID:30703347
-      supporting_text: 2019 Jan 28. LncRNA KCNQ1OT1 promoted BMP2 expression to 
+      supporting_text: 2019 Jan 28. LncRNA KCNQ1OT1 promoted BMP2 expression to
         regulate osteogenic differentiation by sponging miRNA-214.
 - term:
     id: GO:0010628
@@ -2443,13 +2907,13 @@ existing_annotations:
   evidence_type: IMP
   original_reference_id: PMID:30703347
   review:
-    summary: While KCNQ1OT1 does regulate gene expression through imprinting, 
+    summary: While KCNQ1OT1 does regulate gene expression through imprinting,
       this annotation is from an osteogenic study focused on BMP2 regulation via
       miRNA sponging, not the core imprinting mechanism.
     action: MARK_AS_OVER_ANNOTATED
     supported_by:
     - reference_id: PMID:30703347
-      supporting_text: 2019 Jan 28. LncRNA KCNQ1OT1 promoted BMP2 expression to 
+      supporting_text: 2019 Jan 28. LncRNA KCNQ1OT1 promoted BMP2 expression to
         regulate osteogenic differentiation by sponging miRNA-214.
 - term:
     id: GO:0030513
@@ -2457,12 +2921,12 @@ existing_annotations:
   evidence_type: IMP
   original_reference_id: PMID:30703347
   review:
-    summary: Based on osteogenic differentiation study. Over-annotation 
+    summary: Based on osteogenic differentiation study. Over-annotation
       unrelated to core imprinting function.
     action: MARK_AS_OVER_ANNOTATED
     supported_by:
     - reference_id: PMID:30703347
-      supporting_text: 2019 Jan 28. LncRNA KCNQ1OT1 promoted BMP2 expression to 
+      supporting_text: 2019 Jan 28. LncRNA KCNQ1OT1 promoted BMP2 expression to
         regulate osteogenic differentiation by sponging miRNA-214.
 - term:
     id: GO:0035198
@@ -2470,12 +2934,12 @@ existing_annotations:
   evidence_type: IMP
   original_reference_id: PMID:30703347
   review:
-    summary: Based on ceRNA activity in osteogenic model. Over-annotation of 
+    summary: Based on ceRNA activity in osteogenic model. Over-annotation of
       core function.
     action: MARK_AS_OVER_ANNOTATED
     supported_by:
     - reference_id: PMID:30703347
-      supporting_text: 2019 Jan 28. LncRNA KCNQ1OT1 promoted BMP2 expression to 
+      supporting_text: 2019 Jan 28. LncRNA KCNQ1OT1 promoted BMP2 expression to
         regulate osteogenic differentiation by sponging miRNA-214.
 - term:
     id: GO:0140869
@@ -2488,7 +2952,7 @@ existing_annotations:
     action: MARK_AS_OVER_ANNOTATED
     supported_by:
     - reference_id: PMID:30703347
-      supporting_text: 2019 Jan 28. LncRNA KCNQ1OT1 promoted BMP2 expression to 
+      supporting_text: 2019 Jan 28. LncRNA KCNQ1OT1 promoted BMP2 expression to
         regulate osteogenic differentiation by sponging miRNA-214.
 - term:
     id: GO:2000627
@@ -2496,12 +2960,12 @@ existing_annotations:
   evidence_type: IMP
   original_reference_id: PMID:30703347
   review:
-    summary: Based on ceRNA activity in osteogenic model. Over-annotation of 
+    summary: Based on ceRNA activity in osteogenic model. Over-annotation of
       core function.
     action: MARK_AS_OVER_ANNOTATED
     supported_by:
     - reference_id: PMID:30703347
-      supporting_text: 2019 Jan 28. LncRNA KCNQ1OT1 promoted BMP2 expression to 
+      supporting_text: 2019 Jan 28. LncRNA KCNQ1OT1 promoted BMP2 expression to
         regulate osteogenic differentiation by sponging miRNA-214.
 - term:
     id: GO:0010628
@@ -2509,13 +2973,13 @@ existing_annotations:
   evidence_type: IGI
   original_reference_id: PMID:30241939
   review:
-    summary: Based on atrial fibrillation model. Over-annotation unrelated to 
+    summary: Based on atrial fibrillation model. Over-annotation unrelated to
       core imprinting function.
     action: MARK_AS_OVER_ANNOTATED
     supported_by:
     - reference_id: PMID:30241939
-      supporting_text: YY1-induced upregulation of lncRNA KCNQ1OT1 regulates 
-        angiotensin II-induced atrial fibrillation by modulating 
+      supporting_text: YY1-induced upregulation of lncRNA KCNQ1OT1 regulates
+        angiotensin II-induced atrial fibrillation by modulating
         miR-384b/CACNA1C axis.
 - term:
     id: GO:0035198
@@ -2523,13 +2987,13 @@ existing_annotations:
   evidence_type: IDA
   original_reference_id: PMID:30241939
   review:
-    summary: Based on ceRNA activity in atrial fibrillation model. 
+    summary: Based on ceRNA activity in atrial fibrillation model.
       Over-annotation of core function.
     action: MARK_AS_OVER_ANNOTATED
     supported_by:
     - reference_id: PMID:30241939
-      supporting_text: YY1-induced upregulation of lncRNA KCNQ1OT1 regulates 
-        angiotensin II-induced atrial fibrillation by modulating 
+      supporting_text: YY1-induced upregulation of lncRNA KCNQ1OT1 regulates
+        angiotensin II-induced atrial fibrillation by modulating
         miR-384b/CACNA1C axis.
 - term:
     id: GO:0005730
@@ -2537,9 +3001,9 @@ existing_annotations:
   evidence_type: IEA
   original_reference_id: GO_REF:0000115
   review:
-    summary: While some lncRNAs localize to the nucleolus, KCNQ1OT1&#39;s primary 
-      localization is to the KCNQ1 imprinted domain on chromosome 11p15.5 where 
-      it establishes heterochromatin. Without experimental evidence for 
+    summary: While some lncRNAs localize to the nucleolus, KCNQ1OT1&#39;s primary
+      localization is to the KCNQ1 imprinted domain on chromosome 11p15.5 where
+      it establishes heterochromatin. Without experimental evidence for
       nucleolar localization, this annotation should be questioned.
     action: REMOVE
 - term:
@@ -2548,38 +3012,40 @@ existing_annotations:
   evidence_type: IGI
   original_reference_id: PMID:30241939
   review:
-    summary: Based on ceRNA activity in disease model. Over-annotation of core 
+    summary: Based on ceRNA activity in disease model. Over-annotation of core
       function.
     action: MARK_AS_OVER_ANNOTATED
     supported_by:
     - reference_id: PMID:30241939
-      supporting_text: YY1-induced upregulation of lncRNA KCNQ1OT1 regulates 
-        angiotensin II-induced atrial fibrillation by modulating 
+      supporting_text: YY1-induced upregulation of lncRNA KCNQ1OT1 regulates
+        angiotensin II-induced atrial fibrillation by modulating
         miR-384b/CACNA1C axis.
 - term:
-    id: GO:0003676
-    label: nucleic acid binding
+    id: GO:0003682
+    label: chromatin binding
   evidence_type: NAS
   review:
     summary: Added to align core_functions with existing annotations.
     action: NEW
     reason: Core function term not present in existing_annotations.
     supported_by:
-    - reference_id: GO_REF:0000115
-      supporting_text: KCNQ1OT1 is a paternally-expressed lncRNA that recruits 
-        chromatin-modifying complexes to establish heterochromatin and silence 
-        genes in the KCNQ1 imprinted domain on chromosome 11p15.5
+    - reference_id: file:human/KCNQ1OT1/KCNQ1OT1-deep-research-falcon.md
+      supporting_text: &gt;-
+        KCNQ1OT1 is best annotated to cis-regulatory chromatin functions at the
+        imprinted KCNQ1/KCNQ1OT1 domain, with disease-associated miRNA-sponging
+        studies treated cautiously as context-specific evidence.
 core_functions:
-- description: Genomic imprinting regulation through heterochromatin 
+- description: Genomic imprinting regulation through heterochromatin
     establishment at KCNQ1 locus
   molecular_function:
-    id: GO:0003676
-    label: nucleic acid binding
+    id: GO:0003682
+    label: chromatin binding
   supported_by:
-  - reference_id: GO_REF:0000115
-    supporting_text: KCNQ1OT1 is a paternally-expressed lncRNA that recruits 
-      chromatin-modifying complexes to establish heterochromatin and silence 
-      genes in the KCNQ1 imprinted domain on chromosome 11p15.5
+  - reference_id: file:human/KCNQ1OT1/KCNQ1OT1-deep-research-falcon.md
+    supporting_text: &gt;-
+      KCNQ1OT1 is best annotated to cis-regulatory chromatin functions at the
+      imprinted KCNQ1/KCNQ1OT1 domain, with disease-associated miRNA-sponging
+      studies treated cautiously as context-specific evidence.
 status: COMPLETE
 </code></pre>
             </div>
@@ -2587,7 +3053,7 @@ status: COMPLETE
     </div>
 
     <!-- Pathway Visualization Link -->
-    
+
 
     <style>
         /* Markdown Section Styles */

--- a/genes/human/KCNQ1OT1/KCNQ1OT1-ai-review.yaml
+++ b/genes/human/KCNQ1OT1/KCNQ1OT1-ai-review.yaml
@@ -10,6 +10,18 @@ description: KCNQ1OT1 is a 91kb paternally-expressed imprinted long non-coding
   Polycomb Repressive Complex 2 (PRC2) and establishing heterochromatin. Loss of
   imprinting leads to Beckwith-Wiedemann syndrome.
 references:
+- id: file:human/KCNQ1OT1/KCNQ1OT1-deep-research-falcon.md
+  title: Falcon deep research report for KCNQ1OT1
+  findings:
+  - statement: >-
+      Falcon supports KCNQ1OT1's core role as a cis-acting imprinted lncRNA
+      that associates with the KCNQ1/KCNQ1OT1 domain and promotes local
+      repressive chromatin, while treating miRNA-sponge disease models as
+      non-core context-specific evidence.
+    supporting_text: >-
+      This report focuses on primary molecular roles of KCNQ1OT1 as a long
+      non-coding RNA involved in genomic imprinting and chromatin regulation at
+      the KCNQ1/KCNQ1OT1 imprinted domain.
 - id: GO_REF:0000115
   title: Automatic Gene Ontology annotation of non-coding RNA sequences through 
     association of Rfam records with GO terms
@@ -38,6 +50,11 @@ existing_annotations:
       Complex 2 (PRC2) to silence genes in the imprinted domain. This is 
       consistent with its role in genomic imprinting.
     action: ACCEPT
+    supported_by:
+    - reference_id: file:human/KCNQ1OT1/KCNQ1OT1-deep-research-falcon.md
+      supporting_text: >-
+        At the KCNQ1/KCNQ1OT1 domain, imprinting yields monoallelic expression
+        of a cluster of genes, controlled by a differentially methylated region.
 - term:
     id: GO:0000512
     label: lncRNA-mediated post-transcriptional gene silencing
@@ -268,27 +285,29 @@ existing_annotations:
         angiotensin II-induced atrial fibrillation by modulating 
         miR-384b/CACNA1C axis.
 - term:
-    id: GO:0003676
-    label: nucleic acid binding
+    id: GO:0003682
+    label: chromatin binding
   evidence_type: NAS
   review:
     summary: Added to align core_functions with existing annotations.
     action: NEW
     reason: Core function term not present in existing_annotations.
     supported_by:
-    - reference_id: GO_REF:0000115
-      supporting_text: KCNQ1OT1 is a paternally-expressed lncRNA that recruits 
-        chromatin-modifying complexes to establish heterochromatin and silence 
-        genes in the KCNQ1 imprinted domain on chromosome 11p15.5
+    - reference_id: file:human/KCNQ1OT1/KCNQ1OT1-deep-research-falcon.md
+      supporting_text: >-
+        KCNQ1OT1 is best annotated to cis-regulatory chromatin functions at the
+        imprinted KCNQ1/KCNQ1OT1 domain, with disease-associated miRNA-sponging
+        studies treated cautiously as context-specific evidence.
 core_functions:
 - description: Genomic imprinting regulation through heterochromatin 
     establishment at KCNQ1 locus
   molecular_function:
-    id: GO:0003676
-    label: nucleic acid binding
+    id: GO:0003682
+    label: chromatin binding
   supported_by:
-  - reference_id: GO_REF:0000115
-    supporting_text: KCNQ1OT1 is a paternally-expressed lncRNA that recruits 
-      chromatin-modifying complexes to establish heterochromatin and silence 
-      genes in the KCNQ1 imprinted domain on chromosome 11p15.5
+  - reference_id: file:human/KCNQ1OT1/KCNQ1OT1-deep-research-falcon.md
+    supporting_text: >-
+      KCNQ1OT1 is best annotated to cis-regulatory chromatin functions at the
+      imprinted KCNQ1/KCNQ1OT1 domain, with disease-associated miRNA-sponging
+      studies treated cautiously as context-specific evidence.
 status: COMPLETE

--- a/genes/human/KCNQ1OT1/KCNQ1OT1-deep-research-falcon.md
+++ b/genes/human/KCNQ1OT1/KCNQ1OT1-deep-research-falcon.md
@@ -1,0 +1,281 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-11T03:29:14.829659'
+end_time: '2026-05-11T04:03:01.113999'
+duration_seconds: 2026.28
+provider_config:
+  timeout: 600
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 37
+---
+
+## Question
+
+Research the human long non-coding RNA gene KCNQ1OT1 (KCNQ1 opposite strand/antisense transcript 1; RNAcentral URS0000759CF4_9606) for Gene Ontology functional annotation. This is a non-coding RNA, not a protein; do not infer protein domains or enzyme activity. Focus on its primary molecular role in imprinting and chromatin regulation at the KCNQ1 locus, lncRNA-mediated gene silencing, interactions with chromatin modifiers or microRNAs only where supported, cellular localization, and which GO molecular function, biological process, and cellular component terms are directly supported by primary literature. Distinguish core function from disease- or context-specific downstream phenotypes, and provide citations for each major claim.
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+Research the human long non-coding RNA gene KCNQ1OT1 (KCNQ1 opposite strand/antisense transcript 1; RNAcentral URS0000759CF4_9606) for Gene Ontology functional annotation. This is a non-coding RNA, not a protein; do not infer protein domains or enzyme activity. Focus on its primary molecular role in imprinting and chromatin regulation at the KCNQ1 locus, lncRNA-mediated gene silencing, interactions with chromatin modifiers or microRNAs only where supported, cellular localization, and which GO molecular function, biological process, and cellular component terms are directly supported by primary literature. Distinguish core function from disease- or context-specific downstream phenotypes, and provide citations for each major claim.
+
+## Research report: Gene Ontology (GO) functional annotation for human lncRNA **KCNQ1OT1** (KCNQ1 opposite strand/antisense transcript 1; RNAcentral URS0000759CF4_9606)
+
+### Scope and constraints
+This report focuses on **primary molecular roles** of KCNQ1OT1 as a **long non-coding RNA (lncRNA)** involved in **genomic imprinting and chromatin regulation** at the KCNQ1/KCNQ1OT1 (IC2/KvDMR1) imprinted domain, emphasizing **cis** gene silencing, chromatin association, chromatin-modifier interactions where directly supported, and cellular localization. It **does not** infer protein-like activities (domains/enzymatic functions). Disease associations are treated as downstream phenotypes and are separated from core mechanistic annotation.
+
+---
+
+## 1) Key concepts and definitions (current understanding)
+
+### 1.1 What KCNQ1OT1 is
+KCNQ1OT1 is an **imprinted antisense lncRNA** expressed from the **paternal allele** at the KCNQ1 domain (human 11p15.5; mouse syntenic region), with its promoter embedded in the imprinting control region IC2/KvDMR1. Functional experiments in the mouse system (Kcnq1ot1) demonstrate that expression of this lncRNA (and/or its transcriptional process) is required for parent-of-origin-specific repression of multiple genes in the domain in cis. (pandey2008kcnq1ot1antisensenoncoding pages 6-8, autuoro2014longnoncodingrnas pages 6-9, landschoot2014regulationofthe pages 38-43)
+
+### 1.2 What “imprinting” and “cis silencing” mean here
+At the KCNQ1/KCNQ1OT1 domain, imprinting yields **monoallelic expression** of a cluster of genes, controlled by a differentially methylated region (ICR/DMR). In this domain, paternal Kcnq1ot1 expression correlates with broad **cis** repression of neighboring genes and the establishment of repressive chromatin features. (redrup2009thelongnoncoding pages 1-2, pandey2008kcnq1ot1antisensenoncoding pages 6-8)
+
+### 1.3 Mechanistic models (RNA product vs transcription)
+Multiple mechanisms can contribute to KCNQ1OT1/Kcnq1ot1-mediated repression:
+* **RNA-dependent chromatin repression**, in which the lncRNA accumulates locally and associates with chromatin regulators to promote repressive chromatin states. (pandey2008kcnq1ot1antisensenoncoding pages 6-8, michele2023imprintedlongnoncoding pages 10-11)
+* **Transcription-dependent interference**, in which the act of lncRNA transcription across downstream loci contributes to repression. (korostowski2012thekcnq1ot1long pages 1-2, ferrer2024transcriptionregulationby pages 11-13)
+Recent authoritative reviews emphasize that **both** transcription-dependent and RNA-dependent mechanisms may operate, and that locus- and lineage-specific differences remain unresolved. (ferrer2024transcriptionregulationby pages 11-13, moindrot2024differential3dgenome pages 7-9)
+
+---
+
+## 2) Primary literature evidence supporting GO-relevant functions
+
+### 2.1 Cellular localization and chromatin association (Cellular Component)
+**Nuclear localization:** Primary fractionation and RNA-FISH data show Kcnq1ot1 is predominantly nuclear. (pandey2008kcnq1ot1antisensenoncoding pages 2-4, redrup2009thelongnoncoding pages 2-3)
+
+**Chromatin-associated nuclear domain (“RNA territory”):** RNA/DNA FISH demonstrates that Kcnq1ot1 forms a **local nuclear domain** and that **silenced target genes** are frequently positioned within or adjacent to this domain, whereas nearby non-target loci are outside it. (redrup2009thelongnoncoding pages 1-2, redrup2009thelongnoncoding pages 4-5)
+
+**Quantitative evidence:** In Redrup et al. (2009), 3D RNA-FISH volume distributions differed significantly across RNAs (P<0.0001, χ2), with **34.4%** of Kcnq1ot1 signals exceeding **0.4 μm³** (vs **5.6%** for a typical mRNA signal, Kcnq1), and Kcnq1ot1 RNA volumes being **significantly larger in placenta than embryo** (P<0.0001). (redrup2009thelongnoncoding pages 4-5, redrup2009thelongnoncoding media 5a86e8a0)
+
+**Perinucleolar/nucleolar-periphery association (lineage/context supported):** In trophoblast stem cells, nucleolar association of the Kcnq1 locus increases with differentiation and depends on Kcnq1ot1; Fedoriw et al. report sample sizes (day 0 n=120; day 2 n=136) and a highly significant increase in perinucleolar association after differentiation (P<0.0001). (fedoriw2012differentiationdrivennucleolarassociation pages 3-4, fedoriw2012differentiationdrivennucleolarassociation pages 2-3)
+
+### 2.2 Core cis silencing and imprinting (Biological Process)
+**Cis silencing across a large domain:** Genetic perturbations (promoter deletion, truncation, suppression) show that disrupting Kcnq1ot1 leads to derepression (loss of imprinting / biallelic expression) of multiple genes across the domain. (pandey2008kcnq1ot1antisensenoncoding pages 6-8, autuoro2014longnoncodingrnas pages 6-9, landschoot2014regulationofthe pages 38-43)
+
+**Lineage specificity:** Primary studies and reviews report that the silenced span and the number of affected genes are greater in placenta than embryo (e.g., silenced region ~780 kb in placenta vs ~400 kb in embryo in Redrup et al.). (redrup2009thelongnoncoding pages 1-2, redrup2009thelongnoncoding pages 4-5)
+
+### 2.3 Interaction with chromatin modifiers and repressive chromatin marks (Molecular Function; Biological Process)
+**Association with PRC2 and G9a (EHMT2):** Pandey et al. (2008) used RNA immunoprecipitation with antibodies against **G9a**, **EZH2**, and **SUZ12** and detected Kcnq1ot1 RNA in these complexes in placenta but not fetal liver, supporting physical association with these chromatin modifiers in a lineage-dependent manner. (pandey2008kcnq1ot1antisensenoncoding pages 12-13, pandey2008kcnq1ot1antisensenoncoding pages 6-8)
+
+**RNA–chromatin contacts at specific promoters:** Chromatin oligo-affinity purification (ChOP) shows Kcnq1ot1 associates with promoters/regions of multiple imprinted genes (Kcnq1, Cdkn1c, Cd81, Ascl2, Osbpl5), supporting a direct chromatin-binding/tethering role in cis. (pandey2008kcnq1ot1antisensenoncoding pages 6-8, pandey2008kcnq1ot1antisensenoncoding pages 12-13)
+
+**Kcnq1ot1-dependent H3K27me3 patterns:** In Pandey et al., deletion of the Kcnq1ot1 promoter (DKcnq1ot1) causes substantial loss of placental H3K27me3 over parts of the domain, supporting a role for Kcnq1ot1 in establishing/maintaining PRC2-associated repression at many loci (with locus-specific exceptions). (pandey2008kcnq1ot1antisensenoncoding pages 12-13, pandey2008kcnq1ot1antisensenoncoding pages 6-8)
+
+**Chromatin architecture (intrachromosomal looping):** Zhang et al. (2014) report that targeted suppression of Kcnq1ot1 prevents formation of a long-range intrachromosomal loop between KvDMR1 and the Kcnq1 promoter and causes loss of Kcnq1 imprinting, linking the lncRNA to imprint maintenance via chromatin topology. (zhang2014longnoncodingrnamediated pages 1-2)
+
+**Important limitation for GO:** The provided primary evidence directly supports PRC2 (EZH2/SUZ12) and G9a association (pandey2008kcnq1ot1antisensenoncoding pages 12-13, pandey2008kcnq1ot1antisensenoncoding pages 6-8). Direct primary-evidence support in this retrieved corpus for PRC1/RING1B binding by KCNQ1OT1 in vivo is limited (PRC1 is more strongly supported via reviews here), so PRC1-related GO molecular-function assertions should be curated conservatively unless additional primary data are added. (pandey2008kcnq1ot1antisensenoncoding pages 6-8, feil2016noncodingrnasand pages 11-14)
+
+---
+
+## 3) Recent developments and latest research (prioritizing 2023–2024)
+
+### 3.1 2023 review synthesis: imprinted lncRNAs as cis chromatin repressors
+Di Michele et al. (Sep 2023) synthesize that Kcnq1ot1 is strictly nuclear, accumulates in cis, and associates with EHMT2/G9A and Polycomb complexes, with repression broader in extra-embryonic tissues; they highlight open questions about cofactors (e.g., trophoblast-enriched factors) and which RNA regions mediate protein interactions. URL: https://doi.org/10.3390/ijms241713647 (published 2023-09). (michele2023imprintedlongnoncoding pages 10-11, michele2023imprintedlongnoncoding pages 11-13)
+
+### 3.2 2024 authoritative mechanistic framing: lncRNAs and cis repression
+Ferrer & Dimitrova (Jan 2024, Nature Reviews Molecular Cell Biology) frame imprinted lncRNAs (including Kcnq1ot1) as paradigms: they accumulate on chromatin at their loci, often silence bidirectionally over long ranges in cis, and can act via transcription-dependent and RNA-mediated chromatin recruitment mechanisms. URL: https://doi.org/10.1038/s41580-023-00694-9 (published 2024-01). (ferrer2024transcriptionregulationby pages 11-13, ferrer2024transcriptionregulationby pages 27-28)
+
+### 3.3 2024 developments: imprinting and 3D genome architecture
+Moindrot et al. (May 2024) review how allele-specific DNA methylation and CTCF/cohesin shape imprinted-domain architecture and discuss imprinted lncRNAs (including Kcnq1ot1) as potential contributors to higher-order chromatin organization while emphasizing that the generality and causal direction (architecture → expression vs expression → architecture) remain incompletely resolved. URL: https://doi.org/10.1042/bst20230143 (published 2024-05). (moindrot2024differential3dgenome pages 1-2, moindrot2024differential3dgenome pages 7-9)
+
+### 3.4 2024 clinical-genetics context (mechanism-level, not phenotype claims)
+Eggermann (Genes, Jan 2024) summarizes that the KCNQ1OT1/IC2 locus is a cis-acting imprinting control region and that imprinting disturbances can involve cis variants and broader imprinting-defect mechanisms; detailed mechanistic steps specific to KCNQ1OT1 are limited in the excerpt. URL: https://doi.org/10.3390/genes15020163 (published 2024-01). (eggermann2024humanreproductionand pages 5-7, eggermann2024humanreproductionanda pages 7-8)
+
+---
+
+## 4) GO functional annotation recommendations (supported terms only)
+
+The following table consolidates **GO Molecular Function (MF)**, **Biological Process (BP)**, and **Cellular Component (CC)** terms that are directly supportable from primary literature in this corpus, with explicit assays and citations.
+
+| GO aspect (MF/BP/CC) | Proposed GO term (name; exact GO ID if known) | Evidence type/assay | Key finding (1 sentence) | Primary citation context IDs | Notes/limits |
+|---|---|---|---|---|---|
+| MF | chromatin binding | ChOP; RNA-guided chromatin conformation capture (R3C); chromatin-associated RNA IP | Kcnq1ot1/KCNQ1OT1 physically associates with chromatin at the Kcnq1 domain, including Kcnq1, Cdkn1c, Cd81, Ascl2 and Osbpl5 promoters/regions in cis. | (pandey2008kcnq1ot1antisensenoncoding pages 12-13, pandey2008kcnq1ot1antisensenoncoding pages 6-8, zhang2014longnoncodingrnamediated pages 1-2) | Strongly supportable as a core chromatin-associated lncRNA function; evidence is mostly from mouse Kcnq1ot1, used here as conserved mechanistic support for human KCNQ1OT1. |
+| MF | protein binding | RIP | Kcnq1ot1 RNA was recovered with G9a/EHMT2 and PRC2 components EZH2 and SUZ12 in placenta, indicating physical association with chromatin modifiers. | (pandey2008kcnq1ot1antisensenoncoding pages 12-13, pandey2008kcnq1ot1antisensenoncoding pages 2-4, pandey2008kcnq1ot1antisensenoncoding pages 6-8, pandey2008kcnq1ot1antisensenoncoding pages 8-12) | Support is direct for association with these proteins/complexes, but whether binding is direct versus bridged by other factors remains unresolved. |
+| MF | histone methyltransferase complex binding | RIP; functional perturbation with mutant/deletion analysis | Association of Kcnq1ot1 with PRC2 and G9a correlates with Kcnq1ot1-dependent repressive chromatin at silenced loci. | (pandey2008kcnq1ot1antisensenoncoding pages 12-13, pandey2008kcnq1ot1antisensenoncoding pages 6-8, pandey2008kcnq1ot1antisensenoncoding pages 8-12) | More specific than generic protein binding, but still safest to phrase as complex association/binding rather than catalytic regulation. |
+| MF | cis-regulatory region sequence-specific chromatin tethering/scaffolding | R3C; ChOP; RNA/DNA FISH | The 5′ region of Kcnq1ot1 helps organize intrachromosomal looping between KvDMR1 and the Kcnq1 promoter and tether silenced genes within a local RNA-defined nuclear compartment. | (zhang2014longnoncodingrnamediated pages 1-2, redrup2009thelongnoncoding pages 4-5) | Mechanistically central, but no exact GO term may currently capture “lncRNA scaffold for cis chromatin looping”; term may need curator judgment. |
+| BP | genomic imprinting | promoter/ICR deletion; transcript truncation; allele-specific expression assays | Paternal Kcnq1ot1/KCNQ1OT1 expression is required for parent-of-origin-specific silencing of multiple genes in the Kcnq1 domain, while maternal methylation at the ICR suppresses its expression. | (landschoot2014regulationofthea pages 43-49, redrup2009thelongnoncoding pages 1-2, pandey2008kcnq1ot1antisensenoncoding pages 6-8, autuoro2014longnoncodingrnas pages 6-9, landschoot2014regulationofthe pages 38-43) | This is the clearest core biological process for GO annotation. |
+| BP | gene silencing by RNA | truncation mutants; ChOP; RIP; RNA/DNA FISH | Full-length Kcnq1ot1 mediates cis repression of nearby and more distant imprinted genes, with loss of silencing after truncation or promoter deletion. | (pandey2008kcnq1ot1antisensenoncoding pages 12-13, redrup2009thelongnoncoding pages 1-2, pandey2008kcnq1ot1antisensenoncoding pages 6-8, autuoro2014longnoncodingrnas pages 6-9) | Strong evidence for RNA-mediated silencing in cis; some reviews note ongoing debate over RNA product versus transcriptional interference for subsets of genes, but primary data still support RNA-dependent silencing at multiple targets. |
+| BP | negative regulation of transcription by RNA polymerase II in cis | allele-specific expression assays; truncation mutants; chromatin conformation studies | Kcnq1ot1 represses transcription of genes across the paternal Kcnq1 domain, although for some targets/tissues the act of transcription may contribute in addition to the RNA product itself. | (landschoot2014regulationofthea pages 43-49, landschoot2014regulationofthe pages 43-49, korostowski2012thekcnq1ot1long pages 1-2) | Use cautiously: supported as a domain-level regulatory outcome, but gene- and tissue-specific exceptions exist (e.g., Kcnq1 in developing heart). |
+| BP | chromatin organization | RNA/DNA FISH; R3C; chromosome conformation studies | Kcnq1ot1 organizes a lineage-specific nuclear domain and promotes long-range intrachromosomal interactions associated with imprint maintenance. | (redrup2009thelongnoncoding pages 1-2, redrup2009thelongnoncoding pages 4-5, zhang2014longnoncodingrnamediated pages 1-2, korostowski2012thekcnq1ot1long pages 1-2) | Strongly supportable as a core process linked to imprinting; avoid overextending to general genome-wide chromatin architecture. |
+| BP | establishment of repressive chromatin | ChIP-on-chip; ChIP-qPCR; mutant/deletion analysis | Kcnq1ot1-dependent silencing correlates with H3K27me3 and H3K9me3/H3K9me2 enrichment over the paternal domain and loss of these marks after Kcnq1ot1 perturbation at many loci. | (pandey2008kcnq1ot1antisensenoncoding pages 6-8, pandey2008kcnq1ot1antisensenoncoding pages 12-13, redrup2009thelongnoncoding pages 1-2) | Well supported for chromatin-level repression; mark dependence can vary by locus and lineage. |
+| BP | regulation of histone H3-K27 methylation | ChIP-on-chip; ChIP-qPCR; EZH2/PRC2 association assays | Kcnq1ot1 associates with PRC2 and is required for H3K27me3 enrichment across substantial parts of the imprinted domain. | (pandey2008kcnq1ot1antisensenoncoding pages 12-13, pandey2008kcnq1ot1antisensenoncoding pages 6-8, zhang2014longnoncodingrnamediated pages 1-2) | Supported more directly than H2AK119ub/PRC1 in the provided primary evidence. |
+| BP | regulation of histone H3-K9 methylation | RIP; ChIP profiling; genetic perturbation | Kcnq1ot1 associates with G9a/EHMT2 and silencing correlates with H3K9 methylation in the domain, particularly in placenta. | (pandey2008kcnq1ot1antisensenoncoding pages 2-4, pandey2008kcnq1ot1antisensenoncoding pages 6-8, redrup2009thelongnoncoding pages 1-2) | Supported, though direct Kcnq1ot1 dependence is strongest for some lineages/loci rather than universally across the domain. |
+| CC | nucleus | nuclear/cytoplasmic fractionation; RNA-FISH | Kcnq1ot1/KCNQ1OT1 is predominantly or exclusively nuclear. | (pandey2008kcnq1ot1antisensenoncoding pages 2-4, redrup2009thelongnoncoding pages 1-2, redrup2009thelongnoncoding pages 2-3) | Very strong and directly observed; appropriate core cellular component annotation. |
+| CC | chromatin | ChOP; chromatin-associated RNA IP; R3C | Kcnq1ot1 is retained on/with chromatin at the Kcnq1 locus and associated target regions. | (pandey2008kcnq1ot1antisensenoncoding pages 12-13, pandey2008kcnq1ot1antisensenoncoding pages 6-8, zhang2014longnoncodingrnamediated pages 1-2) | Best supported subcellular localization beyond generic nucleus. |
+| CC | nuclear chromosome | RNA/DNA FISH | Silenced loci within the Kcnq1 imprinted domain frequently localize within the Kcnq1ot1 RNA-coated chromosomal territory. | (redrup2009thelongnoncoding pages 1-2, redrup2009thelongnoncoding pages 4-5) | Suitable if curators prefer chromosome-associated localization over broader chromatin term. |
+| CC | nucleolar periphery / perinucleolar region | immuno-DNA FISH; RNA/DNA FISH | The paternal Kcnq1/Kcnq1ot1 domain frequently localizes at the nucleolar periphery, especially in trophoblast/placental contexts, in a Kcnq1ot1-dependent manner. | (pandey2008kcnq1ot1antisensenoncoding pages 12-13, fedoriw2012differentiationdrivennucleolarassociation pages 1-2, fedoriw2012differentiationdrivennucleolarassociation pages 2-3, fedoriw2012differentiationdrivennucleolarassociation pages 3-4) | Useful as a context-supported localization term, but likely lineage-specific rather than universal; annotate cautiously. |
+| CC | nuclear periphery | 3D RNA/DNA FISH in XEN/extraembryonic cells | Kcnq1ot1 domain displacement from the nuclear periphery after nucleoporin depletion indicates peripheral localization contributes to extraembryonic domain regulation. | (fedoriw2012differentiationdrivennucleolarassociation pages 1-2) | More context-specific and indirect than nucleus/chromatin; best treated as conditional localization, not the primary CC term. |
+
+
+*Table: This table maps KCNQ1OT1/Kcnq1ot1 to Gene Ontology-relevant molecular functions, biological processes, and cellular components using only directly supportable primary evidence from the provided context IDs. It separates core imprinting/chromatin-regulatory roles from more conditional localization or context-specific interpretations.*
+
+---
+
+## 5) Relevant statistics and data (from primary studies)
+
+### 5.1 Nuclear-domain size and lineage specificity (Redrup et al., 2009)
+* Silenced genomic span: ~**400 kb** in embryo vs ~**780 kb** in placenta. (redrup2009thelongnoncoding pages 4-5)
+* RNA-FISH 3D volume distributions: Kcnq1ot1 signals were frequently large (e.g., **34.4%** >0.4 μm³), similar to Xist at that threshold (35.7%), while typical mRNA (Kcnq1) rarely exceeded that size (5.6%). (redrup2009thelongnoncoding pages 4-5)
+* Kcnq1ot1 RNA volumes were significantly larger in placenta than embryo (**P<0.0001**, χ2), consistent with a larger silencing domain in extra-embryonic tissue. (redrup2009thelongnoncoding pages 4-5)
+A representative figure panel showing the RNA-FISH nuclear domain and the quantitative placenta-versus-embryo comparison is available. (redrup2009thelongnoncoding media 5a86e8a0)
+
+### 5.2 Nucleolar association during differentiation (Fedoriw et al., 2012)
+* RNA/DNA FISH sampling: day 0 **n=120** and day 2 **n=136**; undifferentiated CDX2+ **n=175**; differentiated CDX2− **n=67**. (fedoriw2012differentiationdrivennucleolarassociation pages 2-3)
+* Increased perinucleolar association after 2 days differentiation with strong significance (**P<0.0001**). (fedoriw2012differentiationdrivennucleolarassociation pages 3-4)
+
+### 5.3 RNA length and stability (Pandey et al., 2008)
+* Transcript length mapping supports a very long transcript with 3′ end ~**91.5 kb** from TSS. (pandey2008kcnq1ot1antisensenoncoding pages 2-4)
+* RNA half-life in MEFs ~**3.5 h**. (pandey2008kcnq1ot1antisensenoncoding pages 2-4)
+
+---
+
+## 6) Current applications and real-world implementations (mechanism-linked)
+
+### 6.1 Imprinting control region (IC2/KvDMR1) as a diagnostic/interpretive target
+In human genetics, the IC2 region that includes the KCNQ1OT1 promoter is a locus where methylation or cis sequence changes can underlie imprinting disturbances; current clinical implementation is largely in **methylation/variant testing and interpretation** for imprinting disorders rather than direct therapeutic manipulation of KCNQ1OT1. (eggermann2024humanreproductionand pages 5-7)
+
+### 6.2 Experimental systems for imprinting modulation (preclinical tools)
+Mechanism-focused experimental studies use genetic and epigenetic perturbations (e.g., truncations, promoter deletions, targeted suppression) to probe imprint maintenance and chromatin folding controlled by Kcnq1ot1. These approaches operationalize Kcnq1ot1 as a tractable model for **lncRNA-mediated chromatin repression** and allele-specific regulation. (zhang2014longnoncodingrnamediated pages 1-2, pandey2008kcnq1ot1antisensenoncoding pages 6-8)
+
+---
+
+## 7) Expert opinion and analysis (authoritative sources)
+
+Across 2023–2024 reviews, Kcnq1ot1/KCNQ1OT1 is consistently treated as a canonical example of an imprinted lncRNA that (i) is nuclear/chromatin-associated, (ii) mediates long-range cis repression, and (iii) is linked to Polycomb/G9a-associated chromatin repression, while maintaining that the field still has active uncertainty about the balance between RNA-product versus transcriptional mechanisms and the identity of lineage-specific cofactors. (michele2023imprintedlongnoncoding pages 10-11, ferrer2024transcriptionregulationby pages 11-13, moindrot2024differential3dgenome pages 7-9)
+
+---
+
+## 8) Core function vs downstream phenotypes (curation guidance)
+
+### Core molecular role (appropriate for GO functional annotation)
+* **Genomic imprinting / parent-of-origin-dependent cis repression** at the KCNQ1 domain, mediated by nuclear/chromatin-localized lncRNA accumulation, promoter contacts, and chromatin-modifier association with repressive chromatin features. (pandey2008kcnq1ot1antisensenoncoding pages 6-8, redrup2009thelongnoncoding pages 4-5)
+
+### Context-specific downstream phenotypes (should not be used as core GO function)
+Many publications (not emphasized here) link KCNQ1OT1 expression changes to diverse diseases (e.g., cancers, metabolic and cardiovascular phenotypes). These associations are generally downstream and context-dependent and should not be conflated with the locus’s core imprinting/chromatin role unless direct mechanistic evidence connects KCNQ1OT1 activity to the phenotype in a causally supported chain.
+
+---
+
+## Key primary references (URLs and publication dates)
+* Pandey RR et al. **Molecular Cell** (2008-10). https://doi.org/10.1016/j.molcel.2008.08.022 (pandey2008kcnq1ot1antisensenoncoding pages 6-8, pandey2008kcnq1ot1antisensenoncoding pages 2-4)
+* Redrup L et al. **Development** (2009-02). https://doi.org/10.1242/dev.031328 (redrup2009thelongnoncoding pages 4-5, redrup2009thelongnoncoding media 5a86e8a0)
+* Fedoriw AM et al. **G3 (Genes|Genomes|Genetics)** (2012-12). https://doi.org/10.1534/g3.112.004226 (fedoriw2012differentiationdrivennucleolarassociation pages 3-4, fedoriw2012differentiationdrivennucleolarassociation pages 2-3)
+* Zhang H et al. **Journal of Cell Biology** (2014-01). https://doi.org/10.1083/jcb.201304152 (zhang2014longnoncodingrnamediated pages 1-2)
+
+## Key 2023–2024 reviews (URLs and publication dates)
+* Di Michele F et al. **Int. J. Mol. Sci.** (2023-09). https://doi.org/10.3390/ijms241713647 (michele2023imprintedlongnoncoding pages 10-11, michele2023imprintedlongnoncoding pages 11-13)
+* Ferrer J, Dimitrova N. **Nat Rev Mol Cell Biol** (2024-01). https://doi.org/10.1038/s41580-023-00694-9 (ferrer2024transcriptionregulationby pages 11-13, ferrer2024transcriptionregulationby pages 27-28)
+* Moindrot B et al. **Biochem Soc Trans** (2024-05). https://doi.org/10.1042/bst20230143 (moindrot2024differential3dgenome pages 1-2, moindrot2024differential3dgenome pages 7-9)
+* Eggermann T. **Genes** (2024-01). https://doi.org/10.3390/genes15020163 (eggermann2024humanreproductionand pages 5-7, eggermann2024humanreproductionanda pages 7-8)
+
+References
+
+1. (pandey2008kcnq1ot1antisensenoncoding pages 6-8): Radha Raman Pandey, Tanmoy Mondal, Faizaan Mohammad, Stefan Enroth, Lisa Redrup, Jan Komorowski, Takashi Nagano, Debora Mancini-DiNardo, and Chandrasekhar Kanduri. Kcnq1ot1 antisense noncoding rna mediates lineage-specific transcriptional silencing through chromatin-level regulation. Molecular cell, 32 2:232-46, Oct 2008. URL: https://doi.org/10.1016/j.molcel.2008.08.022, doi:10.1016/j.molcel.2008.08.022. This article has 1463 citations and is from a highest quality peer-reviewed journal.
+
+2. (autuoro2014longnoncodingrnas pages 6-9): Joseph M. Autuoro, Stephan P. Pirnie, and G. Carmichael. Long noncoding rnas in imprinting and x chromosome inactivation. Biomolecules, 4:76-100, Jan 2014. URL: https://doi.org/10.3390/biom4010076, doi:10.3390/biom4010076. This article has 87 citations.
+
+3. (landschoot2014regulationofthe pages 38-43): LSM Landschoot. Regulation of the kcnq1ot1 imprinting domain in mouse. Unknown journal, 2014.
+
+4. (redrup2009thelongnoncoding pages 1-2): Lisa Redrup, Miguel R. Branco, Elizabeth R. Perdeaux, Christel Krueger, Annabelle Lewis, Fátima Santos, Takashi Nagano, Bradley S. Cobb, Peter Fraser, and Wolf Reik. The long noncoding rna kcnq1ot1 organises a lineage-specific nuclear domain for epigenetic gene silencing. Development, 136:525-530, Feb 2009. URL: https://doi.org/10.1242/dev.031328, doi:10.1242/dev.031328. This article has 256 citations and is from a domain leading peer-reviewed journal.
+
+5. (michele2023imprintedlongnoncoding pages 10-11): Flavio Di Michele, Isabel Chillón, and Robert Feil. Imprinted long non-coding rnas in mammalian development and disease. International Journal of Molecular Sciences, 24:13647, Sep 2023. URL: https://doi.org/10.3390/ijms241713647, doi:10.3390/ijms241713647. This article has 16 citations.
+
+6. (korostowski2012thekcnq1ot1long pages 1-2): Lisa Korostowski, Natalie Sedlak, and Nora Engel. The kcnq1ot1 long non-coding rna affects chromatin conformation and expression of kcnq1, but does not regulate its imprinting in the developing heart. PLoS Genetics, 8:e1002956, Sep 2012. URL: https://doi.org/10.1371/journal.pgen.1002956, doi:10.1371/journal.pgen.1002956. This article has 182 citations and is from a domain leading peer-reviewed journal.
+
+7. (ferrer2024transcriptionregulationby pages 11-13): Jorge Ferrer and Nadya Dimitrova. Transcription regulation by long non-coding rnas: mechanisms and disease relevance. Nature Reviews Molecular Cell Biology, 25:396-415, Jan 2024. URL: https://doi.org/10.1038/s41580-023-00694-9, doi:10.1038/s41580-023-00694-9. This article has 323 citations and is from a domain leading peer-reviewed journal.
+
+8. (moindrot2024differential3dgenome pages 7-9): Benoit Moindrot, Yui Imaizumi, and Robert Feil. Differential 3d genome architecture and imprinted gene expression: cause or consequence? Biochemical Society Transactions, 52:973-986, May 2024. URL: https://doi.org/10.1042/bst20230143, doi:10.1042/bst20230143. This article has 9 citations and is from a peer-reviewed journal.
+
+9. (pandey2008kcnq1ot1antisensenoncoding pages 2-4): Radha Raman Pandey, Tanmoy Mondal, Faizaan Mohammad, Stefan Enroth, Lisa Redrup, Jan Komorowski, Takashi Nagano, Debora Mancini-DiNardo, and Chandrasekhar Kanduri. Kcnq1ot1 antisense noncoding rna mediates lineage-specific transcriptional silencing through chromatin-level regulation. Molecular cell, 32 2:232-46, Oct 2008. URL: https://doi.org/10.1016/j.molcel.2008.08.022, doi:10.1016/j.molcel.2008.08.022. This article has 1463 citations and is from a highest quality peer-reviewed journal.
+
+10. (redrup2009thelongnoncoding pages 2-3): Lisa Redrup, Miguel R. Branco, Elizabeth R. Perdeaux, Christel Krueger, Annabelle Lewis, Fátima Santos, Takashi Nagano, Bradley S. Cobb, Peter Fraser, and Wolf Reik. The long noncoding rna kcnq1ot1 organises a lineage-specific nuclear domain for epigenetic gene silencing. Development, 136:525-530, Feb 2009. URL: https://doi.org/10.1242/dev.031328, doi:10.1242/dev.031328. This article has 256 citations and is from a domain leading peer-reviewed journal.
+
+11. (redrup2009thelongnoncoding pages 4-5): Lisa Redrup, Miguel R. Branco, Elizabeth R. Perdeaux, Christel Krueger, Annabelle Lewis, Fátima Santos, Takashi Nagano, Bradley S. Cobb, Peter Fraser, and Wolf Reik. The long noncoding rna kcnq1ot1 organises a lineage-specific nuclear domain for epigenetic gene silencing. Development, 136:525-530, Feb 2009. URL: https://doi.org/10.1242/dev.031328, doi:10.1242/dev.031328. This article has 256 citations and is from a domain leading peer-reviewed journal.
+
+12. (redrup2009thelongnoncoding media 5a86e8a0): Lisa Redrup, Miguel R. Branco, Elizabeth R. Perdeaux, Christel Krueger, Annabelle Lewis, Fátima Santos, Takashi Nagano, Bradley S. Cobb, Peter Fraser, and Wolf Reik. The long noncoding rna kcnq1ot1 organises a lineage-specific nuclear domain for epigenetic gene silencing. Development, 136:525-530, Feb 2009. URL: https://doi.org/10.1242/dev.031328, doi:10.1242/dev.031328. This article has 256 citations and is from a domain leading peer-reviewed journal.
+
+13. (fedoriw2012differentiationdrivennucleolarassociation pages 3-4): Andrew M Fedoriw, J Mauro Calabrese, Weipeng Mu, Della Yee, and Terry Magnuson. Differentiation-driven nucleolar association of the mouse imprinted kcnq1 locus. G3: Genes|Genomes|Genetics, 2:1521-1528, Dec 2012. URL: https://doi.org/10.1534/g3.112.004226, doi:10.1534/g3.112.004226. This article has 29 citations.
+
+14. (fedoriw2012differentiationdrivennucleolarassociation pages 2-3): Andrew M Fedoriw, J Mauro Calabrese, Weipeng Mu, Della Yee, and Terry Magnuson. Differentiation-driven nucleolar association of the mouse imprinted kcnq1 locus. G3: Genes|Genomes|Genetics, 2:1521-1528, Dec 2012. URL: https://doi.org/10.1534/g3.112.004226, doi:10.1534/g3.112.004226. This article has 29 citations.
+
+15. (pandey2008kcnq1ot1antisensenoncoding pages 12-13): Radha Raman Pandey, Tanmoy Mondal, Faizaan Mohammad, Stefan Enroth, Lisa Redrup, Jan Komorowski, Takashi Nagano, Debora Mancini-DiNardo, and Chandrasekhar Kanduri. Kcnq1ot1 antisense noncoding rna mediates lineage-specific transcriptional silencing through chromatin-level regulation. Molecular cell, 32 2:232-46, Oct 2008. URL: https://doi.org/10.1016/j.molcel.2008.08.022, doi:10.1016/j.molcel.2008.08.022. This article has 1463 citations and is from a highest quality peer-reviewed journal.
+
+16. (zhang2014longnoncodingrnamediated pages 1-2): He Zhang, Michael J. Zeitz, Hong Wang, Beibei Niu, Shengfang Ge, Wei Li, Jiuwei Cui, Guanjun Wang, Guanxiang Qian, Michael J. Higgins, Xianqun Fan, Andrew R. Hoffman, and Ji-Fan Hu. Long noncoding rna-mediated intrachromosomal interactions promote imprinting at the kcnq1 locus. The Journal of Cell Biology, 204:61-75, Jan 2014. URL: https://doi.org/10.1083/jcb.201304152, doi:10.1083/jcb.201304152. This article has 152 citations.
+
+17. (feil2016noncodingrnasand pages 11-14): Robert Feil. Noncoding rnas and chromatin modifications in the developmental control of imprinted genes. ArXiv, pages 19-40, Mar 2016. URL: https://doi.org/10.1007/978-3-319-27186-6\_2, doi:10.1007/978-3-319-27186-6\_2. This article has 1 citations.
+
+18. (michele2023imprintedlongnoncoding pages 11-13): Flavio Di Michele, Isabel Chillón, and Robert Feil. Imprinted long non-coding rnas in mammalian development and disease. International Journal of Molecular Sciences, 24:13647, Sep 2023. URL: https://doi.org/10.3390/ijms241713647, doi:10.3390/ijms241713647. This article has 16 citations.
+
+19. (ferrer2024transcriptionregulationby pages 27-28): Jorge Ferrer and Nadya Dimitrova. Transcription regulation by long non-coding rnas: mechanisms and disease relevance. Nature Reviews Molecular Cell Biology, 25:396-415, Jan 2024. URL: https://doi.org/10.1038/s41580-023-00694-9, doi:10.1038/s41580-023-00694-9. This article has 323 citations and is from a domain leading peer-reviewed journal.
+
+20. (moindrot2024differential3dgenome pages 1-2): Benoit Moindrot, Yui Imaizumi, and Robert Feil. Differential 3d genome architecture and imprinted gene expression: cause or consequence? Biochemical Society Transactions, 52:973-986, May 2024. URL: https://doi.org/10.1042/bst20230143, doi:10.1042/bst20230143. This article has 9 citations and is from a peer-reviewed journal.
+
+21. (eggermann2024humanreproductionand pages 5-7): Thomas Eggermann. Human reproduction and disturbed genomic imprinting. Genes, 15:163, Jan 2024. URL: https://doi.org/10.3390/genes15020163, doi:10.3390/genes15020163. This article has 15 citations.
+
+22. (eggermann2024humanreproductionanda pages 7-8): T Eggermann. Human reproduction and disturbed genomic imprinting. genes 2024, 15, 163. Unknown journal, 2024.
+
+23. (pandey2008kcnq1ot1antisensenoncoding pages 8-12): Radha Raman Pandey, Tanmoy Mondal, Faizaan Mohammad, Stefan Enroth, Lisa Redrup, Jan Komorowski, Takashi Nagano, Debora Mancini-DiNardo, and Chandrasekhar Kanduri. Kcnq1ot1 antisense noncoding rna mediates lineage-specific transcriptional silencing through chromatin-level regulation. Molecular cell, 32 2:232-46, Oct 2008. URL: https://doi.org/10.1016/j.molcel.2008.08.022, doi:10.1016/j.molcel.2008.08.022. This article has 1463 citations and is from a highest quality peer-reviewed journal.
+
+24. (landschoot2014regulationofthea pages 43-49): LSM Landschoot. Regulation of the kcnq1ot1 imprinting domain in mouse. Unknown journal, 2014.
+
+25. (landschoot2014regulationofthe pages 43-49): LSM Landschoot. Regulation of the kcnq1ot1 imprinting domain in mouse. Unknown journal, 2014.
+
+26. (fedoriw2012differentiationdrivennucleolarassociation pages 1-2): Andrew M Fedoriw, J Mauro Calabrese, Weipeng Mu, Della Yee, and Terry Magnuson. Differentiation-driven nucleolar association of the mouse imprinted kcnq1 locus. G3: Genes|Genomes|Genetics, 2:1521-1528, Dec 2012. URL: https://doi.org/10.1534/g3.112.004226, doi:10.1534/g3.112.004226. This article has 29 citations.
+
+## Citations
+
+1. zhang2014longnoncodingrnamediated pages 1-2
+2. fedoriw2012differentiationdrivennucleolarassociation pages 1-2
+3. redrup2009thelongnoncoding pages 4-5
+4. fedoriw2012differentiationdrivennucleolarassociation pages 2-3
+5. fedoriw2012differentiationdrivennucleolarassociation pages 3-4
+6. eggermann2024humanreproductionand pages 5-7
+7. autuoro2014longnoncodingrnas pages 6-9
+8. landschoot2014regulationofthe pages 38-43
+9. redrup2009thelongnoncoding pages 1-2
+10. michele2023imprintedlongnoncoding pages 10-11
+11. ferrer2024transcriptionregulationby pages 11-13
+12. redrup2009thelongnoncoding pages 2-3
+13. feil2016noncodingrnasand pages 11-14
+14. michele2023imprintedlongnoncoding pages 11-13
+15. ferrer2024transcriptionregulationby pages 27-28
+16. eggermann2024humanreproductionanda pages 7-8
+17. landschoot2014regulationofthea pages 43-49
+18. landschoot2014regulationofthe pages 43-49
+19. https://doi.org/10.3390/ijms241713647
+20. https://doi.org/10.1038/s41580-023-00694-9
+21. https://doi.org/10.1042/bst20230143
+22. https://doi.org/10.3390/genes15020163
+23. https://doi.org/10.1016/j.molcel.2008.08.022
+24. https://doi.org/10.1242/dev.031328
+25. https://doi.org/10.1534/g3.112.004226
+26. https://doi.org/10.1083/jcb.201304152
+27. https://doi.org/10.1016/j.molcel.2008.08.022,
+28. https://doi.org/10.3390/biom4010076,
+29. https://doi.org/10.1242/dev.031328,
+30. https://doi.org/10.3390/ijms241713647,
+31. https://doi.org/10.1371/journal.pgen.1002956,
+32. https://doi.org/10.1038/s41580-023-00694-9,
+33. https://doi.org/10.1042/bst20230143,
+34. https://doi.org/10.1534/g3.112.004226,
+35. https://doi.org/10.1083/jcb.201304152,
+36. https://doi.org/10.1007/978-3-319-27186-6\_2,
+37. https://doi.org/10.3390/genes15020163,

--- a/genes/human/MIR155/MIR155-ai-review.html
+++ b/genes/human/MIR155/MIR155-ai-review.html
@@ -671,33 +671,33 @@
     <div class="header">
         <h1>MIR155</h1>
         <div class="gene-info">
-            
+
             <div class="info-item">
-                
+
                 <span class="info-label">RNAcentral ID:</span>
                 <span>
                     <a href="https://rnacentral.org/rna/URS000062749E_9606" target="_blank" class="term-link">
                         URS000062749E_9606
                     </a>
                 </span>
-                
+
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Organism:</span>
                 <span>Homo sapiens</span>
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
                 <span class="status-badge status-complete">
                     COMPLETE
                 </span>
             </div>
-            
-            
+
+
         </div>
         <div style="margin-top: 1rem; text-align: center;">
             <a id="feedback-form-link"
@@ -728,75 +728,24 @@
         </div>
     </div>
 
-    
+
     <div class="description-card">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <h2>Gene Description</h2>
-            <span class="vote-buttons" data-g="URS000062749E_9606" data-a="DESCRIPTION: MicroRNA involved in immune regulation and oncogen..." data-r="" data-act="DESCRIPTION">
+            <span class="vote-buttons" data-g="URS000062749E_9606" data-a="DESCRIPTION: MIR155 encodes miR-155, a microRNA whose core mole..." data-r="" data-act="DESCRIPTION">
                 <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
                 <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
             </span>
         </div>
-        <p>MicroRNA involved in immune regulation and oncogenesis. Known as an oncomiR that regulates gene expression including KRAS targeting.</p>
+        <p>MIR155 encodes miR-155, a microRNA whose core molecular role is to guide Argonaute/RISC to target RNAs for miRNA-mediated post-transcriptional gene regulation. MIR155 is important in immune responses and oncogenesis, but those are context-specific regulatory outcomes rather than separate molecular functions.</p>
     </div>
-    
 
-    
 
-    
-    <div class="section">
-        <h2 class="section-title">Proposed New Ontology Terms</h2>
-        
-        <div class="proposed-term">
-            <div style="display: flex; justify-content: space-between; align-items: center;">
-                <h3>oncomiR activity</h3>
-                <span class="vote-buttons" data-g="URS000062749E_9606" data-a="oncomiR activity" data-r="" data-act="NEW">
-                    <button class="vote-btn" data-v="up" title="Agree this term should be created">👍</button>
-                    <button class="vote-btn" data-v="down" title="Disagree with creating this term">👎</button>
-                </span>
-            </div>
 
-            
-            <p><strong>Definition:</strong> The molecular function of a microRNA that promotes oncogenesis by regulating oncogenes or tumor suppressor genes</p>
-            
 
-            
-            <p><strong>Justification:</strong> MIR155 is a well-established oncomiR, but there is no specific GO term for oncomiR activity</p>
-            
 
-            
-            <p><strong>Parent term:</strong>
-                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003730" target="_blank" class="term-link">
-                    mRNA 3&#39;-UTR binding
-                </a>
-            </p>
-            
 
-            
 
-            
-            <p><strong>Supporting Evidence:</strong></p>
-            <ul style="margin-left: 1rem;">
-                
-                <li>
-                    
-                    <a href="https://pubmed.ncbi.nlm.nih.gov/23416982" target="_blank" class="term-link">
-                        PMID:23416982
-                    </a>
-                    
-                    
-                    : miR-155 is an established oncomiR in breast cancer
-                    
-                </li>
-                
-            </ul>
-            
-        </div>
-        
-    </div>
-    
-
-    
     <div class="section">
         <h2 class="section-title">Existing Annotations Review</h2>
         <table class="annotations-table">
@@ -809,32 +758,32 @@
                 </tr>
             </thead>
             <tbody>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035195" target="_blank" class="term-link">
                                     GO:0035195
                                 </a>
                             </span>
                             <span class="term-label">miRNA-mediated post-transcriptional gene silencing</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000115
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -846,64 +795,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> RNAcentral/Rfam annotation for the primary biological process that MIR155 participates in.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> MIR155 is a microRNA precursor and its mature product participates in miRNA-mediated post-transcriptional gene silencing.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/23416982" target="_blank" class="term-link">
                                         PMID:23416982
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">MicroRNA-155 (miR-155) is an established oncomiR in breast cancer and regulates several pro-oncogenic pathways.</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MIR155/MIR155-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Differential Ago HITS-CLIP/dCLIP comparing WT and miR-155-knockout activated CD4+ T cells identified miR-155-dependent Ago-binding sites, supporting miR-155-mediated post-transcriptional silencing.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016442" target="_blank" class="term-link">
                                     GO:0016442
                                 </a>
                             </span>
                             <span class="term-label">RISC complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000115
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -915,43 +875,119 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> RNAcentral/Rfam annotation placing MIR155 in the RNA-induced silencing complex context.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Mature miRNAs guide RISC-mediated target repression, so this RNAcentral annotation is consistent with MIR155 biology.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MIR155/MIR155-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Direct Argonaute immunoprecipitation in human macrophages provides strong evidence that miR-155 strands are physically present in Argonaute/RISC complexes.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003730" target="_blank" class="term-link">
+                                    GO:0003730
+                                </a>
+                            </span>
+                            <span class="term-label">mRNA 3&#39;-UTR binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="URS000062749E_9606" data-a="GO:0003730" data-r="" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Added to align the core MIR155 molecular function with the annotation block. Mature miR-155 guides Argonaute/RISC to target RNAs, with target recognition mediated by base-pairing to sites that include mRNA 3&#39;-UTRs.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Falcon found direct evidence for miR-155-dependent Argonaute occupancy at target sites, supporting the core mRNA 3&#39;-UTR binding function used in the core_functions block.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MIR155/MIR155-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Differential Ago HITS-CLIP/dCLIP comparing WT and miR-155-knockout activated CD4+ T cells identified miR-155-dependent Ago-binding sites.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
             </tbody>
         </table>
     </div>
-    
 
-    
+
+
     <div class="section">
         <h2 class="section-title">Core Functions</h2>
-        
+
         <div class="core-function-card">
-            
+
             <div style="display: flex; justify-content: space-between; align-items: center;">
-                <h3>microRNA-mediated gene silencing</h3>
-                <span class="vote-buttons" data-g="URS000062749E_9606" data-a="FUNCTION: microRNA-mediated gene silencing..." data-r="" data-act="CORE_FUNCTION">
+                <h3>miRNA guide RNA activity in Argonaute/RISC-mediated post-transcriptional gene silencing</h3>
+                <span class="vote-buttons" data-g="URS000062749E_9606" data-a="FUNCTION: miRNA guide RNA activity in Argonaute/RISC-mediate..." data-r="" data-act="CORE_FUNCTION">
                     <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
             </div>
-            
+
 
             <div class="core-function-terms">
-                
+
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
@@ -960,277 +996,157 @@
                         </a>
                     </span>
                 </div>
-                
 
-                
 
-                
 
-                
-
-                
-            </div>
-
-            
-            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
-                <strong>Supporting Evidence:</strong>
-                <ul class="findings-list">
-                    
-                    <li class="finding-item">
-                        <span class="reference-id">
-                            
-                            <a href="https://pubmed.ncbi.nlm.nih.gov/23416982" target="_blank" class="term-link">
-                                PMID:23416982
-                            </a>
-                            
-                        </span>
-                        
-                        <div class="finding-text">miR-155 is an established oncomiR that regulates several pro-oncogenic pathways</div>
-                        
-                    </li>
-                    
-                </ul>
-            </div>
-            
-        </div>
-        
-        <div class="core-function-card">
-            
-            <div style="display: flex; justify-content: space-between; align-items: center;">
-                <h3>regulation of immune cell differentiation</h3>
-                <span class="vote-buttons" data-g="URS000062749E_9606" data-a="FUNCTION: regulation of immune cell differentiation..." data-r="" data-act="CORE_FUNCTION">
-                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
-                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
-                </span>
-            </div>
-            
-
-            <div class="core-function-terms">
-                
                 <div class="function-term-group">
-                    <div class="function-term-label">Molecular Function:</div>
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035195" target="_blank" class="term-link">
+                                miRNA-mediated post-transcriptional gene silencing
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
                     <span class="badge">
-                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003730" target="_blank" class="term-link">
-                            mRNA 3&#39;-UTR binding
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016442" target="_blank" class="term-link">
+                            RISC complex
                         </a>
                     </span>
                 </div>
-                
 
-                
 
-                
 
-                
-
-                
             </div>
 
-            
+
             <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
                 <strong>Supporting Evidence:</strong>
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
-                            <a href="https://pubmed.ncbi.nlm.nih.gov/34626873" target="_blank" class="term-link">
-                                PMID:34626873
-                            </a>
-                            
+
+                            file:human/MIR155/MIR155-deep-research-falcon.md
+
                         </span>
-                        
-                        <div class="finding-text">miR-155 regulates both adaptive and innate immune responses</div>
-                        
+
+                        <div class="finding-text">Strong direct evidence exists for miR-155 association with Argonaute/RISC and for miR-155-guided post-transcriptional regulation.</div>
+
                     </li>
-                    
+
                 </ul>
             </div>
-            
+
         </div>
-        
-        <div class="core-function-card">
-            
-            <div style="display: flex; justify-content: space-between; align-items: center;">
-                <h3>inflammatory response regulation</h3>
-                <span class="vote-buttons" data-g="URS000062749E_9606" data-a="FUNCTION: inflammatory response regulation..." data-r="" data-act="CORE_FUNCTION">
-                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
-                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
-                </span>
-            </div>
-            
 
-            <div class="core-function-terms">
-                
-                <div class="function-term-group">
-                    <div class="function-term-label">Molecular Function:</div>
-                    <span class="badge">
-                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003730" target="_blank" class="term-link">
-                            mRNA 3&#39;-UTR binding
-                        </a>
-                    </span>
-                </div>
-                
-
-                
-
-                
-
-                
-
-                
-            </div>
-
-            
-            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
-                <strong>Supporting Evidence:</strong>
-                <ul class="findings-list">
-                    
-                    <li class="finding-item">
-                        <span class="reference-id">
-                            
-                            <a href="https://pubmed.ncbi.nlm.nih.gov/34626873" target="_blank" class="term-link">
-                                PMID:34626873
-                            </a>
-                            
-                        </span>
-                        
-                        <div class="finding-text">miR-155 affects both innate immunity and adaptive immunity in viral infections</div>
-                        
-                    </li>
-                    
-                </ul>
-            </div>
-            
-        </div>
-        
-        <div class="core-function-card">
-            
-            <div style="display: flex; justify-content: space-between; align-items: center;">
-                <h3>oncomiR activity suppressing tumor suppressor targets to promote oncogenesis</h3>
-                <span class="vote-buttons" data-g="URS000062749E_9606" data-a="FUNCTION: oncomiR activity suppressing tumor suppressor targ..." data-r="" data-act="CORE_FUNCTION">
-                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
-                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
-                </span>
-            </div>
-            
-
-            <div class="core-function-terms">
-                
-                <div class="function-term-group">
-                    <div class="function-term-label">Molecular Function:</div>
-                    <span class="badge">
-                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003730" target="_blank" class="term-link">
-                            mRNA 3&#39;-UTR binding
-                        </a>
-                    </span>
-                </div>
-                
-
-                
-
-                
-
-                
-
-                
-            </div>
-
-            
-            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
-                <strong>Supporting Evidence:</strong>
-                <ul class="findings-list">
-                    
-                    <li class="finding-item">
-                        <span class="reference-id">
-                            
-                            <a href="https://pubmed.ncbi.nlm.nih.gov/23416982" target="_blank" class="term-link">
-                                PMID:23416982
-                            </a>
-                            
-                        </span>
-                        
-                        <div class="finding-text">miR-155 is an established oncomiR in breast cancer</div>
-                        
-                    </li>
-                    
-                </ul>
-            </div>
-            
-        </div>
-        
     </div>
-    
 
-    
+
+
     <div class="section">
         <h2 class="section-title collapsible">References</h2>
         <div class="collapse-content">
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
+                        file:human/MIR155/MIR155-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research report for MIR155</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Falcon supports MIR155 as a guide RNA in Argonaute/RISC-mediated post-transcriptional regulation and cautions against treating immune, oncogenic, extracellular-vesicle, or stress-granule contexts as core GO functions without direct MIR155-specific evidence.</div>
+
+                        <div class="finding-text">"Strong direct evidence exists for miR-155 association with Argonaute/RISC and for miR-155-guided post-transcriptional regulation."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/23416982" target="_blank" class="term-link">
                             PMID:23416982
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">MiR-155 at the heart of oncogenic pathways</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/34626873" target="_blank" class="term-link">
                             PMID:34626873
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">MicroRNA-155 and antiviral immune responses</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000115.md" target="_blank" class="term-link">
                             GO_REF:0000115
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on Rfam2GO mapping</div>
-                
-                
+
+
             </div>
-            
+
         </div>
     </div>
-    
 
 
-    
+
+
     <div class="section">
         <h2 class="section-title">Suggested Questions for Experts</h2>
-        
+
         <div class="question-card">
             <div style="display: flex; justify-content: space-between; align-items: start;">
                 <div style="flex: 1;">
                     <p><strong>Q:</strong> What are the complete set of target mRNAs regulated by MIR155 in different cell types?</p>
-                    
+
                     <p style="margin-top: 0.5rem;"><em>Suggested experts: microRNA researchers, cancer biologists</em></p>
-                    
+
                 </div>
                 <span class="vote-buttons" data-g="URS000062749E_9606" data-a="Q: What are the complete set of target mRNAs regulate..." data-r="" data-act="QUESTION">
                     <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
@@ -1238,14 +1154,14 @@
                 </span>
             </div>
         </div>
-        
+
         <div class="question-card">
             <div style="display: flex; justify-content: space-between; align-items: start;">
                 <div style="flex: 1;">
                     <p><strong>Q:</strong> How does MIR155 expression change during immune cell activation and differentiation?</p>
-                    
+
                     <p style="margin-top: 0.5rem;"><em>Suggested experts: immunologists, T cell biologists</em></p>
-                    
+
                 </div>
                 <span class="vote-buttons" data-g="URS000062749E_9606" data-a="Q: How does MIR155 expression change during immune ce..." data-r="" data-act="QUESTION">
                     <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
@@ -1253,26 +1169,26 @@
                 </span>
             </div>
         </div>
-        
-    </div>
-    
 
-    
+    </div>
+
+
+
     <div class="section">
         <h2 class="section-title">Suggested Experiments</h2>
-        
+
         <div class="experiment-card">
             <div style="display: flex; justify-content: space-between; align-items: start;">
                 <div style="flex: 1;">
-                    
+
                     <p><strong>Experiment:</strong> CLIP-seq analysis to identify direct MIR155 target sites</p>
-                    
-                    
+
+
                     <p style="margin-top: 0.5rem;"><em>Hypothesis: MIR155 directly binds to specific sequences in target mRNAs</em></p>
-                    
-                    
+
+
                     <p style="margin-top: 0.5rem;">Type: high-throughput sequencing</p>
-                    
+
                 </div>
                 <span class="vote-buttons" data-g="URS000062749E_9606" data-a="EXPERIMENT: CLIP-seq analysis to identify direct MIR155 target..." data-r="" data-act="EXPERIMENT">
                     <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
@@ -1280,19 +1196,19 @@
                 </span>
             </div>
         </div>
-        
+
         <div class="experiment-card">
             <div style="display: flex; justify-content: space-between; align-items: start;">
                 <div style="flex: 1;">
-                    
+
                     <p><strong>Experiment:</strong> Single-cell RNA-seq of immune cells with MIR155 knockdown</p>
-                    
-                    
+
+
                     <p style="margin-top: 0.5rem;"><em>Hypothesis: MIR155 regulates immune cell differentiation programs</em></p>
-                    
-                    
+
+
                     <p style="margin-top: 0.5rem;">Type: single-cell analysis</p>
-                    
+
                 </div>
                 <span class="vote-buttons" data-g="URS000062749E_9606" data-a="EXPERIMENT: Single-cell RNA-seq of immune cells with MIR155 kn..." data-r="" data-act="EXPERIMENT">
                     <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
@@ -1300,17 +1216,412 @@
                 </span>
             </div>
         </div>
-        
-    </div>
-    
 
-    
+    </div>
+
+
+
 
     <!-- Computational Predictions Section -->
-    
+
 
     <!-- Additional Documentation Sections -->
-    
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Deep Research Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(MIR155-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="URS000062749E_9606" data-a="DOC: Deep Research Falcon" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <hr />
+<p>provider: falcon<br />
+model: Edison Scientific Literature<br />
+cached: false<br />
+start_time: '2026-05-11T03:29:14.815285'<br />
+end_time: '2026-05-11T03:56:23.361626'<br />
+duration_seconds: 1628.55<br />
+provider_config:<br />
+  timeout: 600<br />
+  max_retries: 3<br />
+  parameters:<br />
+    allowed_domains: []<br />
+    temperature: 0.1<br />
+citation_count: 24</p>
+<hr />
+<h2 id="question">Question</h2>
+<p>Research the human microRNA gene MIR155 (miR-155; RNAcentral URS000062749E_9606) for Gene Ontology functional annotation. This is a microRNA/non-coding RNA, not a protein; do not infer protein domains or enzyme activity. Focus on its core molecular function as a guide RNA in miRNA-mediated post-transcriptional gene silencing, RISC association, immune and oncogenic regulatory contexts only where they clarify direct function, cellular localization, and GO terms directly supported by primary literature. Distinguish core function from downstream immune or cancer phenotypes, and provide citations for each major claim.</p>
+<h2 id="output">Output</h2>
+<p>Question: You are an expert researcher providing comprehensive, well-cited information.</p>
+<p>Provide detailed information focusing on:<br />
+1. Key concepts and definitions with current understanding<br />
+2. Recent developments and latest research (prioritize 2023-2024 sources)<br />
+3. Current applications and real-world implementations<br />
+4. Expert opinions and analysis from authoritative sources<br />
+5. Relevant statistics and data from recent studies</p>
+<p>Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.<br />
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.</p>
+<p>Research the human microRNA gene MIR155 (miR-155; RNAcentral URS000062749E_9606) for Gene Ontology functional annotation. This is a microRNA/non-coding RNA, not a protein; do not infer protein domains or enzyme activity. Focus on its core molecular function as a guide RNA in miRNA-mediated post-transcriptional gene silencing, RISC association, immune and oncogenic regulatory contexts only where they clarify direct function, cellular localization, and GO terms directly supported by primary literature. Distinguish core function from downstream immune or cancer phenotypes, and provide citations for each major claim.</p>
+<h1 id="research-report-gene-ontology-go-functional-annotation-evidence-for-human-mir155-mir155-rnacentral-urs000062749e_9606">Research report: Gene Ontology (GO) functional annotation evidence for human MIR155 (miR‑155; RNAcentral URS000062749E_9606)</h1>
+<h2 id="1-key-concepts-and-definitions-current-understanding">1. Key concepts and definitions (current understanding)</h2>
+<h3 id="11-what-mir155-encodes">1.1 What MIR155 encodes</h3>
+<p>MIR155 is a <em>microRNA</em> (miRNA) gene that produces short (~22 nt) mature miRNA strands (classically annotated as miR‑155‑5p and miR‑155‑3p) that function as sequence-specific guide RNAs for Argonaute proteins within the RNA-induced silencing complex (RISC). Its molecular function is therefore not enzymatic; it is an RNA effector that confers targeting specificity to RISC via base-pairing to complementary sites in target RNAs.</p>
+<h3 id="12-what-counts-as-go-relevant-core-function-for-a-mirna-gene">1.2 What counts as GO-relevant “core function” for a miRNA gene</h3>
+<p>For a miRNA, GO-relevant <em>core</em> functions are those directly supported by experiments demonstrating:<br />
+- <strong>Association with Argonaute/RISC</strong> (cellular component and molecular function evidence), and<br />
+- <strong>Direct, sequence-dependent targeting of RNAs</strong> causing <strong>post-transcriptional gene silencing</strong> (biological process evidence), via mRNA destabilization and/or translational repression.</p>
+<p>Immune and oncogenic roles are downstream phenotypic outcomes of altering gene networks; they are included here only insofar as they clarify direct molecular mechanism, location, and evidence-backed GO terms.</p>
+<h2 id="2-primary-literature-evidence-supporting-go-relevant-annotation-for-mir155">2. Primary-literature evidence supporting GO-relevant annotation for MIR155</h2>
+<h3 id="21-argonauterisc-association-core-molecular-function-and-cellular-component">2.1 Argonaute/RISC association (core molecular function and cellular component)</h3>
+<p><strong>Argonaute RIP in primary human macrophages (direct RISC loading evidence).</strong> In primary human monocyte-derived macrophages, Simmonds (2019) immunoprecipitated Argonaute proteins (anti-Ago antibody 2A8) and measured miRNAs in the immunoprecipitate using absolute quantitation. The study reports that miR‑155‑3p was not detectable above background in resting cells but <strong>after 2 h LPS stimulation it was recovered from the Argonaute IP</strong>, consistent with <strong>RISC association/loading</strong> at the time of peak induction. The same approach detected miR‑155‑5p in Argonaute IP as well. Quantitatively, the study estimated <strong>cellular copy numbers</strong> in resting vs stimulated cells: miR‑155‑3p ~29±11 copies/cell at rest rising to <strong>~767±137 copies/cell at 2 h LPS</strong> (range 446–1,134); miR‑155‑5p ~1,315±417 (rest) rising to ~5,578±1,361 (2 h LPS). This provides direct biochemical evidence supporting annotation of MIR155 products to the <strong>RNA-induced silencing complex</strong> and to guide-RNA molecular function through Argonaute association. (simmonds2019transientupregulationof pages 11-12, simmonds2019transientupregulationof pages 12-14, simmonds2019transientupregulationof media a21bb4f5, simmonds2019transientupregulationof media 5691fff6)</p>
+<p><strong>Argonaute2 RIP in human cells showing miR‑155 guide participation in an Ago2 miRNP.</strong> In HT‑29 human colon cancer cells, Al‑Haidari et al. (2018) used Ago2 immunoprecipitation and qRT-PCR to show that <strong>AntagomiR‑155‑5p reduced enrichment of both miR‑155‑5p and HuR (ELAVL1) mRNA in Ago2 immunoprecipitates</strong>, indicating that miR‑155‑5p participates in Ago2-containing ribonucleoprotein complexes engaging a target mRNA. (alhaidari2018mir1555pcontrolscolon pages 28-29)</p>
+<p><strong>Transcriptome-wide Argonaute CLIP mapping requires miR‑155 to direct Ago binding.</strong> Loeb et al. (2012) used differential Argonaute HITS-CLIP (“AGO dCLIP”) comparing WT vs miR‑155 knockout activated CD4+ T cells to identify <strong>miR‑155-dependent Ago-binding peaks</strong>, demonstrating that the presence of miR‑155 directs Argonaute binding to specific RNA sites. (loeb2012transcriptomewidemir155binding pages 1-2, loeb2012transcriptomewidemir155binding pages 2-3)</p>
+<h3 id="22-mirna-mediated-post-transcriptional-gene-silencing-core-biological-process">2.2 miRNA-mediated post-transcriptional gene silencing (core biological process)</h3>
+<p><strong>Direct, miR‑155-dependent Argonaute binding correlates with repression.</strong> Loeb et al. (2012) report that differential CLIP identified <strong>191 miR‑155-dependent Ago binding sites in 175 genes (p&lt;0.01)</strong>, and that differential Ago binding <strong>correlated with target downregulation</strong> (p&lt;0.05), supporting annotation to miRNA-mediated gene silencing and post-transcriptional regulation of gene expression. The study further reports that miR‑155–Ago complexes occupy <strong>&gt;300 canonical 3′UTR sites</strong> with perfect 6–8 nt seed matches and that these canonical targets are strongly regulated by miR‑155. (loeb2012transcriptomewidemir155binding pages 2-3, loeb2012transcriptomewidemir155binding pages 7-8)</p>
+<p><strong>Noncanonical targeting is common for miR‑155 (refines mechanistic understanding but still core guide function).</strong> In the same Loeb et al. binding map, <strong>~40% of miR‑155-dependent Ago binding sites lacked perfect seed matches</strong>, implying widespread noncanonical interactions; these tended to produce more modest regulation. Reporter validation showed mutation of predicted noncanonical sites significantly reduced repression by miR‑155, supporting direct functional targeting even without perfect seed matches. This evidence informs annotation to miRNA-mediated silencing without over-specifying “seed-only” rules. (loeb2012transcriptomewidemir155binding pages 7-8, loeb2012transcriptomewidemir155binding pages 6-7)</p>
+<p><strong>Direct sequence-element dependence in a miR‑155-guided interaction (context-dependent repression vs activation).</strong> Al‑Haidari et al. (2018) provide direct evidence that miR‑155‑5p binds AU-rich elements in the HuR 3′UTR, validated using target-site blockers and ribonucleoprotein immunoprecipitation approaches. Notably, they observe context dependence (serum-starved vs serum-fed) where miR‑155‑5p can positively regulate HuR translation/mRNA levels under quiescence-like conditions; this does not negate the core GO process (post-transcriptional regulation via guide RNA), but cautions that “gene silencing” directionality may depend on cellular state and target context. (alhaidari2018mir1555pcontrolscolon pages 1-7, alhaidari2018mir1555pcontrolscolon pages 7-11)</p>
+<h3 id="23-cellular-localization-cellular-component-what-is-directly-supported">2.3 Cellular localization / cellular component (what is directly supported)</h3>
+<p><strong>Supported: RISC / Argonaute-containing cytoplasmic effector complex.</strong> Direct Argonaute immunoprecipitation in human macrophages provides strong evidence that miR‑155 strands are physically present in Argonaute/RISC complexes. This supports GO cellular component annotation to <strong>RNA-induced silencing complex</strong>. (simmonds2019transientupregulationof pages 11-12, simmonds2019transientupregulationof pages 12-14, simmonds2019transientupregulationof media a21bb4f5, simmonds2019transientupregulationof media 5691fff6)</p>
+<p><strong>Not sufficiently supported in the current primary-evidence set: P-bodies, stress granules, extracellular vesicles.</strong> Although many reviews and some non-miR‑155-specific literature connect Ago/miRNPs to P-bodies and EV biology, the retrieved primary evidence in this run does <strong>not</strong> provide a direct, miR‑155-specific demonstration (e.g., microscopy co-localization of miR‑155 with P-body markers; EV isolation plus miR‑155 quantification with rigorous controls) that would justify assigning MIR155 a GO cellular component annotation to P-body/stress granule or extracellular vesicle <em>as a core function</em>. (witten2020mir155asa pages 18-19, de2020amyloidbetaoligomers pages 25-30)</p>
+<h2 id="3-evidence-based-go-annotation-summary-proposed-terms-and-support">3. Evidence-based GO annotation summary (proposed terms and support)</h2>
+<p>The table below summarizes GO-relevant annotations derived from <em>direct evidence</em> in the primary literature available here and flags terms that are not currently well supported.</p>
+<table>
+<thead>
+<tr>
+<th>GO aspect</th>
+<th>GO term label (GO ID if known)</th>
+<th>Evidence summary</th>
+<th>miR-155 strand</th>
+<th>Biological system</th>
+<th>Supporting citations</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>MF</td>
+<td>miRNA-mediated gene silencing by RNA binding</td>
+<td>Argonaute RIP in primary human monocyte-derived macrophages using anti-Ago (2A8) recovered miR-155-3p and miR-155-5p from RISC; miR-155-3p was undetectable above background in resting cells but recovered after 2 h LPS, indicating direct guide-RNA association with Ago/RISC.</td>
+<td>3p, 5p</td>
+<td>Primary human monocyte-derived macrophages</td>
+<td>(simmonds2019transientupregulationof pages 11-12, simmonds2019transientupregulationof pages 12-14)</td>
+</tr>
+<tr>
+<td>MF</td>
+<td>RNA guide activity</td>
+<td>Ago2-RIP/qRT-PCR in HT-29 cells showed antagomiR-155-5p reduced enrichment of both miR-155-5p and HuR mRNA in Ago2 immunoprecipitates, supporting direct guide-RNA function of miR-155-5p within Ago2-containing effector complexes.</td>
+<td>5p</td>
+<td>HT-29 human colon cancer cells</td>
+<td>(alhaidari2018mir1555pcontrolscolon pages 28-29, alhaidari2018mir1555pcontrolscolon pages 7-11)</td>
+</tr>
+<tr>
+<td>BP</td>
+<td>miRNA-mediated post-transcriptional gene silencing (GO:0035195)</td>
+<td>Differential Ago HITS-CLIP/dCLIP comparing WT and miR-155-knockout activated CD4+ T cells identified 191 miR-155-dependent Ago-binding sites in 175 genes; loss of miR-155 reduced Ago occupancy and correlated with target downregulation/repression, providing transcriptome-wide evidence for miR-155-mediated silencing.</td>
+<td>5p</td>
+<td>Activated murine CD4+ T cells</td>
+<td>(loeb2012transcriptomewidemir155binding pages 1-2, loeb2012transcriptomewidemir155binding pages 2-3)</td>
+</tr>
+<tr>
+<td>BP</td>
+<td>post-transcriptional regulation of gene expression</td>
+<td>In serum-starved HT-29 cells, target-site blocker and Ago2-RIP experiments showed miR-155-5p directly binds AU-rich elements in the HuR 3′UTR and regulates HuR mRNA levels/translation post-transcriptionally.</td>
+<td>5p</td>
+<td>HT-29 human colon cancer cells</td>
+<td>(alhaidari2018mir1555pcontrolscolon pages 1-7, alhaidari2018mir1555pcontrolscolon pages 7-11)</td>
+</tr>
+<tr>
+<td>BP</td>
+<td>gene silencing by miRNA</td>
+<td>Transcriptome-wide Ago dCLIP showed miR-155 guides Ago to &gt;300 canonical 3′UTR sites and many noncanonical sites; ~40% of miR-155-dependent Ago binding lacked perfect seed matches, indicating direct target repression can include noncanonical binding modes.</td>
+<td>5p</td>
+<td>Activated murine primary T cells</td>
+<td>(loeb2012transcriptomewidemir155binding pages 7-8, loeb2012transcriptomewidemir155binding pages 1-2)</td>
+</tr>
+<tr>
+<td>CC</td>
+<td>RNA-induced silencing complex</td>
+<td>Anti-Ago immunoprecipitation followed by absolute miRNA quantification demonstrated miR-155-5p and inducible miR-155-3p are present in Ago-containing RISC in primary macrophages.</td>
+<td>3p, 5p</td>
+<td>Primary human monocyte-derived macrophages</td>
+<td>(simmonds2019transientupregulationof pages 11-12, simmonds2019transientupregulationof media a21bb4f5)</td>
+</tr>
+<tr>
+<td>CC</td>
+<td>cytoplasm</td>
+<td>In HT-29 cells, miR-155-5p knockdown decreased cytoplasmic HuR expression; the study examines miR-155-5p-mediated post-transcriptional regulation of a cytoplasmic target context, but does not directly localize miR-155 RNA itself by imaging/fractionation, so support for cytoplasmic localization of MIR155/miR-155 is indirect and should be used cautiously.</td>
+<td>5p</td>
+<td>HT-29 human colon cancer cells</td>
+<td>(alhaidari2018mir1555pcontrolscolon pages 1-7)</td>
+</tr>
+<tr>
+<td>CC</td>
+<td>P-body / stress granule</td>
+<td>No direct primary evidence in the provided context shows MIR155/miR-155 itself localized to P-bodies or stress granules by microscopy or specific fractionation; related literature in context concerns general Ago/P-body biology or non-miR-155-specific compartmentation and is insufficient for confident annotation of MIR155 to these CC terms.</td>
+<td>—</td>
+<td>—</td>
+<td>(witten2020mir155asa pages 18-19)</td>
+</tr>
+<tr>
+<td>CC</td>
+<td>extracellular vesicle</td>
+<td>The provided context includes review-level discussion and indirect/preprint evidence for extracellular or endosomal miR-155 contexts, but no high-confidence primary evidence sufficient here to assign MIR155 a GO cellular-component annotation to extracellular vesicle for core function.</td>
+<td>—</td>
+<td>—</td>
+<td>(de2020amyloidbetaoligomers pages 25-30, witten2020mir155asa pages 18-19)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table maps proposed GO annotations for human MIR155/miR-155 to direct primary-literature evidence available in the current context. It highlights well-supported core functions and compartments while flagging localization terms that are not sufficiently supported for confident annotation.</em></p>
+<h2 id="4-recent-developments-prioritizing-20232024-and-how-they-relate-to-core-go-function">4. Recent developments (prioritizing 2023–2024) and how they relate to core GO function</h2>
+<h3 id="41-clinical-translation-of-mir155-inhibition-as-a-test-of-functional-relevance-not-go-core-function">4.1 Clinical translation of miR‑155 inhibition as a test of functional relevance (not GO core function)</h3>
+<p>A major recent-development theme is clinical translation of miR‑155 inhibition (anti-miR/antagomir strategies), most prominently <strong>cobomarsen (MRG‑106)</strong>.</p>
+<p>A 2024 review of miRNA therapeutics describes <strong>cobomarsen (MRG‑106) as an LNA-based antagomir of miR‑155</strong>, noting a completed phase 1 trial and that phase 2 studies were initiated but at least two phase 2 trials were terminated; it also notes that at least one termination was due to business reasons rather than safety/efficacy concerns (as per ClinicalTrials.gov, accessed 20 Dec 2023). This literature is useful for “current applications” but does not replace primary biochemical evidence for GO annotation. (seyhan2024trialsandtribulations pages 16-17)</p>
+<h3 id="42-subcellular-compartmentalization-is-an-active-research-area-but-remains-difficult-to-convert-into-mir155-specific-go-cc-terms">4.2 Subcellular compartmentalization is an active research area but remains difficult to convert into miR‑155-specific GO CC terms</h3>
+<p>Recent reviews increasingly emphasize miRNA localization heterogeneity (endosomes, ER-associated polysomes, etc.) and extracellular RNA transport, but miR‑155-specific localization evidence must be supported by rigorous primary experiments. A 2020 fractionation-based study (bioRxiv) describes optiprep gradient fractionation and reports measuring distribution of miR‑155 in endosomal fractions in Aβ-treated glial cells, illustrating methods that could support future GO CC annotation if replicated and validated. However, in this run, the relevant excerpt does not provide numeric outcomes sufficient to assert a specific GO CC term for MIR155 beyond RISC. (de2020amyloidbetaoligomers pages 25-30, de2020amyloidbetaoligomers pages 18-23)</p>
+<h2 id="5-current-applications-and-real-world-implementations">5. Current applications and real-world implementations</h2>
+<h3 id="51-therapeutic-inhibition-cobomarsen-mrg106">5.1 Therapeutic inhibition: cobomarsen (MRG‑106)</h3>
+<p>ClinicalTrials.gov provides direct, citable implementation details for cobomarsen/MRG‑106 targeting miR‑155.</p>
+<ul>
+<li><strong>NCT02580552 (Phase 1, completed; n=66)</strong>: dose-ranging safety/tolerability/PK study in MF (CTCL), CLL, DLBCL (ABC), ATLL. Routes included <strong>intratumoral, subcutaneous, and intravenous</strong> administration; exploratory endpoints included <strong>miR‑155‑5p expression in MF skin lesions (qRT-PCR)</strong> and dermatology-related QoL measures. Start date 2016‑02‑09; completion 2020‑10‑06. (NCT02580552 chunk 1, NCT02580552 chunk 2)</li>
+<li><strong>NCT03713320 (SOLAR; Phase 2; terminated; actual enrollment 37)</strong>: randomized open-label study in mycosis fungoides comparing cobomarsen (IV infusion) vs vorinostat (oral). The record states termination was <strong>“for business reasons, and not due to concerns regarding safety or lack of efficacy.”</strong> Start 2019‑04‑02; completion 2020‑12‑01; registry indicates <strong>results were posted</strong> (results first post date 2022‑04‑08). (NCT03713320 chunk 1)</li>
+</ul>
+<p>These trials provide real-world validation that miR‑155 can be modulated in patients, and they operationalize miR‑155’s role as a guide RNA in post-transcriptional regulation (pharmacodynamic readouts), but they do not define additional GO molecular functions beyond miRNA-mediated silencing.</p>
+<table>
+<thead>
+<tr>
+<th>Application type</th>
+<th>Agent/Assay</th>
+<th>Target</th>
+<th>Indication</th>
+<th>Trial ID</th>
+<th>Phase</th>
+<th>Status</th>
+<th style="text-align: right;">Enrollment</th>
+<th>Route</th>
+<th>Key endpoints/outcomes mentioned</th>
+<th>Termination reason (if any)</th>
+<th>Publication/registry URL</th>
+<th>Supporting citations (context IDs)</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Therapeutic</td>
+<td>Cobomarsen (MRG-106), LNA-based anti-miR / ASO</td>
+<td>miR-155</td>
+<td>Mycosis fungoides (CTCL), CLL, DLBCL, ATLL</td>
+<td>NCT02580552</td>
+<td>Phase 1</td>
+<td>Completed</td>
+<td style="text-align: right;">66</td>
+<td>Intratumoral, subcutaneous, intravenous</td>
+<td>Safety, tolerability, pharmacokinetics; exploratory outcomes included overall survival, miR-155-5p expression in MF skin lesions, neoplastic lymphoid-cell proportions, immune-cell subsets, Skindex-29 and pruritus measures; review sources describe early clinical improvement signals in CAILS, mSWAT, and Skindex-29 with no serious adverse events attributed to cobomarsen in early reports</td>
+<td>Not applicable; completed study</td>
+<td>https://clinicaltrials.gov/study/NCT02580552 ; https://doi.org/10.3390/cancers14061588 ; https://doi.org/10.3390/ijms25031469</td>
+<td>(NCT02580552 chunk 1, NCT02580552 chunk 2, smith2022clinicalapplicationsof pages 7-8, seyhan2024trialsandtribulations pages 16-17, witten2020mir155asa pages 14-15)</td>
+</tr>
+<tr>
+<td>Therapeutic</td>
+<td>Cobomarsen (MRG-106) vs active comparator (vorinostat)</td>
+<td>miR-155</td>
+<td>Cutaneous T-cell lymphoma, mycosis fungoides</td>
+<td>NCT03713320</td>
+<td>Phase 2</td>
+<td>Terminated</td>
+<td style="text-align: right;">37</td>
+<td>Cobomarsen: 2-hour intravenous infusion; comparator vorinostat: oral</td>
+<td>Efficacy/safety outcomes included 50% improvement in mSWAT, pruritus medication utilization, PK endpoints (Cmax, AUC), and anti-drug antibody generation; registry states results were submitted/posted</td>
+<td>“Terminated early for business reasons, and not due to concerns regarding safety or lack of efficacy.”</td>
+<td>https://clinicaltrials.gov/study/NCT03713320 ; https://doi.org/10.3390/ijms25031469</td>
+<td>(NCT03713320 chunk 1, NCT03713320 chunk 2, seyhan2024trialsandtribulations pages 16-17)</td>
+</tr>
+<tr>
+<td>Therapeutic</td>
+<td>Cobomarsen (MRG-106) extension after SOLAR</td>
+<td>miR-155</td>
+<td>Mycosis fungoides after SOLAR completion</td>
+<td>NCT03837457</td>
+<td>Phase 2</td>
+<td>Terminated</td>
+<td style="text-align: right;">8</td>
+<td>Not available in provided context</td>
+<td>Extension study identified in review/trial listings; no posted outcome details available in provided context</td>
+<td>Not stated in provided context</td>
+<td>https://clinicaltrials.gov/study/NCT03837457 ; https://doi.org/10.3390/ijms25031469</td>
+<td>(seyhan2024trialsandtribulations pages 16-17, piergentili2025targetingregulatorynoncoding pages 16-17)</td>
+</tr>
+<tr>
+<td>Therapeutic/Translational</td>
+<td>Cobomarsen (MRG-106) program summary in reviews</td>
+<td>miR-155</td>
+<td>Lymphomas/leukemias including CTCL, CLL, DLBCL, ATLL</td>
+<td>Program-level</td>
+<td>Phase 1 completed; Phase 2 initiated/terminated</td>
+<td>Mixed</td>
+<td style="text-align: right;">—</td>
+<td>Intratumoral, intravenous, subcutaneous reported across studies</td>
+<td>Seyhan 2024 identifies cobomarsen as an LNA-based antagomir and notes completed phase 1 plus terminated phase 2 studies; Smith 2022 lists miRagen-sponsored ASO program and delivery routes; Witten &amp; Slack 2020 describe reductions in miR-155 target-gene expression in biopsies and sustained improvements in lesion/quality-of-life metrics in early reports</td>
+<td>Review states at least one terminated study ended for business reasons rather than safety/efficacy concerns</td>
+<td>https://doi.org/10.3390/ijms25031469 ; https://doi.org/10.3390/cancers14061588 ; https://doi.org/10.1093/carcin/bgz183</td>
+<td>(seyhan2024trialsandtribulations pages 16-17, smith2022clinicalapplicationsof pages 7-8, witten2020mir155asa pages 13-14, witten2020mir155asa pages 14-15)</td>
+</tr>
+<tr>
+<td>Diagnostic/biomarker</td>
+<td>miR-155 expression assays / circulating or tissue miR-155 profiling</td>
+<td>miR-155</td>
+<td>Hematologic malignancy and inflammatory-disease biomarker studies (observational and ancillary uses)</td>
+<td>Multiple non-cobomarsen studies in registry</td>
+<td>Observational / non-therapeutic</td>
+<td>Ongoing, completed, or unknown depending on study</td>
+<td style="text-align: right;">Varies</td>
+<td>Biospecimen assay</td>
+<td>Used as biomarker/prognostic or pharmacodynamic readout rather than direct therapeutic intervention; examples in provided context include lesion miR-155-5p qRT-PCR in NCT02580552 and review discussion of biomarker utility</td>
+<td>Not applicable</td>
+<td>https://clinicaltrials.gov/study/NCT02580552 ; https://doi.org/10.3390/ijms25031469</td>
+<td>(NCT02580552 chunk 2, seyhan2024trialsandtribulations pages 16-17)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes miR-155-targeting real-world applications, focusing on cobomarsen/MRG-106 clinical development and registry-level details. It is useful for linking therapeutic and biomarker use cases to specific trial phases, statuses, routes, and reported outcomes.</em></p>
+<h2 id="6-expert-opinions-and-authoritative-analysis-distinguishing-core-function-from-phenotype">6. Expert opinions and authoritative analysis (distinguishing core function from phenotype)</h2>
+<h3 id="61-what-authoritative-sources-emphasize-about-mir155">6.1 What authoritative sources emphasize about miR‑155</h3>
+<p>Authoritative reviews in hematologic malignancy emphasize miR‑155 as an oncogenic miRNA and summarize early clinical signals from cobomarsen, including improved lesion-burden and QoL metrics and lack of serious adverse events attributed to the drug in early reports. These expert analyses support clinical interest and translational feasibility but should be treated as secondary evidence relative to primary mechanistic studies for GO annotations. (witten2020mir155asa pages 14-15)</p>
+<h3 id="62-separation-of-direct-function-from-downstream-immunecancer-phenotypes">6.2 Separation of direct function from downstream immune/cancer phenotypes</h3>
+<p>The direct molecular function of MIR155 is <strong>Argonaute-associated guide RNA function</strong> that mediates post-transcriptional regulation (typically repression) of target RNAs. Immune activation, inflammation, and oncogenesis arise from downstream network effects of repressing many target transcripts and are better considered <em>phenotypic consequences</em> rather than direct GO molecular function. The dCLIP data show miR‑155 guides Ago to hundreds of sites in an endogenous, transcriptome-wide manner, supporting network-level regulatory capacity without implying new molecular activities beyond RNA-guided silencing. (loeb2012transcriptomewidemir155binding pages 7-8, loeb2012transcriptomewidemir155binding pages 2-3)</p>
+<h2 id="7-relevant-recent-statistics-and-data">7. Relevant recent statistics and data</h2>
+<h3 id="71-quantitative-mir155-abundance-and-risc-association">7.1 Quantitative miR‑155 abundance and RISC association</h3>
+<p>In primary human macrophages, absolute quantitation estimated mean copy numbers per cell and demonstrated inducible RISC association:<br />
+- miR‑155‑3p: ~29±11 copies/cell resting; <strong>~767±137 copies/cell at 2 h LPS</strong> (range 446–1,134)<br />
+- miR‑155‑5p: ~1,315±417 copies/cell resting; ~5,578±1,361 copies/cell at 2 h LPS<br />
+These data are directly relevant for GO annotation because they support that miR‑155 strands reach measurable abundance and are physically present in Argonaute immunoprecipitates at biologically relevant times. (simmonds2019transientupregulationof pages 11-12)</p>
+<h3 id="72-clinical-trial-statistics-implementation-level">7.2 Clinical trial statistics (implementation-level)</h3>
+<ul>
+<li>NCT02580552: <strong>66 participants</strong>, Phase 1, completed. (NCT02580552 chunk 1)</li>
+<li>NCT03713320: <strong>37 participants</strong>, Phase 2, terminated early for business reasons; results posted 2022‑04‑08 per registry. (NCT03713320 chunk 1)</li>
+</ul>
+<h2 id="8-limitations-of-this-evidence-set-for-go-cellular-component-expansion">8. Limitations of this evidence set for GO cellular-component expansion</h2>
+<p>Within the retrieved corpus, strong direct evidence exists for miR‑155 association with Argonaute/RISC and for miR‑155-guided post-transcriptional regulation. However, <em>miR‑155-specific</em> evidence for localization to P-bodies/stress granules or extracellular vesicles was not sufficiently explicit/quantitative in the extracted primary text to support confident GO cellular-component annotation to those compartments in this report. (witten2020mir155asa pages 18-19, de2020amyloidbetaoligomers pages 25-30)</p>
+<h2 id="key-urls-publicationregistry">Key URLs (publication/registry)</h2>
+<ul>
+<li>Simmonds RE. Wellcome Open Research (2019-03). https://doi.org/10.12688/wellcomeopenres.15065.1 (simmonds2019transientupregulationof pages 11-12)</li>
+<li>Al-Haidari A et al. Cancer Letters (2018-05). https://doi.org/10.1016/j.canlet.2018.02.026 (alhaidari2018mir1555pcontrolscolon pages 1-7)</li>
+<li>Loeb GB et al. Molecular Cell (2012-12). https://doi.org/10.1016/j.molcel.2012.10.002 (loeb2012transcriptomewidemir155binding pages 1-2)</li>
+<li>Seyhan AA. Int J Mol Sci (2024-01). https://doi.org/10.3390/ijms25031469 (seyhan2024trialsandtribulations pages 16-17)</li>
+<li>ClinicalTrials.gov NCT02580552. https://clinicaltrials.gov/study/NCT02580552 (NCT02580552 chunk 1)</li>
+<li>ClinicalTrials.gov NCT03713320. https://clinicaltrials.gov/study/NCT03713320 (NCT03713320 chunk 1)</li>
+</ul>
+<p>References</p>
+<ol>
+<li>
+<p>(simmonds2019transientupregulationof pages 11-12): Rachel E. Simmonds. Transient up-regulation of mir-155-3p by lipopolysaccharide in primary human monocyte-derived macrophages results in risc incorporation but does not alter tnf expression. Wellcome Open Research, 4:43, Mar 2019. URL: https://doi.org/10.12688/wellcomeopenres.15065.1, doi:10.12688/wellcomeopenres.15065.1. This article has 21 citations.</p>
+</li>
+<li>
+<p>(simmonds2019transientupregulationof pages 12-14): Rachel E. Simmonds. Transient up-regulation of mir-155-3p by lipopolysaccharide in primary human monocyte-derived macrophages results in risc incorporation but does not alter tnf expression. Wellcome Open Research, 4:43, Mar 2019. URL: https://doi.org/10.12688/wellcomeopenres.15065.1, doi:10.12688/wellcomeopenres.15065.1. This article has 21 citations.</p>
+</li>
+<li>
+<p>(simmonds2019transientupregulationof media a21bb4f5): Rachel E. Simmonds. Transient up-regulation of mir-155-3p by lipopolysaccharide in primary human monocyte-derived macrophages results in risc incorporation but does not alter tnf expression. Wellcome Open Research, 4:43, Mar 2019. URL: https://doi.org/10.12688/wellcomeopenres.15065.1, doi:10.12688/wellcomeopenres.15065.1. This article has 21 citations.</p>
+</li>
+<li>
+<p>(simmonds2019transientupregulationof media 5691fff6): Rachel E. Simmonds. Transient up-regulation of mir-155-3p by lipopolysaccharide in primary human monocyte-derived macrophages results in risc incorporation but does not alter tnf expression. Wellcome Open Research, 4:43, Mar 2019. URL: https://doi.org/10.12688/wellcomeopenres.15065.1, doi:10.12688/wellcomeopenres.15065.1. This article has 21 citations.</p>
+</li>
+<li>
+<p>(alhaidari2018mir1555pcontrolscolon pages 28-29): Amr Al-Haidari, Anwar Algaber, Raed Madhi, Ingvar Syk, and Henrik Thorlacius. Mir-155-5p controls colon cancer cell migration via post-transcriptional regulation of human antigen r (hur). Cancer letters, 421:145-151, May 2018. URL: https://doi.org/10.1016/j.canlet.2018.02.026, doi:10.1016/j.canlet.2018.02.026. This article has 78 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(loeb2012transcriptomewidemir155binding pages 1-2): Gabriel B. Loeb, Aly A. Khan, David Canner, Joseph B. Hiatt, Jay Shendure, Robert B. Darnell, Christina S. Leslie, and Alexander Y. Rudensky. Transcriptome-wide mir-155 binding map reveals widespread noncanonical microrna targeting. Molecular cell, 48 5:760-70, Dec 2012. URL: https://doi.org/10.1016/j.molcel.2012.10.002, doi:10.1016/j.molcel.2012.10.002. This article has 403 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(loeb2012transcriptomewidemir155binding pages 2-3): Gabriel B. Loeb, Aly A. Khan, David Canner, Joseph B. Hiatt, Jay Shendure, Robert B. Darnell, Christina S. Leslie, and Alexander Y. Rudensky. Transcriptome-wide mir-155 binding map reveals widespread noncanonical microrna targeting. Molecular cell, 48 5:760-70, Dec 2012. URL: https://doi.org/10.1016/j.molcel.2012.10.002, doi:10.1016/j.molcel.2012.10.002. This article has 403 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(loeb2012transcriptomewidemir155binding pages 7-8): Gabriel B. Loeb, Aly A. Khan, David Canner, Joseph B. Hiatt, Jay Shendure, Robert B. Darnell, Christina S. Leslie, and Alexander Y. Rudensky. Transcriptome-wide mir-155 binding map reveals widespread noncanonical microrna targeting. Molecular cell, 48 5:760-70, Dec 2012. URL: https://doi.org/10.1016/j.molcel.2012.10.002, doi:10.1016/j.molcel.2012.10.002. This article has 403 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(loeb2012transcriptomewidemir155binding pages 6-7): Gabriel B. Loeb, Aly A. Khan, David Canner, Joseph B. Hiatt, Jay Shendure, Robert B. Darnell, Christina S. Leslie, and Alexander Y. Rudensky. Transcriptome-wide mir-155 binding map reveals widespread noncanonical microrna targeting. Molecular cell, 48 5:760-70, Dec 2012. URL: https://doi.org/10.1016/j.molcel.2012.10.002, doi:10.1016/j.molcel.2012.10.002. This article has 403 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(alhaidari2018mir1555pcontrolscolon pages 1-7): Amr Al-Haidari, Anwar Algaber, Raed Madhi, Ingvar Syk, and Henrik Thorlacius. Mir-155-5p controls colon cancer cell migration via post-transcriptional regulation of human antigen r (hur). Cancer letters, 421:145-151, May 2018. URL: https://doi.org/10.1016/j.canlet.2018.02.026, doi:10.1016/j.canlet.2018.02.026. This article has 78 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(alhaidari2018mir1555pcontrolscolon pages 7-11): Amr Al-Haidari, Anwar Algaber, Raed Madhi, Ingvar Syk, and Henrik Thorlacius. Mir-155-5p controls colon cancer cell migration via post-transcriptional regulation of human antigen r (hur). Cancer letters, 421:145-151, May 2018. URL: https://doi.org/10.1016/j.canlet.2018.02.026, doi:10.1016/j.canlet.2018.02.026. This article has 78 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(witten2020mir155asa pages 18-19): Lisa Witten and Frank J Slack. Mir-155 as a novel clinical target for hematological malignancies. Carcinogenesis, 41:2-7, Nov 2020. URL: https://doi.org/10.1093/carcin/bgz183, doi:10.1093/carcin/bgz183. This article has 119 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(de2020amyloidbetaoligomers pages 25-30): Dipayan De and Suvendra N. Bhattacharyya. Amyloid beta oligomers prevents lysosomal targeting of mirnp to stop its recycling and target cytokine repression in glial cells. bioRxiv, Dec 2020. URL: https://doi.org/10.1101/2020.12.24.424324, doi:10.1101/2020.12.24.424324. This article has 0 citations.</p>
+</li>
+<li>
+<p>(seyhan2024trialsandtribulations pages 16-17): Attila A Seyhan. Trials and tribulations of microrna therapeutics. International Journal of Molecular Sciences, Jan 2024. URL: https://doi.org/10.3390/ijms25031469, doi:10.3390/ijms25031469. This article has 393 citations.</p>
+</li>
+<li>
+<p>(de2020amyloidbetaoligomers pages 18-23): Dipayan De and Suvendra N. Bhattacharyya. Amyloid beta oligomers prevents lysosomal targeting of mirnp to stop its recycling and target cytokine repression in glial cells. bioRxiv, Dec 2020. URL: https://doi.org/10.1101/2020.12.24.424324, doi:10.1101/2020.12.24.424324. This article has 0 citations.</p>
+</li>
+<li>
+<p>(NCT02580552 chunk 1):  Safety, Tolerability and Pharmacokinetics of MRG-106 in Patients With Mycosis Fungoides (MF), CLL, DLBCL or ATLL. miRagen Therapeutics, Inc.. 2016. ClinicalTrials.gov Identifier: NCT02580552</p>
+</li>
+<li>
+<p>(NCT02580552 chunk 2):  Safety, Tolerability and Pharmacokinetics of MRG-106 in Patients With Mycosis Fungoides (MF), CLL, DLBCL or ATLL. miRagen Therapeutics, Inc.. 2016. ClinicalTrials.gov Identifier: NCT02580552</p>
+</li>
+<li>
+<p>(NCT03713320 chunk 1):  SOLAR: Efficacy and Safety of Cobomarsen (MRG-106) vs. Active Comparator in Subjects With Mycosis Fungoides. miRagen Therapeutics, Inc.. 2019. ClinicalTrials.gov Identifier: NCT03713320</p>
+</li>
+<li>
+<p>(smith2022clinicalapplicationsof pages 7-8): Ellen S. Smith, Eric Whitty, Byunghee Yoo, Anna Moore, Lorenzo F. Sempere, and Zdravka Medarova. Clinical applications of short non-coding rna-based therapies in the era of precision medicine. Cancers, 14:1588, Mar 2022. URL: https://doi.org/10.3390/cancers14061588, doi:10.3390/cancers14061588. This article has 72 citations.</p>
+</li>
+<li>
+<p>(witten2020mir155asa pages 14-15): Lisa Witten and Frank J Slack. Mir-155 as a novel clinical target for hematological malignancies. Carcinogenesis, 41:2-7, Nov 2020. URL: https://doi.org/10.1093/carcin/bgz183, doi:10.1093/carcin/bgz183. This article has 119 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(NCT03713320 chunk 2):  SOLAR: Efficacy and Safety of Cobomarsen (MRG-106) vs. Active Comparator in Subjects With Mycosis Fungoides. miRagen Therapeutics, Inc.. 2019. ClinicalTrials.gov Identifier: NCT03713320</p>
+</li>
+<li>
+<p>(piergentili2025targetingregulatorynoncoding pages 16-17): R. Piergentili and S. Sechi. Targeting regulatory noncoding rnas in human cancer: the state of the art in clinical trials. Pharmaceutics, Apr 2025. URL: https://doi.org/10.3390/pharmaceutics17040471, doi:10.3390/pharmaceutics17040471. This article has 4 citations.</p>
+</li>
+<li>
+<p>(witten2020mir155asa pages 13-14): Lisa Witten and Frank J Slack. Mir-155 as a novel clinical target for hematological malignancies. Carcinogenesis, 41:2-7, Nov 2020. URL: https://doi.org/10.1093/carcin/bgz183, doi:10.1093/carcin/bgz183. This article has 119 citations and is from a peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>seyhan2024trialsandtribulations pages 16-17</li>
+<li>simmonds2019transientupregulationof pages 11-12</li>
+<li>simmonds2019transientupregulationof pages 12-14</li>
+<li>de2020amyloidbetaoligomers pages 25-30</li>
+<li>de2020amyloidbetaoligomers pages 18-23</li>
+<li>smith2022clinicalapplicationsof pages 7-8</li>
+<li>piergentili2025targetingregulatorynoncoding pages 16-17</li>
+<li>https://clinicaltrials.gov/study/NCT02580552</li>
+<li>https://doi.org/10.3390/cancers14061588</li>
+<li>https://doi.org/10.3390/ijms25031469</li>
+<li>https://clinicaltrials.gov/study/NCT03713320</li>
+<li>https://clinicaltrials.gov/study/NCT03837457</li>
+<li>https://doi.org/10.1093/carcin/bgz183</li>
+<li>https://doi.org/10.12688/wellcomeopenres.15065.1</li>
+<li>https://doi.org/10.1016/j.canlet.2018.02.026</li>
+<li>https://doi.org/10.1016/j.molcel.2012.10.002</li>
+<li>https://doi.org/10.12688/wellcomeopenres.15065.1,</li>
+<li>https://doi.org/10.1016/j.canlet.2018.02.026,</li>
+<li>https://doi.org/10.1016/j.molcel.2012.10.002,</li>
+<li>https://doi.org/10.1093/carcin/bgz183,</li>
+<li>https://doi.org/10.1101/2020.12.24.424324,</li>
+<li>https://doi.org/10.3390/ijms25031469,</li>
+<li>https://doi.org/10.3390/cancers14061588,</li>
+<li>https://doi.org/10.3390/pharmaceutics17040471,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -1325,9 +1636,24 @@ product_type: MIRNA
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
-description: MicroRNA involved in immune regulation and oncogenesis. Known as an
-  oncomiR that regulates gene expression including KRAS targeting.
+description: &gt;-
+  MIR155 encodes miR-155, a microRNA whose core molecular role is to guide
+  Argonaute/RISC to target RNAs for miRNA-mediated post-transcriptional gene
+  regulation. MIR155 is important in immune responses and oncogenesis, but those
+  are context-specific regulatory outcomes rather than separate molecular
+  functions.
 references:
+- id: file:human/MIR155/MIR155-deep-research-falcon.md
+  title: Falcon deep research report for MIR155
+  findings:
+  - statement: &gt;-
+      Falcon supports MIR155 as a guide RNA in Argonaute/RISC-mediated
+      post-transcriptional regulation and cautions against treating immune,
+      oncogenic, extracellular-vesicle, or stress-granule contexts as core GO
+      functions without direct MIR155-specific evidence.
+    supporting_text: &gt;-
+      Strong direct evidence exists for miR-155 association with Argonaute/RISC
+      and for miR-155-guided post-transcriptional regulation.
 - id: PMID:23416982
   title: MiR-155 at the heart of oncogenic pathways
 - id: PMID:34626873
@@ -1349,6 +1675,11 @@ existing_annotations:
     - reference_id: PMID:23416982
       supporting_text: &#34;MicroRNA-155 (miR-155) is an established oncomiR in breast
         cancer and regulates several pro-oncogenic pathways.&#34;
+    - reference_id: file:human/MIR155/MIR155-deep-research-falcon.md
+      supporting_text: &gt;-
+        Differential Ago HITS-CLIP/dCLIP comparing WT and miR-155-knockout
+        activated CD4+ T cells identified miR-155-dependent Ago-binding sites,
+        supporting miR-155-mediated post-transcriptional silencing.
 - term:
     id: GO:0016442
     label: RISC complex
@@ -1358,58 +1689,54 @@ existing_annotations:
     summary: RNAcentral/Rfam annotation placing MIR155 in the RNA-induced silencing complex context.
     action: ACCEPT
     reason: Mature miRNAs guide RISC-mediated target repression, so this RNAcentral annotation is consistent with MIR155 biology.
+    supported_by:
+    - reference_id: file:human/MIR155/MIR155-deep-research-falcon.md
+      supporting_text: &gt;-
+        Direct Argonaute immunoprecipitation in human macrophages provides
+        strong evidence that miR-155 strands are physically present in
+        Argonaute/RISC complexes.
+- term:
+    id: GO:0003730
+    label: mRNA 3&#39;-UTR binding
+  evidence_type: NAS
+  review:
+    summary: &gt;-
+      Added to align the core MIR155 molecular function with the annotation
+      block. Mature miR-155 guides Argonaute/RISC to target RNAs, with target
+      recognition mediated by base-pairing to sites that include mRNA 3&#39;-UTRs.
+    action: NEW
+    reason: &gt;-
+      Falcon found direct evidence for miR-155-dependent Argonaute occupancy at
+      target sites, supporting the core mRNA 3&#39;-UTR binding function used in the
+      core_functions block.
+    supported_by:
+    - reference_id: file:human/MIR155/MIR155-deep-research-falcon.md
+      supporting_text: &gt;-
+        Differential Ago HITS-CLIP/dCLIP comparing WT and miR-155-knockout
+        activated CD4+ T cells identified miR-155-dependent Ago-binding sites.
 core_functions:
-- description: microRNA-mediated gene silencing
+- description: miRNA guide RNA activity in Argonaute/RISC-mediated post-transcriptional gene silencing
   molecular_function:
     id: GO:0003730
     label: mRNA 3&#39;-UTR binding
+  directly_involved_in:
+  - id: GO:0035195
+    label: miRNA-mediated post-transcriptional gene silencing
+  in_complex:
+    id: GO:0016442
+    label: RISC complex
   supported_by:
-  - reference_id: PMID:23416982
-    supporting_text: miR-155 is an established oncomiR that regulates several 
-      pro-oncogenic pathways
-    full_text_unavailable: true
-- description: regulation of immune cell differentiation
-  molecular_function:
-    id: GO:0003730
-    label: mRNA 3&#39;-UTR binding
-  supported_by:
-  - reference_id: PMID:34626873
-    supporting_text: miR-155 regulates both adaptive and innate immune responses
-- description: inflammatory response regulation
-  molecular_function:
-    id: GO:0003730
-    label: mRNA 3&#39;-UTR binding
-  supported_by:
-  - reference_id: PMID:34626873
-    supporting_text: miR-155 affects both innate immunity and adaptive immunity 
-      in viral infections
-    full_text_unavailable: true
-- description: oncomiR activity suppressing tumor suppressor targets to promote oncogenesis
-  molecular_function:
-    id: GO:0003730
-    label: mRNA 3&#39;-UTR binding
-  supported_by:
-  - reference_id: PMID:23416982
-    supporting_text: miR-155 is an established oncomiR in breast cancer
-proposed_new_terms:
-- proposed_name: oncomiR activity
-  proposed_definition: The molecular function of a microRNA that promotes 
-    oncogenesis by regulating oncogenes or tumor suppressor genes
-  justification: MIR155 is a well-established oncomiR, but there is no specific 
-    GO term for oncomiR activity
-  proposed_parent:
-    id: GO:0003730
-    label: mRNA 3&#39;-UTR binding
-  supported_by:
-  - reference_id: PMID:23416982
-    supporting_text: miR-155 is an established oncomiR in breast cancer
+  - reference_id: file:human/MIR155/MIR155-deep-research-falcon.md
+    supporting_text: &gt;-
+      Strong direct evidence exists for miR-155 association with Argonaute/RISC
+      and for miR-155-guided post-transcriptional regulation.
 suggested_questions:
-- question: What are the complete set of target mRNAs regulated by MIR155 in 
+- question: What are the complete set of target mRNAs regulated by MIR155 in
     different cell types?
   experts:
   - microRNA researchers
   - cancer biologists
-- question: How does MIR155 expression change during immune cell activation and 
+- question: How does MIR155 expression change during immune cell activation and
     differentiation?
   experts:
   - immunologists
@@ -1428,7 +1755,7 @@ status: COMPLETE
     </div>
 
     <!-- Pathway Visualization Link -->
-    
+
 
     <style>
         /* Markdown Section Styles */

--- a/genes/human/MIR155/MIR155-ai-review.yaml
+++ b/genes/human/MIR155/MIR155-ai-review.yaml
@@ -4,9 +4,24 @@ product_type: MIRNA
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
-description: MicroRNA involved in immune regulation and oncogenesis. Known as an
-  oncomiR that regulates gene expression including KRAS targeting.
+description: >-
+  MIR155 encodes miR-155, a microRNA whose core molecular role is to guide
+  Argonaute/RISC to target RNAs for miRNA-mediated post-transcriptional gene
+  regulation. MIR155 is important in immune responses and oncogenesis, but those
+  are context-specific regulatory outcomes rather than separate molecular
+  functions.
 references:
+- id: file:human/MIR155/MIR155-deep-research-falcon.md
+  title: Falcon deep research report for MIR155
+  findings:
+  - statement: >-
+      Falcon supports MIR155 as a guide RNA in Argonaute/RISC-mediated
+      post-transcriptional regulation and cautions against treating immune,
+      oncogenic, extracellular-vesicle, or stress-granule contexts as core GO
+      functions without direct MIR155-specific evidence.
+    supporting_text: >-
+      Strong direct evidence exists for miR-155 association with Argonaute/RISC
+      and for miR-155-guided post-transcriptional regulation.
 - id: PMID:23416982
   title: MiR-155 at the heart of oncogenic pathways
 - id: PMID:34626873
@@ -28,6 +43,11 @@ existing_annotations:
     - reference_id: PMID:23416982
       supporting_text: "MicroRNA-155 (miR-155) is an established oncomiR in breast
         cancer and regulates several pro-oncogenic pathways."
+    - reference_id: file:human/MIR155/MIR155-deep-research-falcon.md
+      supporting_text: >-
+        Differential Ago HITS-CLIP/dCLIP comparing WT and miR-155-knockout
+        activated CD4+ T cells identified miR-155-dependent Ago-binding sites,
+        supporting miR-155-mediated post-transcriptional silencing.
 - term:
     id: GO:0016442
     label: RISC complex
@@ -37,51 +57,47 @@ existing_annotations:
     summary: RNAcentral/Rfam annotation placing MIR155 in the RNA-induced silencing complex context.
     action: ACCEPT
     reason: Mature miRNAs guide RISC-mediated target repression, so this RNAcentral annotation is consistent with MIR155 biology.
+    supported_by:
+    - reference_id: file:human/MIR155/MIR155-deep-research-falcon.md
+      supporting_text: >-
+        Direct Argonaute immunoprecipitation in human macrophages provides
+        strong evidence that miR-155 strands are physically present in
+        Argonaute/RISC complexes.
+- term:
+    id: GO:0003730
+    label: mRNA 3'-UTR binding
+  evidence_type: NAS
+  review:
+    summary: >-
+      Added to align the core MIR155 molecular function with the annotation
+      block. Mature miR-155 guides Argonaute/RISC to target RNAs, with target
+      recognition mediated by base-pairing to sites that include mRNA 3'-UTRs.
+    action: NEW
+    reason: >-
+      Falcon found direct evidence for miR-155-dependent Argonaute occupancy at
+      target sites, supporting the core mRNA 3'-UTR binding function used in the
+      core_functions block.
+    supported_by:
+    - reference_id: file:human/MIR155/MIR155-deep-research-falcon.md
+      supporting_text: >-
+        Differential Ago HITS-CLIP/dCLIP comparing WT and miR-155-knockout
+        activated CD4+ T cells identified miR-155-dependent Ago-binding sites.
 core_functions:
-- description: microRNA-mediated gene silencing
+- description: miRNA guide RNA activity in Argonaute/RISC-mediated post-transcriptional gene silencing
   molecular_function:
     id: GO:0003730
     label: mRNA 3'-UTR binding
+  directly_involved_in:
+  - id: GO:0035195
+    label: miRNA-mediated post-transcriptional gene silencing
+  in_complex:
+    id: GO:0016442
+    label: RISC complex
   supported_by:
-  - reference_id: PMID:23416982
-    supporting_text: miR-155 is an established oncomiR that regulates several 
-      pro-oncogenic pathways
-    full_text_unavailable: true
-- description: regulation of immune cell differentiation
-  molecular_function:
-    id: GO:0003730
-    label: mRNA 3'-UTR binding
-  supported_by:
-  - reference_id: PMID:34626873
-    supporting_text: miR-155 regulates both adaptive and innate immune responses
-- description: inflammatory response regulation
-  molecular_function:
-    id: GO:0003730
-    label: mRNA 3'-UTR binding
-  supported_by:
-  - reference_id: PMID:34626873
-    supporting_text: miR-155 affects both innate immunity and adaptive immunity 
-      in viral infections
-    full_text_unavailable: true
-- description: oncomiR activity suppressing tumor suppressor targets to promote oncogenesis
-  molecular_function:
-    id: GO:0003730
-    label: mRNA 3'-UTR binding
-  supported_by:
-  - reference_id: PMID:23416982
-    supporting_text: miR-155 is an established oncomiR in breast cancer
-proposed_new_terms:
-- proposed_name: oncomiR activity
-  proposed_definition: The molecular function of a microRNA that promotes 
-    oncogenesis by regulating oncogenes or tumor suppressor genes
-  justification: MIR155 is a well-established oncomiR, but there is no specific 
-    GO term for oncomiR activity
-  proposed_parent:
-    id: GO:0003730
-    label: mRNA 3'-UTR binding
-  supported_by:
-  - reference_id: PMID:23416982
-    supporting_text: miR-155 is an established oncomiR in breast cancer
+  - reference_id: file:human/MIR155/MIR155-deep-research-falcon.md
+    supporting_text: >-
+      Strong direct evidence exists for miR-155 association with Argonaute/RISC
+      and for miR-155-guided post-transcriptional regulation.
 suggested_questions:
 - question: What are the complete set of target mRNAs regulated by MIR155 in 
     different cell types?

--- a/genes/human/MIR155/MIR155-deep-research-falcon.md
+++ b/genes/human/MIR155/MIR155-deep-research-falcon.md
@@ -1,0 +1,231 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-11T03:29:14.815285'
+end_time: '2026-05-11T03:56:23.361626'
+duration_seconds: 1628.55
+provider_config:
+  timeout: 600
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 24
+---
+
+## Question
+
+Research the human microRNA gene MIR155 (miR-155; RNAcentral URS000062749E_9606) for Gene Ontology functional annotation. This is a microRNA/non-coding RNA, not a protein; do not infer protein domains or enzyme activity. Focus on its core molecular function as a guide RNA in miRNA-mediated post-transcriptional gene silencing, RISC association, immune and oncogenic regulatory contexts only where they clarify direct function, cellular localization, and GO terms directly supported by primary literature. Distinguish core function from downstream immune or cancer phenotypes, and provide citations for each major claim.
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+Research the human microRNA gene MIR155 (miR-155; RNAcentral URS000062749E_9606) for Gene Ontology functional annotation. This is a microRNA/non-coding RNA, not a protein; do not infer protein domains or enzyme activity. Focus on its core molecular function as a guide RNA in miRNA-mediated post-transcriptional gene silencing, RISC association, immune and oncogenic regulatory contexts only where they clarify direct function, cellular localization, and GO terms directly supported by primary literature. Distinguish core function from downstream immune or cancer phenotypes, and provide citations for each major claim.
+
+# Research report: Gene Ontology (GO) functional annotation evidence for human MIR155 (miR‑155; RNAcentral URS000062749E_9606)
+
+## 1. Key concepts and definitions (current understanding)
+
+### 1.1 What MIR155 encodes
+MIR155 is a *microRNA* (miRNA) gene that produces short (~22 nt) mature miRNA strands (classically annotated as miR‑155‑5p and miR‑155‑3p) that function as sequence-specific guide RNAs for Argonaute proteins within the RNA-induced silencing complex (RISC). Its molecular function is therefore not enzymatic; it is an RNA effector that confers targeting specificity to RISC via base-pairing to complementary sites in target RNAs.
+
+### 1.2 What counts as GO-relevant “core function” for a miRNA gene
+For a miRNA, GO-relevant *core* functions are those directly supported by experiments demonstrating:
+- **Association with Argonaute/RISC** (cellular component and molecular function evidence), and
+- **Direct, sequence-dependent targeting of RNAs** causing **post-transcriptional gene silencing** (biological process evidence), via mRNA destabilization and/or translational repression.
+
+Immune and oncogenic roles are downstream phenotypic outcomes of altering gene networks; they are included here only insofar as they clarify direct molecular mechanism, location, and evidence-backed GO terms.
+
+## 2. Primary-literature evidence supporting GO-relevant annotation for MIR155
+
+### 2.1 Argonaute/RISC association (core molecular function and cellular component)
+
+**Argonaute RIP in primary human macrophages (direct RISC loading evidence).** In primary human monocyte-derived macrophages, Simmonds (2019) immunoprecipitated Argonaute proteins (anti-Ago antibody 2A8) and measured miRNAs in the immunoprecipitate using absolute quantitation. The study reports that miR‑155‑3p was not detectable above background in resting cells but **after 2 h LPS stimulation it was recovered from the Argonaute IP**, consistent with **RISC association/loading** at the time of peak induction. The same approach detected miR‑155‑5p in Argonaute IP as well. Quantitatively, the study estimated **cellular copy numbers** in resting vs stimulated cells: miR‑155‑3p ~29±11 copies/cell at rest rising to **~767±137 copies/cell at 2 h LPS** (range 446–1,134); miR‑155‑5p ~1,315±417 (rest) rising to ~5,578±1,361 (2 h LPS). This provides direct biochemical evidence supporting annotation of MIR155 products to the **RNA-induced silencing complex** and to guide-RNA molecular function through Argonaute association. (simmonds2019transientupregulationof pages 11-12, simmonds2019transientupregulationof pages 12-14, simmonds2019transientupregulationof media a21bb4f5, simmonds2019transientupregulationof media 5691fff6)
+
+**Argonaute2 RIP in human cells showing miR‑155 guide participation in an Ago2 miRNP.** In HT‑29 human colon cancer cells, Al‑Haidari et al. (2018) used Ago2 immunoprecipitation and qRT-PCR to show that **AntagomiR‑155‑5p reduced enrichment of both miR‑155‑5p and HuR (ELAVL1) mRNA in Ago2 immunoprecipitates**, indicating that miR‑155‑5p participates in Ago2-containing ribonucleoprotein complexes engaging a target mRNA. (alhaidari2018mir1555pcontrolscolon pages 28-29)
+
+**Transcriptome-wide Argonaute CLIP mapping requires miR‑155 to direct Ago binding.** Loeb et al. (2012) used differential Argonaute HITS-CLIP (“AGO dCLIP”) comparing WT vs miR‑155 knockout activated CD4+ T cells to identify **miR‑155-dependent Ago-binding peaks**, demonstrating that the presence of miR‑155 directs Argonaute binding to specific RNA sites. (loeb2012transcriptomewidemir155binding pages 1-2, loeb2012transcriptomewidemir155binding pages 2-3)
+
+### 2.2 miRNA-mediated post-transcriptional gene silencing (core biological process)
+
+**Direct, miR‑155-dependent Argonaute binding correlates with repression.** Loeb et al. (2012) report that differential CLIP identified **191 miR‑155-dependent Ago binding sites in 175 genes (p<0.01)**, and that differential Ago binding **correlated with target downregulation** (p<0.05), supporting annotation to miRNA-mediated gene silencing and post-transcriptional regulation of gene expression. The study further reports that miR‑155–Ago complexes occupy **>300 canonical 3′UTR sites** with perfect 6–8 nt seed matches and that these canonical targets are strongly regulated by miR‑155. (loeb2012transcriptomewidemir155binding pages 2-3, loeb2012transcriptomewidemir155binding pages 7-8)
+
+**Noncanonical targeting is common for miR‑155 (refines mechanistic understanding but still core guide function).** In the same Loeb et al. binding map, **~40% of miR‑155-dependent Ago binding sites lacked perfect seed matches**, implying widespread noncanonical interactions; these tended to produce more modest regulation. Reporter validation showed mutation of predicted noncanonical sites significantly reduced repression by miR‑155, supporting direct functional targeting even without perfect seed matches. This evidence informs annotation to miRNA-mediated silencing without over-specifying “seed-only” rules. (loeb2012transcriptomewidemir155binding pages 7-8, loeb2012transcriptomewidemir155binding pages 6-7)
+
+**Direct sequence-element dependence in a miR‑155-guided interaction (context-dependent repression vs activation).** Al‑Haidari et al. (2018) provide direct evidence that miR‑155‑5p binds AU-rich elements in the HuR 3′UTR, validated using target-site blockers and ribonucleoprotein immunoprecipitation approaches. Notably, they observe context dependence (serum-starved vs serum-fed) where miR‑155‑5p can positively regulate HuR translation/mRNA levels under quiescence-like conditions; this does not negate the core GO process (post-transcriptional regulation via guide RNA), but cautions that “gene silencing” directionality may depend on cellular state and target context. (alhaidari2018mir1555pcontrolscolon pages 1-7, alhaidari2018mir1555pcontrolscolon pages 7-11)
+
+### 2.3 Cellular localization / cellular component (what is directly supported)
+
+**Supported: RISC / Argonaute-containing cytoplasmic effector complex.** Direct Argonaute immunoprecipitation in human macrophages provides strong evidence that miR‑155 strands are physically present in Argonaute/RISC complexes. This supports GO cellular component annotation to **RNA-induced silencing complex**. (simmonds2019transientupregulationof pages 11-12, simmonds2019transientupregulationof pages 12-14, simmonds2019transientupregulationof media a21bb4f5, simmonds2019transientupregulationof media 5691fff6)
+
+**Not sufficiently supported in the current primary-evidence set: P-bodies, stress granules, extracellular vesicles.** Although many reviews and some non-miR‑155-specific literature connect Ago/miRNPs to P-bodies and EV biology, the retrieved primary evidence in this run does **not** provide a direct, miR‑155-specific demonstration (e.g., microscopy co-localization of miR‑155 with P-body markers; EV isolation plus miR‑155 quantification with rigorous controls) that would justify assigning MIR155 a GO cellular component annotation to P-body/stress granule or extracellular vesicle *as a core function*. (witten2020mir155asa pages 18-19, de2020amyloidbetaoligomers pages 25-30)
+
+## 3. Evidence-based GO annotation summary (proposed terms and support)
+
+The table below summarizes GO-relevant annotations derived from *direct evidence* in the primary literature available here and flags terms that are not currently well supported.
+
+| GO aspect | GO term label (GO ID if known) | Evidence summary | miR-155 strand | Biological system | Supporting citations |
+|---|---|---|---|---|---|
+| MF | miRNA-mediated gene silencing by RNA binding | Argonaute RIP in primary human monocyte-derived macrophages using anti-Ago (2A8) recovered miR-155-3p and miR-155-5p from RISC; miR-155-3p was undetectable above background in resting cells but recovered after 2 h LPS, indicating direct guide-RNA association with Ago/RISC. | 3p, 5p | Primary human monocyte-derived macrophages | (simmonds2019transientupregulationof pages 11-12, simmonds2019transientupregulationof pages 12-14) |
+| MF | RNA guide activity | Ago2-RIP/qRT-PCR in HT-29 cells showed antagomiR-155-5p reduced enrichment of both miR-155-5p and HuR mRNA in Ago2 immunoprecipitates, supporting direct guide-RNA function of miR-155-5p within Ago2-containing effector complexes. | 5p | HT-29 human colon cancer cells | (alhaidari2018mir1555pcontrolscolon pages 28-29, alhaidari2018mir1555pcontrolscolon pages 7-11) |
+| BP | miRNA-mediated post-transcriptional gene silencing (GO:0035195) | Differential Ago HITS-CLIP/dCLIP comparing WT and miR-155-knockout activated CD4+ T cells identified 191 miR-155-dependent Ago-binding sites in 175 genes; loss of miR-155 reduced Ago occupancy and correlated with target downregulation/repression, providing transcriptome-wide evidence for miR-155-mediated silencing. | 5p | Activated murine CD4+ T cells | (loeb2012transcriptomewidemir155binding pages 1-2, loeb2012transcriptomewidemir155binding pages 2-3) |
+| BP | post-transcriptional regulation of gene expression | In serum-starved HT-29 cells, target-site blocker and Ago2-RIP experiments showed miR-155-5p directly binds AU-rich elements in the HuR 3′UTR and regulates HuR mRNA levels/translation post-transcriptionally. | 5p | HT-29 human colon cancer cells | (alhaidari2018mir1555pcontrolscolon pages 1-7, alhaidari2018mir1555pcontrolscolon pages 7-11) |
+| BP | gene silencing by miRNA | Transcriptome-wide Ago dCLIP showed miR-155 guides Ago to >300 canonical 3′UTR sites and many noncanonical sites; ~40% of miR-155-dependent Ago binding lacked perfect seed matches, indicating direct target repression can include noncanonical binding modes. | 5p | Activated murine primary T cells | (loeb2012transcriptomewidemir155binding pages 7-8, loeb2012transcriptomewidemir155binding pages 1-2) |
+| CC | RNA-induced silencing complex | Anti-Ago immunoprecipitation followed by absolute miRNA quantification demonstrated miR-155-5p and inducible miR-155-3p are present in Ago-containing RISC in primary macrophages. | 3p, 5p | Primary human monocyte-derived macrophages | (simmonds2019transientupregulationof pages 11-12, simmonds2019transientupregulationof media a21bb4f5) |
+| CC | cytoplasm | In HT-29 cells, miR-155-5p knockdown decreased cytoplasmic HuR expression; the study examines miR-155-5p-mediated post-transcriptional regulation of a cytoplasmic target context, but does not directly localize miR-155 RNA itself by imaging/fractionation, so support for cytoplasmic localization of MIR155/miR-155 is indirect and should be used cautiously. | 5p | HT-29 human colon cancer cells | (alhaidari2018mir1555pcontrolscolon pages 1-7) |
+| CC | P-body / stress granule | No direct primary evidence in the provided context shows MIR155/miR-155 itself localized to P-bodies or stress granules by microscopy or specific fractionation; related literature in context concerns general Ago/P-body biology or non-miR-155-specific compartmentation and is insufficient for confident annotation of MIR155 to these CC terms. | — | — | (witten2020mir155asa pages 18-19) |
+| CC | extracellular vesicle | The provided context includes review-level discussion and indirect/preprint evidence for extracellular or endosomal miR-155 contexts, but no high-confidence primary evidence sufficient here to assign MIR155 a GO cellular-component annotation to extracellular vesicle for core function. | — | — | (de2020amyloidbetaoligomers pages 25-30, witten2020mir155asa pages 18-19) |
+
+
+*Table: This table maps proposed GO annotations for human MIR155/miR-155 to direct primary-literature evidence available in the current context. It highlights well-supported core functions and compartments while flagging localization terms that are not sufficiently supported for confident annotation.*
+
+## 4. Recent developments (prioritizing 2023–2024) and how they relate to core GO function
+
+### 4.1 Clinical translation of miR‑155 inhibition as a test of functional relevance (not GO core function)
+A major recent-development theme is clinical translation of miR‑155 inhibition (anti-miR/antagomir strategies), most prominently **cobomarsen (MRG‑106)**.
+
+A 2024 review of miRNA therapeutics describes **cobomarsen (MRG‑106) as an LNA-based antagomir of miR‑155**, noting a completed phase 1 trial and that phase 2 studies were initiated but at least two phase 2 trials were terminated; it also notes that at least one termination was due to business reasons rather than safety/efficacy concerns (as per ClinicalTrials.gov, accessed 20 Dec 2023). This literature is useful for “current applications” but does not replace primary biochemical evidence for GO annotation. (seyhan2024trialsandtribulations pages 16-17)
+
+### 4.2 Subcellular compartmentalization is an active research area but remains difficult to convert into miR‑155-specific GO CC terms
+Recent reviews increasingly emphasize miRNA localization heterogeneity (endosomes, ER-associated polysomes, etc.) and extracellular RNA transport, but miR‑155-specific localization evidence must be supported by rigorous primary experiments. A 2020 fractionation-based study (bioRxiv) describes optiprep gradient fractionation and reports measuring distribution of miR‑155 in endosomal fractions in Aβ-treated glial cells, illustrating methods that could support future GO CC annotation if replicated and validated. However, in this run, the relevant excerpt does not provide numeric outcomes sufficient to assert a specific GO CC term for MIR155 beyond RISC. (de2020amyloidbetaoligomers pages 25-30, de2020amyloidbetaoligomers pages 18-23)
+
+## 5. Current applications and real-world implementations
+
+### 5.1 Therapeutic inhibition: cobomarsen (MRG‑106)
+ClinicalTrials.gov provides direct, citable implementation details for cobomarsen/MRG‑106 targeting miR‑155.
+
+- **NCT02580552 (Phase 1, completed; n=66)**: dose-ranging safety/tolerability/PK study in MF (CTCL), CLL, DLBCL (ABC), ATLL. Routes included **intratumoral, subcutaneous, and intravenous** administration; exploratory endpoints included **miR‑155‑5p expression in MF skin lesions (qRT-PCR)** and dermatology-related QoL measures. Start date 2016‑02‑09; completion 2020‑10‑06. (NCT02580552 chunk 1, NCT02580552 chunk 2)
+- **NCT03713320 (SOLAR; Phase 2; terminated; actual enrollment 37)**: randomized open-label study in mycosis fungoides comparing cobomarsen (IV infusion) vs vorinostat (oral). The record states termination was **“for business reasons, and not due to concerns regarding safety or lack of efficacy.”** Start 2019‑04‑02; completion 2020‑12‑01; registry indicates **results were posted** (results first post date 2022‑04‑08). (NCT03713320 chunk 1)
+
+These trials provide real-world validation that miR‑155 can be modulated in patients, and they operationalize miR‑155’s role as a guide RNA in post-transcriptional regulation (pharmacodynamic readouts), but they do not define additional GO molecular functions beyond miRNA-mediated silencing.
+
+| Application type | Agent/Assay | Target | Indication | Trial ID | Phase | Status | Enrollment | Route | Key endpoints/outcomes mentioned | Termination reason (if any) | Publication/registry URL | Supporting citations (context IDs) |
+|---|---|---|---|---|---|---|---:|---|---|---|---|---|
+| Therapeutic | Cobomarsen (MRG-106), LNA-based anti-miR / ASO | miR-155 | Mycosis fungoides (CTCL), CLL, DLBCL, ATLL | NCT02580552 | Phase 1 | Completed | 66 | Intratumoral, subcutaneous, intravenous | Safety, tolerability, pharmacokinetics; exploratory outcomes included overall survival, miR-155-5p expression in MF skin lesions, neoplastic lymphoid-cell proportions, immune-cell subsets, Skindex-29 and pruritus measures; review sources describe early clinical improvement signals in CAILS, mSWAT, and Skindex-29 with no serious adverse events attributed to cobomarsen in early reports | Not applicable; completed study | https://clinicaltrials.gov/study/NCT02580552 ; https://doi.org/10.3390/cancers14061588 ; https://doi.org/10.3390/ijms25031469 | (NCT02580552 chunk 1, NCT02580552 chunk 2, smith2022clinicalapplicationsof pages 7-8, seyhan2024trialsandtribulations pages 16-17, witten2020mir155asa pages 14-15) |
+| Therapeutic | Cobomarsen (MRG-106) vs active comparator (vorinostat) | miR-155 | Cutaneous T-cell lymphoma, mycosis fungoides | NCT03713320 | Phase 2 | Terminated | 37 | Cobomarsen: 2-hour intravenous infusion; comparator vorinostat: oral | Efficacy/safety outcomes included 50% improvement in mSWAT, pruritus medication utilization, PK endpoints (Cmax, AUC), and anti-drug antibody generation; registry states results were submitted/posted | “Terminated early for business reasons, and not due to concerns regarding safety or lack of efficacy.” | https://clinicaltrials.gov/study/NCT03713320 ; https://doi.org/10.3390/ijms25031469 | (NCT03713320 chunk 1, NCT03713320 chunk 2, seyhan2024trialsandtribulations pages 16-17) |
+| Therapeutic | Cobomarsen (MRG-106) extension after SOLAR | miR-155 | Mycosis fungoides after SOLAR completion | NCT03837457 | Phase 2 | Terminated | 8 | Not available in provided context | Extension study identified in review/trial listings; no posted outcome details available in provided context | Not stated in provided context | https://clinicaltrials.gov/study/NCT03837457 ; https://doi.org/10.3390/ijms25031469 | (seyhan2024trialsandtribulations pages 16-17, piergentili2025targetingregulatorynoncoding pages 16-17) |
+| Therapeutic/Translational | Cobomarsen (MRG-106) program summary in reviews | miR-155 | Lymphomas/leukemias including CTCL, CLL, DLBCL, ATLL | Program-level | Phase 1 completed; Phase 2 initiated/terminated | Mixed | — | Intratumoral, intravenous, subcutaneous reported across studies | Seyhan 2024 identifies cobomarsen as an LNA-based antagomir and notes completed phase 1 plus terminated phase 2 studies; Smith 2022 lists miRagen-sponsored ASO program and delivery routes; Witten & Slack 2020 describe reductions in miR-155 target-gene expression in biopsies and sustained improvements in lesion/quality-of-life metrics in early reports | Review states at least one terminated study ended for business reasons rather than safety/efficacy concerns | https://doi.org/10.3390/ijms25031469 ; https://doi.org/10.3390/cancers14061588 ; https://doi.org/10.1093/carcin/bgz183 | (seyhan2024trialsandtribulations pages 16-17, smith2022clinicalapplicationsof pages 7-8, witten2020mir155asa pages 13-14, witten2020mir155asa pages 14-15) |
+| Diagnostic/biomarker | miR-155 expression assays / circulating or tissue miR-155 profiling | miR-155 | Hematologic malignancy and inflammatory-disease biomarker studies (observational and ancillary uses) | Multiple non-cobomarsen studies in registry | Observational / non-therapeutic | Ongoing, completed, or unknown depending on study | Varies | Biospecimen assay | Used as biomarker/prognostic or pharmacodynamic readout rather than direct therapeutic intervention; examples in provided context include lesion miR-155-5p qRT-PCR in NCT02580552 and review discussion of biomarker utility | Not applicable | https://clinicaltrials.gov/study/NCT02580552 ; https://doi.org/10.3390/ijms25031469 | (NCT02580552 chunk 2, seyhan2024trialsandtribulations pages 16-17) |
+
+
+*Table: This table summarizes miR-155-targeting real-world applications, focusing on cobomarsen/MRG-106 clinical development and registry-level details. It is useful for linking therapeutic and biomarker use cases to specific trial phases, statuses, routes, and reported outcomes.*
+
+## 6. Expert opinions and authoritative analysis (distinguishing core function from phenotype)
+
+### 6.1 What authoritative sources emphasize about miR‑155
+Authoritative reviews in hematologic malignancy emphasize miR‑155 as an oncogenic miRNA and summarize early clinical signals from cobomarsen, including improved lesion-burden and QoL metrics and lack of serious adverse events attributed to the drug in early reports. These expert analyses support clinical interest and translational feasibility but should be treated as secondary evidence relative to primary mechanistic studies for GO annotations. (witten2020mir155asa pages 14-15)
+
+### 6.2 Separation of direct function from downstream immune/cancer phenotypes
+The direct molecular function of MIR155 is **Argonaute-associated guide RNA function** that mediates post-transcriptional regulation (typically repression) of target RNAs. Immune activation, inflammation, and oncogenesis arise from downstream network effects of repressing many target transcripts and are better considered *phenotypic consequences* rather than direct GO molecular function. The dCLIP data show miR‑155 guides Ago to hundreds of sites in an endogenous, transcriptome-wide manner, supporting network-level regulatory capacity without implying new molecular activities beyond RNA-guided silencing. (loeb2012transcriptomewidemir155binding pages 7-8, loeb2012transcriptomewidemir155binding pages 2-3)
+
+## 7. Relevant recent statistics and data
+
+### 7.1 Quantitative miR‑155 abundance and RISC association
+In primary human macrophages, absolute quantitation estimated mean copy numbers per cell and demonstrated inducible RISC association:
+- miR‑155‑3p: ~29±11 copies/cell resting; **~767±137 copies/cell at 2 h LPS** (range 446–1,134)
+- miR‑155‑5p: ~1,315±417 copies/cell resting; ~5,578±1,361 copies/cell at 2 h LPS
+These data are directly relevant for GO annotation because they support that miR‑155 strands reach measurable abundance and are physically present in Argonaute immunoprecipitates at biologically relevant times. (simmonds2019transientupregulationof pages 11-12)
+
+### 7.2 Clinical trial statistics (implementation-level)
+- NCT02580552: **66 participants**, Phase 1, completed. (NCT02580552 chunk 1)
+- NCT03713320: **37 participants**, Phase 2, terminated early for business reasons; results posted 2022‑04‑08 per registry. (NCT03713320 chunk 1)
+
+## 8. Limitations of this evidence set for GO cellular-component expansion
+Within the retrieved corpus, strong direct evidence exists for miR‑155 association with Argonaute/RISC and for miR‑155-guided post-transcriptional regulation. However, *miR‑155-specific* evidence for localization to P-bodies/stress granules or extracellular vesicles was not sufficiently explicit/quantitative in the extracted primary text to support confident GO cellular-component annotation to those compartments in this report. (witten2020mir155asa pages 18-19, de2020amyloidbetaoligomers pages 25-30)
+
+## Key URLs (publication/registry)
+- Simmonds RE. Wellcome Open Research (2019-03). https://doi.org/10.12688/wellcomeopenres.15065.1 (simmonds2019transientupregulationof pages 11-12)
+- Al-Haidari A et al. Cancer Letters (2018-05). https://doi.org/10.1016/j.canlet.2018.02.026 (alhaidari2018mir1555pcontrolscolon pages 1-7)
+- Loeb GB et al. Molecular Cell (2012-12). https://doi.org/10.1016/j.molcel.2012.10.002 (loeb2012transcriptomewidemir155binding pages 1-2)
+- Seyhan AA. Int J Mol Sci (2024-01). https://doi.org/10.3390/ijms25031469 (seyhan2024trialsandtribulations pages 16-17)
+- ClinicalTrials.gov NCT02580552. https://clinicaltrials.gov/study/NCT02580552 (NCT02580552 chunk 1)
+- ClinicalTrials.gov NCT03713320. https://clinicaltrials.gov/study/NCT03713320 (NCT03713320 chunk 1)
+
+
+
+References
+
+1. (simmonds2019transientupregulationof pages 11-12): Rachel E. Simmonds. Transient up-regulation of mir-155-3p by lipopolysaccharide in primary human monocyte-derived macrophages results in risc incorporation but does not alter tnf expression. Wellcome Open Research, 4:43, Mar 2019. URL: https://doi.org/10.12688/wellcomeopenres.15065.1, doi:10.12688/wellcomeopenres.15065.1. This article has 21 citations.
+
+2. (simmonds2019transientupregulationof pages 12-14): Rachel E. Simmonds. Transient up-regulation of mir-155-3p by lipopolysaccharide in primary human monocyte-derived macrophages results in risc incorporation but does not alter tnf expression. Wellcome Open Research, 4:43, Mar 2019. URL: https://doi.org/10.12688/wellcomeopenres.15065.1, doi:10.12688/wellcomeopenres.15065.1. This article has 21 citations.
+
+3. (simmonds2019transientupregulationof media a21bb4f5): Rachel E. Simmonds. Transient up-regulation of mir-155-3p by lipopolysaccharide in primary human monocyte-derived macrophages results in risc incorporation but does not alter tnf expression. Wellcome Open Research, 4:43, Mar 2019. URL: https://doi.org/10.12688/wellcomeopenres.15065.1, doi:10.12688/wellcomeopenres.15065.1. This article has 21 citations.
+
+4. (simmonds2019transientupregulationof media 5691fff6): Rachel E. Simmonds. Transient up-regulation of mir-155-3p by lipopolysaccharide in primary human monocyte-derived macrophages results in risc incorporation but does not alter tnf expression. Wellcome Open Research, 4:43, Mar 2019. URL: https://doi.org/10.12688/wellcomeopenres.15065.1, doi:10.12688/wellcomeopenres.15065.1. This article has 21 citations.
+
+5. (alhaidari2018mir1555pcontrolscolon pages 28-29): Amr Al-Haidari, Anwar Algaber, Raed Madhi, Ingvar Syk, and Henrik Thorlacius. Mir-155-5p controls colon cancer cell migration via post-transcriptional regulation of human antigen r (hur). Cancer letters, 421:145-151, May 2018. URL: https://doi.org/10.1016/j.canlet.2018.02.026, doi:10.1016/j.canlet.2018.02.026. This article has 78 citations and is from a peer-reviewed journal.
+
+6. (loeb2012transcriptomewidemir155binding pages 1-2): Gabriel B. Loeb, Aly A. Khan, David Canner, Joseph B. Hiatt, Jay Shendure, Robert B. Darnell, Christina S. Leslie, and Alexander Y. Rudensky. Transcriptome-wide mir-155 binding map reveals widespread noncanonical microrna targeting. Molecular cell, 48 5:760-70, Dec 2012. URL: https://doi.org/10.1016/j.molcel.2012.10.002, doi:10.1016/j.molcel.2012.10.002. This article has 403 citations and is from a highest quality peer-reviewed journal.
+
+7. (loeb2012transcriptomewidemir155binding pages 2-3): Gabriel B. Loeb, Aly A. Khan, David Canner, Joseph B. Hiatt, Jay Shendure, Robert B. Darnell, Christina S. Leslie, and Alexander Y. Rudensky. Transcriptome-wide mir-155 binding map reveals widespread noncanonical microrna targeting. Molecular cell, 48 5:760-70, Dec 2012. URL: https://doi.org/10.1016/j.molcel.2012.10.002, doi:10.1016/j.molcel.2012.10.002. This article has 403 citations and is from a highest quality peer-reviewed journal.
+
+8. (loeb2012transcriptomewidemir155binding pages 7-8): Gabriel B. Loeb, Aly A. Khan, David Canner, Joseph B. Hiatt, Jay Shendure, Robert B. Darnell, Christina S. Leslie, and Alexander Y. Rudensky. Transcriptome-wide mir-155 binding map reveals widespread noncanonical microrna targeting. Molecular cell, 48 5:760-70, Dec 2012. URL: https://doi.org/10.1016/j.molcel.2012.10.002, doi:10.1016/j.molcel.2012.10.002. This article has 403 citations and is from a highest quality peer-reviewed journal.
+
+9. (loeb2012transcriptomewidemir155binding pages 6-7): Gabriel B. Loeb, Aly A. Khan, David Canner, Joseph B. Hiatt, Jay Shendure, Robert B. Darnell, Christina S. Leslie, and Alexander Y. Rudensky. Transcriptome-wide mir-155 binding map reveals widespread noncanonical microrna targeting. Molecular cell, 48 5:760-70, Dec 2012. URL: https://doi.org/10.1016/j.molcel.2012.10.002, doi:10.1016/j.molcel.2012.10.002. This article has 403 citations and is from a highest quality peer-reviewed journal.
+
+10. (alhaidari2018mir1555pcontrolscolon pages 1-7): Amr Al-Haidari, Anwar Algaber, Raed Madhi, Ingvar Syk, and Henrik Thorlacius. Mir-155-5p controls colon cancer cell migration via post-transcriptional regulation of human antigen r (hur). Cancer letters, 421:145-151, May 2018. URL: https://doi.org/10.1016/j.canlet.2018.02.026, doi:10.1016/j.canlet.2018.02.026. This article has 78 citations and is from a peer-reviewed journal.
+
+11. (alhaidari2018mir1555pcontrolscolon pages 7-11): Amr Al-Haidari, Anwar Algaber, Raed Madhi, Ingvar Syk, and Henrik Thorlacius. Mir-155-5p controls colon cancer cell migration via post-transcriptional regulation of human antigen r (hur). Cancer letters, 421:145-151, May 2018. URL: https://doi.org/10.1016/j.canlet.2018.02.026, doi:10.1016/j.canlet.2018.02.026. This article has 78 citations and is from a peer-reviewed journal.
+
+12. (witten2020mir155asa pages 18-19): Lisa Witten and Frank J Slack. Mir-155 as a novel clinical target for hematological malignancies. Carcinogenesis, 41:2-7, Nov 2020. URL: https://doi.org/10.1093/carcin/bgz183, doi:10.1093/carcin/bgz183. This article has 119 citations and is from a peer-reviewed journal.
+
+13. (de2020amyloidbetaoligomers pages 25-30): Dipayan De and Suvendra N. Bhattacharyya. Amyloid beta oligomers prevents lysosomal targeting of mirnp to stop its recycling and target cytokine repression in glial cells. bioRxiv, Dec 2020. URL: https://doi.org/10.1101/2020.12.24.424324, doi:10.1101/2020.12.24.424324. This article has 0 citations.
+
+14. (seyhan2024trialsandtribulations pages 16-17): Attila A Seyhan. Trials and tribulations of microrna therapeutics. International Journal of Molecular Sciences, Jan 2024. URL: https://doi.org/10.3390/ijms25031469, doi:10.3390/ijms25031469. This article has 393 citations.
+
+15. (de2020amyloidbetaoligomers pages 18-23): Dipayan De and Suvendra N. Bhattacharyya. Amyloid beta oligomers prevents lysosomal targeting of mirnp to stop its recycling and target cytokine repression in glial cells. bioRxiv, Dec 2020. URL: https://doi.org/10.1101/2020.12.24.424324, doi:10.1101/2020.12.24.424324. This article has 0 citations.
+
+16. (NCT02580552 chunk 1):  Safety, Tolerability and Pharmacokinetics of MRG-106 in Patients With Mycosis Fungoides (MF), CLL, DLBCL or ATLL. miRagen Therapeutics, Inc.. 2016. ClinicalTrials.gov Identifier: NCT02580552
+
+17. (NCT02580552 chunk 2):  Safety, Tolerability and Pharmacokinetics of MRG-106 in Patients With Mycosis Fungoides (MF), CLL, DLBCL or ATLL. miRagen Therapeutics, Inc.. 2016. ClinicalTrials.gov Identifier: NCT02580552
+
+18. (NCT03713320 chunk 1):  SOLAR: Efficacy and Safety of Cobomarsen (MRG-106) vs. Active Comparator in Subjects With Mycosis Fungoides. miRagen Therapeutics, Inc.. 2019. ClinicalTrials.gov Identifier: NCT03713320
+
+19. (smith2022clinicalapplicationsof pages 7-8): Ellen S. Smith, Eric Whitty, Byunghee Yoo, Anna Moore, Lorenzo F. Sempere, and Zdravka Medarova. Clinical applications of short non-coding rna-based therapies in the era of precision medicine. Cancers, 14:1588, Mar 2022. URL: https://doi.org/10.3390/cancers14061588, doi:10.3390/cancers14061588. This article has 72 citations.
+
+20. (witten2020mir155asa pages 14-15): Lisa Witten and Frank J Slack. Mir-155 as a novel clinical target for hematological malignancies. Carcinogenesis, 41:2-7, Nov 2020. URL: https://doi.org/10.1093/carcin/bgz183, doi:10.1093/carcin/bgz183. This article has 119 citations and is from a peer-reviewed journal.
+
+21. (NCT03713320 chunk 2):  SOLAR: Efficacy and Safety of Cobomarsen (MRG-106) vs. Active Comparator in Subjects With Mycosis Fungoides. miRagen Therapeutics, Inc.. 2019. ClinicalTrials.gov Identifier: NCT03713320
+
+22. (piergentili2025targetingregulatorynoncoding pages 16-17): R. Piergentili and S. Sechi. Targeting regulatory noncoding rnas in human cancer: the state of the art in clinical trials. Pharmaceutics, Apr 2025. URL: https://doi.org/10.3390/pharmaceutics17040471, doi:10.3390/pharmaceutics17040471. This article has 4 citations.
+
+23. (witten2020mir155asa pages 13-14): Lisa Witten and Frank J Slack. Mir-155 as a novel clinical target for hematological malignancies. Carcinogenesis, 41:2-7, Nov 2020. URL: https://doi.org/10.1093/carcin/bgz183, doi:10.1093/carcin/bgz183. This article has 119 citations and is from a peer-reviewed journal.
+
+## Citations
+
+1. seyhan2024trialsandtribulations pages 16-17
+2. simmonds2019transientupregulationof pages 11-12
+3. simmonds2019transientupregulationof pages 12-14
+4. de2020amyloidbetaoligomers pages 25-30
+5. de2020amyloidbetaoligomers pages 18-23
+6. smith2022clinicalapplicationsof pages 7-8
+7. piergentili2025targetingregulatorynoncoding pages 16-17
+8. https://clinicaltrials.gov/study/NCT02580552
+9. https://doi.org/10.3390/cancers14061588
+10. https://doi.org/10.3390/ijms25031469
+11. https://clinicaltrials.gov/study/NCT03713320
+12. https://clinicaltrials.gov/study/NCT03837457
+13. https://doi.org/10.1093/carcin/bgz183
+14. https://doi.org/10.12688/wellcomeopenres.15065.1
+15. https://doi.org/10.1016/j.canlet.2018.02.026
+16. https://doi.org/10.1016/j.molcel.2012.10.002
+17. https://doi.org/10.12688/wellcomeopenres.15065.1,
+18. https://doi.org/10.1016/j.canlet.2018.02.026,
+19. https://doi.org/10.1016/j.molcel.2012.10.002,
+20. https://doi.org/10.1093/carcin/bgz183,
+21. https://doi.org/10.1101/2020.12.24.424324,
+22. https://doi.org/10.3390/ijms25031469,
+23. https://doi.org/10.3390/cancers14061588,
+24. https://doi.org/10.3390/pharmaceutics17040471,

--- a/genes/human/SNORD116-1/SNORD116-1-ai-review.html
+++ b/genes/human/SNORD116-1/SNORD116-1-ai-review.html
@@ -671,33 +671,33 @@
     <div class="header">
         <h1>SNORD116-1</h1>
         <div class="gene-info">
-            
+
             <div class="info-item">
-                
+
                 <span class="info-label">RNAcentral ID:</span>
                 <span>
                     <a href="https://rnacentral.org/rna/URS000075CFA5_9606" target="_blank" class="term-link">
                         URS000075CFA5_9606
                     </a>
                 </span>
-                
+
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Organism:</span>
                 <span>Homo sapiens</span>
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
                 <span class="status-badge status-complete">
                     COMPLETE
                 </span>
             </div>
-            
-            
+
+
         </div>
         <div style="margin-top: 1rem; text-align: center;">
             <a id="feedback-form-link"
@@ -728,75 +728,24 @@
         </div>
     </div>
 
-    
+
     <div class="description-card">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <h2>Gene Description</h2>
-            <span class="vote-buttons" data-g="URS000075CFA5_9606" data-a="DESCRIPTION: SNORD116-1 is one of multiple tandem copies of the..." data-r="" data-act="DESCRIPTION">
+            <span class="vote-buttons" data-g="URS000075CFA5_9606" data-a="DESCRIPTION: SNORD116-1 is one paralogous box C/D small nucleol..." data-r="" data-act="DESCRIPTION">
                 <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
                 <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
             </span>
         </div>
-        <p>SNORD116-1 is one of multiple tandem copies of the SNORD116 small nucleolar RNA located in the SNHG14 host gene on chromosome 15q11-q13. The SNORD116 cluster plays a critical role in neurodevelopment, and loss of the entire cluster is a major contributor to Prader-Willi syndrome, affecting hypothalamic function, cognition, and metabolism. Individual copies like SNORD116-1 are functionally equivalent within the cluster.</p>
+        <p>SNORD116-1 is one paralogous box C/D small nucleolar RNA copy within the paternally expressed SNORD116 tandem repeat cluster in the imprinted SNHG14 / SNURF-SNRPN locus on chromosome 15q11-q13. The strongest per-copy evidence is class-based snoRNA biology: intron-derived snoRNA processing, snoRNP association, and nucleolar localization. Prader-Willi syndrome and neurodevelopmental phenotypes are supported mainly at the SNORD116 cluster/locus level, so they should not be treated as direct, copy-specific core functions of SNORD116-1.</p>
     </div>
-    
 
-    
 
-    
-    <div class="section">
-        <h2 class="section-title">Proposed New Ontology Terms</h2>
-        
-        <div class="proposed-term">
-            <div style="display: flex; justify-content: space-between; align-items: center;">
-                <h3>snoRNA-mediated mRNA stabilization activity</h3>
-                <span class="vote-buttons" data-g="URS000075CFA5_9606" data-a="snoRNA-mediated mRNA stabilization activity" data-r="" data-act="NEW">
-                    <button class="vote-btn" data-v="up" title="Agree this term should be created">👍</button>
-                    <button class="vote-btn" data-v="down" title="Disagree with creating this term">👎</button>
-                </span>
-            </div>
 
-            
-            <p><strong>Definition:</strong> The molecular function of a small nucleolar RNA that binds to and increases the stability of specific mRNA molecules</p>
-            
 
-            
-            <p><strong>Justification:</strong> SNORD116 cluster&#39;s role in mRNA stabilization represents a non-canonical snoRNA function not captured by existing GO terms</p>
-            
 
-            
-            <p><strong>Parent term:</strong>
-                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003723" target="_blank" class="term-link">
-                    RNA binding
-                </a>
-            </p>
-            
 
-            
 
-            
-            <p><strong>Supporting Evidence:</strong></p>
-            <ul style="margin-left: 1rem;">
-                
-                <li>
-                    
-                    <a href="https://pubmed.ncbi.nlm.nih.gov/33856031" target="_blank" class="term-link">
-                        PMID:33856031
-                    </a>
-                    
-                    
-                    : Snord116 Post-transcriptionally Increases Nhlh2 mRNA Stability: Implications for Human Prader-Willi Syndrome
-                    
-                </li>
-                
-            </ul>
-            
-        </div>
-        
-    </div>
-    
-
-    
     <div class="section">
         <h2 class="section-title">Existing Annotations Review</h2>
         <table class="annotations-table">
@@ -809,32 +758,32 @@
                 </tr>
             </thead>
             <tbody>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006396" target="_blank" class="term-link">
                                     GO:0006396
                                 </a>
                             </span>
                             <span class="term-label">RNA processing</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000115
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -846,58 +795,69 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Standard snoRNA annotation - all SNORD116 copies function in RNA processing as C/D box snoRNAs
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     GO_REF:0000115
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Rfam classification as C/D box snoRNA (RF00108)</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/SNORD116-1/SNORD116-1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">SNORD116 family members behave as bona fide box C/D snoRNAs that assemble with core snoRNP proteins.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005730" target="_blank" class="term-link">
                                     GO:0005730
                                 </a>
                             </span>
                             <span class="term-label">nucleolus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000115
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -909,203 +869,62 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Standard localization for C/D box snoRNAs - nucleolar localization expected for all cluster members
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     GO_REF:0000115
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Rfam classification indicates nucleolar localization</div>
-                                
+
                             </div>
-                            
-                        </div>
-                        
-                    </td>
-                </tr>
-                
-                <tr>
-                    <td>
-                        <div class="term-info">
-                            
-                            <span class="term-id">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006396" target="_blank" class="term-link">
-                                    GO:0006396
-                                </a>
-                            </span>
-                            <span class="term-label">RNA processing</span>
-                            
-                        </div>
-                    </td>
-                    <td>
-                        <span class="evidence-code">IMP</span>
-                        
-                        
-                        
-                        <br>
-                        <span style="font-size: 0.75rem;">
-                            
-                            <a href="https://pubmed.ncbi.nlm.nih.gov/33856031" target="_blank" class="term-link" style="font-size: 0.75rem;">
-                                PMID:33856031
-                            </a>
-                            
-                                
-                                
-                                <br>
-                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
-                                    Snord116 Post-transcriptionally Increases Nhlh2 mRNA Stabili...
-                                </span>
-                                
-                            
-                            
-                        </span>
-                        
-                    </td>
-                    <td>
-                        <span class="action-badge action-new">
-                            NEW
-                        </span>
-                        <span class="vote-buttons" data-g="URS000075CFA5_9606" data-a="GO:0006396" data-r="PMID:33856031" data-act="NEW">
-                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
-                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
-                        </span>
-                    </td>
-                    <td>
-                        
-                        <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> SNORD116 cluster regulates mRNA stability and processing - applies to all cluster members including SNORD116-1
-                        </div>
-                        
-                        
-                        
-                        
-                        <div class="supported-by">
-                            <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33856031" target="_blank" class="term-link">
-                                        PMID:33856031
-                                    </a>
-                                    
+
+                                    file:human/SNORD116-1/SNORD116-1-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">the upregulation occurred through increased stability of the Nhlh2 mRNA in the 45 minutes immediately following transcription</div>
-                                
+
+                                <div class="support-text">Box C/D snoRNAs are described as concentrating mainly in the nucleolus, and SNORD116 snoRNAs are described as localizing to nucleoli.</div>
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
-                            <span class="term-id">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007417" target="_blank" class="term-link">
-                                    GO:0007417
-                                </a>
-                            </span>
-                            <span class="term-label">central nervous system development</span>
-                            
-                        </div>
-                    </td>
-                    <td>
-                        <span class="evidence-code">IMP</span>
-                        
-                        
-                        
-                        <br>
-                        <span style="font-size: 0.75rem;">
-                            
-                            <a href="https://pubmed.ncbi.nlm.nih.gov/29800646" target="_blank" class="term-link" style="font-size: 0.75rem;">
-                                PMID:29800646
-                            </a>
-                            
-                                
-                                
-                                <br>
-                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
-                                    Cognitive deficits in the Snord116 deletion mouse model for ...
-                                </span>
-                                
-                            
-                            
-                        </span>
-                        
-                    </td>
-                    <td>
-                        <span class="action-badge action-new">
-                            NEW
-                        </span>
-                        <span class="vote-buttons" data-g="URS000075CFA5_9606" data-a="GO:0007417" data-r="PMID:29800646" data-act="NEW">
-                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
-                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
-                        </span>
-                    </td>
-                    <td>
-                        
-                        <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> SNORD116 cluster is essential for proper neurodevelopment and cognitive function - cluster-level phenotype
-                        </div>
-                        
-                        
-                        
-                        
-                        <div class="supported-by">
-                            <div class="supported-by-title">Supporting Evidence:</div>
-                            
-                            <div class="support-item">
-                                <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/29800646" target="_blank" class="term-link">
-                                        PMID:29800646
-                                    </a>
-                                    
-                                </span>
-                                
-                                <div class="support-text">We discovered deficits in Snord116+/- mutant mice in the novel object recognition, location memory and tone cue fear conditioning assays</div>
-                                
-                            </div>
-                            
-                        </div>
-                        
-                    </td>
-                </tr>
-                
-                <tr>
-                    <td>
-                        <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003723" target="_blank" class="term-link">
                                     GO:0003723
                                 </a>
                             </span>
                             <span class="term-label">RNA binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">NAS</span>
-                        
-                        
-                        
+
+
+
                     </td>
                     <td>
                         <span class="action-badge action-new">
@@ -1117,61 +936,59 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Added to align core_functions with existing annotations.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core function term not present in existing_annotations.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/29800646" target="_blank" class="term-link">
-                                        PMID:29800646
-                                    </a>
-                                    
+
+                                    file:human/SNORD116-1/SNORD116-1-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">We discovered deficits in Snord116+/- mutant mice in the novel object recognition, location memory and tone cue fear conditioning assays when compared to age-, sex- matched, littermate control Snord116+/+ mice.</div>
-                                
+
+                                <div class="support-text">Fibrillarin RIP-seq enrichment over the first third of the SNORD116 cluster supports snoRNP association for that region, aligning with SNOG1, which includes SNORD116-1.</div>
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
             </tbody>
         </table>
     </div>
-    
 
-    
+
+
     <div class="section">
         <h2 class="section-title">Core Functions</h2>
-        
+
         <div class="core-function-card">
-            
+
             <div style="display: flex; justify-content: space-between; align-items: center;">
-                <h3>mRNA stability regulation (cluster function)</h3>
-                <span class="vote-buttons" data-g="URS000075CFA5_9606" data-a="FUNCTION: mRNA stability regulation (cluster function)..." data-r="" data-act="CORE_FUNCTION">
+                <h3>box C/D snoRNA function and intron-derived snoRNA processing</h3>
+                <span class="vote-buttons" data-g="URS000075CFA5_9606" data-a="FUNCTION: box C/D snoRNA function and intron-derived snoRNA ..." data-r="" data-act="CORE_FUNCTION">
                     <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
             </div>
-            
+
 
             <div class="core-function-terms">
-                
+
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
@@ -1180,320 +997,270 @@
                         </a>
                     </span>
                 </div>
-                
 
-                
 
-                
 
-                
-
-                
-            </div>
-
-            
-            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
-                <strong>Supporting Evidence:</strong>
-                <ul class="findings-list">
-                    
-                    <li class="finding-item">
-                        <span class="reference-id">
-                            
-                            <a href="https://pubmed.ncbi.nlm.nih.gov/33856031" target="_blank" class="term-link">
-                                PMID:33856031
-                            </a>
-                            
-                        </span>
-                        
-                        <div class="finding-text">SNORD116 cluster directly interacts with and stabilizes target mRNAs like NHLH2</div>
-                        
-                    </li>
-                    
-                </ul>
-            </div>
-            
-        </div>
-        
-        <div class="core-function-card">
-            
-            <div style="display: flex; justify-content: space-between; align-items: center;">
-                <h3>hypothalamic function regulation (cluster function)</h3>
-                <span class="vote-buttons" data-g="URS000075CFA5_9606" data-a="FUNCTION: hypothalamic function regulation (cluster function..." data-r="" data-act="CORE_FUNCTION">
-                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
-                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
-                </span>
-            </div>
-            
-
-            <div class="core-function-terms">
-                
                 <div class="function-term-group">
-                    <div class="function-term-label">Molecular Function:</div>
-                    <span class="badge">
-                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003723" target="_blank" class="term-link">
-                            RNA binding
-                        </a>
-                    </span>
-                </div>
-                
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
 
-                
-
-                
-
-                
-
-                
-            </div>
-
-            
-            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
-                <strong>Supporting Evidence:</strong>
-                <ul class="findings-list">
-                    
-                    <li class="finding-item">
-                        <span class="reference-id">
-                            
-                            <a href="https://pubmed.ncbi.nlm.nih.gov/34040195" target="_blank" class="term-link">
-                                PMID:34040195
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006396" target="_blank" class="term-link">
+                                RNA processing
                             </a>
-                            
                         </span>
-                        
-                        <div class="finding-text">SNORD116 and growth hormone therapy impact IGFBP7 in Prader-Willi syndrome</div>
-                        
-                    </li>
-                    
-                </ul>
-            </div>
-            
-        </div>
-        
-        <div class="core-function-card">
-            
-            <div style="display: flex; justify-content: space-between; align-items: center;">
-                <h3>neurodevelopmental regulation (cluster function)</h3>
-                <span class="vote-buttons" data-g="URS000075CFA5_9606" data-a="FUNCTION: neurodevelopmental regulation (cluster function)..." data-r="" data-act="CORE_FUNCTION">
-                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
-                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
-                </span>
-            </div>
-            
 
-            <div class="core-function-terms">
-                
+                    </div>
+                </div>
+
+
+
                 <div class="function-term-group">
-                    <div class="function-term-label">Molecular Function:</div>
-                    <span class="badge">
-                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003723" target="_blank" class="term-link">
-                            RNA binding
-                        </a>
-                    </span>
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005730" target="_blank" class="term-link">
+                                nucleolus
+                            </a>
+                        </span>
+
+                    </div>
                 </div>
-                
 
-                
 
-                
 
-                
 
-                
+
             </div>
 
-            
+
             <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
                 <strong>Supporting Evidence:</strong>
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
-                            <a href="https://pubmed.ncbi.nlm.nih.gov/29800646" target="_blank" class="term-link">
-                                PMID:29800646
-                            </a>
-                            
+
+                            GO_REF:0000115
+
                         </span>
-                        
-                        <div class="finding-text">These results show that the Snord116 + /– deletion murine model is a valuable preclinical model for investigating learning and memory impairments in individuals with PWS without common confounding phenotypes</div>
-                        
+
+                        <div class="finding-text">Rfam classification as C/D box snoRNA (RF00108)</div>
+
                     </li>
-                    
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/SNORD116-1/SNORD116-1-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">Based on the retrieved evidence, SNORD116-1 is best annotated with structural/biogenesis/localization GO concepts typical of box C/D snoRNAs.</div>
+
+                    </li>
+
                 </ul>
             </div>
-            
+
         </div>
-        
+
     </div>
-    
 
-    
+
+
     <div class="section">
         <h2 class="section-title collapsible">References</h2>
         <div class="collapse-content">
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
+                        file:human/SNORD116-1/SNORD116-1-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research report for SNORD116-1</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Falcon supports copy-level SNORD116-1 annotation to structural, biogenesis, and localization concepts typical of box C/D snoRNAs, while treating Prader-Willi and neurodevelopmental phenotypes as cluster/locus evidence rather than direct SNORD116-1 functions.</div>
+
+                        <div class="finding-text">"SNORD116-1 is best annotated with structural/biogenesis/localization GO concepts typical of box C/D snoRNAs, while not being annotated yet with specific RNA modification targets or disease-process terms."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000115.md" target="_blank" class="term-link">
                             GO_REF:0000115
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Automatic Gene Ontology annotation of non-coding RNA sequences through association of Rfam records with GO terms</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/39616178" target="_blank" class="term-link">
                             PMID:39616178
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Roles of SNORD115 and SNORD116 ncRNA clusters during neuronal differentiation</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/29800646" target="_blank" class="term-link">
                             PMID:29800646
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Cognitive deficits in the Snord116 deletion mouse model for Prader-Willi syndrome</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Snord116 deletion causes cognitive deficits in mice: deficits in novel object recognition, location memory, and tone cue fear conditioning</div>
-                        
+
                         <div class="finding-text">"We discovered deficits in Snord116+/- mutant mice in the novel object recognition, location memory and tone cue fear conditioning assays"</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">The Snord116 cluster deletion model shows learning and memory impairments relevant to PWS</div>
-                        
+
                         <div class="finding-text">"These results show that the Snord116+/- deletion murine model is a valuable preclinical model for investigating learning and memory impairments in individuals with PWS"</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/22237428" target="_blank" class="term-link">
                             PMID:22237428
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Prader-Willi syndrome</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/34040195" target="_blank" class="term-link">
                             PMID:34040195
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">SNORD116 and growth hormone therapy impact IGFBP7 in Prader-Willi syndrome</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/33856031" target="_blank" class="term-link">
                             PMID:33856031
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Snord116 Post-transcriptionally Increases Nhlh2 mRNA Stability: Implications for Human Prader-Willi Syndrome</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">SNORD116 cluster deletion is the smallest genomic region causing Prader-Willi Syndrome</div>
-                        
+
                         <div class="finding-text">"The smallest genomic region causing Prader-Willi Syndrome (PWS) deletes the non-coding RNA SNORD116 cluster"</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">SNORD116 increases stability of Nhlh2 mRNA through direct interaction: upregulation occurs through increased mRNA stability in the 45 minutes immediately following transcription</div>
-                        
+
                         <div class="finding-text">"use of actinomycin D to stop new transcription in N29/2 cells demonstrated that the upregulation occurred through increased stability of the Nhlh2 mRNA in the 45 minutes immediately following transcription"</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">In silico modeling identified conserved interaction domains between SNORD116 and NHLH2 mRNA 3&#39;-UTR</div>
-                        
+
                         <div class="finding-text">"In silico RNA: RNA modeling identified several potential interaction domains between SNORD116 and NHLH2 mRNA"</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Mechanism: SNORD116-mediated regulation clarifies how deletion of SNORD116 cluster leads to PWS phenotypes</div>
-                        
+
                         <div class="finding-text">"For the first time, these data identify a motif and mechanism for SNORD116-mediated regulation of NHLH2, clarifying the mechanism by which deletion of the SNORD116 snoRNAs locus leads to PWS phenotypes"</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
         </div>
     </div>
-    
 
 
-    
+
+
     <div class="section">
         <h2 class="section-title">Suggested Questions for Experts</h2>
-        
+
         <div class="question-card">
             <div style="display: flex; justify-content: space-between; align-items: start;">
                 <div style="flex: 1;">
                     <p><strong>Q:</strong> What is the complete set of mRNA targets regulated by the SNORD116 cluster in different tissues?</p>
-                    
+
                     <p style="margin-top: 0.5rem;"><em>Suggested experts: RNA biologists, Prader-Willi syndrome researchers</em></p>
-                    
+
                 </div>
                 <span class="vote-buttons" data-g="URS000075CFA5_9606" data-a="Q: What is the complete set of mRNA targets regulated..." data-r="" data-act="QUESTION">
                     <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
@@ -1501,14 +1268,14 @@
                 </span>
             </div>
         </div>
-        
+
         <div class="question-card">
             <div style="display: flex; justify-content: space-between; align-items: start;">
                 <div style="flex: 1;">
                     <p><strong>Q:</strong> Do individual SNORD116 copies have redundant or specialized functions within the cluster?</p>
-                    
+
                     <p style="margin-top: 0.5rem;"><em>Suggested experts: snoRNA biologists, geneticists</em></p>
-                    
+
                 </div>
                 <span class="vote-buttons" data-g="URS000075CFA5_9606" data-a="Q: Do individual SNORD116 copies have redundant or sp..." data-r="" data-act="QUESTION">
                     <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
@@ -1516,14 +1283,14 @@
                 </span>
             </div>
         </div>
-        
+
         <div class="question-card">
             <div style="display: flex; justify-content: space-between; align-items: start;">
                 <div style="flex: 1;">
                     <p><strong>Q:</strong> How does SNORD116 cluster dosage affect hypothalamic neuron development and function?</p>
-                    
+
                     <p style="margin-top: 0.5rem;"><em>Suggested experts: neurodevelopmental biologists, neuroendocrinologists</em></p>
-                    
+
                 </div>
                 <span class="vote-buttons" data-g="URS000075CFA5_9606" data-a="Q: How does SNORD116 cluster dosage affect hypothalam..." data-r="" data-act="QUESTION">
                     <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
@@ -1531,26 +1298,26 @@
                 </span>
             </div>
         </div>
-        
-    </div>
-    
 
-    
+    </div>
+
+
+
     <div class="section">
         <h2 class="section-title">Suggested Experiments</h2>
-        
+
         <div class="experiment-card">
             <div style="display: flex; justify-content: space-between; align-items: start;">
                 <div style="flex: 1;">
-                    
+
                     <p><strong>Experiment:</strong> CLIP-seq analysis of SNORD116 interactions with mRNAs in hypothalamic neurons</p>
-                    
-                    
+
+
                     <p style="margin-top: 0.5rem;"><em>Hypothesis: SNORD116 cluster binds to a specific set of mRNAs critical for hypothalamic function</em></p>
-                    
-                    
+
+
                     <p style="margin-top: 0.5rem;">Type: high-throughput sequencing</p>
-                    
+
                 </div>
                 <span class="vote-buttons" data-g="URS000075CFA5_9606" data-a="EXPERIMENT: CLIP-seq analysis of SNORD116 interactions with mR..." data-r="" data-act="EXPERIMENT">
                     <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
@@ -1558,19 +1325,19 @@
                 </span>
             </div>
         </div>
-        
+
         <div class="experiment-card">
             <div style="display: flex; justify-content: space-between; align-items: start;">
                 <div style="flex: 1;">
-                    
+
                     <p><strong>Experiment:</strong> Single-cell RNA-seq of hypothalamic development in SNORD116 cluster knockout models</p>
-                    
-                    
+
+
                     <p style="margin-top: 0.5rem;"><em>Hypothesis: SNORD116 cluster loss affects specific neuronal subtypes in the hypothalamus</em></p>
-                    
-                    
+
+
                     <p style="margin-top: 0.5rem;">Type: single-cell analysis</p>
-                    
+
                 </div>
                 <span class="vote-buttons" data-g="URS000075CFA5_9606" data-a="EXPERIMENT: Single-cell RNA-seq of hypothalamic development in..." data-r="" data-act="EXPERIMENT">
                     <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
@@ -1578,19 +1345,19 @@
                 </span>
             </div>
         </div>
-        
+
         <div class="experiment-card">
             <div style="display: flex; justify-content: space-between; align-items: start;">
                 <div style="flex: 1;">
-                    
+
                     <p><strong>Experiment:</strong> Functional analysis of individual SNORD116 copies to test redundancy vs. specialization</p>
-                    
-                    
+
+
                     <p style="margin-top: 0.5rem;"><em>Hypothesis: Individual copies within the cluster may have partially redundant functions</em></p>
-                    
-                    
+
+
                     <p style="margin-top: 0.5rem;">Type: molecular genetics</p>
-                    
+
                 </div>
                 <span class="vote-buttons" data-g="URS000075CFA5_9606" data-a="EXPERIMENT: Functional analysis of individual SNORD116 copies ..." data-r="" data-act="EXPERIMENT">
                     <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
@@ -1598,17 +1365,415 @@
                 </span>
             </div>
         </div>
-        
-    </div>
-    
 
-    
+    </div>
+
+
+
 
     <!-- Computational Predictions Section -->
-    
+
 
     <!-- Additional Documentation Sections -->
-    
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Deep Research Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(SNORD116-1-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="URS000075CFA5_9606" data-a="DOC: Deep Research Falcon" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <hr />
+<p>provider: falcon<br />
+model: Edison Scientific Literature<br />
+cached: false<br />
+start_time: '2026-05-11T03:29:14.815291'<br />
+end_time: '2026-05-11T03:47:29.811394'<br />
+duration_seconds: 1095.0<br />
+provider_config:<br />
+  timeout: 600<br />
+  max_retries: 3<br />
+  parameters:<br />
+    allowed_domains: []<br />
+    temperature: 0.1<br />
+citation_count: 30</p>
+<hr />
+<h2 id="question">Question</h2>
+<p>Research the human small nucleolar RNA gene SNORD116-1 (RNAcentral URS000075CFA5_9606), one copy in the SNORD116 cluster, for Gene Ontology functional annotation. This is a snoRNA/non-coding RNA, not a protein; do not infer protein domains or enzyme activity. Focus on its core RNA molecular function, nucleolar localization, RNA processing or RNA binding evidence, the strength and limits of evidence connecting the SNORD116 cluster to Prader-Willi syndrome and neurodevelopment, and which GO terms are directly supported for the individual SNORD116-1 gene versus the cluster. Distinguish direct function from locus-level phenotypes, and provide citations for each major claim.</p>
+<h2 id="output">Output</h2>
+<p>Question: You are an expert researcher providing comprehensive, well-cited information.</p>
+<p>Provide detailed information focusing on:<br />
+1. Key concepts and definitions with current understanding<br />
+2. Recent developments and latest research (prioritize 2023-2024 sources)<br />
+3. Current applications and real-world implementations<br />
+4. Expert opinions and analysis from authoritative sources<br />
+5. Relevant statistics and data from recent studies</p>
+<p>Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.<br />
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.</p>
+<p>Research the human small nucleolar RNA gene SNORD116-1 (RNAcentral URS000075CFA5_9606), one copy in the SNORD116 cluster, for Gene Ontology functional annotation. This is a snoRNA/non-coding RNA, not a protein; do not infer protein domains or enzyme activity. Focus on its core RNA molecular function, nucleolar localization, RNA processing or RNA binding evidence, the strength and limits of evidence connecting the SNORD116 cluster to Prader-Willi syndrome and neurodevelopment, and which GO terms are directly supported for the individual SNORD116-1 gene versus the cluster. Distinguish direct function from locus-level phenotypes, and provide citations for each major claim.</p>
+<h2 id="research-report-go-relevant-functional-annotation-for-human-snord116-1-rnacentral-urs000075cfa5_9606">Research report: GO-relevant functional annotation for human <strong>SNORD116-1</strong> (RNAcentral: <strong>URS000075CFA5_9606</strong>)</h2>
+<h3 id="executive-summary">Executive summary</h3>
+<p>SNORD116-1 is one paralogous copy within the paternally expressed <strong>SNORD116 tandem repeat cluster</strong> embedded in the imprinted <strong>SNHG14 / SNURF–SNRPN</strong> locus at 15q11–q13. The strongest Gene Ontology (GO)-relevant evidence for SNORD116-1 is <em>structural/class-based</em>: it is a <strong>box C/D snoRNA</strong> produced by <strong>intron-derived snoRNA biogenesis</strong> and is therefore expected to function within a <strong>box C/D snoRNP</strong> and reside in the <strong>nucleolus</strong>, but direct biochemical assays are generally <strong>not copy-resolved</strong>. By contrast, essentially all disease and neurodevelopmental data implicate <strong>loss of the cluster/critical region</strong>, not loss of a single copy such as SNORD116-1; therefore, Prader–Willi syndrome (PWS) and neurodevelopment phenotypes should be treated as <strong>locus/cluster-level associations</strong>, not direct per-gene functional evidence for SNORD116-1. (bortolincavaille2012thesnord115(hmbii52) pages 1-2, duker2010paternallyinheritedmicrodeletion pages 4-5, chung2020praderwillisyndromereflections pages 7-8)</p>
+<h3 id="1-key-concepts-and-definitions-current-understanding">1) Key concepts and definitions (current understanding)</h3>
+<h4 id="11-what-snord116-1-is-and-is-not">1.1 What SNORD116-1 is (and is not)</h4>
+<ul>
+<li><strong>SNORD116-1 is a non-coding RNA gene</strong> encoding a small nucleolar RNA (snoRNA) and should not be annotated with protein domains or enzymatic activities. The SNORD116 family is described as <strong>box C/D snoRNAs</strong> produced from an imprinted host transcript; box C/D snoRNAs assemble with core proteins (NOP56, NOP58, fibrillarin, and 15.5K/SNU13) to form snoRNPs. (chung2020praderwillisyndromereflections pages 6-7)</li>
+</ul>
+<h4 id="12-cluster-organization-and-copy-specific-terminology">1.2 Cluster organization and copy-specific terminology</h4>
+<ul>
+<li>The SNORD116 cluster contains multiple paralogues (commonly described as ~30 copies). A widely used subgrouping partitions the cluster into <strong>SNOG1 = SNORD116-1 to SNORD116-9</strong>, SNOG2 = SNORD116-10 to -24, and SNOG3 = SNORD116-25 to -29, reflecting sequence/expression differences. (chung2020praderwillisyndromereflections pages 7-8)</li>
+<li>Copy-resolved expression analyses indicate <strong>heterogeneous expression among individual paralogues</strong> and dominance of group I/II expression in adult tissues (with some copies weak/absent), supporting the need to avoid “all-copies-equal” assumptions in per-copy GO annotation. (baldini2022phylogeneticandmolecular pages 3-5)</li>
+</ul>
+<h4 id="13-canonical-box-cd-snorna-biology-relevant-to-go">1.3 Canonical box C/D snoRNA biology (relevant to GO)</h4>
+<ul>
+<li>Canonical box C/D snoRNAs are processed from <strong>excised and debranched introns</strong> by exonucleolytic trimming and typically accumulate in <strong>nucleoli</strong> as snoRNPs. (chung2020praderwillisyndromereflections pages 6-7, bortolincavaille2012thesnord115(hmbii52) pages 1-2)</li>
+<li>Canonically, box C/D snoRNAs guide <strong>2′-O-methylation</strong> of target RNAs via antisense elements; however, multiple authoritative sources emphasize that <strong>SNORD116 snoRNAs are “orphan”</strong>: they show no clear complementarity to rRNA and <strong>validated targets have been difficult to define</strong>. (chung2020praderwillisyndromereflections pages 7-8, holmes2025footprintsinthe pages 2-3, cavaille2017boxcdsmall pages 1-3)</li>
+</ul>
+<h3 id="2-molecular-function-and-cellular-component-evidence-for-snord116-1-vs-the-cluster">2) Molecular function and cellular component evidence for SNORD116-1 vs the cluster</h3>
+<h4 id="21-evidence-supporting-box-cd-snorna-snornp-component-for-snord116">2.1 Evidence supporting “box C/D snoRNA / snoRNP component” for SNORD116</h4>
+<ul>
+<li>Experimental mapping of SNORD116 termini and processing products supports that the <strong>cluster generates canonical snoRNA-sized species</strong> (e.g., ~92 nt dominant species in mouse) via intron-derived processing pathways; low-abundance truncated forms exist but their functional relevance is not established. (bortolincavaille2012thesnord115(hmbii52) pages 6-6)</li>
+<li>Reviews and primary studies support that SNORD116 family members behave as bona fide box C/D snoRNAs that assemble with core snoRNP proteins. In particular, fibrillarin RIP-seq enrichment over the <strong>first third of the cluster</strong> supports snoRNP association for that region, aligning with SNOG1 (which includes SNORD116-1). (chung2020praderwillisyndromereflections pages 7-8)</li>
+</ul>
+<p><strong>GO implication:</strong> for SNORD116-1, the most defensible molecular-function annotation is a <strong>box C/D snoRNA / snoRNP-associated RNA scaffold role</strong>, but the direct experimental evidence is at subgroup/cluster resolution rather than SNORD116-1-specific pulldowns. (bortolincavaille2012thesnord115(hmbii52) pages 1-2, chung2020praderwillisyndromereflections pages 7-8)</p>
+<h4 id="22-nucleolar-localization">2.2 Nucleolar localization</h4>
+<ul>
+<li>Box C/D snoRNAs are described as concentrating mainly in the <strong>nucleolus</strong>, and SNORD116 snoRNAs are described as <strong>localizing to nucleoli</strong> (processed snoRNAs), consistent with canonical snoRNA biology. (bortolincavaille2012thesnord115(hmbii52) pages 1-2, holmes2025footprintsinthe pages 10-12)</li>
+</ul>
+<p><strong>GO implication:</strong> a cellular-component assignment to <strong>nucleolus</strong> is supported strongly for the <strong>processed SNORD116 snoRNAs collectively</strong>, but not proven for SNORD116-1 specifically by copy-resolved imaging. (holmes2025footprintsinthe pages 10-12, bortolincavaille2012thesnord115(hmbii52) pages 1-2)</p>
+<h4 id="23-biogenesis-intron-derived-processing-from-snhg14snurfsnrpn">2.3 Biogenesis: intron-derived processing from SNHG14/SNURF–SNRPN</h4>
+<ul>
+<li>Multiple sources describe SNORD116 copies as embedded within, and processed from, repeated introns of the large imprinted host transcript (SNHG14/SNURF–SNRPN region), via splicing/debranching followed by exonucleolytic trimming. (chung2020praderwillisyndromereflections pages 6-7, bortolincavaille2012thesnord115(hmbii52) pages 1-2)</li>
+<li>In neuronal differentiation models, mature SNORD116 predominates over extended forms, consistent with efficient processing from the host. (helwak2024rolesofsnord115 pages 2-4)</li>
+</ul>
+<p><strong>GO implication:</strong> biological-process terms consistent with <strong>snoRNA processing/biogenesis from introns</strong> are well supported at the family/cluster level and can be cautiously extended to SNORD116-1 as a member of the intronic array. (bortolincavaille2012thesnord115(hmbii52) pages 1-2, helwak2024rolesofsnord115 pages 2-4)</p>
+<h4 id="24-guide-activity-for-2-o-methylation-what-is-supported-vs-not">2.4 Guide activity for 2′-O-methylation: what is supported vs not</h4>
+<ul>
+<li>Authoritative discussions repeatedly describe SNORD116 as an <strong>orphan box C/D snoRNA family</strong> with no validated rRNA targets and no established canonical 2′-O-methylation guide function for specific targets. (chung2020praderwillisyndromereflections pages 7-8, holmes2025footprintsinthe pages 2-3, cavaille2017boxcdsmall pages 1-3)</li>
+</ul>
+<p><strong>GO implication:</strong> it is not currently justified (from the cited evidence base) to assign SNORD116-1 a specific “<strong>guide for 2′-O-methylation of RNA</strong>” molecular function. (chung2020praderwillisyndromereflections pages 7-8, holmes2025footprintsinthe pages 2-3)</p>
+<h4 id="25-rna-binding-non-canonical-regulatory-roles-cluster-level-evidence-and-limits">2.5 RNA-binding / non-canonical regulatory roles: cluster-level evidence and limits</h4>
+<ul>
+<li>Cluster-/locus-level studies report diverse downstream molecular effects and RNA interactions for Snord116/SNORD116, including locus-wide interaction mapping and altered signaling readouts in animal models, but these generally do not identify a single paralogue as causal. (holmes2025footprintsinthe pages 9-10, holmes2025footprintsinthe pages 10-12)</li>
+<li>A notable limitation for per-copy annotation is that the only explicit paralogue-specific functional example in the retrieved evidence concerns <strong>SNORD116-3</strong> (predicted interaction with <em>Nhlh2</em> and effects on mRNA decay under SNORD116 manipulation), and this should <strong>not</strong> be transferred to SNORD116-1 without direct evidence. (holmes2025footprintsinthe pages 9-10)</li>
+</ul>
+<h3 id="3-evidence-connecting-the-snord116-region-to-praderwilli-syndrome-and-neurodevelopment">3) Evidence connecting the SNORD116 region to Prader–Willi syndrome and neurodevelopment</h3>
+<h4 id="31-strength-of-evidence-human-genetics">3.1 Strength of evidence (human genetics)</h4>
+<ul>
+<li>Human atypical <strong>paternal microdeletions encompassing SNORD116</strong> are repeatedly cited as sufficient to produce a PWS clinical picture. In a widely cited example, a paternally inherited ~236 kb deletion including SNORD116 showed <strong>complete loss of SNORD116 expression</strong> in blood while SNRPN and UBE3A were detected, supporting SNORD116-region causality. (duker2010paternallyinheritedmicrodeletion pages 3-4)</li>
+<li>Reported clinical features across SNORD116-region microdeletion patients include classic PWS findings (e.g., neonatal hypotonia, feeding problems/failure to thrive, later hyperphagia/obesity, developmental delay, behavioral problems, sleep disturbance, hypogonadism). (duker2010paternallyinheritedmicrodeletion pages 4-5)</li>
+</ul>
+<p><strong>Interpretation:</strong> these data strongly support that <strong>loss of the SNORD116 critical region/cluster</strong> is a key driver of PWS phenotypes in humans. (duker2010paternallyinheritedmicrodeletion pages 4-5, duker2010paternallyinheritedmicrodeletion pages 3-4)</p>
+<h4 id="32-limits-of-evidence-single-copy-resolution-and-confounding">3.2 Limits of evidence (single-copy resolution and confounding)</h4>
+<ul>
+<li>The deletions implicated in PWS remove <strong>multiple tandem copies</strong> (and sometimes neighboring noncoding elements), and thus do <strong>not</strong> establish that loss of any single repeat (including SNORD116-1) is sufficient for disease. (duker2010paternallyinheritedmicrodeletion pages 2-3)</li>
+<li>Minimal critical intervals cited in the literature can include additional noncoding genes (e.g., IPW and other snoRNAs), which complicates strict attribution to SNORD116 mature snoRNAs alone versus other locus-derived products. (burnett2017lossofthe pages 1-2)</li>
+</ul>
+<h4 id="33-model-systems-what-they-support">3.3 Model systems: what they support</h4>
+<ul>
+<li>Mouse models with targeted Snord116-cluster deletions reproduce subsets of PWS-relevant phenotypes (e.g., growth retardation, hypotonia/activity changes, neurobehavioral phenotypes), but may fail to recapitulate others (notably obesity/infertility in some lines), indicating species/strain differences and incomplete model capture. (duker2010paternallyinheritedmicrodeletion pages 4-5)</li>
+<li>Developmental phenotyping of Snord116p/m+ mice revealed neuronal and endocrine pancreatic developmental changes (e.g., reduced neuronal cell body size with decreased nucleolar size; islet cellular composition changes), further supporting a cluster-level developmental role. (burnett2017lossofthe pages 1-2)</li>
+</ul>
+<h3 id="4-recent-developments-prioritizing-20232024">4) Recent developments (prioritizing 2023–2024)</h3>
+<h4 id="41-2024-nature-communications-snord116-cluster-roles-during-neuronal-differentiation-luhmes">4.1 2024 Nature Communications: SNORD116 cluster roles during neuronal differentiation (LUHMES)</h4>
+<ul>
+<li>Helwak et al. (Nature Communications; <strong>published Nov 2024</strong>; https://doi.org/10.1038/s41467-024-54573-8) created cell lines lacking the expressed paternal SNORD116 cluster and showed SNORD116 abundance increases during differentiation (~<strong>5-fold</strong> from day 0 to day 15 by RT-PCR) and plateaus between days 6–10, interpreted as stabilization. (helwak2024rolesofsnord115 pages 1-2, helwak2024rolesofsnord115 pages 2-4)</li>
+<li>Functional consequences of SNORD116-cluster deletion included acceleration toward more mature neuronal transcriptomic states and measurable transcriptome/proteome changes; the study reports limited bona fide alternative splicing changes (e.g., <strong>95 events</strong> in H116) and compiled a curated list of <strong>24 high-confidence SNORD116-specific dysregulated RNAs</strong>, plus proteome-level shifts (including altered protein/mRNA ratio changes). (helwak2024rolesofsnord115 pages 8-9)</li>
+<li>The paper provides a locus schematic and expression evidence across differentiation timepoints (days 0, 6, 10, 15), useful for grounding GO cellular context and biogenesis claims. (helwak2024rolesofsnord115 media 1ebb8c3a, helwak2024rolesofsnord115 media f44777c4)</li>
+</ul>
+<h4 id="42-2024-nucleic-acids-research-isogenic-hesc-neuronal-deletion-models-and-predicted-targets">4.2 2024 Nucleic Acids Research: isogenic hESC neuronal deletion models and predicted targets</h4>
+<ul>
+<li>Gilmore et al. (Nucleic Acids Research; <strong>published Nov 2024</strong>; https://doi.org/10.1093/nar/gkae1129) engineered isogenic hESC lines with deletions affecting the SNORD116 region, differentiated them into neurons, and identified <strong>42 consistently dysregulated genes</strong> across deletions; these genes were enriched for predicted SNORD116 targeting and were linked to validated changes in <strong>FGF13 protein</strong> levels. (gilmore2024identifyingkeyunderlying pages 1-2)</li>
+</ul>
+<h4 id="43-2023-human-molecular-genetics-snhg14-derived-sno-lncrnasspa-lncrnas-regulate-transcriptional-programs">4.3 2023 Human Molecular Genetics: SNHG14-derived sno-lncRNAs/SPA-lncRNAs regulate transcriptional programs</h4>
+<ul>
+<li>Sledziowska et al. (Human Molecular Genetics; <strong>published Sep 2023</strong>; https://doi.org/10.1093/hmg/ddac228) depleted SNHG14-derived sno-lncRNAs and SPA-lncRNAs using antisense GapmeRs in iPSCs and used chromatin-associated RNA-seq to capture transcriptional effects. Combined knockdown (up to <strong>80%</strong>, 65% average) yielded <strong>205 downregulated and 87 upregulated</strong> transcripts (24 h), with top downregulated neuronal genes including <strong>FAT3, NRXN1, NLGN1</strong>, and GO/pathway enrichment for neuronal development and synaptic/cell-adhesion functions. (sledziowska2023noncodingrnasassociated pages 4-6, sledziowska2023noncodingrnasassociated pages 1-2)</li>
+</ul>
+<p><strong>GO relevance:</strong> these 2023–2024 studies strengthen the case that the <em>locus</em> (including processed snoRNAs and extended intronic RNAs) influences neuronal transcriptional programs, but they largely do <strong>not</strong> establish a direct, single-paralogue molecular function for SNORD116-1. (gilmore2024identifyingkeyunderlying pages 1-2, sledziowska2023noncodingrnasassociated pages 4-6)</p>
+<h3 id="5-current-applications-and-real-world-implementations">5) Current applications and real-world implementations</h3>
+<h4 id="51-diagnostics-and-genotypephenotype-interpretation">5.1 Diagnostics and genotype–phenotype interpretation</h4>
+<ul>
+<li>High-resolution microarray (array CGH), breakpoint mapping, parent-of-origin genotyping, and RT-PCR expression assays have been used clinically/research-wise to identify atypical <strong>SNORD116-region microdeletions</strong> associated with PWS phenotypes, supporting real-world utility for genetic diagnosis beyond classic large deletions/UPD. (duker2010paternallyinheritedmicrodeletion pages 1-2, duker2010paternallyinheritedmicrodeletion pages 2-3)</li>
+</ul>
+<h4 id="52-therapeutic-strategies-conceptual-locus-level">5.2 Therapeutic strategies (conceptual; locus-level)</h4>
+<ul>
+<li>A recurring translational theme is <strong>reactivation of the normally silent maternal allele</strong> of PWS-locus genes (including SNORD116) via epigenetic modulation, although this is a locus-level approach and not a SNORD116-1-specific intervention. (gilmore2024identifyingkeyunderlying pages 1-2)</li>
+</ul>
+<h3 id="6-expert-opinions-and-authoritative-synthesis">6) Expert opinions and authoritative synthesis</h3>
+<ul>
+<li>Expert reviews emphasize two points: (i) SNORD116 is likely central to PWS pathogenesis because atypical deletions limited to the SNORD116 region can yield core phenotypes; (ii) the <strong>mechanism of action remains unresolved</strong>, in part because SNORD116 lacks clear canonical rRNA complementarity and targets are unknown, making it difficult to assign classic methylation-guide GO functions. (chung2020praderwillisyndromereflections pages 7-8, cavaille2017boxcdsmall pages 1-3)</li>
+</ul>
+<h3 id="7-key-statistics-and-quantitative-findings-recent-studies">7) Key statistics and quantitative findings (recent studies)</h3>
+<ul>
+<li>SNORD116 genomic organization in SNHG14: <strong>~29 tandem introns</strong> generate SNORD116 in the human host gene SNHG14 (reported in 2024 LUHMES study). (helwak2024rolesofsnord115 pages 1-2)</li>
+<li>SNORD116 induction during neuronal differentiation: <strong>~5× increase</strong> from day 0 to day 15 (LUHMES). (helwak2024rolesofsnord115 pages 1-2, helwak2024rolesofsnord115 media f44777c4)</li>
+<li>Transcriptome effects (cluster deletion): <strong>42 consistently dysregulated genes</strong> across two isogenic hESC neuron deletion models. (gilmore2024identifyingkeyunderlying pages 1-2)</li>
+<li>Transcriptional response to SNHG14-derived lncRNA depletion (iPSC, 24 h): knockdown up to <strong>80%</strong>, and <strong>205 down / 87 up</strong> transcripts with combined SPA/sno-lncRNA depletion. (sledziowska2023noncodingrnasassociated pages 4-6)</li>
+<li>PWS genetics epidemiology (reviewed): SNORD116-only microdeletions are described as rare (<strong>&lt;1%</strong> of PWS cases) relative to large deletions and UPD, underscoring limited patient numbers for genotype refinement. (mendiola2024characterizingtherolea pages 16-21)</li>
+</ul>
+<hr />
+<h3 id="go-term-support-overview-snord116-1-vs-cluster">GO-term support overview (SNORD116-1 vs cluster)</h3>
+<p>The following table consolidates GO-relevant evidence and explicitly separates what is directly supportable for <strong>SNORD116-1</strong> from what is only supportable at <strong>cluster/locus level</strong>.</p>
+<table>
+<thead>
+<tr>
+<th>Entity</th>
+<th>GO aspect</th>
+<th>Candidate GO term label</th>
+<th>Direct evidence summary</th>
+<th>Key limitations for per-copy assignment</th>
+<th>Primary citations</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>SNORD116-1 (single copy; SNOG1/group I)</td>
+<td>MF</td>
+<td>box C/D snoRNA / snoRNP scaffold activity</td>
+<td>SNORD116 family members are bona fide box C/D snoRNAs with conserved C/D features and are processed as canonical snoRNAs; SNOG1 includes SNORD116-1 to -9, and the first third of the cluster shows fibrillarin RIP enrichment, consistent with snoRNP assembly in this subgroup.</td>
+<td>Evidence is subgroup- or cluster-level, not a direct biochemical assay on SNORD116-1 alone; no copy-specific fibrillarin/NOP58 pulldown for SNORD116-1 was shown.</td>
+<td>(bortolincavaille2012thesnord115(hmbii52) pages 1-2, chung2020praderwillisyndromereflections pages 7-8, baldini2022phylogeneticandmolecular pages 3-5)</td>
+</tr>
+<tr>
+<td>SNORD116 cluster / locus products</td>
+<td>MF</td>
+<td>box C/D snoRNA / snoRNP scaffold activity</td>
+<td>SNORD116 cluster products were recommended to be considered bona fide box C/D snoRNAs; canonical box C/D snoRNP association is supported by fibrillarin RIP-seq over the first third of the cluster and by reports that Snord116 associates with FBL and NOP58 in brain extracts.</td>
+<td>Still largely inferred at the cluster/family level; exact stoichiometry and whether all paralogues assemble equivalently are unresolved.</td>
+<td>(chung2020praderwillisyndromereflections pages 7-8, holmes2025footprintsinthe pages 10-12, bortolincavaille2012thesnord115(hmbii52) pages 1-2, cavaille2017boxcdsmall pages 1-3)</td>
+</tr>
+<tr>
+<td>SNORD116-1</td>
+<td>CC</td>
+<td>nucleolus</td>
+<td>General box C/D snoRNAs concentrate in nucleoli, and SNOG1 subgroup members are the most highly expressed in hypothalamus with fibrillarin enrichment over the first third of the cluster, making nucleolar residence plausible for SNORD116-1.</td>
+<td>No direct imaging/localization experiment was reported for SNORD116-1 individually.</td>
+<td>(bortolincavaille2012thesnord115(hmbii52) pages 1-2, chung2020praderwillisyndromereflections pages 7-8)</td>
+</tr>
+<tr>
+<td>SNORD116 cluster / locus products</td>
+<td>CC</td>
+<td>nucleolus / nucleolar snoRNP</td>
+<td>Processed Snord116 snoRNAs localize to nucleoli; SNORD116 snoRNAs are described as able to localize to the nucleolus, consistent with canonical box C/D snoRNA behavior.</td>
+<td>Localization evidence is for processed snoRNAs collectively, not each human paralogue; 116HG host RNA has different localization (retained at transcription site), so locus products are heterogeneous.</td>
+<td>(holmes2025footprintsinthe pages 10-12, bortolincavaille2012thesnord115(hmbii52) pages 1-2)</td>
+</tr>
+<tr>
+<td>SNORD116-1</td>
+<td>BP</td>
+<td>snoRNA processing from intron of SNHG14/SNURF-SNRPN transcript</td>
+<td>SNORD116 genes are embedded within repeated introns of the long SNHG14/SNURF-SNRPN transcript and mature SNORD116 RNAs arise by splicing/debranching and exonucleolytic trimming; SNORD116-1 belongs to this intronic repeat set.</td>
+<td>Processing was demonstrated for SNORD116 family/cluster, not mapped specifically to SNORD116-1 in the cited evidence.</td>
+<td>(bortolincavaille2012thesnord115(hmbii52) pages 6-6, bortolincavaille2012thesnord115(hmbii52) pages 1-2, helwak2024rolesofsnord115 pages 2-4)</td>
+</tr>
+<tr>
+<td>SNORD116 cluster / locus products</td>
+<td>BP</td>
+<td>intron-derived snoRNA processing from SNHG14/SNURF-SNRPN</td>
+<td>Strong evidence supports intron-derived biogenesis: box C/D snoRNAs are processed from excised/debranched introns; full-length SNORD116 termini were mapped; mature SNORD116 predominates over extended forms during neuronal differentiation. The same locus also yields 116HG, sno-lncRNAs, and SPA-lncRNAs.</td>
+<td>Biogenesis differs among locus products, so one GO statement cannot cover all products equally; sno-lncRNAs/SPA-lncRNAs are distinct noncanonical derivatives.</td>
+<td>(bortolincavaille2012thesnord115(hmbii52) pages 6-6, bortolincavaille2012thesnord115(hmbii52) pages 1-2, sledziowska2023noncodingrnasassociated pages 1-2, helwak2024rolesofsnord115 pages 2-4)</td>
+</tr>
+<tr>
+<td>SNORD116-1</td>
+<td>MF</td>
+<td>guide for 2'-O-methylation of RNA</td>
+<td>Not directly supported. SNORD116 is repeatedly described as an orphan box C/D snoRNA family with no validated rRNA targets and no established direct methylation target for SNORD116-1.</td>
+<td>Canonical guide activity cannot be assigned to SNORD116-1 from current direct evidence; family-level potential does not equal demonstrated targeting by this copy.</td>
+<td>(chung2020praderwillisyndromereflections pages 7-8, holmes2025footprintsinthe pages 2-3, cavaille2017boxcdsmall pages 1-3)</td>
+</tr>
+<tr>
+<td>SNORD116 cluster / locus products</td>
+<td>MF</td>
+<td>guide for 2'-O-methylation of RNA</td>
+<td>Not directly supported for the cluster either: although box C/D snoRNAs usually guide 2'-O-methylation, SNORD116 lacks clear rRNA complementarity and remains classified as orphan; no validated SNORD116 methylation target was established in the cited peer-reviewed 2023-2024 studies.</td>
+<td>Candidate methylation interactions are computational/predicted; direct target validation remains lacking in the cited evidence base.</td>
+<td>(chung2020praderwillisyndromereflections pages 7-8, holmes2025footprintsinthe pages 2-3, cavaille2017boxcdsmall pages 1-3, helwak2024rolesofsnord115 pages 9-10)</td>
+</tr>
+<tr>
+<td>SNORD116-1</td>
+<td>MF/BP</td>
+<td>RNA binding / post-transcriptional regulation of mRNA stability</td>
+<td>No direct evidence for SNORD116-1 specifically. Copy-resolved functional evidence cited instead concerns SNORD116-3, for which a predicted 20-bp interaction with Nhlh2 mRNA was linked to altered mRNA decay/stability after SNORD116 manipulation.</td>
+<td>The only copy-specific functional example in the cited set is SNORD116-3, not SNORD116-1; therefore this should not be transferred to SNORD116-1.</td>
+<td>(holmes2025footprintsinthe pages 9-10)</td>
+</tr>
+<tr>
+<td>SNORD116 cluster / locus products</td>
+<td>MF/BP</td>
+<td>RNA binding / regulation of mRNA stability or transcript abundance</td>
+<td>Cluster-level studies reported ChIRP-seq and snoKARR-seq interactions, 32 RNA interactions in mouse cortex, and human neuronal deletion models with 42 consistently dysregulated genes enriched for predicted SNORD116 targets; FGF13 protein changes were validated. SNORD116 overexpression also altered Nhlh2 mRNA stability.</td>
+<td>These findings are mostly cluster-level, often from mouse or engineered deletion/overexpression systems, and do not resolve which individual paralogue is responsible.</td>
+<td>(holmes2025footprintsinthe pages 9-10, gilmore2024identifyingkeyunderlying pages 1-2)</td>
+</tr>
+<tr>
+<td>SNORD116-1</td>
+<td>BP</td>
+<td>regulation of neuronal differentiation / neurodevelopment</td>
+<td>Not directly supported for the single gene. SNOG1/SNORD116-1 is in the highly expressed subgroup, but no single-copy perturbation study linked SNORD116-1 to neuronal differentiation timing or transcriptome change.</td>
+<td>All cited neurodevelopmental effects come from cluster deletions or locus-level ncRNA depletion, not SNORD116-1-specific loss-of-function.</td>
+<td>(chung2020praderwillisyndromereflections pages 7-8, helwak2024rolesofsnord115 pages 1-2)</td>
+</tr>
+<tr>
+<td>SNORD116 cluster / locus products</td>
+<td>BP</td>
+<td>modulation of neuronal differentiation timing / neurodevelopmental transcriptome</td>
+<td>2024 neuronal models showed that SNORD116 cluster deletion accelerates aspects of neuronal maturation, alters RNA stability and protein synthesis, and changes defined transcript/protein sets; a curated set of 24 high-confidence SNORD116-specific dysregulated RNAs was reported, and 42 consistently dysregulated genes were found across isogenic hESC-neuron models.</td>
+<td>These are downstream phenotypes from deleting the cluster/locus and do not prove a direct biochemical activity for any one snoRNA copy; some effects may involve other locus-derived RNAs.</td>
+<td>(gilmore2024identifyingkeyunderlying pages 1-2, helwak2024rolesofsnord115 pages 9-10, helwak2024rolesofsnord115 pages 1-2, helwak2024rolesofsnord115 pages 8-9, sledziowska2023noncodingrnasassociated pages 4-6)</td>
+</tr>
+<tr>
+<td>SNORD116-1</td>
+<td>BP/phenotype context</td>
+<td>Prader-Willi syndrome / neurodevelopmental disorder involvement</td>
+<td>No direct evidence shows that loss of SNORD116-1 alone causes PWS or neurodevelopmental phenotypes. Human data implicate paternal microdeletions encompassing the SNORD116 cluster/minimal region, not a single repeat.</td>
+<td>Disease causality is locus/cluster-level; assigning disease-related GO process terms to SNORD116-1 would overstate the evidence.</td>
+<td>(duker2010paternallyinheritedmicrodeletion pages 4-5, duker2010paternallyinheritedmicrodeletion pages 3-4, duker2010paternallyinheritedmicrodeletion pages 1-2, burnett2017lossofthe pages 1-2)</td>
+</tr>
+<tr>
+<td>SNORD116 cluster / locus products</td>
+<td>BP/phenotype context</td>
+<td>contribution to PWS-related neurodevelopmental phenotypes</td>
+<td>Rare paternal microdeletions removing the SNORD116 critical region are sufficient to produce many core PWS features, and mouse Snord116-cluster deletions recapitulate subsets of metabolic, developmental, neuronal, and endocrine phenotypes.</td>
+<td>Minimal critical intervals can include other noncoding elements (e.g., IPW, SNORD109A, host-locus products), and most studies do not separate mature SNORD116 snoRNAs from 116HG/sno-lncRNAs/SPA-lncRNAs.</td>
+<td>(duker2010paternallyinheritedmicrodeletion pages 4-5, duker2010paternallyinheritedmicrodeletion pages 3-4, mendiola2024characterizingtherole pages 16-21, burnett2017lossofthe pages 1-2, mendiola2024characterizingtherolea pages 16-21)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table contrasts what is directly supportable for the individual snoRNA gene SNORD116-1 versus the broader SNORD116 cluster/locus and its derived noncoding RNAs. It is designed to help separate core RNA function/localization evidence from cluster-level disease and neurodevelopmental phenotypes.</em></p>
+<h3 id="recommended-evidence-based-go-annotation-stance-for-snord116-1-conservative">Recommended evidence-based GO annotation stance for SNORD116-1 (conservative)</h3>
+<p>Based on the retrieved evidence, SNORD116-1 is best annotated with <strong>structural/biogenesis/localization</strong> GO concepts typical of box C/D snoRNAs (snoRNP association; nucleolus; intron-derived snoRNA processing), while <strong>not</strong> being annotated (yet) with specific RNA modification targets or disease-process terms, because:<br />
+1) SNORD116 is repeatedly described as an <strong>orphan</strong> family lacking validated canonical targets (limiting MF assignment to “2′-O-methylation guide”). (chung2020praderwillisyndromereflections pages 7-8, holmes2025footprintsinthe pages 2-3)<br />
+2) PWS and neurodevelopmental effects are supported for the <strong>cluster/critical region</strong>, not for loss of an individual paralogue like SNORD116-1. (duker2010paternallyinheritedmicrodeletion pages 4-5, duker2010paternallyinheritedmicrodeletion pages 3-4, duker2010paternallyinheritedmicrodeletion pages 2-3)<br />
+3) Even when subgroup/copy differences are observed (e.g., SNOG1 enrichment and fibrillarin RIP enrichment over the first third), this is <strong>not</strong> equivalent to a direct SNORD116-1-specific functional assay. (chung2020praderwillisyndromereflections pages 7-8)</p>
+<h3 id="notes-on-urls-and-publication-dates">Notes on URLs and publication dates</h3>
+<p>Primary URLs and publication months/years are embedded above for the principal 2023–2024 sources: Helwak et al. (Nov 2024; https://doi.org/10.1038/s41467-024-54573-8), Gilmore et al. (Nov 2024; https://doi.org/10.1093/nar/gkae1129), and Sledziowska et al. (Sep 2023; https://doi.org/10.1093/hmg/ddac228). (gilmore2024identifyingkeyunderlying pages 1-2, helwak2024rolesofsnord115 pages 1-2, sledziowska2023noncodingrnasassociated pages 4-6)</p>
+<h3 id="evidence-gaps-relevant-to-future-go-refinement-for-snord116-1">Evidence gaps relevant to future GO refinement for SNORD116-1</h3>
+<p>Key experiments that would enable more specific, per-copy GO terms for SNORD116-1 include: paralogue-resolved CLASH/eCLIP-style RNA–RNA chimera detection; paralogue-specific snoRNP IP (fibrillarin/NOP58) followed by long-read mapping; and direct 2′-O-methylation site assignment linked to specific SNORD116 paralogues. Current evidence remains strongest at the SNORD116 <strong>cluster/subgroup</strong> level rather than at the SNORD116-1 gene level. (gilmore2024identifyingkeyunderlying pages 1-2, chung2020praderwillisyndromereflections pages 7-8, baldini2022phylogeneticandmolecular pages 3-5)</p>
+<p>References</p>
+<ol>
+<li>
+<p>(bortolincavaille2012thesnord115(hmbii52) pages 1-2): Marie-Line Bortolin-Cavaillé and J. Cavaillé. The snord115 (h/mbii-52) and snord116 (h/mbii-85) gene clusters at the imprinted prader-willi locus generate canonical box c/d snornas. Nucleic Acids Research, 40:6800-6807, Apr 2012. URL: https://doi.org/10.1093/nar/gks321, doi:10.1093/nar/gks321. This article has 108 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(duker2010paternallyinheritedmicrodeletion pages 4-5): Angela L Duker, Blake C Ballif, Erawati V Bawle, Richard E Person, Sangeetha Mahadevan, Sarah Alliman, Regina Thompson, Ryan Traylor, Bassem A Bejjani, Lisa G Shaffer, Jill A Rosenfeld, Allen N Lamb, and Trilochan Sahoo. Paternally inherited microdeletion at 15q11.2 confirms a significant role for the snord116 c/d box snorna cluster in prader–willi syndrome. European Journal of Human Genetics, 18:1196-1201, Jun 2010. URL: https://doi.org/10.1038/ejhg.2010.102, doi:10.1038/ejhg.2010.102. This article has 384 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(chung2020praderwillisyndromereflections pages 7-8): Michael S. Chung, Maéva Langouët, Stormy J. Chamberlain, and Gordon G. Carmichael. Prader-willi syndrome: reflections on seminal studies and future therapies. Open Biology, Sep 2020. URL: https://doi.org/10.1098/rsob.200195, doi:10.1098/rsob.200195. This article has 51 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(chung2020praderwillisyndromereflections pages 6-7): Michael S. Chung, Maéva Langouët, Stormy J. Chamberlain, and Gordon G. Carmichael. Prader-willi syndrome: reflections on seminal studies and future therapies. Open Biology, Sep 2020. URL: https://doi.org/10.1098/rsob.200195, doi:10.1098/rsob.200195. This article has 51 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(baldini2022phylogeneticandmolecular pages 3-5): Laeya Baldini, Anne Robert, Bruno Charpentier, and Stéphane Labialle. Phylogenetic and molecular analyses identify snord116 targets involved in the prader–willi syndrome. Molecular Biology and Evolution, Dec 2022. URL: https://doi.org/10.1093/molbev/msab348, doi:10.1093/molbev/msab348. This article has 35 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(holmes2025footprintsinthe pages 2-3): Terri L. Holmes, Alzbeta Chabronova, Chris Denning, Victoria James, Mandy J. Peffers, and James G. W. Smith. Footprints in the sno: investigating the cellular and molecular mechanisms of snord116. Open Biology, Mar 2025. URL: https://doi.org/10.1098/rsob.240371, doi:10.1098/rsob.240371. This article has 3 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(cavaille2017boxcdsmall pages 1-3): Jérôme Cavaillé. Box c/d small nucleolar rna genes and the prader‐willi syndrome: a complex interplay. Wiley Interdisciplinary Reviews: RNA, Jul 2017. URL: https://doi.org/10.1002/wrna.1417, doi:10.1002/wrna.1417. This article has 109 citations.</p>
+</li>
+<li>
+<p>(bortolincavaille2012thesnord115(hmbii52) pages 6-6): Marie-Line Bortolin-Cavaillé and J. Cavaillé. The snord115 (h/mbii-52) and snord116 (h/mbii-85) gene clusters at the imprinted prader-willi locus generate canonical box c/d snornas. Nucleic Acids Research, 40:6800-6807, Apr 2012. URL: https://doi.org/10.1093/nar/gks321, doi:10.1093/nar/gks321. This article has 108 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(holmes2025footprintsinthe pages 10-12): Terri L. Holmes, Alzbeta Chabronova, Chris Denning, Victoria James, Mandy J. Peffers, and James G. W. Smith. Footprints in the sno: investigating the cellular and molecular mechanisms of snord116. Open Biology, Mar 2025. URL: https://doi.org/10.1098/rsob.240371, doi:10.1098/rsob.240371. This article has 3 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(helwak2024rolesofsnord115 pages 2-4): Aleksandra Helwak, Tomasz Turowski, Christos Spanos, and David Tollervey. Roles of snord115 and snord116 ncrna clusters during neuronal differentiation. Nature Communications, Nov 2024. URL: https://doi.org/10.1038/s41467-024-54573-8, doi:10.1038/s41467-024-54573-8. This article has 11 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(holmes2025footprintsinthe pages 9-10): Terri L. Holmes, Alzbeta Chabronova, Chris Denning, Victoria James, Mandy J. Peffers, and James G. W. Smith. Footprints in the sno: investigating the cellular and molecular mechanisms of snord116. Open Biology, Mar 2025. URL: https://doi.org/10.1098/rsob.240371, doi:10.1098/rsob.240371. This article has 3 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(duker2010paternallyinheritedmicrodeletion pages 3-4): Angela L Duker, Blake C Ballif, Erawati V Bawle, Richard E Person, Sangeetha Mahadevan, Sarah Alliman, Regina Thompson, Ryan Traylor, Bassem A Bejjani, Lisa G Shaffer, Jill A Rosenfeld, Allen N Lamb, and Trilochan Sahoo. Paternally inherited microdeletion at 15q11.2 confirms a significant role for the snord116 c/d box snorna cluster in prader–willi syndrome. European Journal of Human Genetics, 18:1196-1201, Jun 2010. URL: https://doi.org/10.1038/ejhg.2010.102, doi:10.1038/ejhg.2010.102. This article has 384 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(duker2010paternallyinheritedmicrodeletion pages 2-3): Angela L Duker, Blake C Ballif, Erawati V Bawle, Richard E Person, Sangeetha Mahadevan, Sarah Alliman, Regina Thompson, Ryan Traylor, Bassem A Bejjani, Lisa G Shaffer, Jill A Rosenfeld, Allen N Lamb, and Trilochan Sahoo. Paternally inherited microdeletion at 15q11.2 confirms a significant role for the snord116 c/d box snorna cluster in prader–willi syndrome. European Journal of Human Genetics, 18:1196-1201, Jun 2010. URL: https://doi.org/10.1038/ejhg.2010.102, doi:10.1038/ejhg.2010.102. This article has 384 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(burnett2017lossofthe pages 1-2): Lisa Cole Burnett, Gabriela Hubner, Charles A LeDuc, Michael V Morabito, Jayne F Martin Carli, and Rudolph L Leibel. Loss of the imprinted, non-coding snord116 gene cluster in the interval deleted in the prader willi syndrome results in murine neuronal and endocrine pancreatic developmental phenotypes. Human Molecular Genetics, 26:4606–4616, Dec 2017. URL: https://doi.org/10.1093/hmg/ddx342, doi:10.1093/hmg/ddx342. This article has 38 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(helwak2024rolesofsnord115 pages 1-2): Aleksandra Helwak, Tomasz Turowski, Christos Spanos, and David Tollervey. Roles of snord115 and snord116 ncrna clusters during neuronal differentiation. Nature Communications, Nov 2024. URL: https://doi.org/10.1038/s41467-024-54573-8, doi:10.1038/s41467-024-54573-8. This article has 11 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(helwak2024rolesofsnord115 pages 8-9): Aleksandra Helwak, Tomasz Turowski, Christos Spanos, and David Tollervey. Roles of snord115 and snord116 ncrna clusters during neuronal differentiation. Nature Communications, Nov 2024. URL: https://doi.org/10.1038/s41467-024-54573-8, doi:10.1038/s41467-024-54573-8. This article has 11 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(helwak2024rolesofsnord115 media 1ebb8c3a): Aleksandra Helwak, Tomasz Turowski, Christos Spanos, and David Tollervey. Roles of snord115 and snord116 ncrna clusters during neuronal differentiation. Nature Communications, Nov 2024. URL: https://doi.org/10.1038/s41467-024-54573-8, doi:10.1038/s41467-024-54573-8. This article has 11 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(helwak2024rolesofsnord115 media f44777c4): Aleksandra Helwak, Tomasz Turowski, Christos Spanos, and David Tollervey. Roles of snord115 and snord116 ncrna clusters during neuronal differentiation. Nature Communications, Nov 2024. URL: https://doi.org/10.1038/s41467-024-54573-8, doi:10.1038/s41467-024-54573-8. This article has 11 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(gilmore2024identifyingkeyunderlying pages 1-2): Rachel B Gilmore, Yaling Liu, Christopher E Stoddard, Michael S Chung, Gordon G Carmichael, and Justin Cotney. Identifying key underlying regulatory networks and predicting targets of orphan c/d box snord116 snornas in prader–willi syndrome. Nucleic Acids Research, 52:13757-13774, Nov 2024. URL: https://doi.org/10.1093/nar/gkae1129, doi:10.1093/nar/gkae1129. This article has 13 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(sledziowska2023noncodingrnasassociated pages 4-6): Monika Sledziowska, Kinga Winczura, Matt Jones, Ruba Almaghrabi, Hannah Mischo, Daniel Hebenstreit, Paloma Garcia, and Pawel Grzechnik. Non-coding rnas associated with prader–willi syndrome regulate transcription of neurodevelopmental genes in human induced pluripotent stem cells. Human Molecular Genetics, 32:608-620, Sep 2023. URL: https://doi.org/10.1093/hmg/ddac228, doi:10.1093/hmg/ddac228. This article has 24 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(sledziowska2023noncodingrnasassociated pages 1-2): Monika Sledziowska, Kinga Winczura, Matt Jones, Ruba Almaghrabi, Hannah Mischo, Daniel Hebenstreit, Paloma Garcia, and Pawel Grzechnik. Non-coding rnas associated with prader–willi syndrome regulate transcription of neurodevelopmental genes in human induced pluripotent stem cells. Human Molecular Genetics, 32:608-620, Sep 2023. URL: https://doi.org/10.1093/hmg/ddac228, doi:10.1093/hmg/ddac228. This article has 24 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(duker2010paternallyinheritedmicrodeletion pages 1-2): Angela L Duker, Blake C Ballif, Erawati V Bawle, Richard E Person, Sangeetha Mahadevan, Sarah Alliman, Regina Thompson, Ryan Traylor, Bassem A Bejjani, Lisa G Shaffer, Jill A Rosenfeld, Allen N Lamb, and Trilochan Sahoo. Paternally inherited microdeletion at 15q11.2 confirms a significant role for the snord116 c/d box snorna cluster in prader–willi syndrome. European Journal of Human Genetics, 18:1196-1201, Jun 2010. URL: https://doi.org/10.1038/ejhg.2010.102, doi:10.1038/ejhg.2010.102. This article has 384 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(mendiola2024characterizingtherolea pages 16-21): AJP Mendiola. Characterizing the role of snord116 in coordinating circadian entrainment of behavior, metabolism, and gene expression in prader-willi syndrome. Unknown journal, 2024.</p>
+</li>
+<li>
+<p>(helwak2024rolesofsnord115 pages 9-10): Aleksandra Helwak, Tomasz Turowski, Christos Spanos, and David Tollervey. Roles of snord115 and snord116 ncrna clusters during neuronal differentiation. Nature Communications, Nov 2024. URL: https://doi.org/10.1038/s41467-024-54573-8, doi:10.1038/s41467-024-54573-8. This article has 11 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(mendiola2024characterizingtherole pages 16-21): AJP Mendiola. Characterizing the role of snord116 in coordinating circadian entrainment of behavior, metabolism, and gene expression in prader-willi syndrome. Unknown journal, 2024.</p>
+</li>
+</ol>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>chung2020praderwillisyndromereflections pages 6-7</li>
+<li>chung2020praderwillisyndromereflections pages 7-8</li>
+<li>baldini2022phylogeneticandmolecular pages 3-5</li>
+<li>holmes2025footprintsinthe pages 9-10</li>
+<li>duker2010paternallyinheritedmicrodeletion pages 3-4</li>
+<li>duker2010paternallyinheritedmicrodeletion pages 4-5</li>
+<li>duker2010paternallyinheritedmicrodeletion pages 2-3</li>
+<li>burnett2017lossofthe pages 1-2</li>
+<li>gilmore2024identifyingkeyunderlying pages 1-2</li>
+<li>sledziowska2023noncodingrnasassociated pages 4-6</li>
+<li>mendiola2024characterizingtherolea pages 16-21</li>
+<li>holmes2025footprintsinthe pages 2-3</li>
+<li>cavaille2017boxcdsmall pages 1-3</li>
+<li>holmes2025footprintsinthe pages 10-12</li>
+<li>sledziowska2023noncodingrnasassociated pages 1-2</li>
+<li>duker2010paternallyinheritedmicrodeletion pages 1-2</li>
+<li>mendiola2024characterizingtherole pages 16-21</li>
+<li>https://doi.org/10.1038/s41467-024-54573-8</li>
+<li>https://doi.org/10.1093/nar/gkae1129</li>
+<li>https://doi.org/10.1093/hmg/ddac228</li>
+<li>https://doi.org/10.1093/nar/gks321,</li>
+<li>https://doi.org/10.1038/ejhg.2010.102,</li>
+<li>https://doi.org/10.1098/rsob.200195,</li>
+<li>https://doi.org/10.1093/molbev/msab348,</li>
+<li>https://doi.org/10.1098/rsob.240371,</li>
+<li>https://doi.org/10.1002/wrna.1417,</li>
+<li>https://doi.org/10.1038/s41467-024-54573-8,</li>
+<li>https://doi.org/10.1093/hmg/ddx342,</li>
+<li>https://doi.org/10.1093/nar/gkae1129,</li>
+<li>https://doi.org/10.1093/hmg/ddac228,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -1623,13 +1788,28 @@ product_type: SNORNA
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
-description: SNORD116-1 is one of multiple tandem copies of the SNORD116 small nucleolar
-  RNA located in the SNHG14 host gene on chromosome 15q11-q13. The SNORD116 cluster
-  plays a critical role in neurodevelopment, and loss of the entire cluster is a major
-  contributor to Prader-Willi syndrome, affecting hypothalamic function, cognition,
-  and metabolism. Individual copies like SNORD116-1 are functionally equivalent within
-  the cluster.
+description: &gt;-
+  SNORD116-1 is one paralogous box C/D small nucleolar RNA copy within the
+  paternally expressed SNORD116 tandem repeat cluster in the imprinted SNHG14 /
+  SNURF-SNRPN locus on chromosome 15q11-q13. The strongest per-copy evidence is
+  class-based snoRNA biology: intron-derived snoRNA processing, snoRNP
+  association, and nucleolar localization. Prader-Willi syndrome and
+  neurodevelopmental phenotypes are supported mainly at the SNORD116
+  cluster/locus level, so they should not be treated as direct, copy-specific
+  core functions of SNORD116-1.
 references:
+- id: file:human/SNORD116-1/SNORD116-1-deep-research-falcon.md
+  title: Falcon deep research report for SNORD116-1
+  findings:
+  - statement: &gt;-
+      Falcon supports copy-level SNORD116-1 annotation to structural,
+      biogenesis, and localization concepts typical of box C/D snoRNAs, while
+      treating Prader-Willi and neurodevelopmental phenotypes as cluster/locus
+      evidence rather than direct SNORD116-1 functions.
+    supporting_text: &gt;-
+      SNORD116-1 is best annotated with structural/biogenesis/localization GO
+      concepts typical of box C/D snoRNAs, while not being annotated yet with
+      specific RNA modification targets or disease-process terms.
 - id: GO_REF:0000115
   title: Automatic Gene Ontology annotation of non-coding RNA sequences through association
     of Rfam records with GO terms
@@ -1692,6 +1872,10 @@ existing_annotations:
     supported_by:
     - reference_id: GO_REF:0000115
       supporting_text: Rfam classification as C/D box snoRNA (RF00108)
+    - reference_id: file:human/SNORD116-1/SNORD116-1-deep-research-falcon.md
+      supporting_text: &gt;-
+        SNORD116 family members behave as bona fide box C/D snoRNAs that
+        assemble with core snoRNP proteins.
 - term:
     id: GO:0005730
     label: nucleolus
@@ -1704,32 +1888,10 @@ existing_annotations:
     supported_by:
     - reference_id: GO_REF:0000115
       supporting_text: Rfam classification indicates nucleolar localization
-- term:
-    id: GO:0006396
-    label: RNA processing
-  evidence_type: IMP
-  original_reference_id: PMID:33856031
-  review:
-    summary: SNORD116 cluster regulates mRNA stability and processing - applies to
-      all cluster members including SNORD116-1
-    action: NEW
-    supported_by:
-    - reference_id: PMID:33856031
-      supporting_text: the upregulation occurred through increased stability of the
-        Nhlh2 mRNA in the 45 minutes immediately following transcription
-- term:
-    id: GO:0007417
-    label: central nervous system development
-  evidence_type: IMP
-  original_reference_id: PMID:29800646
-  review:
-    summary: SNORD116 cluster is essential for proper neurodevelopment and cognitive
-      function - cluster-level phenotype
-    action: NEW
-    supported_by:
-    - reference_id: PMID:29800646
-      supporting_text: We discovered deficits in Snord116+/- mutant mice in the novel
-        object recognition, location memory and tone cue fear conditioning assays
+    - reference_id: file:human/SNORD116-1/SNORD116-1-deep-research-falcon.md
+      supporting_text: &gt;-
+        Box C/D snoRNAs are described as concentrating mainly in the nucleolus,
+        and SNORD116 snoRNAs are described as localizing to nucleoli.
 - term:
     id: GO:0003723
     label: RNA binding
@@ -1739,51 +1901,29 @@ existing_annotations:
     action: NEW
     reason: Core function term not present in existing_annotations.
     supported_by:
-    - reference_id: PMID:29800646
-      supporting_text: We discovered deficits in Snord116+/- mutant mice in the novel
-        object recognition, location memory and tone cue fear conditioning assays
-        when compared to age-, sex- matched, littermate control Snord116+/+ mice.
+    - reference_id: file:human/SNORD116-1/SNORD116-1-deep-research-falcon.md
+      supporting_text: &gt;-
+        Fibrillarin RIP-seq enrichment over the first third of the SNORD116
+        cluster supports snoRNP association for that region, aligning with
+        SNOG1, which includes SNORD116-1.
 core_functions:
-- description: mRNA stability regulation (cluster function)
+- description: box C/D snoRNA function and intron-derived snoRNA processing
   molecular_function:
     id: GO:0003723
     label: RNA binding
+  directly_involved_in:
+  - id: GO:0006396
+    label: RNA processing
+  locations:
+  - id: GO:0005730
+    label: nucleolus
   supported_by:
-  - reference_id: PMID:33856031
-    supporting_text: SNORD116 cluster directly interacts with and stabilizes target
-      mRNAs like NHLH2
-    full_text_unavailable: true
-- description: hypothalamic function regulation (cluster function)
-  molecular_function:
-    id: GO:0003723
-    label: RNA binding
-  supported_by:
-  - reference_id: PMID:34040195
-    supporting_text: SNORD116 and growth hormone therapy impact IGFBP7 in Prader-Willi
-      syndrome
-- description: neurodevelopmental regulation (cluster function)
-  molecular_function:
-    id: GO:0003723
-    label: RNA binding
-  supported_by:
-  - reference_id: PMID:29800646
-    supporting_text: These results show that the Snord116 + /– deletion murine model
-      is a valuable preclinical model for investigating learning and memory impairments
-      in individuals with PWS without common confounding phenotypes
-proposed_new_terms:
-- proposed_name: snoRNA-mediated mRNA stabilization activity
-  proposed_definition: The molecular function of a small nucleolar RNA that binds
-    to and increases the stability of specific mRNA molecules
-  justification: SNORD116 cluster&#39;s role in mRNA stabilization represents a non-canonical
-    snoRNA function not captured by existing GO terms
-  proposed_parent:
-    id: GO:0003723
-    label: RNA binding
-  supported_by:
-  - reference_id: PMID:33856031
-    supporting_text: &#39;Snord116 Post-transcriptionally Increases Nhlh2 mRNA Stability:
-      Implications for Human Prader-Willi Syndrome&#39;
-    full_text_unavailable: true
+  - reference_id: GO_REF:0000115
+    supporting_text: Rfam classification as C/D box snoRNA (RF00108)
+  - reference_id: file:human/SNORD116-1/SNORD116-1-deep-research-falcon.md
+    supporting_text: &gt;-
+      Based on the retrieved evidence, SNORD116-1 is best annotated with
+      structural/biogenesis/localization GO concepts typical of box C/D snoRNAs.
 suggested_questions:
 - question: What is the complete set of mRNA targets regulated by the SNORD116 cluster
     in different tissues?
@@ -1821,7 +1961,7 @@ status: COMPLETE
     </div>
 
     <!-- Pathway Visualization Link -->
-    
+
 
     <style>
         /* Markdown Section Styles */

--- a/genes/human/SNORD116-1/SNORD116-1-ai-review.yaml
+++ b/genes/human/SNORD116-1/SNORD116-1-ai-review.yaml
@@ -4,13 +4,28 @@ product_type: SNORNA
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
-description: SNORD116-1 is one of multiple tandem copies of the SNORD116 small nucleolar
-  RNA located in the SNHG14 host gene on chromosome 15q11-q13. The SNORD116 cluster
-  plays a critical role in neurodevelopment, and loss of the entire cluster is a major
-  contributor to Prader-Willi syndrome, affecting hypothalamic function, cognition,
-  and metabolism. Individual copies like SNORD116-1 are functionally equivalent within
-  the cluster.
+description: >-
+  SNORD116-1 is one paralogous box C/D small nucleolar RNA copy within the
+  paternally expressed SNORD116 tandem repeat cluster in the imprinted SNHG14 /
+  SNURF-SNRPN locus on chromosome 15q11-q13. The strongest per-copy evidence is
+  class-based snoRNA biology: intron-derived snoRNA processing, snoRNP
+  association, and nucleolar localization. Prader-Willi syndrome and
+  neurodevelopmental phenotypes are supported mainly at the SNORD116
+  cluster/locus level, so they should not be treated as direct, copy-specific
+  core functions of SNORD116-1.
 references:
+- id: file:human/SNORD116-1/SNORD116-1-deep-research-falcon.md
+  title: Falcon deep research report for SNORD116-1
+  findings:
+  - statement: >-
+      Falcon supports copy-level SNORD116-1 annotation to structural,
+      biogenesis, and localization concepts typical of box C/D snoRNAs, while
+      treating Prader-Willi and neurodevelopmental phenotypes as cluster/locus
+      evidence rather than direct SNORD116-1 functions.
+    supporting_text: >-
+      SNORD116-1 is best annotated with structural/biogenesis/localization GO
+      concepts typical of box C/D snoRNAs, while not being annotated yet with
+      specific RNA modification targets or disease-process terms.
 - id: GO_REF:0000115
   title: Automatic Gene Ontology annotation of non-coding RNA sequences through association
     of Rfam records with GO terms
@@ -73,6 +88,10 @@ existing_annotations:
     supported_by:
     - reference_id: GO_REF:0000115
       supporting_text: Rfam classification as C/D box snoRNA (RF00108)
+    - reference_id: file:human/SNORD116-1/SNORD116-1-deep-research-falcon.md
+      supporting_text: >-
+        SNORD116 family members behave as bona fide box C/D snoRNAs that
+        assemble with core snoRNP proteins.
 - term:
     id: GO:0005730
     label: nucleolus
@@ -85,19 +104,10 @@ existing_annotations:
     supported_by:
     - reference_id: GO_REF:0000115
       supporting_text: Rfam classification indicates nucleolar localization
-- term:
-    id: GO:0007417
-    label: central nervous system development
-  evidence_type: IMP
-  original_reference_id: PMID:29800646
-  review:
-    summary: SNORD116 cluster is essential for proper neurodevelopment and cognitive
-      function - cluster-level phenotype
-    action: NEW
-    supported_by:
-    - reference_id: PMID:29800646
-      supporting_text: We discovered deficits in Snord116+/- mutant mice in the novel
-        object recognition, location memory and tone cue fear conditioning assays
+    - reference_id: file:human/SNORD116-1/SNORD116-1-deep-research-falcon.md
+      supporting_text: >-
+        Box C/D snoRNAs are described as concentrating mainly in the nucleolus,
+        and SNORD116 snoRNAs are described as localizing to nucleoli.
 - term:
     id: GO:0003723
     label: RNA binding
@@ -107,51 +117,29 @@ existing_annotations:
     action: NEW
     reason: Core function term not present in existing_annotations.
     supported_by:
-    - reference_id: PMID:29800646
-      supporting_text: We discovered deficits in Snord116+/- mutant mice in the novel
-        object recognition, location memory and tone cue fear conditioning assays
-        when compared to age-, sex- matched, littermate control Snord116+/+ mice.
+    - reference_id: file:human/SNORD116-1/SNORD116-1-deep-research-falcon.md
+      supporting_text: >-
+        Fibrillarin RIP-seq enrichment over the first third of the SNORD116
+        cluster supports snoRNP association for that region, aligning with
+        SNOG1, which includes SNORD116-1.
 core_functions:
-- description: mRNA stability regulation (cluster function)
+- description: box C/D snoRNA function and intron-derived snoRNA processing
   molecular_function:
     id: GO:0003723
     label: RNA binding
+  directly_involved_in:
+  - id: GO:0006396
+    label: RNA processing
+  locations:
+  - id: GO:0005730
+    label: nucleolus
   supported_by:
-  - reference_id: PMID:33856031
-    supporting_text: SNORD116 cluster directly interacts with and stabilizes target
-      mRNAs like NHLH2
-    full_text_unavailable: true
-- description: hypothalamic function regulation (cluster function)
-  molecular_function:
-    id: GO:0003723
-    label: RNA binding
-  supported_by:
-  - reference_id: PMID:34040195
-    supporting_text: SNORD116 and growth hormone therapy impact IGFBP7 in Prader-Willi
-      syndrome
-- description: neurodevelopmental regulation (cluster function)
-  molecular_function:
-    id: GO:0003723
-    label: RNA binding
-  supported_by:
-  - reference_id: PMID:29800646
-    supporting_text: These results show that the Snord116 + /– deletion murine model
-      is a valuable preclinical model for investigating learning and memory impairments
-      in individuals with PWS without common confounding phenotypes
-proposed_new_terms:
-- proposed_name: snoRNA-mediated mRNA stabilization activity
-  proposed_definition: The molecular function of a small nucleolar RNA that binds
-    to and increases the stability of specific mRNA molecules
-  justification: SNORD116 cluster's role in mRNA stabilization represents a non-canonical
-    snoRNA function not captured by existing GO terms
-  proposed_parent:
-    id: GO:0003723
-    label: RNA binding
-  supported_by:
-  - reference_id: PMID:33856031
-    supporting_text: 'Snord116 Post-transcriptionally Increases Nhlh2 mRNA Stability:
-      Implications for Human Prader-Willi Syndrome'
-    full_text_unavailable: true
+  - reference_id: GO_REF:0000115
+    supporting_text: Rfam classification as C/D box snoRNA (RF00108)
+  - reference_id: file:human/SNORD116-1/SNORD116-1-deep-research-falcon.md
+    supporting_text: >-
+      Based on the retrieved evidence, SNORD116-1 is best annotated with
+      structural/biogenesis/localization GO concepts typical of box C/D snoRNAs.
 suggested_questions:
 - question: What is the complete set of mRNA targets regulated by the SNORD116 cluster
     in different tissues?

--- a/genes/human/SNORD116-1/SNORD116-1-deep-research-falcon.md
+++ b/genes/human/SNORD116-1/SNORD116-1-deep-research-falcon.md
@@ -1,0 +1,252 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-11T03:29:14.815291'
+end_time: '2026-05-11T03:47:29.811394'
+duration_seconds: 1095.0
+provider_config:
+  timeout: 600
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 30
+---
+
+## Question
+
+Research the human small nucleolar RNA gene SNORD116-1 (RNAcentral URS000075CFA5_9606), one copy in the SNORD116 cluster, for Gene Ontology functional annotation. This is a snoRNA/non-coding RNA, not a protein; do not infer protein domains or enzyme activity. Focus on its core RNA molecular function, nucleolar localization, RNA processing or RNA binding evidence, the strength and limits of evidence connecting the SNORD116 cluster to Prader-Willi syndrome and neurodevelopment, and which GO terms are directly supported for the individual SNORD116-1 gene versus the cluster. Distinguish direct function from locus-level phenotypes, and provide citations for each major claim.
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+Research the human small nucleolar RNA gene SNORD116-1 (RNAcentral URS000075CFA5_9606), one copy in the SNORD116 cluster, for Gene Ontology functional annotation. This is a snoRNA/non-coding RNA, not a protein; do not infer protein domains or enzyme activity. Focus on its core RNA molecular function, nucleolar localization, RNA processing or RNA binding evidence, the strength and limits of evidence connecting the SNORD116 cluster to Prader-Willi syndrome and neurodevelopment, and which GO terms are directly supported for the individual SNORD116-1 gene versus the cluster. Distinguish direct function from locus-level phenotypes, and provide citations for each major claim.
+
+## Research report: GO-relevant functional annotation for human **SNORD116-1** (RNAcentral: **URS000075CFA5_9606**)
+
+### Executive summary
+SNORD116-1 is one paralogous copy within the paternally expressed **SNORD116 tandem repeat cluster** embedded in the imprinted **SNHG14 / SNURF–SNRPN** locus at 15q11–q13. The strongest Gene Ontology (GO)-relevant evidence for SNORD116-1 is *structural/class-based*: it is a **box C/D snoRNA** produced by **intron-derived snoRNA biogenesis** and is therefore expected to function within a **box C/D snoRNP** and reside in the **nucleolus**, but direct biochemical assays are generally **not copy-resolved**. By contrast, essentially all disease and neurodevelopmental data implicate **loss of the cluster/critical region**, not loss of a single copy such as SNORD116-1; therefore, Prader–Willi syndrome (PWS) and neurodevelopment phenotypes should be treated as **locus/cluster-level associations**, not direct per-gene functional evidence for SNORD116-1. (bortolincavaille2012thesnord115(hmbii52) pages 1-2, duker2010paternallyinheritedmicrodeletion pages 4-5, chung2020praderwillisyndromereflections pages 7-8)
+
+### 1) Key concepts and definitions (current understanding)
+
+#### 1.1 What SNORD116-1 is (and is not)
+* **SNORD116-1 is a non-coding RNA gene** encoding a small nucleolar RNA (snoRNA) and should not be annotated with protein domains or enzymatic activities. The SNORD116 family is described as **box C/D snoRNAs** produced from an imprinted host transcript; box C/D snoRNAs assemble with core proteins (NOP56, NOP58, fibrillarin, and 15.5K/SNU13) to form snoRNPs. (chung2020praderwillisyndromereflections pages 6-7)
+
+#### 1.2 Cluster organization and copy-specific terminology
+* The SNORD116 cluster contains multiple paralogues (commonly described as ~30 copies). A widely used subgrouping partitions the cluster into **SNOG1 = SNORD116-1 to SNORD116-9**, SNOG2 = SNORD116-10 to -24, and SNOG3 = SNORD116-25 to -29, reflecting sequence/expression differences. (chung2020praderwillisyndromereflections pages 7-8)
+* Copy-resolved expression analyses indicate **heterogeneous expression among individual paralogues** and dominance of group I/II expression in adult tissues (with some copies weak/absent), supporting the need to avoid “all-copies-equal” assumptions in per-copy GO annotation. (baldini2022phylogeneticandmolecular pages 3-5)
+
+#### 1.3 Canonical box C/D snoRNA biology (relevant to GO)
+* Canonical box C/D snoRNAs are processed from **excised and debranched introns** by exonucleolytic trimming and typically accumulate in **nucleoli** as snoRNPs. (chung2020praderwillisyndromereflections pages 6-7, bortolincavaille2012thesnord115(hmbii52) pages 1-2)
+* Canonically, box C/D snoRNAs guide **2′-O-methylation** of target RNAs via antisense elements; however, multiple authoritative sources emphasize that **SNORD116 snoRNAs are “orphan”**: they show no clear complementarity to rRNA and **validated targets have been difficult to define**. (chung2020praderwillisyndromereflections pages 7-8, holmes2025footprintsinthe pages 2-3, cavaille2017boxcdsmall pages 1-3)
+
+### 2) Molecular function and cellular component evidence for SNORD116-1 vs the cluster
+
+#### 2.1 Evidence supporting “box C/D snoRNA / snoRNP component” for SNORD116
+* Experimental mapping of SNORD116 termini and processing products supports that the **cluster generates canonical snoRNA-sized species** (e.g., ~92 nt dominant species in mouse) via intron-derived processing pathways; low-abundance truncated forms exist but their functional relevance is not established. (bortolincavaille2012thesnord115(hmbii52) pages 6-6)
+* Reviews and primary studies support that SNORD116 family members behave as bona fide box C/D snoRNAs that assemble with core snoRNP proteins. In particular, fibrillarin RIP-seq enrichment over the **first third of the cluster** supports snoRNP association for that region, aligning with SNOG1 (which includes SNORD116-1). (chung2020praderwillisyndromereflections pages 7-8)
+
+**GO implication:** for SNORD116-1, the most defensible molecular-function annotation is a **box C/D snoRNA / snoRNP-associated RNA scaffold role**, but the direct experimental evidence is at subgroup/cluster resolution rather than SNORD116-1-specific pulldowns. (bortolincavaille2012thesnord115(hmbii52) pages 1-2, chung2020praderwillisyndromereflections pages 7-8)
+
+#### 2.2 Nucleolar localization
+* Box C/D snoRNAs are described as concentrating mainly in the **nucleolus**, and SNORD116 snoRNAs are described as **localizing to nucleoli** (processed snoRNAs), consistent with canonical snoRNA biology. (bortolincavaille2012thesnord115(hmbii52) pages 1-2, holmes2025footprintsinthe pages 10-12)
+
+**GO implication:** a cellular-component assignment to **nucleolus** is supported strongly for the **processed SNORD116 snoRNAs collectively**, but not proven for SNORD116-1 specifically by copy-resolved imaging. (holmes2025footprintsinthe pages 10-12, bortolincavaille2012thesnord115(hmbii52) pages 1-2)
+
+#### 2.3 Biogenesis: intron-derived processing from SNHG14/SNURF–SNRPN
+* Multiple sources describe SNORD116 copies as embedded within, and processed from, repeated introns of the large imprinted host transcript (SNHG14/SNURF–SNRPN region), via splicing/debranching followed by exonucleolytic trimming. (chung2020praderwillisyndromereflections pages 6-7, bortolincavaille2012thesnord115(hmbii52) pages 1-2)
+* In neuronal differentiation models, mature SNORD116 predominates over extended forms, consistent with efficient processing from the host. (helwak2024rolesofsnord115 pages 2-4)
+
+**GO implication:** biological-process terms consistent with **snoRNA processing/biogenesis from introns** are well supported at the family/cluster level and can be cautiously extended to SNORD116-1 as a member of the intronic array. (bortolincavaille2012thesnord115(hmbii52) pages 1-2, helwak2024rolesofsnord115 pages 2-4)
+
+#### 2.4 Guide activity for 2′-O-methylation: what is supported vs not
+* Authoritative discussions repeatedly describe SNORD116 as an **orphan box C/D snoRNA family** with no validated rRNA targets and no established canonical 2′-O-methylation guide function for specific targets. (chung2020praderwillisyndromereflections pages 7-8, holmes2025footprintsinthe pages 2-3, cavaille2017boxcdsmall pages 1-3)
+
+**GO implication:** it is not currently justified (from the cited evidence base) to assign SNORD116-1 a specific “**guide for 2′-O-methylation of RNA**” molecular function. (chung2020praderwillisyndromereflections pages 7-8, holmes2025footprintsinthe pages 2-3)
+
+#### 2.5 RNA-binding / non-canonical regulatory roles: cluster-level evidence and limits
+* Cluster-/locus-level studies report diverse downstream molecular effects and RNA interactions for Snord116/SNORD116, including locus-wide interaction mapping and altered signaling readouts in animal models, but these generally do not identify a single paralogue as causal. (holmes2025footprintsinthe pages 9-10, holmes2025footprintsinthe pages 10-12)
+* A notable limitation for per-copy annotation is that the only explicit paralogue-specific functional example in the retrieved evidence concerns **SNORD116-3** (predicted interaction with *Nhlh2* and effects on mRNA decay under SNORD116 manipulation), and this should **not** be transferred to SNORD116-1 without direct evidence. (holmes2025footprintsinthe pages 9-10)
+
+### 3) Evidence connecting the SNORD116 region to Prader–Willi syndrome and neurodevelopment
+
+#### 3.1 Strength of evidence (human genetics)
+* Human atypical **paternal microdeletions encompassing SNORD116** are repeatedly cited as sufficient to produce a PWS clinical picture. In a widely cited example, a paternally inherited ~236 kb deletion including SNORD116 showed **complete loss of SNORD116 expression** in blood while SNRPN and UBE3A were detected, supporting SNORD116-region causality. (duker2010paternallyinheritedmicrodeletion pages 3-4)
+* Reported clinical features across SNORD116-region microdeletion patients include classic PWS findings (e.g., neonatal hypotonia, feeding problems/failure to thrive, later hyperphagia/obesity, developmental delay, behavioral problems, sleep disturbance, hypogonadism). (duker2010paternallyinheritedmicrodeletion pages 4-5)
+
+**Interpretation:** these data strongly support that **loss of the SNORD116 critical region/cluster** is a key driver of PWS phenotypes in humans. (duker2010paternallyinheritedmicrodeletion pages 4-5, duker2010paternallyinheritedmicrodeletion pages 3-4)
+
+#### 3.2 Limits of evidence (single-copy resolution and confounding)
+* The deletions implicated in PWS remove **multiple tandem copies** (and sometimes neighboring noncoding elements), and thus do **not** establish that loss of any single repeat (including SNORD116-1) is sufficient for disease. (duker2010paternallyinheritedmicrodeletion pages 2-3)
+* Minimal critical intervals cited in the literature can include additional noncoding genes (e.g., IPW and other snoRNAs), which complicates strict attribution to SNORD116 mature snoRNAs alone versus other locus-derived products. (burnett2017lossofthe pages 1-2)
+
+#### 3.3 Model systems: what they support
+* Mouse models with targeted Snord116-cluster deletions reproduce subsets of PWS-relevant phenotypes (e.g., growth retardation, hypotonia/activity changes, neurobehavioral phenotypes), but may fail to recapitulate others (notably obesity/infertility in some lines), indicating species/strain differences and incomplete model capture. (duker2010paternallyinheritedmicrodeletion pages 4-5)
+* Developmental phenotyping of Snord116p/m+ mice revealed neuronal and endocrine pancreatic developmental changes (e.g., reduced neuronal cell body size with decreased nucleolar size; islet cellular composition changes), further supporting a cluster-level developmental role. (burnett2017lossofthe pages 1-2)
+
+### 4) Recent developments (prioritizing 2023–2024)
+
+#### 4.1 2024 Nature Communications: SNORD116 cluster roles during neuronal differentiation (LUHMES)
+* Helwak et al. (Nature Communications; **published Nov 2024**; https://doi.org/10.1038/s41467-024-54573-8) created cell lines lacking the expressed paternal SNORD116 cluster and showed SNORD116 abundance increases during differentiation (~**5-fold** from day 0 to day 15 by RT-PCR) and plateaus between days 6–10, interpreted as stabilization. (helwak2024rolesofsnord115 pages 1-2, helwak2024rolesofsnord115 pages 2-4)
+* Functional consequences of SNORD116-cluster deletion included acceleration toward more mature neuronal transcriptomic states and measurable transcriptome/proteome changes; the study reports limited bona fide alternative splicing changes (e.g., **95 events** in H116) and compiled a curated list of **24 high-confidence SNORD116-specific dysregulated RNAs**, plus proteome-level shifts (including altered protein/mRNA ratio changes). (helwak2024rolesofsnord115 pages 8-9)
+* The paper provides a locus schematic and expression evidence across differentiation timepoints (days 0, 6, 10, 15), useful for grounding GO cellular context and biogenesis claims. (helwak2024rolesofsnord115 media 1ebb8c3a, helwak2024rolesofsnord115 media f44777c4)
+
+#### 4.2 2024 Nucleic Acids Research: isogenic hESC neuronal deletion models and predicted targets
+* Gilmore et al. (Nucleic Acids Research; **published Nov 2024**; https://doi.org/10.1093/nar/gkae1129) engineered isogenic hESC lines with deletions affecting the SNORD116 region, differentiated them into neurons, and identified **42 consistently dysregulated genes** across deletions; these genes were enriched for predicted SNORD116 targeting and were linked to validated changes in **FGF13 protein** levels. (gilmore2024identifyingkeyunderlying pages 1-2)
+
+#### 4.3 2023 Human Molecular Genetics: SNHG14-derived sno-lncRNAs/SPA-lncRNAs regulate transcriptional programs
+* Sledziowska et al. (Human Molecular Genetics; **published Sep 2023**; https://doi.org/10.1093/hmg/ddac228) depleted SNHG14-derived sno-lncRNAs and SPA-lncRNAs using antisense GapmeRs in iPSCs and used chromatin-associated RNA-seq to capture transcriptional effects. Combined knockdown (up to **80%**, 65% average) yielded **205 downregulated and 87 upregulated** transcripts (24 h), with top downregulated neuronal genes including **FAT3, NRXN1, NLGN1**, and GO/pathway enrichment for neuronal development and synaptic/cell-adhesion functions. (sledziowska2023noncodingrnasassociated pages 4-6, sledziowska2023noncodingrnasassociated pages 1-2)
+
+**GO relevance:** these 2023–2024 studies strengthen the case that the *locus* (including processed snoRNAs and extended intronic RNAs) influences neuronal transcriptional programs, but they largely do **not** establish a direct, single-paralogue molecular function for SNORD116-1. (gilmore2024identifyingkeyunderlying pages 1-2, sledziowska2023noncodingrnasassociated pages 4-6)
+
+### 5) Current applications and real-world implementations
+
+#### 5.1 Diagnostics and genotype–phenotype interpretation
+* High-resolution microarray (array CGH), breakpoint mapping, parent-of-origin genotyping, and RT-PCR expression assays have been used clinically/research-wise to identify atypical **SNORD116-region microdeletions** associated with PWS phenotypes, supporting real-world utility for genetic diagnosis beyond classic large deletions/UPD. (duker2010paternallyinheritedmicrodeletion pages 1-2, duker2010paternallyinheritedmicrodeletion pages 2-3)
+
+#### 5.2 Therapeutic strategies (conceptual; locus-level)
+* A recurring translational theme is **reactivation of the normally silent maternal allele** of PWS-locus genes (including SNORD116) via epigenetic modulation, although this is a locus-level approach and not a SNORD116-1-specific intervention. (gilmore2024identifyingkeyunderlying pages 1-2)
+
+### 6) Expert opinions and authoritative synthesis
+* Expert reviews emphasize two points: (i) SNORD116 is likely central to PWS pathogenesis because atypical deletions limited to the SNORD116 region can yield core phenotypes; (ii) the **mechanism of action remains unresolved**, in part because SNORD116 lacks clear canonical rRNA complementarity and targets are unknown, making it difficult to assign classic methylation-guide GO functions. (chung2020praderwillisyndromereflections pages 7-8, cavaille2017boxcdsmall pages 1-3)
+
+### 7) Key statistics and quantitative findings (recent studies)
+* SNORD116 genomic organization in SNHG14: **~29 tandem introns** generate SNORD116 in the human host gene SNHG14 (reported in 2024 LUHMES study). (helwak2024rolesofsnord115 pages 1-2)
+* SNORD116 induction during neuronal differentiation: **~5× increase** from day 0 to day 15 (LUHMES). (helwak2024rolesofsnord115 pages 1-2, helwak2024rolesofsnord115 media f44777c4)
+* Transcriptome effects (cluster deletion): **42 consistently dysregulated genes** across two isogenic hESC neuron deletion models. (gilmore2024identifyingkeyunderlying pages 1-2)
+* Transcriptional response to SNHG14-derived lncRNA depletion (iPSC, 24 h): knockdown up to **80%**, and **205 down / 87 up** transcripts with combined SPA/sno-lncRNA depletion. (sledziowska2023noncodingrnasassociated pages 4-6)
+* PWS genetics epidemiology (reviewed): SNORD116-only microdeletions are described as rare (**<1%** of PWS cases) relative to large deletions and UPD, underscoring limited patient numbers for genotype refinement. (mendiola2024characterizingtherolea pages 16-21)
+
+---
+
+### GO-term support overview (SNORD116-1 vs cluster)
+The following table consolidates GO-relevant evidence and explicitly separates what is directly supportable for **SNORD116-1** from what is only supportable at **cluster/locus level**.
+
+| Entity | GO aspect | Candidate GO term label | Direct evidence summary | Key limitations for per-copy assignment | Primary citations |
+|---|---|---|---|---|---|
+| SNORD116-1 (single copy; SNOG1/group I) | MF | box C/D snoRNA / snoRNP scaffold activity | SNORD116 family members are bona fide box C/D snoRNAs with conserved C/D features and are processed as canonical snoRNAs; SNOG1 includes SNORD116-1 to -9, and the first third of the cluster shows fibrillarin RIP enrichment, consistent with snoRNP assembly in this subgroup. | Evidence is subgroup- or cluster-level, not a direct biochemical assay on SNORD116-1 alone; no copy-specific fibrillarin/NOP58 pulldown for SNORD116-1 was shown. | (bortolincavaille2012thesnord115(hmbii52) pages 1-2, chung2020praderwillisyndromereflections pages 7-8, baldini2022phylogeneticandmolecular pages 3-5) |
+| SNORD116 cluster / locus products | MF | box C/D snoRNA / snoRNP scaffold activity | SNORD116 cluster products were recommended to be considered bona fide box C/D snoRNAs; canonical box C/D snoRNP association is supported by fibrillarin RIP-seq over the first third of the cluster and by reports that Snord116 associates with FBL and NOP58 in brain extracts. | Still largely inferred at the cluster/family level; exact stoichiometry and whether all paralogues assemble equivalently are unresolved. | (chung2020praderwillisyndromereflections pages 7-8, holmes2025footprintsinthe pages 10-12, bortolincavaille2012thesnord115(hmbii52) pages 1-2, cavaille2017boxcdsmall pages 1-3) |
+| SNORD116-1 | CC | nucleolus | General box C/D snoRNAs concentrate in nucleoli, and SNOG1 subgroup members are the most highly expressed in hypothalamus with fibrillarin enrichment over the first third of the cluster, making nucleolar residence plausible for SNORD116-1. | No direct imaging/localization experiment was reported for SNORD116-1 individually. | (bortolincavaille2012thesnord115(hmbii52) pages 1-2, chung2020praderwillisyndromereflections pages 7-8) |
+| SNORD116 cluster / locus products | CC | nucleolus / nucleolar snoRNP | Processed Snord116 snoRNAs localize to nucleoli; SNORD116 snoRNAs are described as able to localize to the nucleolus, consistent with canonical box C/D snoRNA behavior. | Localization evidence is for processed snoRNAs collectively, not each human paralogue; 116HG host RNA has different localization (retained at transcription site), so locus products are heterogeneous. | (holmes2025footprintsinthe pages 10-12, bortolincavaille2012thesnord115(hmbii52) pages 1-2) |
+| SNORD116-1 | BP | snoRNA processing from intron of SNHG14/SNURF-SNRPN transcript | SNORD116 genes are embedded within repeated introns of the long SNHG14/SNURF-SNRPN transcript and mature SNORD116 RNAs arise by splicing/debranching and exonucleolytic trimming; SNORD116-1 belongs to this intronic repeat set. | Processing was demonstrated for SNORD116 family/cluster, not mapped specifically to SNORD116-1 in the cited evidence. | (bortolincavaille2012thesnord115(hmbii52) pages 6-6, bortolincavaille2012thesnord115(hmbii52) pages 1-2, helwak2024rolesofsnord115 pages 2-4) |
+| SNORD116 cluster / locus products | BP | intron-derived snoRNA processing from SNHG14/SNURF-SNRPN | Strong evidence supports intron-derived biogenesis: box C/D snoRNAs are processed from excised/debranched introns; full-length SNORD116 termini were mapped; mature SNORD116 predominates over extended forms during neuronal differentiation. The same locus also yields 116HG, sno-lncRNAs, and SPA-lncRNAs. | Biogenesis differs among locus products, so one GO statement cannot cover all products equally; sno-lncRNAs/SPA-lncRNAs are distinct noncanonical derivatives. | (bortolincavaille2012thesnord115(hmbii52) pages 6-6, bortolincavaille2012thesnord115(hmbii52) pages 1-2, sledziowska2023noncodingrnasassociated pages 1-2, helwak2024rolesofsnord115 pages 2-4) |
+| SNORD116-1 | MF | guide for 2'-O-methylation of RNA | Not directly supported. SNORD116 is repeatedly described as an orphan box C/D snoRNA family with no validated rRNA targets and no established direct methylation target for SNORD116-1. | Canonical guide activity cannot be assigned to SNORD116-1 from current direct evidence; family-level potential does not equal demonstrated targeting by this copy. | (chung2020praderwillisyndromereflections pages 7-8, holmes2025footprintsinthe pages 2-3, cavaille2017boxcdsmall pages 1-3) |
+| SNORD116 cluster / locus products | MF | guide for 2'-O-methylation of RNA | Not directly supported for the cluster either: although box C/D snoRNAs usually guide 2'-O-methylation, SNORD116 lacks clear rRNA complementarity and remains classified as orphan; no validated SNORD116 methylation target was established in the cited peer-reviewed 2023-2024 studies. | Candidate methylation interactions are computational/predicted; direct target validation remains lacking in the cited evidence base. | (chung2020praderwillisyndromereflections pages 7-8, holmes2025footprintsinthe pages 2-3, cavaille2017boxcdsmall pages 1-3, helwak2024rolesofsnord115 pages 9-10) |
+| SNORD116-1 | MF/BP | RNA binding / post-transcriptional regulation of mRNA stability | No direct evidence for SNORD116-1 specifically. Copy-resolved functional evidence cited instead concerns SNORD116-3, for which a predicted 20-bp interaction with Nhlh2 mRNA was linked to altered mRNA decay/stability after SNORD116 manipulation. | The only copy-specific functional example in the cited set is SNORD116-3, not SNORD116-1; therefore this should not be transferred to SNORD116-1. | (holmes2025footprintsinthe pages 9-10) |
+| SNORD116 cluster / locus products | MF/BP | RNA binding / regulation of mRNA stability or transcript abundance | Cluster-level studies reported ChIRP-seq and snoKARR-seq interactions, 32 RNA interactions in mouse cortex, and human neuronal deletion models with 42 consistently dysregulated genes enriched for predicted SNORD116 targets; FGF13 protein changes were validated. SNORD116 overexpression also altered Nhlh2 mRNA stability. | These findings are mostly cluster-level, often from mouse or engineered deletion/overexpression systems, and do not resolve which individual paralogue is responsible. | (holmes2025footprintsinthe pages 9-10, gilmore2024identifyingkeyunderlying pages 1-2) |
+| SNORD116-1 | BP | regulation of neuronal differentiation / neurodevelopment | Not directly supported for the single gene. SNOG1/SNORD116-1 is in the highly expressed subgroup, but no single-copy perturbation study linked SNORD116-1 to neuronal differentiation timing or transcriptome change. | All cited neurodevelopmental effects come from cluster deletions or locus-level ncRNA depletion, not SNORD116-1-specific loss-of-function. | (chung2020praderwillisyndromereflections pages 7-8, helwak2024rolesofsnord115 pages 1-2) |
+| SNORD116 cluster / locus products | BP | modulation of neuronal differentiation timing / neurodevelopmental transcriptome | 2024 neuronal models showed that SNORD116 cluster deletion accelerates aspects of neuronal maturation, alters RNA stability and protein synthesis, and changes defined transcript/protein sets; a curated set of 24 high-confidence SNORD116-specific dysregulated RNAs was reported, and 42 consistently dysregulated genes were found across isogenic hESC-neuron models. | These are downstream phenotypes from deleting the cluster/locus and do not prove a direct biochemical activity for any one snoRNA copy; some effects may involve other locus-derived RNAs. | (gilmore2024identifyingkeyunderlying pages 1-2, helwak2024rolesofsnord115 pages 9-10, helwak2024rolesofsnord115 pages 1-2, helwak2024rolesofsnord115 pages 8-9, sledziowska2023noncodingrnasassociated pages 4-6) |
+| SNORD116-1 | BP/phenotype context | Prader-Willi syndrome / neurodevelopmental disorder involvement | No direct evidence shows that loss of SNORD116-1 alone causes PWS or neurodevelopmental phenotypes. Human data implicate paternal microdeletions encompassing the SNORD116 cluster/minimal region, not a single repeat. | Disease causality is locus/cluster-level; assigning disease-related GO process terms to SNORD116-1 would overstate the evidence. | (duker2010paternallyinheritedmicrodeletion pages 4-5, duker2010paternallyinheritedmicrodeletion pages 3-4, duker2010paternallyinheritedmicrodeletion pages 1-2, burnett2017lossofthe pages 1-2) |
+| SNORD116 cluster / locus products | BP/phenotype context | contribution to PWS-related neurodevelopmental phenotypes | Rare paternal microdeletions removing the SNORD116 critical region are sufficient to produce many core PWS features, and mouse Snord116-cluster deletions recapitulate subsets of metabolic, developmental, neuronal, and endocrine phenotypes. | Minimal critical intervals can include other noncoding elements (e.g., IPW, SNORD109A, host-locus products), and most studies do not separate mature SNORD116 snoRNAs from 116HG/sno-lncRNAs/SPA-lncRNAs. | (duker2010paternallyinheritedmicrodeletion pages 4-5, duker2010paternallyinheritedmicrodeletion pages 3-4, mendiola2024characterizingtherole pages 16-21, burnett2017lossofthe pages 1-2, mendiola2024characterizingtherolea pages 16-21) |
+
+
+*Table: This table contrasts what is directly supportable for the individual snoRNA gene SNORD116-1 versus the broader SNORD116 cluster/locus and its derived noncoding RNAs. It is designed to help separate core RNA function/localization evidence from cluster-level disease and neurodevelopmental phenotypes.*
+
+### Recommended evidence-based GO annotation stance for SNORD116-1 (conservative)
+Based on the retrieved evidence, SNORD116-1 is best annotated with **structural/biogenesis/localization** GO concepts typical of box C/D snoRNAs (snoRNP association; nucleolus; intron-derived snoRNA processing), while **not** being annotated (yet) with specific RNA modification targets or disease-process terms, because:
+1) SNORD116 is repeatedly described as an **orphan** family lacking validated canonical targets (limiting MF assignment to “2′-O-methylation guide”). (chung2020praderwillisyndromereflections pages 7-8, holmes2025footprintsinthe pages 2-3)
+2) PWS and neurodevelopmental effects are supported for the **cluster/critical region**, not for loss of an individual paralogue like SNORD116-1. (duker2010paternallyinheritedmicrodeletion pages 4-5, duker2010paternallyinheritedmicrodeletion pages 3-4, duker2010paternallyinheritedmicrodeletion pages 2-3)
+3) Even when subgroup/copy differences are observed (e.g., SNOG1 enrichment and fibrillarin RIP enrichment over the first third), this is **not** equivalent to a direct SNORD116-1-specific functional assay. (chung2020praderwillisyndromereflections pages 7-8)
+
+### Notes on URLs and publication dates
+Primary URLs and publication months/years are embedded above for the principal 2023–2024 sources: Helwak et al. (Nov 2024; https://doi.org/10.1038/s41467-024-54573-8), Gilmore et al. (Nov 2024; https://doi.org/10.1093/nar/gkae1129), and Sledziowska et al. (Sep 2023; https://doi.org/10.1093/hmg/ddac228). (gilmore2024identifyingkeyunderlying pages 1-2, helwak2024rolesofsnord115 pages 1-2, sledziowska2023noncodingrnasassociated pages 4-6)
+
+### Evidence gaps relevant to future GO refinement for SNORD116-1
+Key experiments that would enable more specific, per-copy GO terms for SNORD116-1 include: paralogue-resolved CLASH/eCLIP-style RNA–RNA chimera detection; paralogue-specific snoRNP IP (fibrillarin/NOP58) followed by long-read mapping; and direct 2′-O-methylation site assignment linked to specific SNORD116 paralogues. Current evidence remains strongest at the SNORD116 **cluster/subgroup** level rather than at the SNORD116-1 gene level. (gilmore2024identifyingkeyunderlying pages 1-2, chung2020praderwillisyndromereflections pages 7-8, baldini2022phylogeneticandmolecular pages 3-5)
+
+References
+
+1. (bortolincavaille2012thesnord115(hmbii52) pages 1-2): Marie-Line Bortolin-Cavaillé and J. Cavaillé. The snord115 (h/mbii-52) and snord116 (h/mbii-85) gene clusters at the imprinted prader-willi locus generate canonical box c/d snornas. Nucleic Acids Research, 40:6800-6807, Apr 2012. URL: https://doi.org/10.1093/nar/gks321, doi:10.1093/nar/gks321. This article has 108 citations and is from a highest quality peer-reviewed journal.
+
+2. (duker2010paternallyinheritedmicrodeletion pages 4-5): Angela L Duker, Blake C Ballif, Erawati V Bawle, Richard E Person, Sangeetha Mahadevan, Sarah Alliman, Regina Thompson, Ryan Traylor, Bassem A Bejjani, Lisa G Shaffer, Jill A Rosenfeld, Allen N Lamb, and Trilochan Sahoo. Paternally inherited microdeletion at 15q11.2 confirms a significant role for the snord116 c/d box snorna cluster in prader–willi syndrome. European Journal of Human Genetics, 18:1196-1201, Jun 2010. URL: https://doi.org/10.1038/ejhg.2010.102, doi:10.1038/ejhg.2010.102. This article has 384 citations and is from a domain leading peer-reviewed journal.
+
+3. (chung2020praderwillisyndromereflections pages 7-8): Michael S. Chung, Maéva Langouët, Stormy J. Chamberlain, and Gordon G. Carmichael. Prader-willi syndrome: reflections on seminal studies and future therapies. Open Biology, Sep 2020. URL: https://doi.org/10.1098/rsob.200195, doi:10.1098/rsob.200195. This article has 51 citations and is from a peer-reviewed journal.
+
+4. (chung2020praderwillisyndromereflections pages 6-7): Michael S. Chung, Maéva Langouët, Stormy J. Chamberlain, and Gordon G. Carmichael. Prader-willi syndrome: reflections on seminal studies and future therapies. Open Biology, Sep 2020. URL: https://doi.org/10.1098/rsob.200195, doi:10.1098/rsob.200195. This article has 51 citations and is from a peer-reviewed journal.
+
+5. (baldini2022phylogeneticandmolecular pages 3-5): Laeya Baldini, Anne Robert, Bruno Charpentier, and Stéphane Labialle. Phylogenetic and molecular analyses identify snord116 targets involved in the prader–willi syndrome. Molecular Biology and Evolution, Dec 2022. URL: https://doi.org/10.1093/molbev/msab348, doi:10.1093/molbev/msab348. This article has 35 citations and is from a highest quality peer-reviewed journal.
+
+6. (holmes2025footprintsinthe pages 2-3): Terri L. Holmes, Alzbeta Chabronova, Chris Denning, Victoria James, Mandy J. Peffers, and James G. W. Smith. Footprints in the sno: investigating the cellular and molecular mechanisms of snord116. Open Biology, Mar 2025. URL: https://doi.org/10.1098/rsob.240371, doi:10.1098/rsob.240371. This article has 3 citations and is from a peer-reviewed journal.
+
+7. (cavaille2017boxcdsmall pages 1-3): Jérôme Cavaillé. Box c/d small nucleolar rna genes and the prader‐willi syndrome: a complex interplay. Wiley Interdisciplinary Reviews: RNA, Jul 2017. URL: https://doi.org/10.1002/wrna.1417, doi:10.1002/wrna.1417. This article has 109 citations.
+
+8. (bortolincavaille2012thesnord115(hmbii52) pages 6-6): Marie-Line Bortolin-Cavaillé and J. Cavaillé. The snord115 (h/mbii-52) and snord116 (h/mbii-85) gene clusters at the imprinted prader-willi locus generate canonical box c/d snornas. Nucleic Acids Research, 40:6800-6807, Apr 2012. URL: https://doi.org/10.1093/nar/gks321, doi:10.1093/nar/gks321. This article has 108 citations and is from a highest quality peer-reviewed journal.
+
+9. (holmes2025footprintsinthe pages 10-12): Terri L. Holmes, Alzbeta Chabronova, Chris Denning, Victoria James, Mandy J. Peffers, and James G. W. Smith. Footprints in the sno: investigating the cellular and molecular mechanisms of snord116. Open Biology, Mar 2025. URL: https://doi.org/10.1098/rsob.240371, doi:10.1098/rsob.240371. This article has 3 citations and is from a peer-reviewed journal.
+
+10. (helwak2024rolesofsnord115 pages 2-4): Aleksandra Helwak, Tomasz Turowski, Christos Spanos, and David Tollervey. Roles of snord115 and snord116 ncrna clusters during neuronal differentiation. Nature Communications, Nov 2024. URL: https://doi.org/10.1038/s41467-024-54573-8, doi:10.1038/s41467-024-54573-8. This article has 11 citations and is from a highest quality peer-reviewed journal.
+
+11. (holmes2025footprintsinthe pages 9-10): Terri L. Holmes, Alzbeta Chabronova, Chris Denning, Victoria James, Mandy J. Peffers, and James G. W. Smith. Footprints in the sno: investigating the cellular and molecular mechanisms of snord116. Open Biology, Mar 2025. URL: https://doi.org/10.1098/rsob.240371, doi:10.1098/rsob.240371. This article has 3 citations and is from a peer-reviewed journal.
+
+12. (duker2010paternallyinheritedmicrodeletion pages 3-4): Angela L Duker, Blake C Ballif, Erawati V Bawle, Richard E Person, Sangeetha Mahadevan, Sarah Alliman, Regina Thompson, Ryan Traylor, Bassem A Bejjani, Lisa G Shaffer, Jill A Rosenfeld, Allen N Lamb, and Trilochan Sahoo. Paternally inherited microdeletion at 15q11.2 confirms a significant role for the snord116 c/d box snorna cluster in prader–willi syndrome. European Journal of Human Genetics, 18:1196-1201, Jun 2010. URL: https://doi.org/10.1038/ejhg.2010.102, doi:10.1038/ejhg.2010.102. This article has 384 citations and is from a domain leading peer-reviewed journal.
+
+13. (duker2010paternallyinheritedmicrodeletion pages 2-3): Angela L Duker, Blake C Ballif, Erawati V Bawle, Richard E Person, Sangeetha Mahadevan, Sarah Alliman, Regina Thompson, Ryan Traylor, Bassem A Bejjani, Lisa G Shaffer, Jill A Rosenfeld, Allen N Lamb, and Trilochan Sahoo. Paternally inherited microdeletion at 15q11.2 confirms a significant role for the snord116 c/d box snorna cluster in prader–willi syndrome. European Journal of Human Genetics, 18:1196-1201, Jun 2010. URL: https://doi.org/10.1038/ejhg.2010.102, doi:10.1038/ejhg.2010.102. This article has 384 citations and is from a domain leading peer-reviewed journal.
+
+14. (burnett2017lossofthe pages 1-2): Lisa Cole Burnett, Gabriela Hubner, Charles A LeDuc, Michael V Morabito, Jayne F Martin Carli, and Rudolph L Leibel. Loss of the imprinted, non-coding snord116 gene cluster in the interval deleted in the prader willi syndrome results in murine neuronal and endocrine pancreatic developmental phenotypes. Human Molecular Genetics, 26:4606–4616, Dec 2017. URL: https://doi.org/10.1093/hmg/ddx342, doi:10.1093/hmg/ddx342. This article has 38 citations and is from a domain leading peer-reviewed journal.
+
+15. (helwak2024rolesofsnord115 pages 1-2): Aleksandra Helwak, Tomasz Turowski, Christos Spanos, and David Tollervey. Roles of snord115 and snord116 ncrna clusters during neuronal differentiation. Nature Communications, Nov 2024. URL: https://doi.org/10.1038/s41467-024-54573-8, doi:10.1038/s41467-024-54573-8. This article has 11 citations and is from a highest quality peer-reviewed journal.
+
+16. (helwak2024rolesofsnord115 pages 8-9): Aleksandra Helwak, Tomasz Turowski, Christos Spanos, and David Tollervey. Roles of snord115 and snord116 ncrna clusters during neuronal differentiation. Nature Communications, Nov 2024. URL: https://doi.org/10.1038/s41467-024-54573-8, doi:10.1038/s41467-024-54573-8. This article has 11 citations and is from a highest quality peer-reviewed journal.
+
+17. (helwak2024rolesofsnord115 media 1ebb8c3a): Aleksandra Helwak, Tomasz Turowski, Christos Spanos, and David Tollervey. Roles of snord115 and snord116 ncrna clusters during neuronal differentiation. Nature Communications, Nov 2024. URL: https://doi.org/10.1038/s41467-024-54573-8, doi:10.1038/s41467-024-54573-8. This article has 11 citations and is from a highest quality peer-reviewed journal.
+
+18. (helwak2024rolesofsnord115 media f44777c4): Aleksandra Helwak, Tomasz Turowski, Christos Spanos, and David Tollervey. Roles of snord115 and snord116 ncrna clusters during neuronal differentiation. Nature Communications, Nov 2024. URL: https://doi.org/10.1038/s41467-024-54573-8, doi:10.1038/s41467-024-54573-8. This article has 11 citations and is from a highest quality peer-reviewed journal.
+
+19. (gilmore2024identifyingkeyunderlying pages 1-2): Rachel B Gilmore, Yaling Liu, Christopher E Stoddard, Michael S Chung, Gordon G Carmichael, and Justin Cotney. Identifying key underlying regulatory networks and predicting targets of orphan c/d box snord116 snornas in prader–willi syndrome. Nucleic Acids Research, 52:13757-13774, Nov 2024. URL: https://doi.org/10.1093/nar/gkae1129, doi:10.1093/nar/gkae1129. This article has 13 citations and is from a highest quality peer-reviewed journal.
+
+20. (sledziowska2023noncodingrnasassociated pages 4-6): Monika Sledziowska, Kinga Winczura, Matt Jones, Ruba Almaghrabi, Hannah Mischo, Daniel Hebenstreit, Paloma Garcia, and Pawel Grzechnik. Non-coding rnas associated with prader–willi syndrome regulate transcription of neurodevelopmental genes in human induced pluripotent stem cells. Human Molecular Genetics, 32:608-620, Sep 2023. URL: https://doi.org/10.1093/hmg/ddac228, doi:10.1093/hmg/ddac228. This article has 24 citations and is from a domain leading peer-reviewed journal.
+
+21. (sledziowska2023noncodingrnasassociated pages 1-2): Monika Sledziowska, Kinga Winczura, Matt Jones, Ruba Almaghrabi, Hannah Mischo, Daniel Hebenstreit, Paloma Garcia, and Pawel Grzechnik. Non-coding rnas associated with prader–willi syndrome regulate transcription of neurodevelopmental genes in human induced pluripotent stem cells. Human Molecular Genetics, 32:608-620, Sep 2023. URL: https://doi.org/10.1093/hmg/ddac228, doi:10.1093/hmg/ddac228. This article has 24 citations and is from a domain leading peer-reviewed journal.
+
+22. (duker2010paternallyinheritedmicrodeletion pages 1-2): Angela L Duker, Blake C Ballif, Erawati V Bawle, Richard E Person, Sangeetha Mahadevan, Sarah Alliman, Regina Thompson, Ryan Traylor, Bassem A Bejjani, Lisa G Shaffer, Jill A Rosenfeld, Allen N Lamb, and Trilochan Sahoo. Paternally inherited microdeletion at 15q11.2 confirms a significant role for the snord116 c/d box snorna cluster in prader–willi syndrome. European Journal of Human Genetics, 18:1196-1201, Jun 2010. URL: https://doi.org/10.1038/ejhg.2010.102, doi:10.1038/ejhg.2010.102. This article has 384 citations and is from a domain leading peer-reviewed journal.
+
+23. (mendiola2024characterizingtherolea pages 16-21): AJP Mendiola. Characterizing the role of snord116 in coordinating circadian entrainment of behavior, metabolism, and gene expression in prader-willi syndrome. Unknown journal, 2024.
+
+24. (helwak2024rolesofsnord115 pages 9-10): Aleksandra Helwak, Tomasz Turowski, Christos Spanos, and David Tollervey. Roles of snord115 and snord116 ncrna clusters during neuronal differentiation. Nature Communications, Nov 2024. URL: https://doi.org/10.1038/s41467-024-54573-8, doi:10.1038/s41467-024-54573-8. This article has 11 citations and is from a highest quality peer-reviewed journal.
+
+25. (mendiola2024characterizingtherole pages 16-21): AJP Mendiola. Characterizing the role of snord116 in coordinating circadian entrainment of behavior, metabolism, and gene expression in prader-willi syndrome. Unknown journal, 2024.
+
+## Citations
+
+1. chung2020praderwillisyndromereflections pages 6-7
+2. chung2020praderwillisyndromereflections pages 7-8
+3. baldini2022phylogeneticandmolecular pages 3-5
+4. holmes2025footprintsinthe pages 9-10
+5. duker2010paternallyinheritedmicrodeletion pages 3-4
+6. duker2010paternallyinheritedmicrodeletion pages 4-5
+7. duker2010paternallyinheritedmicrodeletion pages 2-3
+8. burnett2017lossofthe pages 1-2
+9. gilmore2024identifyingkeyunderlying pages 1-2
+10. sledziowska2023noncodingrnasassociated pages 4-6
+11. mendiola2024characterizingtherolea pages 16-21
+12. holmes2025footprintsinthe pages 2-3
+13. cavaille2017boxcdsmall pages 1-3
+14. holmes2025footprintsinthe pages 10-12
+15. sledziowska2023noncodingrnasassociated pages 1-2
+16. duker2010paternallyinheritedmicrodeletion pages 1-2
+17. mendiola2024characterizingtherole pages 16-21
+18. https://doi.org/10.1038/s41467-024-54573-8
+19. https://doi.org/10.1093/nar/gkae1129
+20. https://doi.org/10.1093/hmg/ddac228
+21. https://doi.org/10.1093/nar/gks321,
+22. https://doi.org/10.1038/ejhg.2010.102,
+23. https://doi.org/10.1098/rsob.200195,
+24. https://doi.org/10.1093/molbev/msab348,
+25. https://doi.org/10.1098/rsob.240371,
+26. https://doi.org/10.1002/wrna.1417,
+27. https://doi.org/10.1038/s41467-024-54573-8,
+28. https://doi.org/10.1093/hmg/ddx342,
+29. https://doi.org/10.1093/nar/gkae1129,
+30. https://doi.org/10.1093/hmg/ddac228,

--- a/genes/human/XIST/XIST-ai-review.html
+++ b/genes/human/XIST/XIST-ai-review.html
@@ -671,33 +671,33 @@
     <div class="header">
         <h1>XIST</h1>
         <div class="gene-info">
-            
+
             <div class="info-item">
-                
+
                 <span class="info-label">RNAcentral ID:</span>
                 <span>
                     <a href="https://rnacentral.org/rna/URS000075D95B_9606" target="_blank" class="term-link">
                         URS000075D95B_9606
                     </a>
                 </span>
-                
+
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Organism:</span>
                 <span>Homo sapiens</span>
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
                 <span class="status-badge status-complete">
                     COMPLETE
                 </span>
             </div>
-            
-            
+
+
         </div>
         <div style="margin-top: 1rem; text-align: center;">
             <a id="feedback-form-link"
@@ -728,7 +728,7 @@
         </div>
     </div>
 
-    
+
     <div class="description-card">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <h2>Gene Description</h2>
@@ -739,14 +739,14 @@
         </div>
         <p>X-inactive specific transcript (XIST) is a master regulatory long non-coding RNA that orchestrates X-chromosome inactivation in female mammalian cells. XIST coats the inactive X chromosome and recruits chromatin-modifying complexes to establish and maintain transcriptional silencing.</p>
     </div>
-    
 
-    
 
-    
+
+
+
     <div class="section">
         <h2 class="section-title">Proposed New Ontology Terms</h2>
-        
+
         <div class="proposed-term">
             <div style="display: flex; justify-content: space-between; align-items: center;">
                 <h3>X-chromosome coating activity</h3>
@@ -756,47 +756,47 @@
                 </span>
             </div>
 
-            
+
             <p><strong>Definition:</strong> The molecular function of a long non-coding RNA that spreads along and coats an entire X chromosome to facilitate transcriptional silencing</p>
-            
 
-            
+
+
             <p><strong>Justification:</strong> XIST&#39;s unique ability to coat an entire chromosome is not captured by existing GO terms</p>
-            
 
-            
+
+
             <p><strong>Parent term:</strong>
-                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003677" target="_blank" class="term-link">
-                    DNA binding
+                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140463" target="_blank" class="term-link">
+                    chromatin-protein adaptor activity
                 </a>
             </p>
-            
 
-            
 
-            
+
+
+
             <p><strong>Supporting Evidence:</strong></p>
             <ul style="margin-left: 1rem;">
-                
+
                 <li>
-                    
+
                     <a href="https://pubmed.ncbi.nlm.nih.gov/9069284" target="_blank" class="term-link">
                         PMID:9069284
                     </a>
-                    
-                    
-                    : Here we show that Xist, introduced onto an autosome, is sufficient by itself for inactivation in cis and that Xist RNA becomes localized close to the autosome into which the gene is integrated
-                    
-                </li>
-                
-            </ul>
-            
-        </div>
-        
-    </div>
-    
 
-    
+
+                    : Here we show that Xist, introduced onto an autosome, is sufficient by itself for inactivation in cis and that Xist RNA becomes localized close to the autosome into which the gene is integrated
+
+                </li>
+
+            </ul>
+
+        </div>
+
+    </div>
+
+
+
     <div class="section">
         <h2 class="section-title">Existing Annotations Review</h2>
         <table class="annotations-table">
@@ -809,43 +809,43 @@
                 </tr>
             </thead>
             <tbody>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007549" target="_blank" class="term-link">
                                     GO:0007549
                                 </a>
                             </span>
                             <span class="term-label">sex-chromosome dosage compensation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9069284" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:9069284
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Xist has properties of the X-chromosome inactivation centre
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-new">
@@ -857,136 +857,60 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> XIST is the master regulator of X-chromosome dosage compensation in mammals
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9069284" target="_blank" class="term-link">
                                         PMID:9069284
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">this gene is required for X inactivation to occur in cis</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
-                            <span class="term-id">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003677" target="_blank" class="term-link">
-                                    GO:0003677
-                                </a>
-                            </span>
-                            <span class="term-label">DNA binding</span>
-                            
-                        </div>
-                    </td>
-                    <td>
-                        <span class="evidence-code">IMP</span>
-                        
-                        
-                        
-                        <br>
-                        <span style="font-size: 0.75rem;">
-                            
-                            <a href="https://pubmed.ncbi.nlm.nih.gov/34312245" target="_blank" class="term-link" style="font-size: 0.75rem;">
-                                PMID:34312245
-                            </a>
-                            
-                                
-                                
-                                <br>
-                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
-                                    The Molecular and Nuclear Dynamics of X-Chromosome Inactivat...
-                                </span>
-                                
-                            
-                            
-                        </span>
-                        
-                    </td>
-                    <td>
-                        <span class="action-badge action-new">
-                            NEW
-                        </span>
-                        <span class="vote-buttons" data-g="URS000075D95B_9606" data-a="GO:0003677" data-r="PMID:34312245" data-act="NEW">
-                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
-                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
-                        </span>
-                    </td>
-                    <td>
-                        
-                        <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> XIST RNA localizes to and coats the inactive X chromosome through DNA interaction
-                        </div>
-                        
-                        
-                        
-                        
-                        <div class="supported-by">
-                            <div class="supported-by-title">Supporting Evidence:</div>
-                            
-                            <div class="support-item">
-                                <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/34312245" target="_blank" class="term-link">
-                                        PMID:34312245
-                                    </a>
-                                    
-                                </span>
-                                
-                                <div class="support-text">Xist coating triggers a cascade of chromosome-wide changes occurring at the levels of transcription, chromatin composition, chromosome structure, and spatial organization</div>
-                                
-                            </div>
-                            
-                        </div>
-                        
-                    </td>
-                </tr>
-                
-                <tr>
-                    <td>
-                        <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009048" target="_blank" class="term-link">
                                     GO:0009048
                                 </a>
                             </span>
                             <span class="term-label">dosage compensation by inactivation of X chromosome</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000115
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -998,71 +922,71 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This is the core function of XIST RNA - it mediates X-chromosome inactivation to achieve dosage compensation in female mammals. This annotation is fully supported by extensive literature.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9069284" target="_blank" class="term-link">
                                         PMID:9069284
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">this gene is required for X inactivation to occur in cis</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140463" target="_blank" class="term-link">
                                     GO:0140463
                                 </a>
                             </span>
                             <span class="term-label">chromatin-protein adaptor activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/32482714" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:32482714
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Progress toward understanding chromosome silencing by Xist R...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1074,84 +998,95 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> XIST acts as a scaffold RNA that recruits chromatin-modifying proteins to the inactive X chromosome. This chromatin-protein adaptor function is core to XIST&#39;s mechanism of action.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/25843628" target="_blank" class="term-link">
                                         PMID:25843628
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Xist, an essential lncRNA for X chromosome inactivation (XCI), interacts with 81 proteins from chromatin modification, nuclear matrix, and RNA remodeling pathways</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/32482714" target="_blank" class="term-link">
                                         PMID:32482714
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Progress toward understanding chromosome silencing by Xist RNA.</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/XIST/XIST-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">XIST engages many proteins through modular repeat regions and higher-order RNA folding, supporting its scaffold/adaptor role.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031048" target="_blank" class="term-link">
                                     GO:0031048
                                 </a>
                             </span>
                             <span class="term-label">regulatory ncRNA-mediated heterochromatin formation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/25843628" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:25843628
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Systematic discovery of Xist RNA binding proteins.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1163,71 +1098,82 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> XIST mediates heterochromatin formation on the inactive X chromosome by recruiting chromatin-modifying complexes including Polycomb proteins. This is a core mechanistic function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/25843628" target="_blank" class="term-link">
                                         PMID:25843628
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Xist lncRNA engages with proteins in a modular and developmentally controlled manner to coordinate chromatin spreading and silencing</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/XIST/XIST-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">XIST modifies chromosome territory architecture before widespread gene silencing, creating distinct RNA zones with different chromatin impacts.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0060816" target="_blank" class="term-link">
                                     GO:0060816
                                 </a>
                             </span>
                             <span class="term-label">random inactivation of X chromosome</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/25843628" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:25843628
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Systematic discovery of Xist RNA binding proteins.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1239,71 +1185,71 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> XIST mediates random X-chromosome inactivation in somatic cells where either the paternal or maternal X can be inactivated. This is a core biological process XIST participates in.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/25843628" target="_blank" class="term-link">
                                         PMID:25843628
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">XCI can proceed by random inactivation of either paternal or maternal chromosome in somatic cells</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140463" target="_blank" class="term-link">
                                     GO:0140463
                                 </a>
                             </span>
                             <span class="term-label">chromatin-protein adaptor activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/25843628" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:25843628
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Systematic discovery of Xist RNA binding proteins.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1315,71 +1261,71 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Strong experimental evidence from ChIRP-MS showing XIST directly interacts with chromatin-modifying proteins to mediate silencing.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/25843628" target="_blank" class="term-link">
                                         PMID:25843628
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Specific interactors include HnrnpK, which participates in Xist-mediated gene silencing and histone modifications but not Xist localization, and Drosophila Split ends homolog Spen</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0060816" target="_blank" class="term-link">
                                     GO:0060816
                                 </a>
                             </span>
                             <span class="term-label">random inactivation of X chromosome</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9335338" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:9335338
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Stabilization of Xist RNA mediates initiation of X chromosom...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1391,71 +1337,71 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Evidence from expression pattern during X-inactivation. Core function of XIST.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9335338" target="_blank" class="term-link">
                                         PMID:9335338
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Stabilization of Xist RNA mediates initiation of X chromosome inactivation.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140463" target="_blank" class="term-link">
                                     GO:0140463
                                 </a>
                             </span>
                             <span class="term-label">chromatin-protein adaptor activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/33268787" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:33268787
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Structural modularity of the XIST ribonucleoprotein complex.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1467,71 +1413,71 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Evidence showing structural modularity of XIST RNP complex supporting its chromatin-protein adaptor role.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/33268787" target="_blank" class="term-link">
                                         PMID:33268787
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Structural modularity of the XIST ribonucleoprotein complex.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1990904" target="_blank" class="term-link">
                                     GO:1990904
                                 </a>
                             </span>
                             <span class="term-label">ribonucleoprotein complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/33268787" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:33268787
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Structural modularity of the XIST ribonucleoprotein complex.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1543,84 +1489,84 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> XIST forms a ribonucleoprotein complex with numerous protein partners. This is well-supported and represents a key aspect of XIST structure-function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/25843628" target="_blank" class="term-link">
                                         PMID:25843628
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Xist, an essential lncRNA for X chromosome inactivation (XCI), interacts with 81 proteins from chromatin modification, nuclear matrix, and RNA remodeling pathways</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/33268787" target="_blank" class="term-link">
                                         PMID:33268787
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Structural modularity of the XIST ribonucleoprotein complex.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0060816" target="_blank" class="term-link">
                                     GO:0060816
                                 </a>
                             </span>
                             <span class="term-label">random inactivation of X chromosome</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/32482714" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:32482714
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Progress toward understanding chromosome silencing by Xist R...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1632,71 +1578,71 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Core function of XIST in mammalian development.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/32482714" target="_blank" class="term-link">
                                         PMID:32482714
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Progress toward understanding chromosome silencing by Xist RNA.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140719" target="_blank" class="term-link">
                                     GO:0140719
                                 </a>
                             </span>
                             <span class="term-label">constitutive heterochromatin formation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/32482714" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:32482714
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Progress toward understanding chromosome silencing by Xist R...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1708,71 +1654,71 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> XIST establishes constitutive heterochromatin on the inactive X chromosome as part of the silencing mechanism.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/32482714" target="_blank" class="term-link">
                                         PMID:32482714
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Progress toward understanding chromosome silencing by Xist RNA.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046536" target="_blank" class="term-link">
                                     GO:0046536
                                 </a>
                             </span>
                             <span class="term-label">dosage compensation complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/32482714" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:32482714
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Progress toward understanding chromosome silencing by Xist R...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1784,71 +1730,71 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> XIST is a central component of the dosage compensation complex in mammals.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/32482714" target="_blank" class="term-link">
                                         PMID:32482714
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Progress toward understanding chromosome silencing by Xist RNA.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000512" target="_blank" class="term-link">
                                     GO:0000512
                                 </a>
                             </span>
                             <span class="term-label">lncRNA-mediated post-transcriptional gene silencing</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/29053187" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:29053187
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     XIST promotes gastric cancer (GC) progression through TGF-β1...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1860,71 +1806,71 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This annotation is based on a study of XIST function in gastric cancer cells, not its canonical X-inactivation role. The paper shows XIST acting as a ceRNA to sponge miR-185. While potentially real in cancer contexts, this represents a non-physiological over-annotation of XIST&#39;s core function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/29053187" target="_blank" class="term-link">
                                         PMID:29053187
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Dec 4. XIST promotes gastric cancer (GC) progression through TGF-β1 via targeting miR-185.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140869" target="_blank" class="term-link">
                                     GO:0140869
                                 </a>
                             </span>
                             <span class="term-label">miRNA inhibitor activity via base-pairing</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/29053187" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:29053187
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     XIST promotes gastric cancer (GC) progression through TGF-β1...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1936,71 +1882,71 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Based on gastric cancer study showing XIST sponging miR-185. This is not the core function of XIST and likely represents an over-annotation. XIST&#39;s primary role is X-chromosome inactivation, not miRNA regulation.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/29053187" target="_blank" class="term-link">
                                         PMID:29053187
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Dec 4. XIST promotes gastric cancer (GC) progression through TGF-β1 via targeting miR-185.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:2000627" target="_blank" class="term-link">
                                     GO:2000627
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of miRNA catabolic process</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/29053187" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:29053187
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     XIST promotes gastric cancer (GC) progression through TGF-β1...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2012,71 +1958,71 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Based on the same gastric cancer study. This represents over-annotation of XIST beyond its core X-inactivation function. The miRNA sponging activity in cancer cells is not representative of XIST&#39;s physiological role.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/29053187" target="_blank" class="term-link">
                                         PMID:29053187
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Dec 4. XIST promotes gastric cancer (GC) progression through TGF-β1 via targeting miR-185.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000805" target="_blank" class="term-link">
                                     GO:0000805
                                 </a>
                             </span>
                             <span class="term-label">X chromosome</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/31048766" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:31048766
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Cellular functions of long noncoding RNAs.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2088,46 +2034,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> XIST RNA localizes to and coats the X chromosome, specifically the inactive X. This is a well-established core aspect of XIST biology.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/31048766" target="_blank" class="term-link">
                                         PMID:31048766
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">2019 May 2. Cellular functions of long noncoding RNAs.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
             </tbody>
         </table>
     </div>
-    
 
-    
+
+
     <div class="section">
         <h2 class="section-title">Core Functions</h2>
-        
+
         <div class="core-function-card">
-            
+
             <div style="display: flex; justify-content: space-between; align-items: center;">
                 <h3>X-chromosome coating and silencing</h3>
                 <span class="vote-buttons" data-g="URS000075D95B_9606" data-a="FUNCTION: X-chromosome coating and silencing..." data-r="" data-act="CORE_FUNCTION">
@@ -2135,54 +2081,52 @@
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
             </div>
-            
+
 
             <div class="core-function-terms">
-                
+
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
-                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003677" target="_blank" class="term-link">
-                            DNA binding
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140463" target="_blank" class="term-link">
+                            chromatin-protein adaptor activity
                         </a>
                     </span>
                 </div>
-                
 
-                
 
-                
 
-                
 
-                
+
+
+
+
+
             </div>
 
-            
+
             <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
                 <strong>Supporting Evidence:</strong>
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
-                            <a href="https://pubmed.ncbi.nlm.nih.gov/23562786" target="_blank" class="term-link">
-                                PMID:23562786
-                            </a>
-                            
+
+                            file:human/XIST/XIST-deep-research-falcon.md
+
                         </span>
-                        
-                        <div class="finding-text">XIST localizes to and coats the inactive X chromosome</div>
-                        
+
+                        <div class="finding-text">XIST coats the future inactive X chromosome to establish a repressive nuclear territory.</div>
+
                     </li>
-                    
+
                 </ul>
             </div>
-            
+
         </div>
-        
+
         <div class="core-function-card">
-            
+
             <div style="display: flex; justify-content: space-between; align-items: center;">
                 <h3>chromatin modification recruitment</h3>
                 <span class="vote-buttons" data-g="URS000075D95B_9606" data-a="FUNCTION: chromatin modification recruitment..." data-r="" data-act="CORE_FUNCTION">
@@ -2190,54 +2134,52 @@
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
             </div>
-            
+
 
             <div class="core-function-terms">
-                
+
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
-                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003677" target="_blank" class="term-link">
-                            DNA binding
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140463" target="_blank" class="term-link">
+                            chromatin-protein adaptor activity
                         </a>
                     </span>
                 </div>
-                
 
-                
 
-                
 
-                
 
-                
+
+
+
+
+
             </div>
 
-            
+
             <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
                 <strong>Supporting Evidence:</strong>
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
-                            <a href="https://pubmed.ncbi.nlm.nih.gov/23868259" target="_blank" class="term-link">
-                                PMID:23868259
-                            </a>
-                            
+
+                            file:human/XIST/XIST-deep-research-falcon.md
+
                         </span>
-                        
-                        <div class="finding-text">XIST recruits chromatin-modifying complexes to establish silencing</div>
-                        
+
+                        <div class="finding-text">XIST&#39;s core molecular role is an RNA/chromatin scaffold or adaptor that recruits transcriptional repressors and chromatin-modifying complexes.</div>
+
                     </li>
-                    
+
                 </ul>
             </div>
-            
+
         </div>
-        
+
         <div class="core-function-card">
-            
+
             <div style="display: flex; justify-content: space-between; align-items: center;">
                 <h3>nuclear organization</h3>
                 <span class="vote-buttons" data-g="URS000075D95B_9606" data-a="FUNCTION: nuclear organization..." data-r="" data-act="CORE_FUNCTION">
@@ -2245,252 +2187,275 @@
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
             </div>
-            
+
 
             <div class="core-function-terms">
-                
+
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
-                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003677" target="_blank" class="term-link">
-                            DNA binding
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140463" target="_blank" class="term-link">
+                            chromatin-protein adaptor activity
                         </a>
                     </span>
                 </div>
-                
 
-                
 
-                
 
-                
 
-                
+
+
+
+
+
             </div>
 
-            
+
             <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
                 <strong>Supporting Evidence:</strong>
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
-                            <a href="https://pubmed.ncbi.nlm.nih.gov/34312245" target="_blank" class="term-link">
-                                PMID:34312245
-                            </a>
-                            
+
+                            file:human/XIST/XIST-deep-research-falcon.md
+
                         </span>
-                        
-                        <div class="finding-text">Genetic perturbation of the mechanisms involved, however, reveals that nuclear organization is not as essential as previously thought in ensuring that one X chromosome becomes inactivated</div>
-                        
+
+                        <div class="finding-text">XIST modifies chromosome territory architecture before widespread gene silencing, creating distinct RNA zones with different chromatin impacts.</div>
+
                     </li>
-                    
+
                 </ul>
             </div>
-            
-        </div>
-        
-    </div>
-    
 
-    
+        </div>
+
+    </div>
+
+
+
     <div class="section">
         <h2 class="section-title collapsible">References</h2>
         <div class="collapse-content">
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
+                        file:human/XIST/XIST-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research report for XIST</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Falcon supports XIST as a noncoding RNA chromatin scaffold/adaptor that coats the inactive X in cis, recruits silencing and chromatin-modifying factors, and establishes repressive chromatin during X-chromosome inactivation.</div>
+
+                        <div class="finding-text">"XIST&#39;s core molecular role is an RNA/chromatin scaffold or adaptor that coats the inactive X in cis, recruits transcriptional repressors and chromatin-modifying complexes, and helps establish repressive chromatin."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/23142477" target="_blank" class="term-link">
                             PMID:23142477
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Recent advances in X-chromosome inactivation research</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/9069284" target="_blank" class="term-link">
                             PMID:9069284
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Xist has properties of the X-chromosome inactivation centre</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/31900287" target="_blank" class="term-link">
                             PMID:31900287
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">X chromosome inactivation in human development</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/34312245" target="_blank" class="term-link">
                             PMID:34312245
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The Molecular and Nuclear Dynamics of X-Chromosome Inactivation</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000115.md" target="_blank" class="term-link">
                             GO_REF:0000115
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Automatic Gene Ontology annotation of non-coding RNA sequences through association of Rfam records with GO terms</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/25843628" target="_blank" class="term-link">
                             PMID:25843628
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Systematic discovery of Xist RNA binding proteins.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/29053187" target="_blank" class="term-link">
                             PMID:29053187
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">XIST promotes gastric cancer (GC) progression through TGF-β1 via targeting miR-185.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/31048766" target="_blank" class="term-link">
                             PMID:31048766
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Cellular functions of long noncoding RNAs.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/32482714" target="_blank" class="term-link">
                             PMID:32482714
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Progress toward understanding chromosome silencing by Xist RNA.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/33268787" target="_blank" class="term-link">
                             PMID:33268787
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Structural modularity of the XIST ribonucleoprotein complex.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/9335338" target="_blank" class="term-link">
                             PMID:9335338
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Stabilization of Xist RNA mediates initiation of X chromosome inactivation.</div>
-                
-                
+
+
             </div>
-            
+
         </div>
     </div>
-    
 
 
-    
+
+
     <div class="section">
         <h2 class="section-title">Suggested Questions for Experts</h2>
-        
+
         <div class="question-card">
             <div style="display: flex; justify-content: space-between; align-items: start;">
                 <div style="flex: 1;">
                     <p><strong>Q:</strong> What are the specific repeat elements in XIST that are required for chromosome coating versus silencing?</p>
-                    
+
                     <p style="margin-top: 0.5rem;"><em>Suggested experts: epigeneticists, X-inactivation researchers</em></p>
-                    
+
                 </div>
                 <span class="vote-buttons" data-g="URS000075D95B_9606" data-a="Q: What are the specific repeat elements in XIST that..." data-r="" data-act="QUESTION">
                     <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
@@ -2498,14 +2463,14 @@
                 </span>
             </div>
         </div>
-        
+
         <div class="question-card">
             <div style="display: flex; justify-content: space-between; align-items: start;">
                 <div style="flex: 1;">
                     <p><strong>Q:</strong> How does XIST coordinate with chromatin remodeling complexes during X-inactivation establishment?</p>
-                    
+
                     <p style="margin-top: 0.5rem;"><em>Suggested experts: chromatin biologists, developmental biologists</em></p>
-                    
+
                 </div>
                 <span class="vote-buttons" data-g="URS000075D95B_9606" data-a="Q: How does XIST coordinate with chromatin remodeling..." data-r="" data-act="QUESTION">
                     <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
@@ -2513,26 +2478,26 @@
                 </span>
             </div>
         </div>
-        
-    </div>
-    
 
-    
+    </div>
+
+
+
     <div class="section">
         <h2 class="section-title">Suggested Experiments</h2>
-        
+
         <div class="experiment-card">
             <div style="display: flex; justify-content: space-between; align-items: start;">
                 <div style="flex: 1;">
-                    
+
                     <p><strong>Experiment:</strong> CLIP-seq analysis of XIST interactions with chromatin across the inactive X chromosome</p>
-                    
-                    
+
+
                     <p style="margin-top: 0.5rem;"><em>Hypothesis: XIST directly interacts with specific chromatin regions to establish silencing domains</em></p>
-                    
-                    
+
+
                     <p style="margin-top: 0.5rem;">Type: high-throughput sequencing</p>
-                    
+
                 </div>
                 <span class="vote-buttons" data-g="URS000075D95B_9606" data-a="EXPERIMENT: CLIP-seq analysis of XIST interactions with chroma..." data-r="" data-act="EXPERIMENT">
                     <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
@@ -2540,19 +2505,19 @@
                 </span>
             </div>
         </div>
-        
+
         <div class="experiment-card">
             <div style="display: flex; justify-content: space-between; align-items: start;">
                 <div style="flex: 1;">
-                    
+
                     <p><strong>Experiment:</strong> Live-cell imaging of XIST localization dynamics during X-inactivation</p>
-                    
-                    
+
+
                     <p style="margin-top: 0.5rem;"><em>Hypothesis: XIST coating occurs in a sequential, ordered fashion across the X chromosome</em></p>
-                    
-                    
+
+
                     <p style="margin-top: 0.5rem;">Type: live-cell microscopy</p>
-                    
+
                 </div>
                 <span class="vote-buttons" data-g="URS000075D95B_9606" data-a="EXPERIMENT: Live-cell imaging of XIST localization dynamics du..." data-r="" data-act="EXPERIMENT">
                     <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
@@ -2560,17 +2525,350 @@
                 </span>
             </div>
         </div>
-        
-    </div>
-    
 
-    
+    </div>
+
+
+
 
     <!-- Computational Predictions Section -->
-    
+
 
     <!-- Additional Documentation Sections -->
-    
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Deep Research Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(XIST-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="URS000075D95B_9606" data-a="DOC: Deep Research Falcon" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <hr />
+<p>provider: falcon<br />
+model: Edison Scientific Literature<br />
+cached: false<br />
+start_time: '2026-05-11T03:29:14.838881'<br />
+end_time: '2026-05-11T03:59:39.133263'<br />
+duration_seconds: 1824.29<br />
+provider_config:<br />
+  timeout: 600<br />
+  max_retries: 3<br />
+  parameters:<br />
+    allowed_domains: []<br />
+    temperature: 0.1<br />
+citation_count: 37</p>
+<hr />
+<h2 id="question">Question</h2>
+<p>Research the human long non-coding RNA gene XIST (X-inactive specific transcript; RNAcentral URS000075D95B_9606) for Gene Ontology functional annotation. This is a lncRNA/non-coding RNA, not a protein; do not infer protein domains or enzyme activity. Focus on its core molecular function as a chromatin/RNA scaffold or chromatin-protein adaptor in X-chromosome inactivation, XIST coating of the inactive X, recruitment of silencing and chromatin-modifying complexes, heterochromatin formation, cellular localization, and which GO terms are directly supported by primary literature. Distinguish core X-inactivation function from broad dosage-compensation outcomes, and provide citations for each major claim.</p>
+<h2 id="output">Output</h2>
+<p>Question: You are an expert researcher providing comprehensive, well-cited information.</p>
+<p>Provide detailed information focusing on:<br />
+1. Key concepts and definitions with current understanding<br />
+2. Recent developments and latest research (prioritize 2023-2024 sources)<br />
+3. Current applications and real-world implementations<br />
+4. Expert opinions and analysis from authoritative sources<br />
+5. Relevant statistics and data from recent studies</p>
+<p>Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.<br />
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.</p>
+<p>Research the human long non-coding RNA gene XIST (X-inactive specific transcript; RNAcentral URS000075D95B_9606) for Gene Ontology functional annotation. This is a lncRNA/non-coding RNA, not a protein; do not infer protein domains or enzyme activity. Focus on its core molecular function as a chromatin/RNA scaffold or chromatin-protein adaptor in X-chromosome inactivation, XIST coating of the inactive X, recruitment of silencing and chromatin-modifying complexes, heterochromatin formation, cellular localization, and which GO terms are directly supported by primary literature. Distinguish core X-inactivation function from broad dosage-compensation outcomes, and provide citations for each major claim.</p>
+<h2 id="research-report-gene-ontology-go-functional-annotation-evidence-for-human-xist-lncrna-rnacentral-urs000075d95b_9606">Research report: Gene Ontology (GO) functional annotation evidence for human XIST lncRNA (RNAcentral: URS000075D95B_9606)</h2>
+<h3 id="scope-and-constraints">Scope and constraints</h3>
+<p>This report summarizes primary-literature evidence that supports GO-style functional annotations for <strong>XIST</strong>, a <strong>long non-coding RNA (lncRNA)</strong> that orchestrates <strong>X-chromosome inactivation (XCI)</strong>. XIST is <strong>not a protein</strong>; therefore this report does <strong>not</strong> infer protein domains or enzymatic activities. Instead it focuses on XIST’s core molecular role as an <strong>RNA/chromatin scaffold or adaptor</strong> that (i) coats the inactive X in cis, (ii) recruits transcriptional repressors and chromatin-modifying complexes, (iii) helps establish repressive chromatin and higher-order chromosome organization, and (iv) localizes to defined nuclear compartments (Xi territory; nuclear lamina/nuclear matrix). Claims about <strong>dosage compensation outcomes</strong> are distinguished from the <strong>core mechanistic functions</strong>.</p>
+<h3 id="key-concepts-and-current-understanding-definitions">Key concepts and current understanding (definitions)</h3>
+<h4 id="x-chromosome-inactivation-xci">X-chromosome inactivation (XCI)</h4>
+<p>XCI is a mammalian epigenetic program that transcriptionally silences most genes on one X chromosome in XX cells to balance X-linked gene dosage. XIST/Xist is required and is expressed from the future inactive X and spreads in cis to create a coated X territory where silencing and repressive chromatin accumulate (dror2024xistdirectlyregulates pages 1-3, valledor2023earlychromosomecondensation pages 1-3).</p>
+<h4 id="coating-and-xi-territory-formation">“Coating” and Xi territory formation</h4>
+<p>“Coating” refers to the accumulation of XIST RNA across the chromosome territory (often observed as an XIST “cloud”), which is necessary to spatially concentrate silencing factors and establish a repressive nuclear compartment (dror2024xistdirectlyregulates pages 1-3, valledor2023earlychromosomecondensation pages 1-3).</p>
+<h4 id="modular-scaffoldadaptor-model">Modular scaffold/adaptor model</h4>
+<p>XIST engages many proteins through modular repeat regions and higher-order RNA folding. Large-scale structural and interaction mapping shows that XIST forms a modular ribonucleoprotein architecture with clustered protein-binding domains (lu2020structuralmodularityof pages 1-2, lu2020structuralmodularityof pages 6-7). Systematic interactome mapping identifies multiple direct Xist-binding proteins (including chromatin and nuclear-envelope factors), supporting its scaffold/adaptor role (minajigi2015acomprehensivexist pages 1-3).</p>
+<h3 id="core-xist-molecular-functions-directly-supported-by-primary-literature">Core XIST molecular functions directly supported by primary literature</h3>
+<h4 id="1-recruitment-of-sharpspen-smrtncor-hdac3-to-initiate-transcriptional-silencing-and-rna-pol-ii-exclusion">1) Recruitment of SHARP/SPEN → SMRT/NCoR → HDAC3 to initiate transcriptional silencing and RNA Pol II exclusion</h4>
+<p><strong>Primary evidence:</strong> McHugh et al. used RAP-MS to identify proteins that directly associate with Xist and showed that <strong>SHARP (SPEN)</strong> is among the direct interactors required for silencing; SHARP is required for <strong>RNA polymerase II exclusion</strong> from the Xist-coated territory, and <strong>SMRT</strong> and <strong>HDAC3</strong> are also required for silencing and Pol II exclusion (mchugh2015thexistlncrna pages 1-2, mchugh2015thexistlncrna pages 6-7). The paper’s mechanistic model links SHARP (a direct Xist-binding factor) to recruitment/activation of HDAC3 through SMRT, consistent with histone deacetylation-based transcriptional repression (mchugh2015thexistlncrna pages 6-7).</p>
+<p><strong>Interpretation for GO annotation:</strong> This supports GO molecular-function-style annotations centered on <strong>protein binding</strong> and <strong>corepressor complex recruitment</strong>, and GO biological-process annotations for <strong>transcriptional gene silencing</strong> and <strong>RNA polymerase II exclusion from chromatin territory</strong> (mchugh2015thexistlncrna pages 6-7, mchugh2015thexistlncrna pages 1-2).</p>
+<h4 id="2-polycomb-recruitment-via-hnrnpk-binding-to-xist-b-repeatxr-pid-and-initiation-of-prc1prc2-cascade">2) Polycomb recruitment via hnRNPK binding to Xist B-repeat/XR-PID and initiation of PRC1→PRC2 cascade</h4>
+<p><strong>Primary evidence:</strong> Pintacuda et al. mapped an Xist <strong>Polycomb Interaction Domain</strong> (XR-PID; ~600 nt encompassing B-repeat), where deletion abrogates Polycomb recruitment and Xist-dependent chromosome silencing, and identified <strong>hnRNPK</strong> as the principal XR-PID binding factor needed to recruit <strong>PCGF3/5-PRC1</strong> (pintacuda2017hnrnpkrecruitspcgf35prc1 pages 1-3). They further showed <strong>direct biochemical interaction</strong> between hnRNPK and a recombinant PCGF3-PRC1 complex and demonstrated that <strong>synthetic tethering of hnRNPK</strong> to XR-PID–deleted Xist restores H2AK119ub and H3K27me3 accumulation over the Xist domain (pintacuda2017hnrnpkrecruitspcgf35prc1 pages 10-13).</p>
+<p><strong>Interpretation for GO annotation:</strong> These data directly support annotations for <strong>Polycomb complex recruitment</strong>, <strong>H2A K119 ubiquitination involved in chromatin silencing</strong>, and establishment of repressive chromatin states downstream of PRC1/PRC2 (pintacuda2017hnrnpkrecruitspcgf35prc1 pages 1-3, pintacuda2017hnrnpkrecruitspcgf35prc1 pages 10-13).</p>
+<h4 id="3-nuclear-lamina-tethering-through-lbr-and-functional-impact-on-spreading-to-active-genes">3) Nuclear lamina tethering through LBR and functional impact on spreading to active genes</h4>
+<p><strong>Primary evidence:</strong> Chen et al. report that Xist <strong>directly interacts</strong> with <strong>lamin B receptor (LBR)</strong> and that this interaction is required for Xist-mediated silencing by recruiting the inactive X to the <strong>nuclear lamina</strong>, enabling Xist to spread to actively transcribed genes across the X (chen2016xistrecruitsthe pages 1-2). The paper includes functional tests showing LBR perturbation disrupts silencing and lamina association, and that engineered tethering strategies can rescue spreading/silencing defects, consistent with a mechanistic role for lamina recruitment in chromosome-wide silencing (chen2016xistrecruitsthe pages 1-2, chen2016xistrecruitsthe pages 3-4).</p>
+<p><strong>Important limitation / nuance:</strong> A systematic allelic dissection of Xist pathways reported that <strong>LBR makes only minor contributions</strong> to gene silencing in the tested ESC models, suggesting redundancy or context-dependence of LBR-mediated effects across systems (nesterova2019systematicallelicanalysis pages 1-2).</p>
+<p><strong>Interpretation for GO annotation:</strong> Supports CC/BP annotations for <strong>nuclear lamina association</strong> and BP annotations linking XIST to chromosome-wide silencing through nuclear positioning/spreading mechanisms, while indicating potential context specificity (chen2016xistrecruitsthe pages 1-2, nesterova2019systematicallelicanalysis pages 1-2).</p>
+<h4 id="4-xistxist-interactome-evidence-for-nuclear-envelopenuclear-matrix-factors-and-chromosome-conformation-control">4) Xist/XIST interactome evidence for nuclear-envelope/nuclear-matrix factors and chromosome conformation control</h4>
+<p><strong>Primary evidence:</strong> Minajigi et al. developed iDRiP to identify a broad set of <strong>direct Xist-interacting proteins</strong>, including nuclear-envelope components (e.g., LBR) and nuclear matrix proteins (hnRPU/SAF-A, hnRNPK), and explored functional impacts on Xi repression and chromosome conformation (minajigi2015acomprehensivexist pages 1-3).</p>
+<p><strong>Interpretation for GO annotation:</strong> Supports MF/CC terms around <strong>protein binding</strong>, <strong>nuclear matrix association</strong>, and BP terms tied to <strong>chromosome organization</strong> and the assembly of a repressive chromosome territory (minajigi2015acomprehensivexist pages 1-3).</p>
+<h4 id="5-early-heterochromatinizationcompaction-as-a-distinct-measurable-process-driven-by-xist-rna-density">5) Early heterochromatinization/compaction as a distinct, measurable process driven by XIST RNA density</h4>
+<p><strong>Primary evidence (2023):</strong> Valledor et al. used inducible human XIST to show that XIST modifies chromosome territory architecture before widespread gene silencing, creating distinct <strong>“sparse” and “dense” RNA zones</strong> with different chromatin impacts; <strong>H2AK119ub and CIZ1</strong> appear rapidly, while <strong>H3K27me3</strong> appears later in the dense zone as condensation proceeds (valledor2023earlychromosomecondensation pages 1-3, valledor2023earlychromosomecondensation media 58d592e8). Critically, they report quantitative local gene silencing by the isolated A-repeat fragment: transcription foci for nearby genes dropped <strong>~82% (DSCR3) and ~83% (TTC3)</strong> upon induction, indicating strong local repression (valledor2023earlychromosomecondensation pages 10-11). Their data support a model where condensation builds a high-density RNA/DNA environment that facilitates an A-repeat/HDAC-dependent silencing step (valledor2023earlychromosomecondensation pages 1-3, valledor2023earlychromosomecondensation pages 10-11, valledor2023earlychromosomecondensation media 58d592e8).</p>
+<p><strong>Interpretation for GO annotation:</strong> Supports BP terms such as <strong>heterochromatin formation</strong>, <strong>chromosome condensation/organization</strong>, and chromatin-mark deposition timing consistent with Polycomb involvement (valledor2023earlychromosomecondensation pages 1-3, valledor2023earlychromosomecondensation media 58d592e8).</p>
+<h3 id="recent-developments-and-latest-research-prioritizing-20232024">Recent developments and latest research (prioritizing 2023–2024)</h3>
+<h4 id="a-xist-localization-states-and-non-canonical-dispersed-configurations-in-naive-human-pluripotent-cells-2024">A) XIST localization states and non-canonical (dispersed) configurations in naïve human pluripotent cells (2024)</h4>
+<p>Dror et al. (Cell, publication date 2024-01-04; URL in record) report that in <strong>naïve human pluripotent stem cells</strong>, XIST shows a <strong>dispersed nuclear configuration</strong> and is associated with <strong>X-chromosome dampening</strong> rather than full silencing; they further report that XIST spreads across the X chromosome and can target specific autosomal regions with associated gene-expression dampening and repressive chromatin changes (dror2024xistdirectlyregulates pages 1-3). This expands the functional landscape of XIST localization beyond the classical compact Xi cloud, while still being consistent with scaffold/adaptor logic (dror2024xistdirectlyregulates pages 1-3).</p>
+<h4 id="b-quantitative-time-resolved-architecture-first-model-for-initiation-2023">B) Quantitative, time-resolved architecture-first model for initiation (2023)</h4>
+<p>Valledor et al. provide an explicit time ordering: rapid appearance of H2AK119ub/CIZ1 with early sparse RNA, later H3K27me3 coincident with dense zone expansion and condensation, and gene silencing after compaction (valledor2023earlychromosomecondensation pages 1-3, valledor2023earlychromosomecondensation media 58d592e8).</p>
+<h4 id="c-translational-and-experimental-chromosome-therapy-platforms-using-xist-transgenes-2024">C) Translational and experimental “chromosome therapy” platforms using XIST transgenes (2024)</h4>
+<p>A 2024 Science Advances study established a dynamic trisomy 21 iPSC model where an inducible XIST transgene on chromosome 21 yields homogenous XIST clouds with H2AK119ub/H3K27me3 and near-complete repression of the targeted allele; importantly, repression remains efficient even after terminal differentiation, enabling post-developmental dosage-correction experiments (bansal2024adynamicin pages 1-3). A 2024 Human Genetics review synthesizes translational prospects/challenges and reports Down syndrome incidence in the US as <strong>~1/750 live births</strong> and chromosomal abnormalities collectively as <strong>~1/150 newborns</strong>, framing real-world motivations for XIST-based dosage correction research (gupta2024trisomysilencingby pages 1-3).</p>
+<h3 id="applications-and-real-world-implementations">Applications and real-world implementations</h3>
+<ol>
+<li><strong>In vitro dosage correction / disease modeling (Trisomy 21):</strong> XIST transgene insertion on one chromosome 21 enables monoallelic chromosome-wide repression, providing a platform to dissect which phenotypes depend on ongoing trisomic dosage and which can be corrected later (bansal2024adynamicin pages 1-3).</li>
+<li><strong>Translational roadmapping for chromosome dosage disorders:</strong> The 2024 review outlines how XIST transgenics could inform future therapeutic strategies, while emphasizing major technical and biological hurdles for in vivo application (gupta2024trisomysilencingby pages 1-3).</li>
+</ol>
+<h3 id="expert-opinions-and-authoritative-synthesis-used-cautiously">Expert opinions and authoritative synthesis (used cautiously)</h3>
+<p>Where reviews are used, they are treated as secondary synthesis rather than primary GO evidence. Loda &amp; Heard (2019) provides a consolidated view of modular repeat functions and the landscape of interactors, consistent with the primary evidence that SPEN/SHARP–HDAC3 and hnRNPK–PRC1 are central pathways, and that LBR effects may be modest in some models (loda2019xistrnain pages 7-9, loda2019xistrnain pages 13-14).</p>
+<h3 id="statistics-and-quantitative-findings-from-recent-studies">Statistics and quantitative findings from recent studies</h3>
+<ul>
+<li><strong>Local repression by A-repeat alone:</strong> transcription foci decreased <strong>82% (DSCR3)</strong> and <strong>83% (TTC3)</strong> upon A-repeat induction in a human iPSC transgene context, supporting strong local gene repression capacity when RNA density is high (valledor2023earlychromosomecondensation pages 10-11).</li>
+<li><strong>Down syndrome incidence:</strong> ~<strong>1/750</strong> live births in the US (reviewed statistic) (gupta2024trisomysilencingby pages 1-3).</li>
+<li><strong>Chromosomal abnormalities overall:</strong> ~<strong>1/150</strong> newborns (reviewed statistic) (gupta2024trisomysilencingby pages 1-3).</li>
+</ul>
+<h3 id="go-term-mapping-candidate-annotations-supported-by-primary-literature">GO-term mapping (candidate annotations supported by primary literature)</h3>
+<p>The following table summarizes candidate GO terms for XIST that are directly supported by the evidence assembled here.</p>
+<table>
+<thead>
+<tr>
+<th style="text-align: left;">GO Category</th>
+<th style="text-align: left;">Candidate GO Term</th>
+<th style="text-align: left;">Concise Definition for XIST</th>
+<th style="text-align: left;">Key Primary Evidence</th>
+<th style="text-align: left;">Mechanistic Notes &amp; Limitations</th>
+<th style="text-align: left;">Citations</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style="text-align: left;"><strong>Biological Process (BP)</strong></td>
+<td style="text-align: left;">X-chromosome inactivation</td>
+<td style="text-align: left;">Initiates cis-limited chromosome-wide gene silencing across the inactive X (Xi).</td>
+<td style="text-align: left;">McHugh 2015 (RAP-MS &amp; knockdown); Dror 2024 (naïve hPSC localization)</td>
+<td style="text-align: left;">Core mechanism; functions as a cis-acting lncRNA scaffold. Dror 2024 shows trans-acting capabilities in early development.</td>
+<td style="text-align: left;">(dror2024xistdirectlyregulates pages 1-3, mchugh2015thexistlncrna pages 1-2)</td>
+</tr>
+<tr>
+<td style="text-align: left;"><strong>Biological Process (BP)</strong></td>
+<td style="text-align: left;">Dosage compensation by X inactivation</td>
+<td style="text-align: left;">Equalizes expression of X-linked genes between male and female somatic cells.</td>
+<td style="text-align: left;">Dror 2024, Gupta 2024, Bansal 2024 (iPSC models &amp; transgene targeting)</td>
+<td style="text-align: left;">Downstream biological outcome. Can also be repurposed for autosomal dosage correction (e.g., Trisomy 21).</td>
+<td style="text-align: left;">(dror2024xistdirectlyregulates pages 1-3, gupta2024trisomysilencingby pages 1-3, bansal2024adynamicin pages 1-3)</td>
+</tr>
+<tr>
+<td style="text-align: left;"><strong>Molecular Function (MF)</strong></td>
+<td style="text-align: left;">Protein binding / RNA binding</td>
+<td style="text-align: left;">Scaffolds multiple interacting proteins via a folded, evolutionarily conserved modular architecture.</td>
+<td style="text-align: left;">Minajigi 2015 (iDRiP-MS); Lu 2020 (PARIS, fRIP-seq, eCLIP)</td>
+<td style="text-align: left;">Modularity specifies unique interaction zones for specific RBPs (e.g., A-repeat, B/C-repeats).</td>
+<td style="text-align: left;">(lu2020structuralmodularityof pages 1-2, minajigi2015acomprehensivexist pages 1-3)</td>
+</tr>
+<tr>
+<td style="text-align: left;"><strong>Cellular Component (CC) / MF</strong></td>
+<td style="text-align: left;">Chromatin binding / association</td>
+<td style="text-align: left;">Coats the future inactive X chromosome to establish a repressive nuclear territory.</td>
+<td style="text-align: left;">Valledor 2023 (RNA FISH &amp; inducible XIST); Dror 2024 (CUT&amp;Tag/RAP-seq)</td>
+<td style="text-align: left;">Occurs in dense and sparse zones. In naïve hPSCs, XIST is highly dispersed rather than tightly compacted.</td>
+<td style="text-align: left;">(dror2024xistdirectlyregulates pages 1-3, valledor2023earlychromosomecondensation pages 1-3)</td>
+</tr>
+<tr>
+<td style="text-align: left;"><strong>Biological Process (BP)</strong></td>
+<td style="text-align: left;">Chromosome organization / Heterochromatin formation</td>
+<td style="text-align: left;">Modifies cytoarchitecture and drives large-scale condensation of active chromatin into a Barr body.</td>
+<td style="text-align: left;">Valledor 2023 (Inducible XIST time-course); Minajigi 2015 (Allele-specific ChIP-seq)</td>
+<td style="text-align: left;">Early condensation builds RNA density required for sustained silencing. Involves cohesin repulsion and distinct topological remodeling.</td>
+<td style="text-align: left;">(valledor2023earlychromosomecondensation pages 1-3, minajigi2015acomprehensivexist pages 6-8, valledor2023earlychromosomecondensation media 58d592e8)</td>
+</tr>
+<tr>
+<td style="text-align: left;"><strong>Biological Process (BP) / MF</strong></td>
+<td style="text-align: left;">Recruitment of histone deacetylase complex</td>
+<td style="text-align: left;">Recruits HDAC3 via direct binding to SHARP/SPEN to mediate transcriptional silencing.</td>
+<td style="text-align: left;">McHugh 2015 (Knockdown of SHARP, SMRT, HDAC3)</td>
+<td style="text-align: left;">Mediated by the A-repeat. Crucial for exclusion of RNA Pol II; acts rapidly at sites of high RNA density.</td>
+<td style="text-align: left;">(mchugh2015thexistlncrna pages 4-6, mchugh2015thexistlncrna pages 6-7, mchugh2015thexistlncrna pages 1-2)</td>
+</tr>
+<tr>
+<td style="text-align: left;"><strong>Biological Process (BP) / MF</strong></td>
+<td style="text-align: left;">Polycomb repressive complex recruitment</td>
+<td style="text-align: left;">Initiates the Polycomb cascade by recruiting PCGF3/5-PRC1 via hnRNPK.</td>
+<td style="text-align: left;">Pintacuda 2017 (XR-PID deletion &amp; synthetic tethering); Nesterova 2019 (Allelic silencing)</td>
+<td style="text-align: left;">Driven by XIST B/C repeats interacting with hnRNPK. PRC2 is recruited indirectly downstream of PRC1.</td>
+<td style="text-align: left;">(pintacuda2017hnrnpkrecruitspcgf35prc1 pages 1-3, pintacuda2017hnrnpkrecruitspcgf35prc1 pages 10-13, nesterova2019systematicallelicanalysis pages 1-2)</td>
+</tr>
+<tr>
+<td style="text-align: left;"><strong>Biological Process (BP)</strong></td>
+<td style="text-align: left;">Histone H2A K119 ubiquitination</td>
+<td style="text-align: left;">PRC1-mediated deposition of repressive ubiquitin marks on H2A across the Xi territory.</td>
+<td style="text-align: left;">Pintacuda 2017 (ImmunoFISH &amp; Xist tethering); Valledor 2023 (Timing assays)</td>
+<td style="text-align: left;">Appears early in the 'sparse' XIST zone concurrent with CIZ1 recruitment and preceding widespread gene silencing.</td>
+<td style="text-align: left;">(valledor2023earlychromosomecondensation pages 1-3, pintacuda2017hnrnpkrecruitspcgf35prc1 pages 1-3, valledor2023earlychromosomecondensation media 58d592e8)</td>
+</tr>
+<tr>
+<td style="text-align: left;"><strong>Biological Process (BP)</strong></td>
+<td style="text-align: left;">Histone H3K27 methylation enrichment</td>
+<td style="text-align: left;">PRC2-mediated trimethylation of H3K27 to maintain and stabilize facultative heterochromatin.</td>
+<td style="text-align: left;">Pintacuda 2017 (Tethering complementation); Valledor 2023 (Time-course)</td>
+<td style="text-align: left;">Follows H2AK119ub deposition. Accumulates later in 'dense' RNA zones during chromosome condensation.</td>
+<td style="text-align: left;">(valledor2023earlychromosomecondensation pages 1-3, pintacuda2017hnrnpkrecruitspcgf35prc1 pages 10-13, valledor2023earlychromosomecondensation media 58d592e8)</td>
+</tr>
+<tr>
+<td style="text-align: left;"><strong>Biological Process (BP) / CC</strong></td>
+<td style="text-align: left;">Nuclear lamina tethering</td>
+<td style="text-align: left;">Recruits the Xi to the nuclear lamina to facilitate spreading to active genes.</td>
+<td style="text-align: left;">Chen 2016 (LBR knockdown, DLBS-Xist cells); Nesterova 2019 (Allelic analysis)</td>
+<td style="text-align: left;">Interaction with Lamin B Receptor (LBR). Nesterova 2019 indicates LBR plays only a minor or redundant role in aggregate silencing.</td>
+<td style="text-align: left;">(nesterova2019systematicallelicanalysis pages 1-2, chen2016xistrecruitsthe pages 1-2, chen2016xistrecruitsthe pages 3-4)</td>
+</tr>
+<tr>
+<td style="text-align: left;"><strong>Cellular Component (CC)</strong></td>
+<td style="text-align: left;">Nuclear matrix association</td>
+<td style="text-align: left;">Anchors XIST RNPs and Xi chromatin to the insoluble nuclear scaffold.</td>
+<td style="text-align: left;">Minajigi 2015 (Interactome); Valledor 2023 (CIZ1 immunofluorescence)</td>
+<td style="text-align: left;">Involves interactions with SAF-A (hnRNP U) and CIZ1. Recruited immediately alongside sparse XIST RNA.</td>
+<td style="text-align: left;">(valledor2023earlychromosomecondensation pages 1-3, minajigi2015acomprehensivexist pages 1-3, valledor2023earlychromosomecondensation media 58d592e8)</td>
+</tr>
+<tr>
+<td style="text-align: left;"><strong>Cellular Component (CC)</strong></td>
+<td style="text-align: left;">Nuclear localization to Xi territory</td>
+<td style="text-align: left;">Highly concentrated accumulation in a specific sub-nuclear compartment (the Xist cloud).</td>
+<td style="text-align: left;">Valledor 2023 (RNA FISH spatial mapping); Dror 2024 (Imaging)</td>
+<td style="text-align: left;">Forms a biphasic structure ('dense' vs 'sparse' zones) essential for bridging architectural changes and local gene repression.</td>
+<td style="text-align: left;">(dror2024xistdirectlyregulates pages 1-3, valledor2023earlychromosomecondensation pages 1-3, valledor2023earlychromosomecondensation media 58d592e8)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table maps specific Gene Ontology (GO) functional annotations for the human XIST lncRNA to their primary supporting literature and key mechanistic details.</em></p>
+<h3 id="distinguishing-core-mechanism-from-downstream-outcomes">Distinguishing core mechanism from downstream outcomes</h3>
+<ul>
+<li><strong>Core XIST molecular functions (mechanistic GO focus):</strong> cis coating/association with Xi territory; direct binding to SHARP/SPEN; recruitment/activation of SMRT/HDAC3 for histone deacetylation and Pol II exclusion; recruitment of hnRNPK to bring PCGF3/5-PRC1 and initiate Polycomb marking (H2AK119ub → PRC2/H3K27me3); nuclear lamina tethering via LBR enabling spreading to active genes; and driving chromosome condensation/organization (mchugh2015thexistlncrna pages 6-7, pintacuda2017hnrnpkrecruitspcgf35prc1 pages 10-13, chen2016xistrecruitsthe pages 1-2, valledor2023earlychromosomecondensation pages 1-3).</li>
+<li><strong>Downstream outcomes (should not be over-annotated as direct functions):</strong> organismal dosage compensation, sex-biased traits, and disease phenotypes are emergent consequences of the above molecular functions and should be annotated as higher-level BP outcomes only with careful scoping (gupta2024trisomysilencingby pages 1-3, dror2024xistdirectlyregulates pages 1-3).</li>
+</ul>
+<h3 id="notes-on-evidence-gaps-and-caution-for-go-annotation">Notes on evidence gaps and caution for GO annotation</h3>
+<ul>
+<li><strong>Context dependence:</strong> LBR/LBR-binding-site perturbations show strong effects in some systems (chen2016xistrecruitsthe pages 1-2) but only minor contributions in others (nesterova2019systematicallelicanalysis pages 1-2); GO annotations should reflect this as “contributes to” rather than strictly “essential for” across all contexts.</li>
+<li><strong>PRC2 recruitment:</strong> McHugh et al. report PRC2 enrichment depends on SHARP/HDAC3 and note that PRC2 components were not robustly identified as direct Xist interactors by RAP-MS, supporting an <strong>indirect</strong> or downstream recruitment model (mchugh2015thexistlncrna pages 6-7).</li>
+</ul>
+<h3 id="key-primary-references-with-urls-and-publication-dates">Key primary references (with URLs and publication dates)</h3>
+<ul>
+<li>McHugh CA et al. <strong>Nature</strong> (Apr 2015). “The Xist lncRNA interacts directly with SHARP to silence transcription through HDAC3.” https://doi.org/10.1038/nature14443 (mchugh2015thexistlncrna pages 1-2, mchugh2015thexistlncrna pages 6-7)</li>
+<li>Minajigi A et al. <strong>Science</strong> (Jun 2015). “A comprehensive Xist interactome reveals cohesin repulsion and an RNA-directed chromosome conformation.” https://doi.org/10.1126/science.aab2276 (minajigi2015acomprehensivexist pages 1-3)</li>
+<li>Chen C-K et al. <strong>Science</strong> (Oct 2016). “Xist recruits the X chromosome to the nuclear lamina to enable chromosome-wide silencing.” https://doi.org/10.1126/science.aae0047 (chen2016xistrecruitsthe pages 1-2, chen2016xistrecruitsthe pages 3-4)</li>
+<li>Pintacuda G et al. <strong>Molecular Cell</strong> (Dec 2017). “hnRNPK Recruits PCGF3/5-PRC1 to the Xist RNA B-Repeat to Establish Polycomb-Mediated Chromosomal Silencing.” https://doi.org/10.1016/j.molcel.2017.11.013 (pintacuda2017hnrnpkrecruitspcgf35prc1 pages 1-3, pintacuda2017hnrnpkrecruitspcgf35prc1 pages 10-13)</li>
+<li>Nesterova TB et al. <strong>Nature Communications</strong> (Nov 2019). “Systematic allelic analysis defines the interplay of key pathways in X chromosome inactivation.” https://doi.org/10.1038/s41467-019-11171-3 (nesterova2019systematicallelicanalysis pages 1-2)</li>
+<li>Valledor M et al. <strong>Cell Reports</strong> (Jul 2023). “Early chromosome condensation by XIST builds A-repeat RNA density that facilitates gene silencing.” https://doi.org/10.1016/j.celrep.2023.112686 (valledor2023earlychromosomecondensation pages 1-3, valledor2023earlychromosomecondensation pages 10-11, valledor2023earlychromosomecondensation media 58d592e8)</li>
+<li>Dror I et al. <strong>Cell</strong> (Jan 2024). “XIST directly regulates X-linked and autosomal genes in naive human pluripotent cells.” https://doi.org/10.1016/j.cell.2023.11.033 (dror2024xistdirectlyregulates pages 1-3)</li>
+<li>Bansal P et al. <strong>Science Advances</strong> (Jun 2024). “A dynamic in vitro model of Down syndrome neurogenesis with trisomy 21 gene dosage correction.” https://doi.org/10.1126/sciadv.adj0385 (bansal2024adynamicin pages 1-3)</li>
+<li>Gupta K et al. <strong>Human Genetics</strong> (Mar 2024). “Trisomy silencing by XIST: translational prospects and challenges.” https://doi.org/10.1007/s00439-024-02651-8 (gupta2024trisomysilencingby pages 1-3)</li>
+</ul>
+<p>References</p>
+<ol>
+<li>
+<p>(dror2024xistdirectlyregulates pages 1-3): Iris Dror, Tsotne Chitiashvili, Shawn Y.X. Tan, Clara T. Cano, Anna Sahakyan, Yolanda Markaki, Constantinos Chronis, Amanda J. Collier, Weixian Deng, Guohao Liang, Yu Sun, Anna Afasizheva, Jarrett Miller, Wen Xiao, Douglas L. Black, Fangyuan Ding, and Kathrin Plath. Xist directly regulates x-linked and autosomal genes in naive human pluripotent cells. Cell, 187:110-129.e31, Jan 2024. URL: https://doi.org/10.1016/j.cell.2023.11.033, doi:10.1016/j.cell.2023.11.033. This article has 74 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(valledor2023earlychromosomecondensation pages 1-3): Melvys Valledor, Meg Byron, Brett Dumas, Dawn M. Carone, Lisa L. Hall, and Jeanne B. Lawrence. Early chromosome condensation by xist builds a-repeat rna density that facilitates gene silencing. Cell Reports, 42:112686, Jul 2023. URL: https://doi.org/10.1016/j.celrep.2023.112686, doi:10.1016/j.celrep.2023.112686. This article has 23 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lu2020structuralmodularityof pages 1-2): Zhipeng Lu, Jimmy K. Guo, Yuning Wei, Diana R. Dou, Brian Zarnegar, Qing Ma, Rui Li, Yang Zhao, Fan Liu, Hani Choudhry, Paul A. Khavari, and Howard Y. Chang. Structural modularity of the xist ribonucleoprotein complex. Nature Communications, Dec 2020. URL: https://doi.org/10.1038/s41467-020-20040-3, doi:10.1038/s41467-020-20040-3. This article has 102 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lu2020structuralmodularityof pages 6-7): Zhipeng Lu, Jimmy K. Guo, Yuning Wei, Diana R. Dou, Brian Zarnegar, Qing Ma, Rui Li, Yang Zhao, Fan Liu, Hani Choudhry, Paul A. Khavari, and Howard Y. Chang. Structural modularity of the xist ribonucleoprotein complex. Nature Communications, Dec 2020. URL: https://doi.org/10.1038/s41467-020-20040-3, doi:10.1038/s41467-020-20040-3. This article has 102 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(minajigi2015acomprehensivexist pages 1-3): Anand Minajigi, John E. Froberg, Chunyao Wei, Hongjae Sunwoo, Barry Kesner, David Colognori, Derek Lessing, Bernhard Payer, Myriam Boukhali, Wilhelm Haas, and Jeannie T. Lee. A comprehensive xist interactome reveals cohesin repulsion and an rna-directed chromosome conformation. Science, Jul 2015. URL: https://doi.org/10.1126/science.aab2276, doi:10.1126/science.aab2276. This article has 587 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(mchugh2015thexistlncrna pages 1-2): Colleen A. McHugh, Chun-Kan Chen, Amy Chow, Christine F. Surka, Christina Tran, Patrick McDonel, Amy Pandya-Jones, Mario Blanco, Christina Burghard, Annie Moradian, Michael J. Sweredoski, Alexander A. Shishkin, Julia Su, Eric S. Lander, Sonja Hess, Kathrin Plath, and Mitchell Guttman. The xist lncrna interacts directly with sharp to silence transcription through hdac3. Nature, 521:232-236, Apr 2015. URL: https://doi.org/10.1038/nature14443, doi:10.1038/nature14443. This article has 1319 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(mchugh2015thexistlncrna pages 6-7): Colleen A. McHugh, Chun-Kan Chen, Amy Chow, Christine F. Surka, Christina Tran, Patrick McDonel, Amy Pandya-Jones, Mario Blanco, Christina Burghard, Annie Moradian, Michael J. Sweredoski, Alexander A. Shishkin, Julia Su, Eric S. Lander, Sonja Hess, Kathrin Plath, and Mitchell Guttman. The xist lncrna interacts directly with sharp to silence transcription through hdac3. Nature, 521:232-236, Apr 2015. URL: https://doi.org/10.1038/nature14443, doi:10.1038/nature14443. This article has 1319 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(pintacuda2017hnrnpkrecruitspcgf35prc1 pages 1-3): Greta Pintacuda, Guifeng Wei, Chloë Roustan, Burcu Anil Kirmizitas, Nicolae Solcan, Andrea Cerase, Alfredo Castello, Shabaz Mohammed, Benoît Moindrot, Tatyana B. Nesterova, and Neil Brockdorff. Hnrnpk recruits pcgf3/5-prc1 to the xist rna b-repeat to establish polycomb-mediated chromosomal silencing. Molecular Cell, 68:955-969.e10, Dec 2017. URL: https://doi.org/10.1016/j.molcel.2017.11.013, doi:10.1016/j.molcel.2017.11.013. This article has 403 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(pintacuda2017hnrnpkrecruitspcgf35prc1 pages 10-13): Greta Pintacuda, Guifeng Wei, Chloë Roustan, Burcu Anil Kirmizitas, Nicolae Solcan, Andrea Cerase, Alfredo Castello, Shabaz Mohammed, Benoît Moindrot, Tatyana B. Nesterova, and Neil Brockdorff. Hnrnpk recruits pcgf3/5-prc1 to the xist rna b-repeat to establish polycomb-mediated chromosomal silencing. Molecular Cell, 68:955-969.e10, Dec 2017. URL: https://doi.org/10.1016/j.molcel.2017.11.013, doi:10.1016/j.molcel.2017.11.013. This article has 403 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(chen2016xistrecruitsthe pages 1-2): Chun-Kan Chen, Mario Blanco, Constanza Jackson, Erik Aznauryan, Noah Ollikainen, Christine Surka, Amy Chow, Andrea Cerase, Patrick McDonel, and Mitchell Guttman. Xist recruits the x chromosome to the nuclear lamina to enable chromosome-wide silencing. Science, 354:468-472, Oct 2016. URL: https://doi.org/10.1126/science.aae0047, doi:10.1126/science.aae0047. This article has 348 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(chen2016xistrecruitsthe pages 3-4): Chun-Kan Chen, Mario Blanco, Constanza Jackson, Erik Aznauryan, Noah Ollikainen, Christine Surka, Amy Chow, Andrea Cerase, Patrick McDonel, and Mitchell Guttman. Xist recruits the x chromosome to the nuclear lamina to enable chromosome-wide silencing. Science, 354:468-472, Oct 2016. URL: https://doi.org/10.1126/science.aae0047, doi:10.1126/science.aae0047. This article has 348 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(nesterova2019systematicallelicanalysis pages 1-2): Tatyana B Nesterova, Guifeng Wei, Heather Coker, Greta Pintacuda, Joseph S Bowness, Tianyi Zhang, Mafalda Almeida, Bianca Bloechl, Benoit Moindrot, Emma J Carter, Ines Alvarez Rodrigo, Qi Pan, Ying Bi, Chun-Xiao Song, and Neil Brockdorff. Systematic allelic analysis defines the interplay of key pathways in x chromosome inactivation. Nature Communications, Nov 2019. URL: https://doi.org/10.1038/s41467-019-11171-3, doi:10.1038/s41467-019-11171-3. This article has 160 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(valledor2023earlychromosomecondensation media 58d592e8): Melvys Valledor, Meg Byron, Brett Dumas, Dawn M. Carone, Lisa L. Hall, and Jeanne B. Lawrence. Early chromosome condensation by xist builds a-repeat rna density that facilitates gene silencing. Cell Reports, 42:112686, Jul 2023. URL: https://doi.org/10.1016/j.celrep.2023.112686, doi:10.1016/j.celrep.2023.112686. This article has 23 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(valledor2023earlychromosomecondensation pages 10-11): Melvys Valledor, Meg Byron, Brett Dumas, Dawn M. Carone, Lisa L. Hall, and Jeanne B. Lawrence. Early chromosome condensation by xist builds a-repeat rna density that facilitates gene silencing. Cell Reports, 42:112686, Jul 2023. URL: https://doi.org/10.1016/j.celrep.2023.112686, doi:10.1016/j.celrep.2023.112686. This article has 23 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(bansal2024adynamicin pages 1-3): Prakhar Bansal, Erin C. Banda, Heather R. Glatt-Deeley, Christopher E. Stoddard, Jeremy W. Linsley, Neha Arora, Cécile Deleschaux, Darcy T. Ahern, Yuvabharath Kondaveeti, Rachael E. Massey, Michael Nicouleau, Shijie Wang, Miguel Sabariego-Navarro, Mara Dierssen, Steven Finkbeiner, and Stefan F. Pinter. A dynamic in vitro model of down syndrome neurogenesis with trisomy 21 gene dosage correction. Science Advances, Jun 2024. URL: https://doi.org/10.1126/sciadv.adj0385, doi:10.1126/sciadv.adj0385. This article has 14 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(gupta2024trisomysilencingby pages 1-3): Khusali Gupta, Jan T. Czerminski, and Jeanne B. Lawrence. Trisomy silencing by xist: translational prospects and challenges. Human Genetics, 143:843-855, Mar 2024. URL: https://doi.org/10.1007/s00439-024-02651-8, doi:10.1007/s00439-024-02651-8. This article has 18 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(loda2019xistrnain pages 7-9): Agnese Loda and Edith Heard. Xist rna in action: past, present, and future. PLOS Genetics, 15:e1008333, Sep 2019. URL: https://doi.org/10.1371/journal.pgen.1008333, doi:10.1371/journal.pgen.1008333. This article has 313 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(loda2019xistrnain pages 13-14): Agnese Loda and Edith Heard. Xist rna in action: past, present, and future. PLOS Genetics, 15:e1008333, Sep 2019. URL: https://doi.org/10.1371/journal.pgen.1008333, doi:10.1371/journal.pgen.1008333. This article has 313 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(minajigi2015acomprehensivexist pages 6-8): Anand Minajigi, John E. Froberg, Chunyao Wei, Hongjae Sunwoo, Barry Kesner, David Colognori, Derek Lessing, Bernhard Payer, Myriam Boukhali, Wilhelm Haas, and Jeannie T. Lee. A comprehensive xist interactome reveals cohesin repulsion and an rna-directed chromosome conformation. Science, Jul 2015. URL: https://doi.org/10.1126/science.aab2276, doi:10.1126/science.aab2276. This article has 587 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(mchugh2015thexistlncrna pages 4-6): Colleen A. McHugh, Chun-Kan Chen, Amy Chow, Christine F. Surka, Christina Tran, Patrick McDonel, Amy Pandya-Jones, Mario Blanco, Christina Burghard, Annie Moradian, Michael J. Sweredoski, Alexander A. Shishkin, Julia Su, Eric S. Lander, Sonja Hess, Kathrin Plath, and Mitchell Guttman. The xist lncrna interacts directly with sharp to silence transcription through hdac3. Nature, 521:232-236, Apr 2015. URL: https://doi.org/10.1038/nature14443, doi:10.1038/nature14443. This article has 1319 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>minajigi2015acomprehensivexist pages 1-3</li>
+<li>mchugh2015thexistlncrna pages 6-7</li>
+<li>chen2016xistrecruitsthe pages 1-2</li>
+<li>nesterova2019systematicallelicanalysis pages 1-2</li>
+<li>valledor2023earlychromosomecondensation pages 10-11</li>
+<li>dror2024xistdirectlyregulates pages 1-3</li>
+<li>bansal2024adynamicin pages 1-3</li>
+<li>gupta2024trisomysilencingby pages 1-3</li>
+<li>valledor2023earlychromosomecondensation pages 1-3</li>
+<li>lu2020structuralmodularityof pages 1-2</li>
+<li>lu2020structuralmodularityof pages 6-7</li>
+<li>mchugh2015thexistlncrna pages 1-2</li>
+<li>chen2016xistrecruitsthe pages 3-4</li>
+<li>loda2019xistrnain pages 7-9</li>
+<li>loda2019xistrnain pages 13-14</li>
+<li>minajigi2015acomprehensivexist pages 6-8</li>
+<li>mchugh2015thexistlncrna pages 4-6</li>
+<li>https://doi.org/10.1038/nature14443</li>
+<li>https://doi.org/10.1126/science.aab2276</li>
+<li>https://doi.org/10.1126/science.aae0047</li>
+<li>https://doi.org/10.1016/j.molcel.2017.11.013</li>
+<li>https://doi.org/10.1038/s41467-019-11171-3</li>
+<li>https://doi.org/10.1016/j.celrep.2023.112686</li>
+<li>https://doi.org/10.1016/j.cell.2023.11.033</li>
+<li>https://doi.org/10.1126/sciadv.adj0385</li>
+<li>https://doi.org/10.1007/s00439-024-02651-8</li>
+<li>https://doi.org/10.1016/j.cell.2023.11.033,</li>
+<li>https://doi.org/10.1016/j.celrep.2023.112686,</li>
+<li>https://doi.org/10.1038/s41467-020-20040-3,</li>
+<li>https://doi.org/10.1126/science.aab2276,</li>
+<li>https://doi.org/10.1038/nature14443,</li>
+<li>https://doi.org/10.1016/j.molcel.2017.11.013,</li>
+<li>https://doi.org/10.1126/science.aae0047,</li>
+<li>https://doi.org/10.1038/s41467-019-11171-3,</li>
+<li>https://doi.org/10.1126/sciadv.adj0385,</li>
+<li>https://doi.org/10.1007/s00439-024-02651-8,</li>
+<li>https://doi.org/10.1371/journal.pgen.1008333,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -2587,6 +2885,18 @@ taxon:
   label: Homo sapiens
 description: X-inactive specific transcript (XIST) is a master regulatory long non-coding RNA that orchestrates X-chromosome inactivation in female mammalian cells. XIST coats the inactive X chromosome and recruits chromatin-modifying complexes to establish and maintain transcriptional silencing.
 references:
+- id: file:human/XIST/XIST-deep-research-falcon.md
+  title: Falcon deep research report for XIST
+  findings:
+  - statement: &gt;-
+      Falcon supports XIST as a noncoding RNA chromatin scaffold/adaptor that
+      coats the inactive X in cis, recruits silencing and chromatin-modifying
+      factors, and establishes repressive chromatin during X-chromosome
+      inactivation.
+    supporting_text: &gt;-
+      XIST&#39;s core molecular role is an RNA/chromatin scaffold or adaptor that
+      coats the inactive X in cis, recruits transcriptional repressors and
+      chromatin-modifying complexes, and helps establish repressive chromatin.
 - id: PMID:23142477
   title: Recent advances in X-chromosome inactivation research
 - id: PMID:9069284
@@ -2629,17 +2939,6 @@ existing_annotations:
     - reference_id: PMID:9069284
       supporting_text: this gene is required for X inactivation to occur in cis
 - term:
-    id: GO:0003677
-    label: DNA binding
-  evidence_type: IMP
-  original_reference_id: PMID:34312245
-  review:
-    summary: XIST RNA localizes to and coats the inactive X chromosome through DNA interaction
-    action: NEW
-    supported_by:
-    - reference_id: PMID:34312245
-      supporting_text: &#34;Xist coating triggers a cascade of chromosome-wide changes occurring at the levels of transcription, chromatin composition, chromosome structure, and spatial organization&#34;
-- term:
     id: GO:0009048
     label: dosage compensation by inactivation of X chromosome
   evidence_type: IEA
@@ -2663,6 +2962,10 @@ existing_annotations:
       supporting_text: &#34;Xist, an essential lncRNA for X chromosome inactivation (XCI), interacts with 81 proteins from chromatin modification, nuclear matrix, and RNA remodeling pathways&#34;
     - reference_id: PMID:32482714
       supporting_text: Progress toward understanding chromosome silencing by Xist RNA.
+    - reference_id: file:human/XIST/XIST-deep-research-falcon.md
+      supporting_text: &gt;-
+        XIST engages many proteins through modular repeat regions and
+        higher-order RNA folding, supporting its scaffold/adaptor role.
 - term:
     id: GO:0031048
     label: regulatory ncRNA-mediated heterochromatin formation
@@ -2674,6 +2977,10 @@ existing_annotations:
     supported_by:
     - reference_id: PMID:25843628
       supporting_text: &#34;Xist lncRNA engages with proteins in a modular and developmentally controlled manner to coordinate chromatin spreading and silencing&#34;
+    - reference_id: file:human/XIST/XIST-deep-research-falcon.md
+      supporting_text: &gt;-
+        XIST modifies chromosome territory architecture before widespread gene
+        silencing, creating distinct RNA zones with different chromatin impacts.
 - term:
     id: GO:0060816
     label: random inactivation of X chromosome
@@ -2811,34 +3118,38 @@ existing_annotations:
 core_functions:
 - description: X-chromosome coating and silencing
   molecular_function:
-    id: GO:0003677
-    label: DNA binding
+    id: GO:0140463
+    label: chromatin-protein adaptor activity
   supported_by:
-  - reference_id: PMID:23562786
-    supporting_text: XIST localizes to and coats the inactive X chromosome
-    full_text_unavailable: true
+  - reference_id: file:human/XIST/XIST-deep-research-falcon.md
+    supporting_text: &gt;-
+      XIST coats the future inactive X chromosome to establish a repressive
+      nuclear territory.
 - description: chromatin modification recruitment
   molecular_function:
-    id: GO:0003677
-    label: DNA binding
+    id: GO:0140463
+    label: chromatin-protein adaptor activity
   supported_by:
-  - reference_id: PMID:23868259
-    supporting_text: XIST recruits chromatin-modifying complexes to establish silencing
-    full_text_unavailable: true
+  - reference_id: file:human/XIST/XIST-deep-research-falcon.md
+    supporting_text: &gt;-
+      XIST&#39;s core molecular role is an RNA/chromatin scaffold or adaptor that
+      recruits transcriptional repressors and chromatin-modifying complexes.
 - description: nuclear organization
   molecular_function:
-    id: GO:0003677
-    label: DNA binding
+    id: GO:0140463
+    label: chromatin-protein adaptor activity
   supported_by:
-  - reference_id: PMID:34312245
-    supporting_text: Genetic perturbation of the mechanisms involved, however, reveals that nuclear organization is not as essential as previously thought in ensuring that one X chromosome becomes inactivated
+  - reference_id: file:human/XIST/XIST-deep-research-falcon.md
+    supporting_text: &gt;-
+      XIST modifies chromosome territory architecture before widespread gene
+      silencing, creating distinct RNA zones with different chromatin impacts.
 proposed_new_terms:
 - proposed_name: X-chromosome coating activity
   proposed_definition: The molecular function of a long non-coding RNA that spreads along and coats an entire X chromosome to facilitate transcriptional silencing
   justification: XIST&#39;s unique ability to coat an entire chromosome is not captured by existing GO terms
   proposed_parent:
-    id: GO:0003677
-    label: DNA binding
+    id: GO:0140463
+    label: chromatin-protein adaptor activity
   supported_by:
   - reference_id: PMID:9069284
     supporting_text: Here we show that Xist, introduced onto an autosome, is sufficient by itself for inactivation in cis and that Xist RNA becomes localized close to the autosome into which the gene is integrated
@@ -2866,7 +3177,7 @@ status: COMPLETE
     </div>
 
     <!-- Pathway Visualization Link -->
-    
+
 
     <style>
         /* Markdown Section Styles */

--- a/genes/human/XIST/XIST-ai-review.yaml
+++ b/genes/human/XIST/XIST-ai-review.yaml
@@ -6,6 +6,18 @@ taxon:
   label: Homo sapiens
 description: X-inactive specific transcript (XIST) is a master regulatory long non-coding RNA that orchestrates X-chromosome inactivation in female mammalian cells. XIST coats the inactive X chromosome and recruits chromatin-modifying complexes to establish and maintain transcriptional silencing.
 references:
+- id: file:human/XIST/XIST-deep-research-falcon.md
+  title: Falcon deep research report for XIST
+  findings:
+  - statement: >-
+      Falcon supports XIST as a noncoding RNA chromatin scaffold/adaptor that
+      coats the inactive X in cis, recruits silencing and chromatin-modifying
+      factors, and establishes repressive chromatin during X-chromosome
+      inactivation.
+    supporting_text: >-
+      XIST's core molecular role is an RNA/chromatin scaffold or adaptor that
+      coats the inactive X in cis, recruits transcriptional repressors and
+      chromatin-modifying complexes, and helps establish repressive chromatin.
 - id: PMID:23142477
   title: Recent advances in X-chromosome inactivation research
 - id: PMID:9069284
@@ -48,17 +60,6 @@ existing_annotations:
     - reference_id: PMID:9069284
       supporting_text: this gene is required for X inactivation to occur in cis
 - term:
-    id: GO:0003677
-    label: DNA binding
-  evidence_type: IMP
-  original_reference_id: PMID:34312245
-  review:
-    summary: XIST RNA localizes to and coats the inactive X chromosome through DNA interaction
-    action: NEW
-    supported_by:
-    - reference_id: PMID:34312245
-      supporting_text: "Xist coating triggers a cascade of chromosome-wide changes occurring at the levels of transcription, chromatin composition, chromosome structure, and spatial organization"
-- term:
     id: GO:0009048
     label: dosage compensation by inactivation of X chromosome
   evidence_type: IEA
@@ -82,6 +83,10 @@ existing_annotations:
       supporting_text: "Xist, an essential lncRNA for X chromosome inactivation (XCI), interacts with 81 proteins from chromatin modification, nuclear matrix, and RNA remodeling pathways"
     - reference_id: PMID:32482714
       supporting_text: Progress toward understanding chromosome silencing by Xist RNA.
+    - reference_id: file:human/XIST/XIST-deep-research-falcon.md
+      supporting_text: >-
+        XIST engages many proteins through modular repeat regions and
+        higher-order RNA folding, supporting its scaffold/adaptor role.
 - term:
     id: GO:0031048
     label: regulatory ncRNA-mediated heterochromatin formation
@@ -93,6 +98,10 @@ existing_annotations:
     supported_by:
     - reference_id: PMID:25843628
       supporting_text: "Xist lncRNA engages with proteins in a modular and developmentally controlled manner to coordinate chromatin spreading and silencing"
+    - reference_id: file:human/XIST/XIST-deep-research-falcon.md
+      supporting_text: >-
+        XIST modifies chromosome territory architecture before widespread gene
+        silencing, creating distinct RNA zones with different chromatin impacts.
 - term:
     id: GO:0060816
     label: random inactivation of X chromosome
@@ -230,34 +239,38 @@ existing_annotations:
 core_functions:
 - description: X-chromosome coating and silencing
   molecular_function:
-    id: GO:0003677
-    label: DNA binding
+    id: GO:0140463
+    label: chromatin-protein adaptor activity
   supported_by:
-  - reference_id: PMID:23562786
-    supporting_text: XIST localizes to and coats the inactive X chromosome
-    full_text_unavailable: true
+  - reference_id: file:human/XIST/XIST-deep-research-falcon.md
+    supporting_text: >-
+      XIST coats the future inactive X chromosome to establish a repressive
+      nuclear territory.
 - description: chromatin modification recruitment
   molecular_function:
-    id: GO:0003677
-    label: DNA binding
+    id: GO:0140463
+    label: chromatin-protein adaptor activity
   supported_by:
-  - reference_id: PMID:23868259
-    supporting_text: XIST recruits chromatin-modifying complexes to establish silencing
-    full_text_unavailable: true
+  - reference_id: file:human/XIST/XIST-deep-research-falcon.md
+    supporting_text: >-
+      XIST's core molecular role is an RNA/chromatin scaffold or adaptor that
+      recruits transcriptional repressors and chromatin-modifying complexes.
 - description: nuclear organization
   molecular_function:
-    id: GO:0003677
-    label: DNA binding
+    id: GO:0140463
+    label: chromatin-protein adaptor activity
   supported_by:
-  - reference_id: PMID:34312245
-    supporting_text: Genetic perturbation of the mechanisms involved, however, reveals that nuclear organization is not as essential as previously thought in ensuring that one X chromosome becomes inactivated
+  - reference_id: file:human/XIST/XIST-deep-research-falcon.md
+    supporting_text: >-
+      XIST modifies chromosome territory architecture before widespread gene
+      silencing, creating distinct RNA zones with different chromatin impacts.
 proposed_new_terms:
 - proposed_name: X-chromosome coating activity
   proposed_definition: The molecular function of a long non-coding RNA that spreads along and coats an entire X chromosome to facilitate transcriptional silencing
   justification: XIST's unique ability to coat an entire chromosome is not captured by existing GO terms
   proposed_parent:
-    id: GO:0003677
-    label: DNA binding
+    id: GO:0140463
+    label: chromatin-protein adaptor activity
   supported_by:
   - reference_id: PMID:9069284
     supporting_text: Here we show that Xist, introduced onto an autosome, is sufficient by itself for inactivation in cis and that Xist RNA becomes localized close to the autosome into which the gene is integrated

--- a/genes/human/XIST/XIST-deep-research-falcon.md
+++ b/genes/human/XIST/XIST-deep-research-falcon.md
@@ -1,0 +1,227 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-11T03:29:14.838881'
+end_time: '2026-05-11T03:59:39.133263'
+duration_seconds: 1824.29
+provider_config:
+  timeout: 600
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 37
+---
+
+## Question
+
+Research the human long non-coding RNA gene XIST (X-inactive specific transcript; RNAcentral URS000075D95B_9606) for Gene Ontology functional annotation. This is a lncRNA/non-coding RNA, not a protein; do not infer protein domains or enzyme activity. Focus on its core molecular function as a chromatin/RNA scaffold or chromatin-protein adaptor in X-chromosome inactivation, XIST coating of the inactive X, recruitment of silencing and chromatin-modifying complexes, heterochromatin formation, cellular localization, and which GO terms are directly supported by primary literature. Distinguish core X-inactivation function from broad dosage-compensation outcomes, and provide citations for each major claim.
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+Research the human long non-coding RNA gene XIST (X-inactive specific transcript; RNAcentral URS000075D95B_9606) for Gene Ontology functional annotation. This is a lncRNA/non-coding RNA, not a protein; do not infer protein domains or enzyme activity. Focus on its core molecular function as a chromatin/RNA scaffold or chromatin-protein adaptor in X-chromosome inactivation, XIST coating of the inactive X, recruitment of silencing and chromatin-modifying complexes, heterochromatin formation, cellular localization, and which GO terms are directly supported by primary literature. Distinguish core X-inactivation function from broad dosage-compensation outcomes, and provide citations for each major claim.
+
+## Research report: Gene Ontology (GO) functional annotation evidence for human XIST lncRNA (RNAcentral: URS000075D95B_9606)
+
+### Scope and constraints
+This report summarizes primary-literature evidence that supports GO-style functional annotations for **XIST**, a **long non-coding RNA (lncRNA)** that orchestrates **X-chromosome inactivation (XCI)**. XIST is **not a protein**; therefore this report does **not** infer protein domains or enzymatic activities. Instead it focuses on XIST’s core molecular role as an **RNA/chromatin scaffold or adaptor** that (i) coats the inactive X in cis, (ii) recruits transcriptional repressors and chromatin-modifying complexes, (iii) helps establish repressive chromatin and higher-order chromosome organization, and (iv) localizes to defined nuclear compartments (Xi territory; nuclear lamina/nuclear matrix). Claims about **dosage compensation outcomes** are distinguished from the **core mechanistic functions**.
+
+### Key concepts and current understanding (definitions)
+
+#### X-chromosome inactivation (XCI)
+XCI is a mammalian epigenetic program that transcriptionally silences most genes on one X chromosome in XX cells to balance X-linked gene dosage. XIST/Xist is required and is expressed from the future inactive X and spreads in cis to create a coated X territory where silencing and repressive chromatin accumulate (dror2024xistdirectlyregulates pages 1-3, valledor2023earlychromosomecondensation pages 1-3).
+
+#### “Coating” and Xi territory formation
+“Coating” refers to the accumulation of XIST RNA across the chromosome territory (often observed as an XIST “cloud”), which is necessary to spatially concentrate silencing factors and establish a repressive nuclear compartment (dror2024xistdirectlyregulates pages 1-3, valledor2023earlychromosomecondensation pages 1-3).
+
+#### Modular scaffold/adaptor model
+XIST engages many proteins through modular repeat regions and higher-order RNA folding. Large-scale structural and interaction mapping shows that XIST forms a modular ribonucleoprotein architecture with clustered protein-binding domains (lu2020structuralmodularityof pages 1-2, lu2020structuralmodularityof pages 6-7). Systematic interactome mapping identifies multiple direct Xist-binding proteins (including chromatin and nuclear-envelope factors), supporting its scaffold/adaptor role (minajigi2015acomprehensivexist pages 1-3).
+
+### Core XIST molecular functions directly supported by primary literature
+
+#### 1) Recruitment of SHARP/SPEN → SMRT/NCoR → HDAC3 to initiate transcriptional silencing and RNA Pol II exclusion
+**Primary evidence:** McHugh et al. used RAP-MS to identify proteins that directly associate with Xist and showed that **SHARP (SPEN)** is among the direct interactors required for silencing; SHARP is required for **RNA polymerase II exclusion** from the Xist-coated territory, and **SMRT** and **HDAC3** are also required for silencing and Pol II exclusion (mchugh2015thexistlncrna pages 1-2, mchugh2015thexistlncrna pages 6-7). The paper’s mechanistic model links SHARP (a direct Xist-binding factor) to recruitment/activation of HDAC3 through SMRT, consistent with histone deacetylation-based transcriptional repression (mchugh2015thexistlncrna pages 6-7).
+
+**Interpretation for GO annotation:** This supports GO molecular-function-style annotations centered on **protein binding** and **corepressor complex recruitment**, and GO biological-process annotations for **transcriptional gene silencing** and **RNA polymerase II exclusion from chromatin territory** (mchugh2015thexistlncrna pages 6-7, mchugh2015thexistlncrna pages 1-2).
+
+#### 2) Polycomb recruitment via hnRNPK binding to Xist B-repeat/XR-PID and initiation of PRC1→PRC2 cascade
+**Primary evidence:** Pintacuda et al. mapped an Xist **Polycomb Interaction Domain** (XR-PID; ~600 nt encompassing B-repeat), where deletion abrogates Polycomb recruitment and Xist-dependent chromosome silencing, and identified **hnRNPK** as the principal XR-PID binding factor needed to recruit **PCGF3/5-PRC1** (pintacuda2017hnrnpkrecruitspcgf35prc1 pages 1-3). They further showed **direct biochemical interaction** between hnRNPK and a recombinant PCGF3-PRC1 complex and demonstrated that **synthetic tethering of hnRNPK** to XR-PID–deleted Xist restores H2AK119ub and H3K27me3 accumulation over the Xist domain (pintacuda2017hnrnpkrecruitspcgf35prc1 pages 10-13).
+
+**Interpretation for GO annotation:** These data directly support annotations for **Polycomb complex recruitment**, **H2A K119 ubiquitination involved in chromatin silencing**, and establishment of repressive chromatin states downstream of PRC1/PRC2 (pintacuda2017hnrnpkrecruitspcgf35prc1 pages 1-3, pintacuda2017hnrnpkrecruitspcgf35prc1 pages 10-13).
+
+#### 3) Nuclear lamina tethering through LBR and functional impact on spreading to active genes
+**Primary evidence:** Chen et al. report that Xist **directly interacts** with **lamin B receptor (LBR)** and that this interaction is required for Xist-mediated silencing by recruiting the inactive X to the **nuclear lamina**, enabling Xist to spread to actively transcribed genes across the X (chen2016xistrecruitsthe pages 1-2). The paper includes functional tests showing LBR perturbation disrupts silencing and lamina association, and that engineered tethering strategies can rescue spreading/silencing defects, consistent with a mechanistic role for lamina recruitment in chromosome-wide silencing (chen2016xistrecruitsthe pages 1-2, chen2016xistrecruitsthe pages 3-4).
+
+**Important limitation / nuance:** A systematic allelic dissection of Xist pathways reported that **LBR makes only minor contributions** to gene silencing in the tested ESC models, suggesting redundancy or context-dependence of LBR-mediated effects across systems (nesterova2019systematicallelicanalysis pages 1-2).
+
+**Interpretation for GO annotation:** Supports CC/BP annotations for **nuclear lamina association** and BP annotations linking XIST to chromosome-wide silencing through nuclear positioning/spreading mechanisms, while indicating potential context specificity (chen2016xistrecruitsthe pages 1-2, nesterova2019systematicallelicanalysis pages 1-2).
+
+#### 4) Xist/XIST interactome evidence for nuclear-envelope/nuclear-matrix factors and chromosome conformation control
+**Primary evidence:** Minajigi et al. developed iDRiP to identify a broad set of **direct Xist-interacting proteins**, including nuclear-envelope components (e.g., LBR) and nuclear matrix proteins (hnRPU/SAF-A, hnRNPK), and explored functional impacts on Xi repression and chromosome conformation (minajigi2015acomprehensivexist pages 1-3).
+
+**Interpretation for GO annotation:** Supports MF/CC terms around **protein binding**, **nuclear matrix association**, and BP terms tied to **chromosome organization** and the assembly of a repressive chromosome territory (minajigi2015acomprehensivexist pages 1-3).
+
+#### 5) Early heterochromatinization/compaction as a distinct, measurable process driven by XIST RNA density
+**Primary evidence (2023):** Valledor et al. used inducible human XIST to show that XIST modifies chromosome territory architecture before widespread gene silencing, creating distinct **“sparse” and “dense” RNA zones** with different chromatin impacts; **H2AK119ub and CIZ1** appear rapidly, while **H3K27me3** appears later in the dense zone as condensation proceeds (valledor2023earlychromosomecondensation pages 1-3, valledor2023earlychromosomecondensation media 58d592e8). Critically, they report quantitative local gene silencing by the isolated A-repeat fragment: transcription foci for nearby genes dropped **~82% (DSCR3) and ~83% (TTC3)** upon induction, indicating strong local repression (valledor2023earlychromosomecondensation pages 10-11). Their data support a model where condensation builds a high-density RNA/DNA environment that facilitates an A-repeat/HDAC-dependent silencing step (valledor2023earlychromosomecondensation pages 1-3, valledor2023earlychromosomecondensation pages 10-11, valledor2023earlychromosomecondensation media 58d592e8).
+
+**Interpretation for GO annotation:** Supports BP terms such as **heterochromatin formation**, **chromosome condensation/organization**, and chromatin-mark deposition timing consistent with Polycomb involvement (valledor2023earlychromosomecondensation pages 1-3, valledor2023earlychromosomecondensation media 58d592e8).
+
+### Recent developments and latest research (prioritizing 2023–2024)
+
+#### A) XIST localization states and non-canonical (dispersed) configurations in naïve human pluripotent cells (2024)
+Dror et al. (Cell, publication date 2024-01-04; URL in record) report that in **naïve human pluripotent stem cells**, XIST shows a **dispersed nuclear configuration** and is associated with **X-chromosome dampening** rather than full silencing; they further report that XIST spreads across the X chromosome and can target specific autosomal regions with associated gene-expression dampening and repressive chromatin changes (dror2024xistdirectlyregulates pages 1-3). This expands the functional landscape of XIST localization beyond the classical compact Xi cloud, while still being consistent with scaffold/adaptor logic (dror2024xistdirectlyregulates pages 1-3).
+
+#### B) Quantitative, time-resolved architecture-first model for initiation (2023)
+Valledor et al. provide an explicit time ordering: rapid appearance of H2AK119ub/CIZ1 with early sparse RNA, later H3K27me3 coincident with dense zone expansion and condensation, and gene silencing after compaction (valledor2023earlychromosomecondensation pages 1-3, valledor2023earlychromosomecondensation media 58d592e8).
+
+#### C) Translational and experimental “chromosome therapy” platforms using XIST transgenes (2024)
+A 2024 Science Advances study established a dynamic trisomy 21 iPSC model where an inducible XIST transgene on chromosome 21 yields homogenous XIST clouds with H2AK119ub/H3K27me3 and near-complete repression of the targeted allele; importantly, repression remains efficient even after terminal differentiation, enabling post-developmental dosage-correction experiments (bansal2024adynamicin pages 1-3). A 2024 Human Genetics review synthesizes translational prospects/challenges and reports Down syndrome incidence in the US as **~1/750 live births** and chromosomal abnormalities collectively as **~1/150 newborns**, framing real-world motivations for XIST-based dosage correction research (gupta2024trisomysilencingby pages 1-3).
+
+### Applications and real-world implementations
+
+1. **In vitro dosage correction / disease modeling (Trisomy 21):** XIST transgene insertion on one chromosome 21 enables monoallelic chromosome-wide repression, providing a platform to dissect which phenotypes depend on ongoing trisomic dosage and which can be corrected later (bansal2024adynamicin pages 1-3).
+2. **Translational roadmapping for chromosome dosage disorders:** The 2024 review outlines how XIST transgenics could inform future therapeutic strategies, while emphasizing major technical and biological hurdles for in vivo application (gupta2024trisomysilencingby pages 1-3).
+
+### Expert opinions and authoritative synthesis (used cautiously)
+Where reviews are used, they are treated as secondary synthesis rather than primary GO evidence. Loda & Heard (2019) provides a consolidated view of modular repeat functions and the landscape of interactors, consistent with the primary evidence that SPEN/SHARP–HDAC3 and hnRNPK–PRC1 are central pathways, and that LBR effects may be modest in some models (loda2019xistrnain pages 7-9, loda2019xistrnain pages 13-14).
+
+### Statistics and quantitative findings from recent studies
+- **Local repression by A-repeat alone:** transcription foci decreased **82% (DSCR3)** and **83% (TTC3)** upon A-repeat induction in a human iPSC transgene context, supporting strong local gene repression capacity when RNA density is high (valledor2023earlychromosomecondensation pages 10-11).
+- **Down syndrome incidence:** ~**1/750** live births in the US (reviewed statistic) (gupta2024trisomysilencingby pages 1-3).
+- **Chromosomal abnormalities overall:** ~**1/150** newborns (reviewed statistic) (gupta2024trisomysilencingby pages 1-3).
+
+### GO-term mapping (candidate annotations supported by primary literature)
+The following table summarizes candidate GO terms for XIST that are directly supported by the evidence assembled here.
+
+| GO Category | Candidate GO Term | Concise Definition for XIST | Key Primary Evidence | Mechanistic Notes & Limitations | Citations |
+| :--- | :--- | :--- | :--- | :--- | :--- |
+| **Biological Process (BP)** | X-chromosome inactivation | Initiates cis-limited chromosome-wide gene silencing across the inactive X (Xi). | McHugh 2015 (RAP-MS & knockdown); Dror 2024 (naïve hPSC localization) | Core mechanism; functions as a cis-acting lncRNA scaffold. Dror 2024 shows trans-acting capabilities in early development. | (dror2024xistdirectlyregulates pages 1-3, mchugh2015thexistlncrna pages 1-2) |
+| **Biological Process (BP)** | Dosage compensation by X inactivation | Equalizes expression of X-linked genes between male and female somatic cells. | Dror 2024, Gupta 2024, Bansal 2024 (iPSC models & transgene targeting) | Downstream biological outcome. Can also be repurposed for autosomal dosage correction (e.g., Trisomy 21). | (dror2024xistdirectlyregulates pages 1-3, gupta2024trisomysilencingby pages 1-3, bansal2024adynamicin pages 1-3) |
+| **Molecular Function (MF)** | Protein binding / RNA binding | Scaffolds multiple interacting proteins via a folded, evolutionarily conserved modular architecture. | Minajigi 2015 (iDRiP-MS); Lu 2020 (PARIS, fRIP-seq, eCLIP) | Modularity specifies unique interaction zones for specific RBPs (e.g., A-repeat, B/C-repeats). | (lu2020structuralmodularityof pages 1-2, minajigi2015acomprehensivexist pages 1-3) |
+| **Cellular Component (CC) / MF** | Chromatin binding / association | Coats the future inactive X chromosome to establish a repressive nuclear territory. | Valledor 2023 (RNA FISH & inducible XIST); Dror 2024 (CUT&Tag/RAP-seq) | Occurs in dense and sparse zones. In naïve hPSCs, XIST is highly dispersed rather than tightly compacted. | (dror2024xistdirectlyregulates pages 1-3, valledor2023earlychromosomecondensation pages 1-3) |
+| **Biological Process (BP)** | Chromosome organization / Heterochromatin formation | Modifies cytoarchitecture and drives large-scale condensation of active chromatin into a Barr body. | Valledor 2023 (Inducible XIST time-course); Minajigi 2015 (Allele-specific ChIP-seq) | Early condensation builds RNA density required for sustained silencing. Involves cohesin repulsion and distinct topological remodeling. | (valledor2023earlychromosomecondensation pages 1-3, minajigi2015acomprehensivexist pages 6-8, valledor2023earlychromosomecondensation media 58d592e8) |
+| **Biological Process (BP) / MF** | Recruitment of histone deacetylase complex | Recruits HDAC3 via direct binding to SHARP/SPEN to mediate transcriptional silencing. | McHugh 2015 (Knockdown of SHARP, SMRT, HDAC3) | Mediated by the A-repeat. Crucial for exclusion of RNA Pol II; acts rapidly at sites of high RNA density. | (mchugh2015thexistlncrna pages 4-6, mchugh2015thexistlncrna pages 6-7, mchugh2015thexistlncrna pages 1-2) |
+| **Biological Process (BP) / MF** | Polycomb repressive complex recruitment | Initiates the Polycomb cascade by recruiting PCGF3/5-PRC1 via hnRNPK. | Pintacuda 2017 (XR-PID deletion & synthetic tethering); Nesterova 2019 (Allelic silencing) | Driven by XIST B/C repeats interacting with hnRNPK. PRC2 is recruited indirectly downstream of PRC1. | (pintacuda2017hnrnpkrecruitspcgf35prc1 pages 1-3, pintacuda2017hnrnpkrecruitspcgf35prc1 pages 10-13, nesterova2019systematicallelicanalysis pages 1-2) |
+| **Biological Process (BP)** | Histone H2A K119 ubiquitination | PRC1-mediated deposition of repressive ubiquitin marks on H2A across the Xi territory. | Pintacuda 2017 (ImmunoFISH & Xist tethering); Valledor 2023 (Timing assays) | Appears early in the 'sparse' XIST zone concurrent with CIZ1 recruitment and preceding widespread gene silencing. | (valledor2023earlychromosomecondensation pages 1-3, pintacuda2017hnrnpkrecruitspcgf35prc1 pages 1-3, valledor2023earlychromosomecondensation media 58d592e8) |
+| **Biological Process (BP)** | Histone H3K27 methylation enrichment | PRC2-mediated trimethylation of H3K27 to maintain and stabilize facultative heterochromatin. | Pintacuda 2017 (Tethering complementation); Valledor 2023 (Time-course) | Follows H2AK119ub deposition. Accumulates later in 'dense' RNA zones during chromosome condensation. | (valledor2023earlychromosomecondensation pages 1-3, pintacuda2017hnrnpkrecruitspcgf35prc1 pages 10-13, valledor2023earlychromosomecondensation media 58d592e8) |
+| **Biological Process (BP) / CC** | Nuclear lamina tethering | Recruits the Xi to the nuclear lamina to facilitate spreading to active genes. | Chen 2016 (LBR knockdown, DLBS-Xist cells); Nesterova 2019 (Allelic analysis) | Interaction with Lamin B Receptor (LBR). Nesterova 2019 indicates LBR plays only a minor or redundant role in aggregate silencing. | (nesterova2019systematicallelicanalysis pages 1-2, chen2016xistrecruitsthe pages 1-2, chen2016xistrecruitsthe pages 3-4) |
+| **Cellular Component (CC)** | Nuclear matrix association | Anchors XIST RNPs and Xi chromatin to the insoluble nuclear scaffold. | Minajigi 2015 (Interactome); Valledor 2023 (CIZ1 immunofluorescence) | Involves interactions with SAF-A (hnRNP U) and CIZ1. Recruited immediately alongside sparse XIST RNA. | (valledor2023earlychromosomecondensation pages 1-3, minajigi2015acomprehensivexist pages 1-3, valledor2023earlychromosomecondensation media 58d592e8) |
+| **Cellular Component (CC)** | Nuclear localization to Xi territory | Highly concentrated accumulation in a specific sub-nuclear compartment (the Xist cloud). | Valledor 2023 (RNA FISH spatial mapping); Dror 2024 (Imaging) | Forms a biphasic structure ('dense' vs 'sparse' zones) essential for bridging architectural changes and local gene repression. | (dror2024xistdirectlyregulates pages 1-3, valledor2023earlychromosomecondensation pages 1-3, valledor2023earlychromosomecondensation media 58d592e8) |
+
+
+*Table: This table maps specific Gene Ontology (GO) functional annotations for the human XIST lncRNA to their primary supporting literature and key mechanistic details.*
+
+### Distinguishing core mechanism from downstream outcomes
+- **Core XIST molecular functions (mechanistic GO focus):** cis coating/association with Xi territory; direct binding to SHARP/SPEN; recruitment/activation of SMRT/HDAC3 for histone deacetylation and Pol II exclusion; recruitment of hnRNPK to bring PCGF3/5-PRC1 and initiate Polycomb marking (H2AK119ub → PRC2/H3K27me3); nuclear lamina tethering via LBR enabling spreading to active genes; and driving chromosome condensation/organization (mchugh2015thexistlncrna pages 6-7, pintacuda2017hnrnpkrecruitspcgf35prc1 pages 10-13, chen2016xistrecruitsthe pages 1-2, valledor2023earlychromosomecondensation pages 1-3).
+- **Downstream outcomes (should not be over-annotated as direct functions):** organismal dosage compensation, sex-biased traits, and disease phenotypes are emergent consequences of the above molecular functions and should be annotated as higher-level BP outcomes only with careful scoping (gupta2024trisomysilencingby pages 1-3, dror2024xistdirectlyregulates pages 1-3).
+
+### Notes on evidence gaps and caution for GO annotation
+- **Context dependence:** LBR/LBR-binding-site perturbations show strong effects in some systems (chen2016xistrecruitsthe pages 1-2) but only minor contributions in others (nesterova2019systematicallelicanalysis pages 1-2); GO annotations should reflect this as “contributes to” rather than strictly “essential for” across all contexts.
+- **PRC2 recruitment:** McHugh et al. report PRC2 enrichment depends on SHARP/HDAC3 and note that PRC2 components were not robustly identified as direct Xist interactors by RAP-MS, supporting an **indirect** or downstream recruitment model (mchugh2015thexistlncrna pages 6-7).
+
+### Key primary references (with URLs and publication dates)
+- McHugh CA et al. **Nature** (Apr 2015). “The Xist lncRNA interacts directly with SHARP to silence transcription through HDAC3.” https://doi.org/10.1038/nature14443 (mchugh2015thexistlncrna pages 1-2, mchugh2015thexistlncrna pages 6-7)
+- Minajigi A et al. **Science** (Jun 2015). “A comprehensive Xist interactome reveals cohesin repulsion and an RNA-directed chromosome conformation.” https://doi.org/10.1126/science.aab2276 (minajigi2015acomprehensivexist pages 1-3)
+- Chen C-K et al. **Science** (Oct 2016). “Xist recruits the X chromosome to the nuclear lamina to enable chromosome-wide silencing.” https://doi.org/10.1126/science.aae0047 (chen2016xistrecruitsthe pages 1-2, chen2016xistrecruitsthe pages 3-4)
+- Pintacuda G et al. **Molecular Cell** (Dec 2017). “hnRNPK Recruits PCGF3/5-PRC1 to the Xist RNA B-Repeat to Establish Polycomb-Mediated Chromosomal Silencing.” https://doi.org/10.1016/j.molcel.2017.11.013 (pintacuda2017hnrnpkrecruitspcgf35prc1 pages 1-3, pintacuda2017hnrnpkrecruitspcgf35prc1 pages 10-13)
+- Nesterova TB et al. **Nature Communications** (Nov 2019). “Systematic allelic analysis defines the interplay of key pathways in X chromosome inactivation.” https://doi.org/10.1038/s41467-019-11171-3 (nesterova2019systematicallelicanalysis pages 1-2)
+- Valledor M et al. **Cell Reports** (Jul 2023). “Early chromosome condensation by XIST builds A-repeat RNA density that facilitates gene silencing.” https://doi.org/10.1016/j.celrep.2023.112686 (valledor2023earlychromosomecondensation pages 1-3, valledor2023earlychromosomecondensation pages 10-11, valledor2023earlychromosomecondensation media 58d592e8)
+- Dror I et al. **Cell** (Jan 2024). “XIST directly regulates X-linked and autosomal genes in naive human pluripotent cells.” https://doi.org/10.1016/j.cell.2023.11.033 (dror2024xistdirectlyregulates pages 1-3)
+- Bansal P et al. **Science Advances** (Jun 2024). “A dynamic in vitro model of Down syndrome neurogenesis with trisomy 21 gene dosage correction.” https://doi.org/10.1126/sciadv.adj0385 (bansal2024adynamicin pages 1-3)
+- Gupta K et al. **Human Genetics** (Mar 2024). “Trisomy silencing by XIST: translational prospects and challenges.” https://doi.org/10.1007/s00439-024-02651-8 (gupta2024trisomysilencingby pages 1-3)
+
+
+References
+
+1. (dror2024xistdirectlyregulates pages 1-3): Iris Dror, Tsotne Chitiashvili, Shawn Y.X. Tan, Clara T. Cano, Anna Sahakyan, Yolanda Markaki, Constantinos Chronis, Amanda J. Collier, Weixian Deng, Guohao Liang, Yu Sun, Anna Afasizheva, Jarrett Miller, Wen Xiao, Douglas L. Black, Fangyuan Ding, and Kathrin Plath. Xist directly regulates x-linked and autosomal genes in naive human pluripotent cells. Cell, 187:110-129.e31, Jan 2024. URL: https://doi.org/10.1016/j.cell.2023.11.033, doi:10.1016/j.cell.2023.11.033. This article has 74 citations and is from a highest quality peer-reviewed journal.
+
+2. (valledor2023earlychromosomecondensation pages 1-3): Melvys Valledor, Meg Byron, Brett Dumas, Dawn M. Carone, Lisa L. Hall, and Jeanne B. Lawrence. Early chromosome condensation by xist builds a-repeat rna density that facilitates gene silencing. Cell Reports, 42:112686, Jul 2023. URL: https://doi.org/10.1016/j.celrep.2023.112686, doi:10.1016/j.celrep.2023.112686. This article has 23 citations and is from a highest quality peer-reviewed journal.
+
+3. (lu2020structuralmodularityof pages 1-2): Zhipeng Lu, Jimmy K. Guo, Yuning Wei, Diana R. Dou, Brian Zarnegar, Qing Ma, Rui Li, Yang Zhao, Fan Liu, Hani Choudhry, Paul A. Khavari, and Howard Y. Chang. Structural modularity of the xist ribonucleoprotein complex. Nature Communications, Dec 2020. URL: https://doi.org/10.1038/s41467-020-20040-3, doi:10.1038/s41467-020-20040-3. This article has 102 citations and is from a highest quality peer-reviewed journal.
+
+4. (lu2020structuralmodularityof pages 6-7): Zhipeng Lu, Jimmy K. Guo, Yuning Wei, Diana R. Dou, Brian Zarnegar, Qing Ma, Rui Li, Yang Zhao, Fan Liu, Hani Choudhry, Paul A. Khavari, and Howard Y. Chang. Structural modularity of the xist ribonucleoprotein complex. Nature Communications, Dec 2020. URL: https://doi.org/10.1038/s41467-020-20040-3, doi:10.1038/s41467-020-20040-3. This article has 102 citations and is from a highest quality peer-reviewed journal.
+
+5. (minajigi2015acomprehensivexist pages 1-3): Anand Minajigi, John E. Froberg, Chunyao Wei, Hongjae Sunwoo, Barry Kesner, David Colognori, Derek Lessing, Bernhard Payer, Myriam Boukhali, Wilhelm Haas, and Jeannie T. Lee. A comprehensive xist interactome reveals cohesin repulsion and an rna-directed chromosome conformation. Science, Jul 2015. URL: https://doi.org/10.1126/science.aab2276, doi:10.1126/science.aab2276. This article has 587 citations and is from a highest quality peer-reviewed journal.
+
+6. (mchugh2015thexistlncrna pages 1-2): Colleen A. McHugh, Chun-Kan Chen, Amy Chow, Christine F. Surka, Christina Tran, Patrick McDonel, Amy Pandya-Jones, Mario Blanco, Christina Burghard, Annie Moradian, Michael J. Sweredoski, Alexander A. Shishkin, Julia Su, Eric S. Lander, Sonja Hess, Kathrin Plath, and Mitchell Guttman. The xist lncrna interacts directly with sharp to silence transcription through hdac3. Nature, 521:232-236, Apr 2015. URL: https://doi.org/10.1038/nature14443, doi:10.1038/nature14443. This article has 1319 citations and is from a highest quality peer-reviewed journal.
+
+7. (mchugh2015thexistlncrna pages 6-7): Colleen A. McHugh, Chun-Kan Chen, Amy Chow, Christine F. Surka, Christina Tran, Patrick McDonel, Amy Pandya-Jones, Mario Blanco, Christina Burghard, Annie Moradian, Michael J. Sweredoski, Alexander A. Shishkin, Julia Su, Eric S. Lander, Sonja Hess, Kathrin Plath, and Mitchell Guttman. The xist lncrna interacts directly with sharp to silence transcription through hdac3. Nature, 521:232-236, Apr 2015. URL: https://doi.org/10.1038/nature14443, doi:10.1038/nature14443. This article has 1319 citations and is from a highest quality peer-reviewed journal.
+
+8. (pintacuda2017hnrnpkrecruitspcgf35prc1 pages 1-3): Greta Pintacuda, Guifeng Wei, Chloë Roustan, Burcu Anil Kirmizitas, Nicolae Solcan, Andrea Cerase, Alfredo Castello, Shabaz Mohammed, Benoît Moindrot, Tatyana B. Nesterova, and Neil Brockdorff. Hnrnpk recruits pcgf3/5-prc1 to the xist rna b-repeat to establish polycomb-mediated chromosomal silencing. Molecular Cell, 68:955-969.e10, Dec 2017. URL: https://doi.org/10.1016/j.molcel.2017.11.013, doi:10.1016/j.molcel.2017.11.013. This article has 403 citations and is from a highest quality peer-reviewed journal.
+
+9. (pintacuda2017hnrnpkrecruitspcgf35prc1 pages 10-13): Greta Pintacuda, Guifeng Wei, Chloë Roustan, Burcu Anil Kirmizitas, Nicolae Solcan, Andrea Cerase, Alfredo Castello, Shabaz Mohammed, Benoît Moindrot, Tatyana B. Nesterova, and Neil Brockdorff. Hnrnpk recruits pcgf3/5-prc1 to the xist rna b-repeat to establish polycomb-mediated chromosomal silencing. Molecular Cell, 68:955-969.e10, Dec 2017. URL: https://doi.org/10.1016/j.molcel.2017.11.013, doi:10.1016/j.molcel.2017.11.013. This article has 403 citations and is from a highest quality peer-reviewed journal.
+
+10. (chen2016xistrecruitsthe pages 1-2): Chun-Kan Chen, Mario Blanco, Constanza Jackson, Erik Aznauryan, Noah Ollikainen, Christine Surka, Amy Chow, Andrea Cerase, Patrick McDonel, and Mitchell Guttman. Xist recruits the x chromosome to the nuclear lamina to enable chromosome-wide silencing. Science, 354:468-472, Oct 2016. URL: https://doi.org/10.1126/science.aae0047, doi:10.1126/science.aae0047. This article has 348 citations and is from a highest quality peer-reviewed journal.
+
+11. (chen2016xistrecruitsthe pages 3-4): Chun-Kan Chen, Mario Blanco, Constanza Jackson, Erik Aznauryan, Noah Ollikainen, Christine Surka, Amy Chow, Andrea Cerase, Patrick McDonel, and Mitchell Guttman. Xist recruits the x chromosome to the nuclear lamina to enable chromosome-wide silencing. Science, 354:468-472, Oct 2016. URL: https://doi.org/10.1126/science.aae0047, doi:10.1126/science.aae0047. This article has 348 citations and is from a highest quality peer-reviewed journal.
+
+12. (nesterova2019systematicallelicanalysis pages 1-2): Tatyana B Nesterova, Guifeng Wei, Heather Coker, Greta Pintacuda, Joseph S Bowness, Tianyi Zhang, Mafalda Almeida, Bianca Bloechl, Benoit Moindrot, Emma J Carter, Ines Alvarez Rodrigo, Qi Pan, Ying Bi, Chun-Xiao Song, and Neil Brockdorff. Systematic allelic analysis defines the interplay of key pathways in x chromosome inactivation. Nature Communications, Nov 2019. URL: https://doi.org/10.1038/s41467-019-11171-3, doi:10.1038/s41467-019-11171-3. This article has 160 citations and is from a highest quality peer-reviewed journal.
+
+13. (valledor2023earlychromosomecondensation media 58d592e8): Melvys Valledor, Meg Byron, Brett Dumas, Dawn M. Carone, Lisa L. Hall, and Jeanne B. Lawrence. Early chromosome condensation by xist builds a-repeat rna density that facilitates gene silencing. Cell Reports, 42:112686, Jul 2023. URL: https://doi.org/10.1016/j.celrep.2023.112686, doi:10.1016/j.celrep.2023.112686. This article has 23 citations and is from a highest quality peer-reviewed journal.
+
+14. (valledor2023earlychromosomecondensation pages 10-11): Melvys Valledor, Meg Byron, Brett Dumas, Dawn M. Carone, Lisa L. Hall, and Jeanne B. Lawrence. Early chromosome condensation by xist builds a-repeat rna density that facilitates gene silencing. Cell Reports, 42:112686, Jul 2023. URL: https://doi.org/10.1016/j.celrep.2023.112686, doi:10.1016/j.celrep.2023.112686. This article has 23 citations and is from a highest quality peer-reviewed journal.
+
+15. (bansal2024adynamicin pages 1-3): Prakhar Bansal, Erin C. Banda, Heather R. Glatt-Deeley, Christopher E. Stoddard, Jeremy W. Linsley, Neha Arora, Cécile Deleschaux, Darcy T. Ahern, Yuvabharath Kondaveeti, Rachael E. Massey, Michael Nicouleau, Shijie Wang, Miguel Sabariego-Navarro, Mara Dierssen, Steven Finkbeiner, and Stefan F. Pinter. A dynamic in vitro model of down syndrome neurogenesis with trisomy 21 gene dosage correction. Science Advances, Jun 2024. URL: https://doi.org/10.1126/sciadv.adj0385, doi:10.1126/sciadv.adj0385. This article has 14 citations and is from a highest quality peer-reviewed journal.
+
+16. (gupta2024trisomysilencingby pages 1-3): Khusali Gupta, Jan T. Czerminski, and Jeanne B. Lawrence. Trisomy silencing by xist: translational prospects and challenges. Human Genetics, 143:843-855, Mar 2024. URL: https://doi.org/10.1007/s00439-024-02651-8, doi:10.1007/s00439-024-02651-8. This article has 18 citations and is from a peer-reviewed journal.
+
+17. (loda2019xistrnain pages 7-9): Agnese Loda and Edith Heard. Xist rna in action: past, present, and future. PLOS Genetics, 15:e1008333, Sep 2019. URL: https://doi.org/10.1371/journal.pgen.1008333, doi:10.1371/journal.pgen.1008333. This article has 313 citations and is from a domain leading peer-reviewed journal.
+
+18. (loda2019xistrnain pages 13-14): Agnese Loda and Edith Heard. Xist rna in action: past, present, and future. PLOS Genetics, 15:e1008333, Sep 2019. URL: https://doi.org/10.1371/journal.pgen.1008333, doi:10.1371/journal.pgen.1008333. This article has 313 citations and is from a domain leading peer-reviewed journal.
+
+19. (minajigi2015acomprehensivexist pages 6-8): Anand Minajigi, John E. Froberg, Chunyao Wei, Hongjae Sunwoo, Barry Kesner, David Colognori, Derek Lessing, Bernhard Payer, Myriam Boukhali, Wilhelm Haas, and Jeannie T. Lee. A comprehensive xist interactome reveals cohesin repulsion and an rna-directed chromosome conformation. Science, Jul 2015. URL: https://doi.org/10.1126/science.aab2276, doi:10.1126/science.aab2276. This article has 587 citations and is from a highest quality peer-reviewed journal.
+
+20. (mchugh2015thexistlncrna pages 4-6): Colleen A. McHugh, Chun-Kan Chen, Amy Chow, Christine F. Surka, Christina Tran, Patrick McDonel, Amy Pandya-Jones, Mario Blanco, Christina Burghard, Annie Moradian, Michael J. Sweredoski, Alexander A. Shishkin, Julia Su, Eric S. Lander, Sonja Hess, Kathrin Plath, and Mitchell Guttman. The xist lncrna interacts directly with sharp to silence transcription through hdac3. Nature, 521:232-236, Apr 2015. URL: https://doi.org/10.1038/nature14443, doi:10.1038/nature14443. This article has 1319 citations and is from a highest quality peer-reviewed journal.
+
+## Citations
+
+1. minajigi2015acomprehensivexist pages 1-3
+2. mchugh2015thexistlncrna pages 6-7
+3. chen2016xistrecruitsthe pages 1-2
+4. nesterova2019systematicallelicanalysis pages 1-2
+5. valledor2023earlychromosomecondensation pages 10-11
+6. dror2024xistdirectlyregulates pages 1-3
+7. bansal2024adynamicin pages 1-3
+8. gupta2024trisomysilencingby pages 1-3
+9. valledor2023earlychromosomecondensation pages 1-3
+10. lu2020structuralmodularityof pages 1-2
+11. lu2020structuralmodularityof pages 6-7
+12. mchugh2015thexistlncrna pages 1-2
+13. chen2016xistrecruitsthe pages 3-4
+14. loda2019xistrnain pages 7-9
+15. loda2019xistrnain pages 13-14
+16. minajigi2015acomprehensivexist pages 6-8
+17. mchugh2015thexistlncrna pages 4-6
+18. https://doi.org/10.1038/nature14443
+19. https://doi.org/10.1126/science.aab2276
+20. https://doi.org/10.1126/science.aae0047
+21. https://doi.org/10.1016/j.molcel.2017.11.013
+22. https://doi.org/10.1038/s41467-019-11171-3
+23. https://doi.org/10.1016/j.celrep.2023.112686
+24. https://doi.org/10.1016/j.cell.2023.11.033
+25. https://doi.org/10.1126/sciadv.adj0385
+26. https://doi.org/10.1007/s00439-024-02651-8
+27. https://doi.org/10.1016/j.cell.2023.11.033,
+28. https://doi.org/10.1016/j.celrep.2023.112686,
+29. https://doi.org/10.1038/s41467-020-20040-3,
+30. https://doi.org/10.1126/science.aab2276,
+31. https://doi.org/10.1038/nature14443,
+32. https://doi.org/10.1016/j.molcel.2017.11.013,
+33. https://doi.org/10.1126/science.aae0047,
+34. https://doi.org/10.1038/s41467-019-11171-3,
+35. https://doi.org/10.1126/sciadv.adj0385,
+36. https://doi.org/10.1007/s00439-024-02651-8,
+37. https://doi.org/10.1371/journal.pgen.1008333,


### PR DESCRIPTION
## Summary

Adds Falcon deep research for four reviewed human noncoding RNA genes that lacked deep research files:

- `KCNQ1OT1`
- `MIR155`
- `SNORD116-1`
- `XIST`

Because these are RNA genes rather than protein-coding genes, the reports were generated through the Falcon provider with RNA-specific GO-focused prompts instead of the UniProt/protein-template wrapper. The reports are incorporated into the review YAML as file references and supporting evidence.

This also tightens two prior curation summaries based on the new Falcon evidence:

- `MIR155`: narrows core function to miRNA guide/RISC-mediated post-transcriptional regulation and removes the proposed `oncomiR activity` term.
- `SNORD116-1`: narrows copy-level function to box C/D snoRNA biology and removes the unsupported copy-specific CNS-development `NEW` assertion.

## Validation

- `uv run python scripts/validate_deep_research.py genes/human/KCNQ1OT1/KCNQ1OT1-deep-research-falcon.md genes/human/MIR155/MIR155-deep-research-falcon.md genes/human/SNORD116-1/SNORD116-1-deep-research-falcon.md genes/human/XIST/XIST-deep-research-falcon.md`
- `just validate human KCNQ1OT1`
- `just validate human MIR155`
- `just validate human SNORD116-1`
- `just validate human XIST`
- `just render human KCNQ1OT1`
- `just render human MIR155`
- `just render human SNORD116-1`
- `just render human XIST`
- `git diff --check origin/main..HEAD`