### PR TITLE
[codex] Add falcon deep research batch 8

### DIFF
--- a/genes/SCHPO/scm3/scm3-ai-review.html
+++ b/genes/SCHPO/scm3/scm3-ai-review.html
@@ -671,33 +671,33 @@
     <div class="header">
         <h1>scm3</h1>
         <div class="gene-info">
-            
+
             <div class="info-item">
-                
+
                 <span class="info-label">UniProt ID:</span>
                 <span>
                     <a href="https://www.uniprot.org/uniprotkb/Q9HDY7" target="_blank" class="term-link">
                         Q9HDY7
                     </a>
                 </span>
-                
+
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Organism:</span>
                 <span>Schizosaccharomyces pombe (strain 972 / ATCC 24843)</span>
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
-                <span class="status-badge status-draft">
-                    DRAFT
+                <span class="status-badge status-complete">
+                    COMPLETE
                 </span>
             </div>
-            
-            
+
+
         </div>
         <div style="margin-top: 1rem; text-align: center;">
             <a id="feedback-form-link"
@@ -728,7 +728,7 @@
         </div>
     </div>
 
-    
+
     <div class="description-card">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <h2>Gene Description</h2>
@@ -739,13 +739,13 @@
         </div>
         <p>Scm3 is the dedicated CENP-A/Cnp1 histone chaperone in S. pombe, orthologous to human HJURP. It mediates the stable deposition of the centromere-specific histone H3 variant Cnp1/CENP-A into centromeric chromatin, which is essential for kinetochore assembly and chromosome segregation. Scm3 contains an N-terminal CENP-A binding domain, a Mis16-binding domain, and a C-terminal cysteine-rich zinc-binding domain required for centromere targeting. It acts downstream of the Mis16-Mis18 complex and dynamically dissociates from centromeres during mitosis.</p>
     </div>
-    
 
-    
 
-    
 
-    
+
+
+
+
     <div class="section">
         <h2 class="section-title">Existing Annotations Review</h2>
         <table class="annotations-table">
@@ -758,32 +758,32 @@
                 </tr>
             </thead>
             <tbody>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -795,42 +795,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Correct but non-specific. Scm3 localizes to the nucleus, confirmed by HDA evidence (PMID:16823372) and fluorescence microscopy showing nuclear foci (PMID:19217403). However, the more informative localization is to centromeric chromatin (GO:0034506).
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -842,42 +842,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Scm3 was detected in the cytoplasm/cytosol in the large-scale localization study (PMID:16823372). However, the primary functional localization is nuclear/centromeric. Cytoplasmic localization may reflect the pool of Scm3 before nuclear import or during mitotic dissociation from centromeres.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042393" target="_blank" class="term-link">
                                     GO:0042393
                                 </a>
                             </span>
                             <span class="term-label">histone binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -889,42 +889,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Scm3 specifically binds the CENP-A histone variant Cnp1 via its N-terminal domain (PMID:19217403). It does not bind canonical histone H3 or H4 (no interaction detected in Y2H). The term histone binding is technically correct but too general; the histone chaperone activity annotation (GO:0140713) better captures the functional specificity.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046982" target="_blank" class="term-link">
                                     GO:0046982
                                 </a>
                             </span>
                             <span class="term-label">protein heterodimerization activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -936,53 +936,53 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Likely derived from the InterPro histone-fold domain annotation. While Scm3 does interact with Cnp1/CENP-A and self-associates (PMID:19217403), its mechanism of action is as a histone chaperone, not as a classical histone-fold heterodimerization partner. The S. pombe Scm3 is not an integral nucleosome component. This annotation is misleading.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000785" target="_blank" class="term-link">
                                     GO:0000785
                                 </a>
                             </span>
                             <span class="term-label">chromatin</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19217404" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19217404
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Fission yeast Scm3: A CENP-A receptor required for integrity...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -994,53 +994,53 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Scm3 associates with centromeric chromatin as shown by ChIP and biochemical fractionation (PMID:19217404). While not incorrect, this is less informative than the more specific annotation to centromeric core domain (GO:0034506), which is also annotated with IDA evidence from the same paper. Keeping as non-core since the specific term is preferred.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008270" target="_blank" class="term-link">
                                     GO:0008270
                                 </a>
                             </span>
                             <span class="term-label">zinc ion binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/38084929" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:38084929
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The cysteine-rich domain in CENP-A chaperone Scm3HJURP ensur...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1052,60 +1052,60 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> The C-terminal cysteine-rich domain (CYS) of Scm3 binds zinc in vitro, demonstrated by direct biochemical assays (PMID:38084929). Point mutations in the zinc-binding motif abolish centromere localization and compromise kinetochore integrity, indicating functional significance. Well-supported.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/38084929" target="_blank" class="term-link">
                                         PMID:38084929
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">we find that CYS binds zinc in vitro and is essential for the localization and function of fission yeast Scm3</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140713" target="_blank" class="term-link">
                                     GO:0140713
                                 </a>
                             </span>
                             <span class="term-label">histone chaperone activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">NAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000051
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1117,53 +1117,53 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Histone chaperone activity is the core molecular function of Scm3. This NAS annotation from PomBase keyword mapping is correct and consistent with the EXP annotation from PMID:19217404. Both support the core function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034080" target="_blank" class="term-link">
                                     GO:0034080
                                 </a>
                             </span>
                             <span class="term-label">CENP-A containing chromatin assembly</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19217403" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19217403
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Fission yeast Scm3 mediates stable assembly of Cnp1/CENP-A i...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1175,71 +1175,71 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Core biological process annotation. scm3 temperature-sensitive mutants lose Cnp1/CENP-A from centromeres without affecting Cnp1 protein levels, and canonical histones H3/H2A/H2B invade centromeric chromatin (PMID:19217403). This directly demonstrates Scm3 is required for CENP-A chromatin assembly.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/19217403" target="_blank" class="term-link">
                                         PMID:19217403
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Cnp1 foci formation was reduced in the scm3-6 and scm3-19 mutants at 20°C and abolished at 36°C...The abundance of Cnp1-GFP was unaffected in the scm3-ts mutants</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034080" target="_blank" class="term-link">
                                     GO:0034080
                                 </a>
                             </span>
                             <span class="term-label">CENP-A containing chromatin assembly</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19217404" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19217404
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Fission yeast Scm3: A CENP-A receptor required for integrity...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1251,71 +1251,71 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Independent confirmation of the core process annotation. Pidoux et al. show Scm3 co-purifies with CENP-A and is required for integrity of subkinetochore chromatin (PMID:19217404). Complementary to the Williams et al. evidence.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/19217404" target="_blank" class="term-link">
                                         PMID:19217404
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Scm3(Sp) coaffinity purifies with CENP-A(Cnp1) and associates with CENP-A(Cnp1) in vitro</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19217404" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19217404
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Fission yeast Scm3: A CENP-A receptor required for integrity...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -1327,64 +1327,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Too vague per curation guidelines. PMID:19217404 shows Scm3 interacts with Cnp1/CENP-A (co-affinity purification) and Mis16 (co-IP). These are specific functional interactions better captured by histone chaperone activity (GO:0140713) which is already annotated with EXP evidence from the same paper. Protein binding adds no informational value.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140713" target="_blank" class="term-link">
                                     histone chaperone activity
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034506" target="_blank" class="term-link">
                                     GO:0034506
                                 </a>
                             </span>
                             <span class="term-label">chromosome, centromeric core domain</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19217404" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19217404
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Fission yeast Scm3: A CENP-A receptor required for integrity...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1396,71 +1396,71 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Core localization annotation. Pidoux et al. show Scm3 localizes to the centromeric central domain by ChIP, colocalizing with CENP-A/Cnp1 (PMID:19217404). Scm3 is differentially released from chromatin compared to CENP-A, consistent with its role as a chaperone rather than a stable nucleosome component.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/19217404" target="_blank" class="term-link">
                                         PMID:19217404
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Importantly, Scm3(Sp) coaffinity purifies with CENP-A(Cnp1) and associates with CENP-A(Cnp1) in vitro, yet localizes independently of intact CENP-A(Cnp1) chromatin and is differentially released from chromatin</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140713" target="_blank" class="term-link">
                                     GO:0140713
                                 </a>
                             </span>
                             <span class="term-label">histone chaperone activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">EXP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19217404" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19217404
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Fission yeast Scm3: A CENP-A receptor required for integrity...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1472,71 +1472,82 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Core molecular function annotation with strong experimental evidence. Scm3 directly binds CENP-A/Cnp1 and mediates its deposition into centromeric chromatin (PMID:19217404, PMID:19217403). This is the defining molecular function of Scm3, well-supported by multiple independent studies.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/19217404" target="_blank" class="term-link">
                                         PMID:19217404
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">we favor a model in which Scm3(Sp) acts as a CENP-A(Cnp1) receptor/assembly factor, cooperating with Mis16 and Mis18 to receive CENP-A(Cnp1) from the Sim3 escort and mediate assembly of CENP-A(Cnp1) into subkinetochore chromatin</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:SCHPO/scm3/scm3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Scm3 is the dedicated CENP-A/Cnp1 assembly factor required for stable enrichment/deposition of Cnp1 at the centromeric central domain.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000775" target="_blank" class="term-link">
                                     GO:0000775
                                 </a>
                             </span>
                             <span class="term-label">chromosome, centromeric region</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/26275423" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:26275423
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Inner Kinetochore Protein Interactions with Regional Centrom...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -1548,53 +1559,53 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Supported by ChIP-seq showing Scm3 is enriched throughout the centromeric central domain (PMID:26275423). This is a parent term of centromeric core domain (GO:0034506). The more specific term is already annotated with IDA evidence, making this somewhat redundant but not incorrect.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034506" target="_blank" class="term-link">
                                     GO:0034506
                                 </a>
                             </span>
                             <span class="term-label">chromosome, centromeric core domain</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19217403" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19217403
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Fission yeast Scm3 mediates stable assembly of Cnp1/CENP-A i...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1606,71 +1617,71 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Core localization annotation. Williams et al. show by ChIP that Scm3 is enriched at cnt1/imr1 (central core) but not at dg repeats or euchromatic lys1 (PMID:19217403). Scm3-CFP foci colocalize with Cnp1-GFP and Mis12. Independent confirmation of PMID:19217404 data.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/19217403" target="_blank" class="term-link">
                                         PMID:19217403
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The Scm3-FLAG and Mis18-FLAG immunoprecipitates were enriched at cnt1/imr1 but not at the dg motifs or the euchromatic lys1 probe</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16823372" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16823372
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     ORFeome cloning and global analysis of protein localization ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -1682,53 +1693,53 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Supported by proteome-wide YFP-tagging localization study in S. pombe (PMID:16823372). Nuclear localization is consistent with Scm3&#39;s centromeric function. Redundant with more specific centromeric localization annotations.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16823372" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16823372
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     ORFeome cloning and global analysis of protein localization ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -1740,53 +1751,53 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Detected in the cytosol in the proteome-wide localization study (PMID:16823372). Likely represents the soluble pool of Scm3 before nuclear import or after mitotic release from centromeres. Not the primary functional localization.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19217403" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19217403
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Fission yeast Scm3 mediates stable assembly of Cnp1/CENP-A i...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -1798,64 +1809,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Too vague per curation guidelines. This IPI row is supported by PMID:19217403 for Scm3 interaction with Cnp1/CENP-A by Y2H and co-immunoprecipitation. The functional consequence is CENP-A-specific histone chaperone activity, so the annotation is better captured by GO:0140713.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140713" target="_blank" class="term-link">
                                     histone chaperone activity
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19217403" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19217403
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Fission yeast Scm3 mediates stable assembly of Cnp1/CENP-A i...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -1867,64 +1878,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Too vague per curation guidelines. PMID:19217403 supports Scm3 self-association by yeast two-hybrid analysis, but the generic protein binding term does not describe the curated function of Scm3. The experimentally supported core molecular function is histone chaperone activity.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140713" target="_blank" class="term-link">
                                     histone chaperone activity
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19217403" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19217403
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Fission yeast Scm3 mediates stable assembly of Cnp1/CENP-A i...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -1936,46 +1947,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This Mis18 IPI annotation is not supported by PMID:19217403. The paper supports a Mis18-dependent localization/recruitment relationship in the CENP-A loading pathway, but explicitly reports no positive Scm3-Mis18 Y2H interaction. This GOA row should therefore be removed rather than modified to histone chaperone activity.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/19217403" target="_blank" class="term-link">
                                         PMID:19217403
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">We did not observe a positive Y2H interaction between Scm3 and Mis18 (Figure 5B), although we did find that Mis18 self-associates</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
             </tbody>
         </table>
     </div>
-    
 
-    
+
+
     <div class="section">
         <h2 class="section-title">Core Functions</h2>
-        
+
         <div class="core-function-card">
-            
+
             <div style="display: flex; justify-content: space-between; align-items: center;">
                 <h3>CENP-A/Cnp1-specific histone chaperone that mediates the deposition of the centromere-specific histone H3 variant Cnp1 into centromeric chromatin. Scm3 binds Cnp1 via its N-terminal domain, is recruited to centromeres by the Mis16-Mis18 complex, and uses its zinc-binding CYS domain for centromere targeting. Essential for kinetochore integrity and chromosome segregation.</h3>
                 <span class="vote-buttons" data-g="Q9HDY7" data-a="FUNCTION: CENP-A/Cnp1-specific histone chaperone that mediat..." data-r="" data-act="CORE_FUNCTION">
@@ -1983,10 +1994,10 @@
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
             </div>
-            
+
 
             <div class="core-function-terms">
-                
+
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
@@ -1995,412 +2006,889 @@
                         </a>
                     </span>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Directly Involved In:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034080" target="_blank" class="term-link">
                                 CENP-A containing chromatin assembly
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Cellular Locations:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034506" target="_blank" class="term-link">
                                 chromosome, centromeric core domain
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
 
-                
+
+
+
             </div>
 
-            
-        </div>
-        
-    </div>
-    
 
-    
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:SCHPO/scm3/scm3-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">Scm3 is the dedicated CENP-A/Cnp1 assembly factor required for stable enrichment/deposition of Cnp1 at the centromeric central domain.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class="section">
         <h2 class="section-title collapsible">References</h2>
         <div class="collapse-content">
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
+                        file:SCHPO/scm3/scm3-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research report for scm3</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Falcon supports scm3 as the fission yeast CENP-A/Cnp1 histone chaperone that deposits and maintains Cnp1 at centromeric chromatin.</div>
+
+                        <div class="finding-text">"Scm3 is the dedicated CENP-A/Cnp1 assembly factor required for stable enrichment/deposition of Cnp1 at the centromeric central domain."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
                             GO_REF:0000002
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
                             GO_REF:0000044
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000051.md" target="_blank" class="term-link">
                             GO_REF:0000051
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">S. pombe keyword mapping</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
                             GO_REF:0000120
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/16823372" target="_blank" class="term-link">
                             PMID:16823372
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">ORFeome cloning and global analysis of protein localization in the fission yeast Schizosaccharomyces pombe.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Scm3 (SPAPB1A10.02) protein localizes to both the nucleus and cytosol in a proteome-wide localization study of S. pombe.</div>
-                        
+
                         <div class="finding-text">"we determined the localization of 4,431 proteins, corresponding to approximately 90% of the fission yeast proteome, by tagging each ORF with the yellow fluorescent protein"</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/19217403" target="_blank" class="term-link">
                             PMID:19217403
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Fission yeast Scm3 mediates stable assembly of Cnp1/CENP-A into centromeric chromatin.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Scm3 directly interacts with the CENP-A histone variant Cnp1 via its conserved N-terminal domain (first 194 amino acids), demonstrated by yeast two-hybrid and co-immunoprecipitation.</div>
-                        
+
                         <div class="finding-text">"We first investigated whether S. pombe Scm3 interacts with Cnp1 using a yeast two-hybrid (Y2H) assay...Interactions in both bait and prey orientations were observed, while no interaction was detected between Scm3 and histone H4...Truncation analysis revealed that the first 194 amino acids of Scm3 (including the homology domain) are required for the interaction with Cnp1...Immunoblotting showed that only GST-Scm3 complexes contained Cnp1-GFP"</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Scm3 self-associates in vivo, forming homodimers.</div>
-                        
+
                         <div class="finding-text">"The Y2H analysis also detected a robust Scm3-Scm3 interaction (Figure 1B), indicating that Scm3 self-associates in vivo."</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Scm3 localizes specifically to the central core domain (cnt/imr) of centromeres, colocalizing with Cnp1 and Mis12, as shown by microscopy and ChIP.</div>
-                        
+
                         <div class="finding-text">"A single nuclear Scm3-CFP focus was observed in the majority of live cells...The Scm3-CFP and Cnp1-GFP foci colocalized...The Scm3-FLAG and Mis18-FLAG immunoprecipitates were enriched at cnt1/imr1 but not at the dg motifs or the euchromatic lys1 probe"</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Scm3 is essential for viability; scm3-null spores arrest after 1-2 divisions.</div>
-                        
+
                         <div class="finding-text">"scm3Δ spores germinated and underwent 1 or 2 divisions before arresting growth"</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Scm3 is required for centromeric localization of Cnp1/CENP-A; loss of Scm3 function abolishes Cnp1 centromeric foci without affecting Cnp1 protein levels.</div>
-                        
+
                         <div class="finding-text">"Cnp1 foci formation was reduced in the scm3-6 and scm3-19 mutants at 20°C and abolished at 36°C...The abundance of Cnp1-GFP was unaffected in the scm3-ts mutants"</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Scm3 localizes to centromeres independently of Cnp1, indicating it is not an integral nucleosome component but rather acts upstream of Cnp1 deposition.</div>
-                        
+
                         <div class="finding-text">"Scm3-GFP foci were readily detected in cnp1-1 cells incubated at 36°C, although the frequency was somewhat reduced compared to wild type...These data indicate that Scm3 localization at centromeres is largely independent of Cnp1"</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Scm3 centromere localization requires Mis6, Mis16, and Mis18, but not Mis12, placing it downstream of the Mis16-Mis18 complex in the CENP-A loading pathway.</div>
-                        
+
                         <div class="finding-text">"formation of Scm3-GFP foci was nearly abolished in the mis6, mis16 and mis18-ts mutants at 36°C...In contrast, Scm3-GFP foci were unaffected by the mis12-ts mutation"</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Scm3 interacts with Mis16 via its C-terminal 141 amino acids, shown by yeast two-hybrid analysis.</div>
-                        
+
                         <div class="finding-text">"Scm3 and Mis16 showed a robust Y2H interaction using either orientation of plasmids on high-stringency selective medium...The C-terminal 141 amino acids of Scm3 are required for interaction with Mis16"</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Scm3 does not show a positive yeast two-hybrid interaction with Mis18 in this study; Mis18 supports Scm3 localization rather than a direct physical interaction in this assay.</div>
-                        
+
                         <div class="finding-text">"We did not observe a positive Y2H interaction between Scm3 and Mis18 (Figure 5B), although we did find that Mis18 self-associates"</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Scm3 dynamically dissociates from centromeres during mitosis (metaphase to early/mid-anaphase), similar to Mis16 and Mis18, while Cnp1 remains constitutively associated.</div>
-                        
+
                         <div class="finding-text">"Scm3 formed nuclear foci that colocalized with Mis12 in interphase cells. However, like Mis16 and Mis18, Scm3 foci were not detectable in cells during metaphase or early to mid-anaphase...the Scm3 signal is nearly abolished in the nda3-KM311 mutant at the restrictive temperature, whereas Cnp1 enrichment is largely unchanged"</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Loss of Scm3 or Mis18 function leads to replacement of Cnp1 by canonical histones H3 and H2A/H2B at the central centromere region, and increased histone H4 acetylation.</div>
-                        
+
                         <div class="finding-text">"The loss of Cnp1 at cnt1/imr1 in the scm3-ts and mis18-ts mutants was accompanied by a large increase in the H3 signal in these regions"</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Scm3 is required for proper chromosome segregation; scm3 temperature-sensitive mutants show chromosome missegregation and minichromosome loss.</div>
-                        
+
                         <div class="finding-text">"chromosome segregation defects were observed in the scm3-ts mutants...The scm3-ts cells often failed to segregate their chromosomes equally following mitosis...there was an enhanced loss rate of minichromosome 16 in the scm3-ts mutants"</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/19217404" target="_blank" class="term-link">
                             PMID:19217404
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Fission yeast Scm3: A CENP-A receptor required for integrity of subkinetochore chromatin.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Scm3 co-affinity purifies with CENP-A/Cnp1 and associates with Cnp1 in vitro, confirming direct physical interaction.</div>
-                        
+
                         <div class="finding-text">"Scm3(Sp) coaffinity purifies with CENP-A(Cnp1) and associates with CENP-A(Cnp1) in vitro"</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Scm3 localizes to centromeres independently of intact CENP-A chromatin, supporting its role as a receptor rather than nucleosome component.</div>
-                        
+
                         <div class="finding-text">"Importantly, Scm3(Sp) coaffinity purifies with CENP-A(Cnp1) and associates with CENP-A(Cnp1) in vitro, yet localizes independently of intact CENP-A(Cnp1) chromatin and is differentially released from chromatin"</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Scm3 depends on Mis16/Mis18 for centromere localization and is recruited to centromeres in late anaphase.</div>
-                        
+
                         <div class="finding-text">"Scm3(Sp) depends on Mis16/18 for its centromere localization and like them is recruited to centromeres in late anaphase"</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Scm3 is proposed to act as a CENP-A receptor/assembly factor cooperating with Mis16 and Mis18 to receive CENP-A from the Sim3 escort and mediate chromatin assembly.</div>
-                        
+
                         <div class="finding-text">"we favor a model in which Scm3(Sp) acts as a CENP-A(Cnp1) receptor/assembly factor, cooperating with Mis16 and Mis18 to receive CENP-A(Cnp1) from the Sim3 escort and mediate assembly of CENP-A(Cnp1) into subkinetochore chromatin"</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Scm3 interacts with Mis16 (IPI with PomBase:SPCC970.12) and Cnp1 (IPI with PomBase:SPBC1105.17) shown by co-immunoprecipitation.</div>
-                        
+
                         <div class="finding-text">"Scm3(Sp) coaffinity purifies with CENP-A(Cnp1) and associates with CENP-A(Cnp1) in vitro...Scm3(Sp) depends on Mis16/18 for its centromere localization"</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/26275423" target="_blank" class="term-link">
                             PMID:26275423
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Inner Kinetochore Protein Interactions with Regional Centromeres of Fission Yeast.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Scm3 is highly enriched throughout the centromeric central domain by ChIP-seq, similar to CENP-A, CENP-C, CENP-T, and CENP-I, except at tRNA genes.</div>
-                        
+
                         <div class="finding-text">"Inner kinetochore proteins CENP-A, CENP-C, CENP-T, CENP-I, and Scm3 are highly enriched throughout the central domain except at tRNA genes, with no evidence for preferred kinetochore assembly sites"</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Scm3 is weakly enriched and less stably incorporated in H3-rich heterochromatin outer repeats compared to the central domain.</div>
-                        
+
                         <div class="finding-text">"These proteins are weakly enriched and less stably incorporated in H3-rich heterochromatin"</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/38084929" target="_blank" class="term-link">
                             PMID:38084929
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The cysteine-rich domain in CENP-A chaperone Scm3HJURP ensures centromere targeting and kinetochore integrity.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">The C-terminal cysteine-rich domain (CYS) of Scm3 binds zinc in vitro and is essential for centromere localization and function.</div>
-                        
+
                         <div class="finding-text">"we find that CYS binds zinc in vitro and is essential for the localization and function of fission yeast Scm3"</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Disrupting CYS by deletion or point mutations in the zinc-binding motif prevents Scm3 centromere localization and compromises kinetochore integrity.</div>
-                        
+
                         <div class="finding-text">"Disrupting CYS by deletion or introduction of point mutations within its zinc-binding motif prevents Scm3 centromere localization and compromises kinetochore integrity"</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">CYS alone can localize to the centromere weakly, and its targeting is greatly enhanced when combined with the Mis16-binding domain (Mis16-BD).</div>
-                        
+
                         <div class="finding-text">"CYS alone can localize to the centromere, albeit weakly, but its targeting is greatly enhanced when combined with Mis16-BD"</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">CYS binds centromeric DNA, providing additional anchoring of Scm3 to centromeres independent of Mis16-BD.</div>
-                        
+
                         <div class="finding-text">"we provide evidence that CYS binds centromeric DNA and can itself localize to the centromere"</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Overexpression of truncated Scm3 containing Mis16-BD and CYS but lacking the CENP-A binding domain causes toxicity, chromosome missegregation, and kinetochore loss.</div>
-                        
+
                         <div class="finding-text">"Expressing a truncated protein containing both Mis16-BD and CYS, but lacking the CENP-A binding domain, causes toxicity and is accompanied by considerable chromosome missegregation and kinetochore loss"</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
         </div>
     </div>
-    
 
 
-    
 
-    
 
-    
+
+
+
+
 
     <!-- Computational Predictions Section -->
-    
+
 
     <!-- Additional Documentation Sections -->
-    
+
     <div class="section">
         <h2 class="section-title">📚 Additional Documentation</h2>
-        
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Deep Research Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(scm3-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q9HDY7" data-a="DOC: Deep Research Falcon" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <hr />
+<p>provider: falcon<br />
+model: Edison Scientific Literature<br />
+cached: false<br />
+start_time: '2026-05-11T06:30:51.930176'<br />
+end_time: '2026-05-11T06:55:33.705799'<br />
+duration_seconds: 1481.78<br />
+template_file: templates/gene_research_go_focused.md<br />
+template_variables:<br />
+  organism: SCHPO<br />
+  gene_id: scm3<br />
+  gene_symbol: scm3<br />
+  uniprot_accession: Q9HDY7<br />
+  protein_description: 'RecName: Full=CENP-A histone chaperone scm3 {ECO:0000312|PomBase:SPAPB1A10.02};'<br />
+  gene_info: Name=scm3 {ECO:0000312|PomBase:SPAPB1A10.02}; ORFNames=SPAPB1A10.02;<br />
+  organism_full: Schizosaccharomyces pombe (strain 972 / ATCC 24843) (Fission yeast).<br />
+  protein_family: Not specified in UniProt<br />
+  protein_domains: Histone-fold. (IPR009072); Scm3/HJURP. (IPR018465); Scm3 (PF10384)<br />
+provider_config:<br />
+  timeout: 600<br />
+  max_retries: 3<br />
+  parameters:<br />
+    allowed_domains: []<br />
+    temperature: 0.1<br />
+citation_count: 24</p>
+<hr />
+<h2 id="question">Question</h2>
+<h1 id="gene-research-for-functional-annotation">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> Q9HDY7</li>
+<li><strong>Protein Description:</strong> RecName: Full=CENP-A histone chaperone scm3 {ECO:0000312|PomBase:SPAPB1A10.02};</li>
+<li><strong>Gene Information:</strong> Name=scm3 {ECO:0000312|PomBase:SPAPB1A10.02}; ORFNames=SPAPB1A10.02;</li>
+<li><strong>Organism (full):</strong> Schizosaccharomyces pombe (strain 972 / ATCC 24843) (Fission yeast).</li>
+<li><strong>Protein Family:</strong> Not specified in UniProt</li>
+<li><strong>Key Domains:</strong> Histone-fold. (IPR009072); Scm3/HJURP. (IPR018465); Scm3 (PF10384)</li>
+</ul>
+<h3 id="mandatory-verification-steps">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "scm3" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Schizosaccharomyces pombe (strain 972 / ATCC 24843) (Fission yeast).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'scm3' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>scm3</strong> (gene ID: scm3, UniProt: Q9HDY7) in SCHPO.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="output">Output</h2>
+<p>Question: You are an expert researcher providing comprehensive, well-cited information.</p>
+<p>Provide detailed information focusing on:<br />
+1. Key concepts and definitions with current understanding<br />
+2. Recent developments and latest research (prioritize 2023-2024 sources)<br />
+3. Current applications and real-world implementations<br />
+4. Expert opinions and analysis from authoritative sources<br />
+5. Relevant statistics and data from recent studies</p>
+<p>Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.<br />
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.</p>
+<h1 id="gene-research-for-functional-annotation_1">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context_1">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot_1">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> Q9HDY7</li>
+<li><strong>Protein Description:</strong> RecName: Full=CENP-A histone chaperone scm3 {ECO:0000312|PomBase:SPAPB1A10.02};</li>
+<li><strong>Gene Information:</strong> Name=scm3 {ECO:0000312|PomBase:SPAPB1A10.02}; ORFNames=SPAPB1A10.02;</li>
+<li><strong>Organism (full):</strong> Schizosaccharomyces pombe (strain 972 / ATCC 24843) (Fission yeast).</li>
+<li><strong>Protein Family:</strong> Not specified in UniProt</li>
+<li><strong>Key Domains:</strong> Histone-fold. (IPR009072); Scm3/HJURP. (IPR018465); Scm3 (PF10384)</li>
+</ul>
+<h3 id="mandatory-verification-steps_1">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "scm3" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Schizosaccharomyces pombe (strain 972 / ATCC 24843) (Fission yeast).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature_1">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'scm3' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target_1">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>scm3</strong> (gene ID: scm3, UniProt: Q9HDY7) in SCHPO.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="research-report-functional-annotation-of-schizosaccharomyces-pombe-scm3-uniprot-q9hdy7-orf-spapb1a1002">Research report: Functional annotation of <em>Schizosaccharomyces pombe</em> <strong>scm3</strong> (UniProt <strong>Q9HDY7</strong>, ORF <strong>SPAPB1A10.02</strong>)</h2>
+<h3 id="0-target-identity-verification-mandatory">0) Target identity verification (mandatory)</h3>
+<p>The gene symbol <strong>scm3</strong> in this report refers specifically to <strong>SPAPB1A10.02</strong> from <em>Schizosaccharomyces pombe</em> (strain 972), encoding a <strong>336 aa</strong> protein (predicted <strong>~37.6 kDa</strong>) that is a fungal ortholog of vertebrate <strong>HJURP</strong> and functions as a <strong>CENP-A (Cnp1) histone chaperone/assembly factor</strong> at centromeres. This is explicitly established in the foundational <em>S. pombe</em> Scm3 studies that map SPAPB1A10.02 to Scm3/Sim1 and characterize its role in Cnp1 deposition. (williams2009fissionyeastscm3 pages 1-2, pidoux2009fissionyeastscm3 pages 1-3, folco2024thecysteinerichdomain pages 1-2)</p>
+<hr />
+<h3 id="1-key-concepts-and-definitions-current-understanding">1) Key concepts and definitions (current understanding)</h3>
+<h4 id="11-centromere-identity-and-cenp-a-chromatin">1.1 Centromere identity and CENP-A chromatin</h4>
+<p>In most eukaryotes (including fission yeast), centromere identity is specified <strong>epigenetically</strong> by nucleosomes containing the histone H3 variant <strong>CENP-A</strong> (called <strong>Cnp1</strong> in <em>S. pombe</em>), which seeds kinetochore assembly and supports faithful chromosome segregation. (lim2024set2regulatesccp1 pages 1-2, salinasluypaert2024canonicalandnoncanonical pages 1-3)</p>
+<h4 id="12-cenp-a-deposition-requires-dedicated-chaperone-pathways">1.2 CENP-A deposition requires dedicated chaperone pathways</h4>
+<p>CENP-A deposition is not a passive histone replacement event; it requires <strong>dedicated chaperones and licensing factors</strong>. In metazoans, the central chaperone is <strong>HJURP</strong>, recruited by the <strong>Mis18 complex</strong> in a cell-cycle-regulated manner. A recent review emphasizes this “canonical” pathway as centered on <strong>Mis18 complex + HJURP</strong> (with CCAN components as readers of pre-existing CENP-A) and highlights multi-layered post-translational and cell-cycle regulation. (salinasluypaert2024canonicalandnoncanonical pages 1-3)</p>
+<h4 id="13-scm3hjurp-family-and-role-in-fungi">1.3 Scm3/HJURP family and role in fungi</h4>
+<p>In fungi, <strong>Scm3</strong> is the functional counterpart of HJURP. In <em>S. pombe</em>, Scm3 is not interpreted as a constitutive nucleosome subunit; rather it behaves as a <strong>CENP-A assembly/maintenance factor</strong> whose centromeric association is <strong>dynamic</strong> across the cell cycle. (williams2009fissionyeastscm3 pages 1-2, williams2009fissionyeastscm3 pages 9-10, pidoux2009fissionyeastscm3 pages 5-6)</p>
+<hr />
+<h3 id="2-molecular-function-of-scm3-in-s-pombe">2) Molecular function of Scm3 in <em>S. pombe</em></h3>
+<h4 id="21-primary-molecular-function">2.1 Primary molecular function</h4>
+<p><strong>Scm3 is the dedicated CENP-A/Cnp1 assembly factor</strong> required for stable enrichment/deposition of Cnp1 at the centromeric central domain. Loss or inactivation of Scm3 leads to loss of centromeric Cnp1 and replacement/encroachment of canonical histones (H3, H2B/H2A/H2B) into centromeric chromatin. (williams2009fissionyeastscm3 pages 1-2, williams2009fissionyeastscm3 pages 8-9)</p>
+<p>Williams et al. show Scm3 is required for centromeric Cnp1 localization, while Scm3 itself localizes to centromeres <strong>independently of Cnp1</strong>, consistent with an upstream assembly role. (williams2009fissionyeastscm3 pages 1-2, williams2009fissionyeastscm3 pages 7-8)</p>
+<h4 id="22-scm3-is-a-receptorassembly-factor-rather-than-a-nucleosome-core-component">2.2 Scm3 is a receptor/assembly factor rather than a nucleosome core component</h4>
+<p>Biochemical fractionation in Pidoux et al. supports the view that Scm3 is unlikely to be a stable stoichiometric nucleosome subunit: during MNase digestion, <strong>most Cnp1 and bulk histones are released after 2–10 min</strong>, whereas <strong>Scm3 remains pellet-associated even after 20 min</strong>, indicating distinct biochemical behavior from canonical nucleosomes. (pidoux2009fissionyeastscm3 pages 5-6)</p>
+<hr />
+<h3 id="3-domain-architecture-and-determinants-of-centromere-targeting">3) Domain architecture and determinants of centromere targeting</h3>
+<h4 id="31-modular-organization">3.1 Modular organization</h4>
+<p>Scm3 exhibits modularity typical of Scm3/HJURP-family proteins:<br />
+- An <strong>N-terminal conserved region</strong> responsible for <strong>specific interaction with CENP-A/Cnp1</strong>. (folco2024thecysteinerichdomain pages 1-2, pidoux2009fissionyeastscm3 pages 3-4)<br />
+- A <strong>C-terminal region</strong> required for centromere targeting via interaction with upstream centromere licensing machinery, including a <strong>Mis16-binding domain (Mis16-BD)</strong> in fission yeast. (folco2024thecysteinerichdomain pages 1-2)</p>
+<p>Williams et al. map a Cnp1-interaction region within <strong>Scm3 aa 1–194</strong> and identify multiple temperature-sensitive alleles affecting Scm3 function (e.g., N100S, N50S). (williams2009fissionyeastscm3 pages 9-10)</p>
+<h4 id="32-mis16-binding-domain-mis16-bd">3.2 Mis16-binding domain (Mis16-BD)</h4>
+<p>Folco et al. summarize prior mapping that <strong>residues ~270–305</strong> comprise the <strong>minimal Mis16-binding domain</strong> (Mis16-BD) required for centromere targeting via the Mis18 holocomplex; the <strong>S281L</strong> mutation (sim1-15) in this region impairs Scm3 function, supporting its importance. (folco2024thecysteinerichdomain pages 1-2, pidoux2009fissionyeastscm3 pages 3-4)</p>
+<h4 id="33-2024-development-fungal-specific-cysteine-rich-cys-zinc-binding-motif">3.3 2024 development: fungal-specific cysteine-rich CYS zinc-binding motif</h4>
+<p>A major 2024 advance is the demonstration that fungal Scm3 proteins contain a <strong>conserved cysteine-rich (CYS) motif</strong> that <strong>binds zinc in vitro</strong> and is <strong>essential for Scm3 centromere localization and kinetochore integrity</strong> in <em>S. pombe</em>. Disrupting the zinc-binding motif prevents Scm3 localization and compromises kinetochore function. (folco2024thecysteinerichdomain pages 1-1, folco2024thecysteinerichdomain pages 1-2)</p>
+<p>Mechanistically, the CYS domain:<br />
+- can <strong>bind centromeric DNA fragments in vitro</strong> using GST-fusion pull-downs, and<br />
+- can <strong>localize autonomously to centromeres</strong> (weakly), but centromere targeting is <strong>strongly enhanced when combined with Mis16-BD</strong>, indicating cooperative targeting. (folco2024thecysteinerichdomain pages 7-8, folco2024thecysteinerichdomain pages 1-2)</p>
+<hr />
+<h3 id="4-interaction-partners-and-pathway-placement">4) Interaction partners and pathway placement</h3>
+<h4 id="41-direct-binding-partners-supported-by-experiments">4.1 Direct binding partners supported by experiments</h4>
+<p><strong>Cnp1/CENP-A:</strong> Scm3 interacts with Cnp1 by yeast two-hybrid and via biochemical association/co-purification and in vitro binding (preferentially with GST-CENP-A vs GST-H3), supporting specificity for CENP-A. (williams2009fissionyeastscm3 pages 1-2, pidoux2009fissionyeastscm3 pages 7-8)</p>
+<p><strong>Mis16:</strong> Scm3 shows a robust Y2H interaction with Mis16, requiring Scm3’s C-terminal region (C-terminal 141 aa in one mapping). (williams2009fissionyeastscm3 pages 7-8, williams2009fissionyeastscm3 pages 8-9)</p>
+<p><strong>Sim3 (NASP-like escort):</strong> Pidoux et al. report that the Scm3–CENP-A interaction is disrupted in sim3Δ, consistent with a handover path in which Sim3 escorts nascent Cnp1 and facilitates transfer to Scm3 at centromeres. (pidoux2009fissionyeastscm3 pages 7-8)</p>
+<h4 id="42-dependency-relationships-targeting-and-assembly-hierarchy">4.2 Dependency relationships (targeting and assembly hierarchy)</h4>
+<p>Both Williams et al. and Pidoux et al. show that <strong>centromere localization of Scm3 requires</strong> kinetochore/centromere factors including <strong>Mis6/Sim4/Mis16/Mis18</strong>, while Scm3 localization is largely <strong>independent of Cnp1</strong> (cnp1-1 does not displace Scm3). (williams2009fissionyeastscm3 pages 7-8, pidoux2009fissionyeastscm3 pages 7-8, pidoux2009fissionyeastscm3 pages 5-6)</p>
+<p>Conversely, Scm3 is required for stable centromeric enrichment of Cnp1. (williams2009fissionyeastscm3 pages 1-2, williams2009fissionyeastscm3 pages 8-9)</p>
+<h4 id="43-structural-context-for-recruitment-machinery">4.3 Structural context for recruitment machinery</h4>
+<p>Structural/architectural work on the <strong>Mis16–Mis18–Mis19</strong> complex supports a recruitment model where Mis16 is positioned to recruit the <strong>Scm3–Cnp1–H4</strong> complex, while Mis19 bridges Mis16 and Mis18; importantly, <em>S. pombe</em> appears to lack a large Mis18BP1-like subunit and instead uses smaller partners (Mis19/Eic1, etc.). (korntnervetter2019subunitinteractionsand pages 1-2)</p>
+<hr />
+<h3 id="5-cellular-localization-and-cell-cycle-regulation">5) Cellular localization and cell-cycle regulation</h3>
+<h4 id="51-where-scm3-acts">5.1 Where Scm3 acts</h4>
+<p>Scm3 functions in the <strong>nucleus</strong> at <strong>centromeres</strong>, specifically the <strong>central centromere domain</strong> (subkinetochore chromatin). (williams2009fissionyeastscm3 pages 7-8, pidoux2009fissionyeastscm3 pages 3-4)</p>
+<h4 id="52-cell-cycle-timing-scm3-is-dynamic">5.2 Cell-cycle timing (Scm3 is dynamic)</h4>
+<p>A defining feature of <em>S. pombe</em> Scm3 is cell-cycle-regulated centromere association:<br />
+- Scm3 is present at centromeres in <strong>interphase/G2</strong>.<br />
+- It <strong>dissociates at mitotic onset/early mitosis</strong> and<br />
+- <strong>reassociates in late anaphase/telophase</strong>.<br />
+This mirrors Mis16/Mis18 dynamics rather than the more constitutive presence of Cnp1. (williams2009fissionyeastscm3 pages 7-8, pidoux2009fissionyeastscm3 pages 3-4)</p>
+<p>Williams et al. used a metaphase arrest (nda3-KM311) at <strong>20°C for 8 hr</strong> and observed near-complete loss of Scm3 centromeric ChIP signal with little change in Cnp1, supporting the conclusion that Scm3 temporarily disengages while Cnp1 persists through mitosis. (williams2009fissionyeastscm3 pages 7-8, williams2009fissionyeastscm3 pages 9-10)</p>
+<hr />
+<h3 id="6-phenotypes-and-quantitative-data-supporting-functional-annotation">6) Phenotypes and quantitative data supporting functional annotation</h3>
+<h4 id="61-scm3-loss-of-function-phenotypes">6.1 Scm3 loss-of-function phenotypes</h4>
+<p>Disrupting Scm3 disrupts CENP-A chromatin and leads to defective kinetochore assembly, chromosome segregation errors, and inviability/toxicity depending on the perturbation. (folco2024thecysteinerichdomain pages 1-1, williams2009fissionyeastscm3 pages 8-9)</p>
+<h4 id="62-quantitative-chromosome-missegregation-data-2024">6.2 Quantitative chromosome missegregation data (2024)</h4>
+<p>Folco et al. report strong quantitative effects when mis-targeting Scm3 domains:<br />
+- Control: <strong>3.3% (4/121)</strong> ChrII missegregation.<br />
+- GFP-scm3FL: <strong>4.5% (6/133)</strong>.<br />
+- Toxic C-terminal fragment (GFP-scm3-CT): <strong>83.2% (94/113)</strong>.<br />
+- Zinc-motif mutant (GFP-scm3-CT4A): <strong>2.4% (3/124)</strong>.<br />
+- CYS alone (GFP-scm3-CYS): <strong>7.0% (10/143)</strong>.<br />
+These data support that the CYS zinc-binding motif and its proper regulatory context are critical for kinetochore integrity. (folco2024thecysteinerichdomain pages 9-10)</p>
+<p>The same study quantifies CENP-C focus intensity and chromosome II segregation with sample sizes and confidence intervals (see figure panels below). (folco2024thecysteinerichdomain pages 8-9, folco2024thecysteinerichdomain media 39b30728, folco2024thecysteinerichdomain media a784a709, folco2024thecysteinerichdomain media 6ed87ec6)</p>
+<hr />
+<h3 id="7-recent-developments-prioritizing-20232024">7) Recent developments (prioritizing 2023–2024)</h3>
+<h4 id="71-2024-new-centromere-targeting-mechanism-cys-zinc-binding-mis16-bd-cooperativity">7.1 2024: New centromere targeting mechanism (CYS zinc-binding + Mis16-BD cooperativity)</h4>
+<p>Folco et al. (received 2023-05-11; accepted 2023-11-28; published in NAR 2024) establish that <strong>fungal Scm3 proteins have an essential zinc-binding cysteine-rich CYS domain</strong> and show it is required for centromere targeting and kinetochore integrity, adding a centromere-targeting determinant beyond the canonical Mis16/Mis18 pathway. (folco2024thecysteinerichdomain pages 1-2, folco2024thecysteinerichdomain pages 9-10)</p>
+<h4 id="72-2024-back-up-cenp-a-retargeting-pathway-contextualizing-scm3-within-broader-homeostasis">7.2 2024: “Back-up” CENP-A retargeting pathway contextualizing Scm3 within broader homeostasis</h4>
+<p>Lim et al. (Advance access publication date <strong>5 March 2024</strong>) report that <strong>rDNA</strong> can act as a sink for delocalized CENP-A in a temperature-sensitive <strong>cnp1-1</strong> mutant, and that <strong>Set2 downregulation</strong> can reverse aneuploidy by redirecting mislocalized CENP-A back to centromeres. This relocalization depends on canonical loaders <strong>Mis16/Mis17/Mis18</strong>, and the paper reiterates the early assembly handover in which newly synthesized CENP-A complexes with H4 and <strong>Scm3</strong>. (lim2024set2regulatesccp1 pages 1-2)</p>
+<hr />
+<h3 id="8-current-applications-and-real-world-implementations">8) Current applications and real-world implementations</h3>
+<h4 id="81-model-for-conserved-cenp-a-chaperoning-principles">8.1 Model for conserved CENP-A chaperoning principles</h4>
+<p>Although Scm3 itself is a yeast protein, it serves as a <strong>high-tractability genetic and biochemical model</strong> for the conserved logic of CENP-A deposition used in metazoans (HJURP + Mis18 licensing). The 2024 review literature frames this axis as central to centromere inheritance and genome stability, and fission yeast provides mechanistic dissection of recruitment and targeting determinants (e.g., Mis16-dependent targeting; fungal-specific DNA/zinc-binding motifs). (salinasluypaert2024canonicalandnoncanonical pages 1-3, folco2024thecysteinerichdomain pages 1-2)</p>
+<h4 id="82-quantitative-phenotype-assays-for-centromere-integrity">8.2 Quantitative phenotype assays for centromere integrity</h4>
+<p>Scm3 studies support widely used assays for centromere/kinetochore function in vivo, including:<br />
+- chromosome missegregation quantification using lacO/tetO labeling,<br />
+- minichromosome-loss assays (e.g., pNBg), and<br />
+- fluorescence intensity quantification of kinetochore foci (CENP-A/CENP-C readouts). (folco2024thecysteinerichdomain pages 8-9)</p>
+<p>These assays are broadly implemented in centromere biology to measure stability, segregation fidelity, and epigenetic inheritance mechanisms.</p>
+<hr />
+<h3 id="9-expert-synthesis-and-mechanistic-interpretation">9) Expert synthesis and mechanistic interpretation</h3>
+<p>The combined evidence supports a mechanistic model for <em>S. pombe</em> Scm3 as a <strong>centromere-localized CENP-A receptor/assembly factor</strong> that is recruited/retained through a <strong>multi-input targeting system</strong>:<br />
+1) <strong>Mis16/Mis18/Mis6/Sim4-dependent licensing</strong> is required to localize Scm3 to centromeres, positioning it upstream of stable Cnp1 deposition. (williams2009fissionyeastscm3 pages 7-8, pidoux2009fissionyeastscm3 pages 7-8)<br />
+2) <strong>Direct specificity for CENP-A</strong> is supported by Scm3–Cnp1 binding (Y2H, in vitro specificity vs H3). (pidoux2009fissionyeastscm3 pages 7-8, williams2009fissionyeastscm3 pages 1-2)<br />
+3) <strong>Cell-cycle gating</strong> (mitotic dissociation and late-anaphase return) likely functions to couple (re)loading competence to a specific cell-cycle window, analogous in principle (but not identical in timing) to the Mis18–HJURP regulation reviewed for metazoans. (williams2009fissionyeastscm3 pages 9-10, salinasluypaert2024canonicalandnoncanonical pages 1-3)<br />
+4) The 2024 discovery of a <strong>fungal-specific CYS zinc-binding motif</strong> implies that fungal Scm3 proteins have evolved additional <strong>DNA- and/or chromatin-interaction modules</strong> that reinforce centromere targeting in organisms lacking sequence-specific centromere DNA-binding proteins like budding yeast Ndc10. (folco2024thecysteinerichdomain pages 1-2)</p>
+<hr />
+<h3 id="10-evidence-map-summary-table">10) Evidence map (summary table)</h3>
+<p>The following table provides a compact mapping from functional claims to assays, quantitative data, and sources.</p>
+<table>
+<thead>
+<tr>
+<th>Aspect</th>
+<th>Key findings</th>
+<th>Evidence type</th>
+<th>Quantitative/statistical data if available</th>
+<th>Primary source with year + URL</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Molecular function</td>
+<td>Scm3 is the dedicated CENP-A/Cnp1 assembly factor in <em>S. pombe</em>; it binds Cnp1 and is required for stable deposition/maintenance of Cnp1 chromatin at centromeres, while itself is not a stable nucleosome component (williams2009fissionyeastscm3 pages 1-2, pidoux2009fissionyeastscm3 pages 7-8, pidoux2009fissionyeastscm3 pages 5-6)</td>
+<td>Y2H, co-IP/co-purification, in vitro binding, ChIP, genetics, MNase fractionation</td>
+<td>In scm3-ts cells, Cnp1 enrichment at cnt1/imr1 is lost; H2B signal at centromeres increased ~3-fold in one assay after shift to restrictive conditions (williams2009fissionyeastscm3 pages 8-9)</td>
+<td>Williams 2009 — https://doi.org/10.1016/j.molcel.2009.01.017; Pidoux 2009 — https://doi.org/10.1016/j.molcel.2009.01.019</td>
+</tr>
+<tr>
+<td>Domain architecture</td>
+<td>SPAPB1A10.02 encodes a 336 aa (~37.6 kDa) Scm3/HJURP-family protein with an N-terminal conserved CENP-A-binding region and a divergent C-terminus that mediates centromere targeting; the minimum Mis16-binding region maps to ~aa 270–305 (williams2009fissionyeastscm3 pages 1-2, folco2024thecysteinerichdomain pages 1-2, williams2009fissionyeastscm3 pages 9-10)</td>
+<td>Sequence analysis, domain mapping, Y2H, mutational analysis</td>
+<td>Protein length 336 aa; predicted mass 37.6 kDa; Mis16-BD mapped to residues ~270–305; Cnp1-interacting region reported within aa 1–194 (williams2009fissionyeastscm3 pages 1-2, folco2024thecysteinerichdomain pages 1-2, williams2009fissionyeastscm3 pages 9-10)</td>
+<td>Williams 2009 — https://doi.org/10.1016/j.molcel.2009.01.017; Pidoux 2009 — https://doi.org/10.1016/j.molcel.2009.01.019; Folco 2024 — https://doi.org/10.1093/nar/gkad1182</td>
+</tr>
+<tr>
+<td>Fungal-specific CYS domain</td>
+<td>A conserved C-terminal cysteine-rich (CYS) zinc-binding motif is essential for efficient centromere localization and kinetochore integrity; CYS alone can weakly target centromeres and binds centromeric DNA in vitro, but acts best with Mis16-BD (folco2024thecysteinerichdomain pages 1-1, folco2024thecysteinerichdomain pages 7-8, folco2024thecysteinerichdomain pages 1-2)</td>
+<td>In vitro zinc binding, GST-DNA pull-down, ChIP-qPCR, live-cell imaging, mutagenesis</td>
+<td>CYS spans residues 303–336; a 34-aa CYS fragment was used in DNA-binding assays; ApoI centromeric fragments ranged 6–710 bp (folco2024thecysteinerichdomain pages 7-8, folco2024thecysteinerichdomain pages 1-2)</td>
+<td>Folco 2024 — https://doi.org/10.1093/nar/gkad1182</td>
+</tr>
+<tr>
+<td>Subcellular localization</td>
+<td>Scm3 localizes to centromeric central domains/subkinetochore chromatin in interphase/G2 and is enriched across the central domain with other inner kinetochore proteins (williams2009fissionyeastscm3 pages 7-8, pidoux2009fissionyeastscm3 pages 3-4)</td>
+<td>GFP imaging, IF, ChIP, ChIP-seq</td>
+<td>Centromeric enrichment detected at cnt/imr regions; imaging quantified in multiple later studies (williams2009fissionyeastscm3 pages 7-8, pidoux2009fissionyeastscm3 pages 3-4)</td>
+<td>Williams 2009 — https://doi.org/10.1016/j.molcel.2009.01.017; Pidoux 2009 — https://doi.org/10.1016/j.molcel.2009.01.019</td>
+</tr>
+<tr>
+<td>Interaction partners</td>
+<td>Scm3 interacts with Cnp1/CENP-A and Mis16; associates genetically/biochemically with Mis16-Mis18, Mis6 complex, and Sim3 escort pathway; Scm3 self-association has also been reported (williams2009fissionyeastscm3 pages 1-2, williams2009fissionyeastscm3 pages 7-8, pidoux2009fissionyeastscm3 pages 7-8)</td>
+<td>Y2H, co-IP/co-purification, in vitro binding, genetics</td>
+<td>Robust Y2H for Scm3–Mis16; Y2H interaction with Cnp1 seen in both bait/prey orientations; no Y2H detected for Scm3–Mis18 in Williams et al. (williams2009fissionyeastscm3 pages 7-8, williams2009fissionyeastscm3 pages 1-2)</td>
+<td>Williams 2009 — https://doi.org/10.1016/j.molcel.2009.01.017; Pidoux 2009 — https://doi.org/10.1016/j.molcel.2009.01.019</td>
+</tr>
+<tr>
+<td>Dependency relationships for centromere targeting</td>
+<td>Scm3 centromere localization depends on Mis6, Sim4, Mis16, and Mis18, but not on Cnp1 itself; conversely, Scm3 is required for centromeric Cnp1 enrichment (williams2009fissionyeastscm3 pages 7-8, pidoux2009fissionyeastscm3 pages 7-8, pidoux2009fissionyeastscm3 pages 5-6)</td>
+<td>Mutant analysis, ChIP, IF/imaging, genetics</td>
+<td>Dependency tests used cnp1-1, mis6-302, sim4-193, mis16-53, mis18-262, typically after 36°C for 6 h (pidoux2009fissionyeastscm3 pages 7-8, pidoux2009fissionyeastscm3 pages 3-4)</td>
+<td>Williams 2009 — https://doi.org/10.1016/j.molcel.2009.01.017; Pidoux 2009 — https://doi.org/10.1016/j.molcel.2009.01.019</td>
+</tr>
+<tr>
+<td>Cell-cycle regulation</td>
+<td>Scm3 dissociates from centromeres from mitotic onset/early mitosis and reassociates in late anaphase/telophase, paralleling Mis16/Mis18 rather than constitutive Cnp1 (williams2009fissionyeastscm3 pages 7-8, williams2009fissionyeastscm3 pages 8-9, pidoux2009fissionyeastscm3 pages 3-4)</td>
+<td>Live-cell imaging, IF, ChIP, mitotic arrest experiments</td>
+<td>nda3-KM311 metaphase arrest at 20°C for 8 h caused near-complete loss of Scm3 centromeric signal with little change in Cnp1 signal (williams2009fissionyeastscm3 pages 7-8, williams2009fissionyeastscm3 pages 9-10)</td>
+<td>Williams 2009 — https://doi.org/10.1016/j.molcel.2009.01.017; Pidoux 2009 — https://doi.org/10.1016/j.molcel.2009.01.019</td>
+</tr>
+<tr>
+<td>Biochemical behavior vs nucleosome core</td>
+<td>Scm3 behaves differently from core histones/CENP-A nucleosomes in MNase fractionation, supporting a receptor/assembly-factor role rather than a stoichiometric nucleosome subunit (pidoux2009fissionyeastscm3 pages 5-6)</td>
+<td>MNase digestion, chromatin fractionation</td>
+<td>Most CENP-A and bulk histones released after 2–10 min MNase; Scm3 remained pellet-associated even after 20 min digestion (pidoux2009fissionyeastscm3 pages 5-6)</td>
+<td>Pidoux 2009 — https://doi.org/10.1016/j.molcel.2009.01.019</td>
+</tr>
+<tr>
+<td>Mutant/allelic evidence</td>
+<td>Functional alleles include sim1-15/S281L in the Mis16-BD region and sim1-106/L73F, sim1-139/L56F in the conserved N-terminal Scm3 domain; Williams also isolated scm3-6/N100S and scm3-19/N50S ts alleles (pidoux2009fissionyeastscm3 pages 3-4, williams2009fissionyeastscm3 pages 9-10)</td>
+<td>Genetics, temperature-sensitive phenotyping, ChIP, IF</td>
+<td>Common restrictive condition: 36°C for 6 h (Pidoux); Williams selected ts mutants at 35.5°C and used semipermissive 30°C in survival assays (pidoux2009fissionyeastscm3 pages 3-4, williams2009fissionyeastscm3 pages 9-10)</td>
+<td>Pidoux 2009 — https://doi.org/10.1016/j.molcel.2009.01.019; Williams 2009 — https://doi.org/10.1016/j.molcel.2009.01.017</td>
+</tr>
+<tr>
+<td>Chromosome segregation/kinetochore phenotypes</td>
+<td>Loss or disruption of Scm3 causes chromosome segregation defects, kinetochore loss, and inviability/strong toxicity depending on allele/construct; CYS motif mutants compromise kinetochore integrity even when bulk growth is modestly affected (folco2024thecysteinerichdomain pages 1-1, folco2024thecysteinerichdomain pages 5-6, folco2024thecysteinerichdomain pages 11-12)</td>
+<td>Genetics, live-cell imaging, fluorescence quantification, minichromosome assay</td>
+<td>Overexpressed GFP-scm3-CT caused 83.2% ChrII missegregation (94/113) versus 3.3% in control (4/121); GFP-scm3-CT4A reduced this to 2.4% (3/124); GFP-scm3-CYS gave 7.0% (10/143) (folco2024thecysteinerichdomain pages 9-10)</td>
+<td>Folco 2024 — https://doi.org/10.1093/nar/gkad1182</td>
+</tr>
+<tr>
+<td>Recent development (2024): centromere targeting mechanism</td>
+<td>2024 work added a new mechanistic layer: Scm3 targeting is not explained solely by Mis16-BD/Mis18; the fungal-specific zinc-binding CYS motif contributes independently and cooperatively to centromere targeting, likely via DNA interaction (folco2024thecysteinerichdomain pages 1-1, folco2024thecysteinerichdomain pages 7-8, folco2024thecysteinerichdomain pages 9-10)</td>
+<td>In vitro zinc binding, DNA affinity assay, ChIP-qPCR, imaging, overexpression genetics</td>
+<td>GFP-Scm3-CYS focus intensity was &gt; half that of full-length Scm3; combined Mis16-BD + CYS gave near-full targeting; sample sizes in focus quantification included N=310, 275, 217 in one panel set (folco2024thecysteinerichdomain pages 7-8)</td>
+<td>Folco 2024 — https://doi.org/10.1093/nar/gkad1182</td>
+</tr>
+<tr>
+<td>Recent development (2024): CENP-A retargeting pathway context</td>
+<td>A 2024 fission-yeast study on centromere stability places Scm3 within a broader correction pathway for mislocalized CENP-A: Set2 downregulation can retarget cnp1-1 from rDNA back to centromeres, requiring canonical loaders Mis16/Mis17/Mis18 and reiterating Scm3 as the CENP-A/H4 chaperone partner (lim2024set2regulatesccp1 pages 1-2)</td>
+<td>Genetics, RNA-seq, ChIP, microscopy</td>
+<td>RNA-seq DEG cutoff &gt;1.5-fold; cells shifted from 22°C to 33°C for 4 h in some assays; cultures concentrated to 10^7 cells/ml for spotting (lim2024set2regulatesccp1 pages 2-3)</td>
+<td>Lim 2024 — https://doi.org/10.1093/nar/gkae084</td>
+</tr>
+<tr>
+<td>Structural recruitment context</td>
+<td>Structural work on the Mis16–Mis18–Mis19 complex supports the recruitment framework in which Mis16 is positioned to recruit the Scm3–Cnp1–H4 complex, while Mis19 bridges Mis16 and Mis18 (korntnervetter2019subunitinteractionsand pages 1-2)</td>
+<td>X-ray crystallography, structural/biochemical analysis</td>
+<td>Mis19 residues 56–63 form a β-strand contact; residues 79–97 and 99–111 contribute additional Mis16 interfaces; Mis16–Mis19C structure solved at 2.0 Å (korntnervetter2019subunitinteractionsand pages 1-2)</td>
+<td>Korntner-Vetter 2019 — https://doi.org/10.26508/lsa.201900408</td>
+</tr>
+<tr>
+<td>Applications / real-world relevance</td>
+<td>Scm3 is used as a model for conserved HJURP-family centromere licensing/chaperoning, informing how CENP-A is targeted, how ectopic CENP-A may be corrected, and how chromosome missegregation/aneuploidy can arise when centromere identity fails (salinasluypaert2024canonicalandnoncanonical pages 1-3, lim2024set2regulatesccp1 pages 1-2)</td>
+<td>Comparative review, fission-yeast genetics, centromere biology applications</td>
+<td>No direct translational metric for Scm3 itself, but related centromere misregulation is tied to aneuploidy/cancer risk in broader literature summarized in recent review/context (salinasluypaert2024canonicalandnoncanonical pages 1-3, lim2024set2regulatesccp1 pages 1-2)</td>
+<td>Salinas-Luypaert &amp; Fachinetti 2024 — https://doi.org/10.1016/j.ceb.2024.102396; Lim 2024 — https://doi.org/10.1093/nar/gkae084</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes experimentally supported functional annotation for Schizosaccharomyces pombe Scm3/Q9HDY7, including mechanism, localization, interactions, domain organization, phenotypes, and recent 2023–2024 developments. It is useful as a compact evidence map linking each claim to methods, quantitative data, and primary sources.</em></p>
+<hr />
+<h3 id="11-key-figure-evidence-visual">11) Key figure evidence (visual)</h3>
+<p>Quantitative evidence for the functional requirement of the Scm3 CYS zinc-binding motif in kinetochore integrity and chromosome segregation is shown in Folco et al. Figure 4 panels (CENP-C focus intensity, minichromosome loss, and chromosome II missegregation). (folco2024thecysteinerichdomain media 39b30728, folco2024thecysteinerichdomain media a784a709, folco2024thecysteinerichdomain media 6ed87ec6)</p>
+<hr />
+<h2 id="references-urls-and-publication-dates-where-available">References (URLs and publication dates where available)</h2>
+<ul>
+<li>Williams JS, Hayashi T, Yanagida M, Russell P. <strong>Fission yeast Scm3 mediates stable assembly of Cnp1/CENP-A into centromeric chromatin.</strong> <em>Molecular Cell</em> (Feb 2009). https://doi.org/10.1016/j.molcel.2009.01.017 (williams2009fissionyeastscm3 pages 1-2)</li>
+<li>Pidoux AL, Choi ES, Abbott JKR, et al. <strong>Fission Yeast Scm3: A CENP-A Receptor Required for Integrity of Subkinetochore Chromatin.</strong> <em>Molecular Cell</em> (Feb 2009). https://doi.org/10.1016/j.molcel.2009.01.019 (pidoux2009fissionyeastscm3 pages 1-3)</li>
+<li>Folco HD, Xiao H, Wheeler D, et al. <strong>The cysteine-rich domain in CENP-A chaperone Scm3/HJURP ensures centromere targeting and kinetochore integrity.</strong> <em>Nucleic Acids Research</em> (2024; accepted 28 Nov 2023). https://doi.org/10.1093/nar/gkad1182 (folco2024thecysteinerichdomain pages 1-2)</li>
+<li>Lim KK, Lam UTF, Li Y, et al. <strong>Set2 regulates Ccp1 and Swc2 to ensure centromeric stability by retargeting CENP-A.</strong> <em>Nucleic Acids Research</em> (Advance access publication date: <strong>5 March 2024</strong>). https://doi.org/10.1093/nar/gkae084 (lim2024set2regulatesccp1 pages 1-2)</li>
+<li>Salinas-Luypaert C, Fachinetti D. <strong>Canonical and noncanonical regulators of centromere assembly and maintenance.</strong> <em>Current Opinion in Cell Biology</em> (Aug 2024). https://doi.org/10.1016/j.ceb.2024.102396 (salinasluypaert2024canonicalandnoncanonical pages 1-3)</li>
+<li>Korntner-Vetter M, Lefèvre S, Hu X-W, et al. <strong>Subunit interactions and arrangements in the fission yeast Mis16–Mis18–Mis19 complex.</strong> <em>Life Science Alliance</em> (1 Aug 2019). https://doi.org/10.26508/lsa.201900408 (korntnervetter2019subunitinteractionsand pages 1-2)</li>
+</ul>
+<p>References</p>
+<ol>
+<li>
+<p>(williams2009fissionyeastscm3 pages 1-2): Jessica S. Williams, Takeshi Hayashi, Mitsuhiro Yanagida, and Paul Russell. Fission yeast scm3 mediates stable assembly of cnp1/cenp-a into centromeric chromatin. Molecular cell, 33 3:287-98, Feb 2009. URL: https://doi.org/10.1016/j.molcel.2009.01.017, doi:10.1016/j.molcel.2009.01.017. This article has 237 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(pidoux2009fissionyeastscm3 pages 1-3): Alison L. Pidoux, Eun Shik Choi, Johanna K.R. Abbott, Xingkun Liu, Alexander Kagansky, Araceli G. Castillo, Georgina L. Hamilton, William Richardson, Juri Rappsilber, Xiangwei He, and Robin C. Allshire. Fission yeast scm3: a cenp-a receptor required for integrity of subkinetochore chromatin. Molecular Cell, 33:299-311, Feb 2009. URL: https://doi.org/10.1016/j.molcel.2009.01.019, doi:10.1016/j.molcel.2009.01.019. This article has 221 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(folco2024thecysteinerichdomain pages 1-2): H Diego Folco, Hua Xiao, David Wheeler, Hanqiao Feng, Yawen Bai, and Shiv I S Grewal. The cysteine-rich domain in cenp-a chaperone scm3hjurp ensures centromere targeting and kinetochore integrity. Nucleic acids research, 52:1688-1701, Dec 2024. URL: https://doi.org/10.1093/nar/gkad1182, doi:10.1093/nar/gkad1182. This article has 5 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lim2024set2regulatesccp1 pages 1-2): Kim Kiat Lim, Ulysses Tsz Fung Lam, Ying Li, Yi Bing Zeng, Henry Yang, and Ee Sin Chen. Set2 regulates ccp1 and swc2 to ensure centromeric stability by retargeting cenp-a. Nucleic Acids Research, 52:4198-4214, Mar 2024. URL: https://doi.org/10.1093/nar/gkae084, doi:10.1093/nar/gkae084. This article has 2 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(salinasluypaert2024canonicalandnoncanonical pages 1-3): Catalina Salinas-Luypaert and Daniele Fachinetti. Canonical and noncanonical regulators of centromere assembly and maintenance. Current Opinion in Cell Biology, 89:102396, Aug 2024. URL: https://doi.org/10.1016/j.ceb.2024.102396, doi:10.1016/j.ceb.2024.102396. This article has 8 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(williams2009fissionyeastscm3 pages 9-10): Jessica S. Williams, Takeshi Hayashi, Mitsuhiro Yanagida, and Paul Russell. Fission yeast scm3 mediates stable assembly of cnp1/cenp-a into centromeric chromatin. Molecular cell, 33 3:287-98, Feb 2009. URL: https://doi.org/10.1016/j.molcel.2009.01.017, doi:10.1016/j.molcel.2009.01.017. This article has 237 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(pidoux2009fissionyeastscm3 pages 5-6): Alison L. Pidoux, Eun Shik Choi, Johanna K.R. Abbott, Xingkun Liu, Alexander Kagansky, Araceli G. Castillo, Georgina L. Hamilton, William Richardson, Juri Rappsilber, Xiangwei He, and Robin C. Allshire. Fission yeast scm3: a cenp-a receptor required for integrity of subkinetochore chromatin. Molecular Cell, 33:299-311, Feb 2009. URL: https://doi.org/10.1016/j.molcel.2009.01.019, doi:10.1016/j.molcel.2009.01.019. This article has 221 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(williams2009fissionyeastscm3 pages 8-9): Jessica S. Williams, Takeshi Hayashi, Mitsuhiro Yanagida, and Paul Russell. Fission yeast scm3 mediates stable assembly of cnp1/cenp-a into centromeric chromatin. Molecular cell, 33 3:287-98, Feb 2009. URL: https://doi.org/10.1016/j.molcel.2009.01.017, doi:10.1016/j.molcel.2009.01.017. This article has 237 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(williams2009fissionyeastscm3 pages 7-8): Jessica S. Williams, Takeshi Hayashi, Mitsuhiro Yanagida, and Paul Russell. Fission yeast scm3 mediates stable assembly of cnp1/cenp-a into centromeric chromatin. Molecular cell, 33 3:287-98, Feb 2009. URL: https://doi.org/10.1016/j.molcel.2009.01.017, doi:10.1016/j.molcel.2009.01.017. This article has 237 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(pidoux2009fissionyeastscm3 pages 3-4): Alison L. Pidoux, Eun Shik Choi, Johanna K.R. Abbott, Xingkun Liu, Alexander Kagansky, Araceli G. Castillo, Georgina L. Hamilton, William Richardson, Juri Rappsilber, Xiangwei He, and Robin C. Allshire. Fission yeast scm3: a cenp-a receptor required for integrity of subkinetochore chromatin. Molecular Cell, 33:299-311, Feb 2009. URL: https://doi.org/10.1016/j.molcel.2009.01.019, doi:10.1016/j.molcel.2009.01.019. This article has 221 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(folco2024thecysteinerichdomain pages 1-1): H Diego Folco, Hua Xiao, David Wheeler, Hanqiao Feng, Yawen Bai, and Shiv I S Grewal. The cysteine-rich domain in cenp-a chaperone scm3hjurp ensures centromere targeting and kinetochore integrity. Nucleic acids research, 52:1688-1701, Dec 2024. URL: https://doi.org/10.1093/nar/gkad1182, doi:10.1093/nar/gkad1182. This article has 5 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(folco2024thecysteinerichdomain pages 7-8): H Diego Folco, Hua Xiao, David Wheeler, Hanqiao Feng, Yawen Bai, and Shiv I S Grewal. The cysteine-rich domain in cenp-a chaperone scm3hjurp ensures centromere targeting and kinetochore integrity. Nucleic acids research, 52:1688-1701, Dec 2024. URL: https://doi.org/10.1093/nar/gkad1182, doi:10.1093/nar/gkad1182. This article has 5 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(pidoux2009fissionyeastscm3 pages 7-8): Alison L. Pidoux, Eun Shik Choi, Johanna K.R. Abbott, Xingkun Liu, Alexander Kagansky, Araceli G. Castillo, Georgina L. Hamilton, William Richardson, Juri Rappsilber, Xiangwei He, and Robin C. Allshire. Fission yeast scm3: a cenp-a receptor required for integrity of subkinetochore chromatin. Molecular Cell, 33:299-311, Feb 2009. URL: https://doi.org/10.1016/j.molcel.2009.01.019, doi:10.1016/j.molcel.2009.01.019. This article has 221 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(korntnervetter2019subunitinteractionsand pages 1-2): Melanie Korntner-Vetter, Stéphane Lefèvre, Xiao-Wen Hu, Roger George, and Martin R Singleton. Subunit interactions and arrangements in the fission yeast mis16–mis18–mis19 complex. Life Science Alliance, 2:e201900408, Aug 2019. URL: https://doi.org/10.26508/lsa.201900408, doi:10.26508/lsa.201900408. This article has 5 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(folco2024thecysteinerichdomain pages 9-10): H Diego Folco, Hua Xiao, David Wheeler, Hanqiao Feng, Yawen Bai, and Shiv I S Grewal. The cysteine-rich domain in cenp-a chaperone scm3hjurp ensures centromere targeting and kinetochore integrity. Nucleic acids research, 52:1688-1701, Dec 2024. URL: https://doi.org/10.1093/nar/gkad1182, doi:10.1093/nar/gkad1182. This article has 5 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(folco2024thecysteinerichdomain pages 8-9): H Diego Folco, Hua Xiao, David Wheeler, Hanqiao Feng, Yawen Bai, and Shiv I S Grewal. The cysteine-rich domain in cenp-a chaperone scm3hjurp ensures centromere targeting and kinetochore integrity. Nucleic acids research, 52:1688-1701, Dec 2024. URL: https://doi.org/10.1093/nar/gkad1182, doi:10.1093/nar/gkad1182. This article has 5 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(folco2024thecysteinerichdomain media 39b30728): H Diego Folco, Hua Xiao, David Wheeler, Hanqiao Feng, Yawen Bai, and Shiv I S Grewal. The cysteine-rich domain in cenp-a chaperone scm3hjurp ensures centromere targeting and kinetochore integrity. Nucleic acids research, 52:1688-1701, Dec 2024. URL: https://doi.org/10.1093/nar/gkad1182, doi:10.1093/nar/gkad1182. This article has 5 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(folco2024thecysteinerichdomain media a784a709): H Diego Folco, Hua Xiao, David Wheeler, Hanqiao Feng, Yawen Bai, and Shiv I S Grewal. The cysteine-rich domain in cenp-a chaperone scm3hjurp ensures centromere targeting and kinetochore integrity. Nucleic acids research, 52:1688-1701, Dec 2024. URL: https://doi.org/10.1093/nar/gkad1182, doi:10.1093/nar/gkad1182. This article has 5 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(folco2024thecysteinerichdomain media 6ed87ec6): H Diego Folco, Hua Xiao, David Wheeler, Hanqiao Feng, Yawen Bai, and Shiv I S Grewal. The cysteine-rich domain in cenp-a chaperone scm3hjurp ensures centromere targeting and kinetochore integrity. Nucleic acids research, 52:1688-1701, Dec 2024. URL: https://doi.org/10.1093/nar/gkad1182, doi:10.1093/nar/gkad1182. This article has 5 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(folco2024thecysteinerichdomain pages 5-6): H Diego Folco, Hua Xiao, David Wheeler, Hanqiao Feng, Yawen Bai, and Shiv I S Grewal. The cysteine-rich domain in cenp-a chaperone scm3hjurp ensures centromere targeting and kinetochore integrity. Nucleic acids research, 52:1688-1701, Dec 2024. URL: https://doi.org/10.1093/nar/gkad1182, doi:10.1093/nar/gkad1182. This article has 5 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(folco2024thecysteinerichdomain pages 11-12): H Diego Folco, Hua Xiao, David Wheeler, Hanqiao Feng, Yawen Bai, and Shiv I S Grewal. The cysteine-rich domain in cenp-a chaperone scm3hjurp ensures centromere targeting and kinetochore integrity. Nucleic acids research, 52:1688-1701, Dec 2024. URL: https://doi.org/10.1093/nar/gkad1182, doi:10.1093/nar/gkad1182. This article has 5 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lim2024set2regulatesccp1 pages 2-3): Kim Kiat Lim, Ulysses Tsz Fung Lam, Ying Li, Yi Bing Zeng, Henry Yang, and Ee Sin Chen. Set2 regulates ccp1 and swc2 to ensure centromeric stability by retargeting cenp-a. Nucleic Acids Research, 52:4198-4214, Mar 2024. URL: https://doi.org/10.1093/nar/gkae084, doi:10.1093/nar/gkae084. This article has 2 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>salinasluypaert2024canonicalandnoncanonical pages 1-3</li>
+<li>folco2024thecysteinerichdomain pages 1-2</li>
+<li>korntnervetter2019subunitinteractionsand pages 1-2</li>
+<li>folco2024thecysteinerichdomain pages 9-10</li>
+<li>folco2024thecysteinerichdomain pages 8-9</li>
+<li>folco2024thecysteinerichdomain pages 7-8</li>
+<li>folco2024thecysteinerichdomain pages 1-1</li>
+<li>folco2024thecysteinerichdomain pages 5-6</li>
+<li>folco2024thecysteinerichdomain pages 11-12</li>
+<li>https://doi.org/10.1016/j.molcel.2009.01.017;</li>
+<li>https://doi.org/10.1016/j.molcel.2009.01.019</li>
+<li>https://doi.org/10.1016/j.molcel.2009.01.019;</li>
+<li>https://doi.org/10.1093/nar/gkad1182</li>
+<li>https://doi.org/10.1016/j.molcel.2009.01.017</li>
+<li>https://doi.org/10.1093/nar/gkae084</li>
+<li>https://doi.org/10.26508/lsa.201900408</li>
+<li>https://doi.org/10.1016/j.ceb.2024.102396;</li>
+<li>https://doi.org/10.1016/j.ceb.2024.102396</li>
+<li>https://doi.org/10.1016/j.molcel.2009.01.017,</li>
+<li>https://doi.org/10.1016/j.molcel.2009.01.019,</li>
+<li>https://doi.org/10.1093/nar/gkad1182,</li>
+<li>https://doi.org/10.1093/nar/gkae084,</li>
+<li>https://doi.org/10.1016/j.ceb.2024.102396,</li>
+<li>https://doi.org/10.26508/lsa.201900408,</li>
+</ol>
+            </div>
+        </details>
+
         <details class="markdown-section">
             <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
                 <div style="flex: 1;">
@@ -2490,9 +2978,9 @@ which is essential for kinetochore assembly and proper chromosome segregation.</
 </ul>
             </div>
         </details>
-        
+
     </div>
-    
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -2504,7 +2992,7 @@ which is essential for kinetochore assembly and proper chromosome segregation.</
                 <pre><code>id: Q9HDY7
 gene_symbol: scm3
 product_type: PROTEIN
-status: DRAFT
+status: COMPLETE
 taxon:
   id: NCBITaxon:284812
   label: Schizosaccharomyces pombe (strain 972 / ATCC 24843)
@@ -2704,6 +3192,10 @@ existing_annotations:
           receptor/assembly factor, cooperating with Mis16 and Mis18 to
           receive CENP-A(Cnp1) from the Sim3 escort and mediate assembly
           of CENP-A(Cnp1) into subkinetochore chromatin
+      - reference_id: file:SCHPO/scm3/scm3-deep-research-falcon.md
+        supporting_text: &gt;-
+          Scm3 is the dedicated CENP-A/Cnp1 assembly factor required for stable
+          enrichment/deposition of Cnp1 at the centromeric central domain.
 - term:
     id: GO:0000775
     label: chromosome, centromeric region
@@ -2831,7 +3323,21 @@ core_functions:
   locations:
     - id: GO:0034506
       label: chromosome, centromeric core domain
+  supported_by:
+    - reference_id: file:SCHPO/scm3/scm3-deep-research-falcon.md
+      supporting_text: &gt;-
+        Scm3 is the dedicated CENP-A/Cnp1 assembly factor required for stable
+        enrichment/deposition of Cnp1 at the centromeric central domain.
 references:
+- id: file:SCHPO/scm3/scm3-deep-research-falcon.md
+  title: Falcon deep research report for scm3
+  findings:
+    - statement: &gt;-
+        Falcon supports scm3 as the fission yeast CENP-A/Cnp1 histone
+        chaperone that deposits and maintains Cnp1 at centromeric chromatin.
+      supporting_text: &gt;-
+        Scm3 is the dedicated CENP-A/Cnp1 assembly factor required for stable
+        enrichment/deposition of Cnp1 at the centromeric central domain.
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO
     terms
@@ -3055,7 +3561,7 @@ references:
     </div>
 
     <!-- Pathway Visualization Link -->
-    
+
 
     <style>
         /* Markdown Section Styles */

--- a/genes/SCHPO/scm3/scm3-ai-review.yaml
+++ b/genes/SCHPO/scm3/scm3-ai-review.yaml
@@ -1,7 +1,7 @@
 id: Q9HDY7
 gene_symbol: scm3
 product_type: PROTEIN
-status: DRAFT
+status: COMPLETE
 taxon:
   id: NCBITaxon:284812
   label: Schizosaccharomyces pombe (strain 972 / ATCC 24843)
@@ -201,6 +201,10 @@ existing_annotations:
           receptor/assembly factor, cooperating with Mis16 and Mis18 to
           receive CENP-A(Cnp1) from the Sim3 escort and mediate assembly
           of CENP-A(Cnp1) into subkinetochore chromatin
+      - reference_id: file:SCHPO/scm3/scm3-deep-research-falcon.md
+        supporting_text: >-
+          Scm3 is the dedicated CENP-A/Cnp1 assembly factor required for stable
+          enrichment/deposition of Cnp1 at the centromeric central domain.
 - term:
     id: GO:0000775
     label: chromosome, centromeric region
@@ -328,7 +332,21 @@ core_functions:
   locations:
     - id: GO:0034506
       label: chromosome, centromeric core domain
+  supported_by:
+    - reference_id: file:SCHPO/scm3/scm3-deep-research-falcon.md
+      supporting_text: >-
+        Scm3 is the dedicated CENP-A/Cnp1 assembly factor required for stable
+        enrichment/deposition of Cnp1 at the centromeric central domain.
 references:
+- id: file:SCHPO/scm3/scm3-deep-research-falcon.md
+  title: Falcon deep research report for scm3
+  findings:
+    - statement: >-
+        Falcon supports scm3 as the fission yeast CENP-A/Cnp1 histone
+        chaperone that deposits and maintains Cnp1 at centromeric chromatin.
+      supporting_text: >-
+        Scm3 is the dedicated CENP-A/Cnp1 assembly factor required for stable
+        enrichment/deposition of Cnp1 at the centromeric central domain.
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO
     terms

--- a/genes/SCHPO/scm3/scm3-deep-research-falcon.md
+++ b/genes/SCHPO/scm3/scm3-deep-research-falcon.md
@@ -1,0 +1,386 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-11T06:30:51.930176'
+end_time: '2026-05-11T06:55:33.705799'
+duration_seconds: 1481.78
+template_file: templates/gene_research_go_focused.md
+template_variables:
+  organism: SCHPO
+  gene_id: scm3
+  gene_symbol: scm3
+  uniprot_accession: Q9HDY7
+  protein_description: 'RecName: Full=CENP-A histone chaperone scm3 {ECO:0000312|PomBase:SPAPB1A10.02};'
+  gene_info: Name=scm3 {ECO:0000312|PomBase:SPAPB1A10.02}; ORFNames=SPAPB1A10.02;
+  organism_full: Schizosaccharomyces pombe (strain 972 / ATCC 24843) (Fission yeast).
+  protein_family: Not specified in UniProt
+  protein_domains: Histone-fold. (IPR009072); Scm3/HJURP. (IPR018465); Scm3 (PF10384)
+provider_config:
+  timeout: 600
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 24
+---
+
+## Question
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** Q9HDY7
+- **Protein Description:** RecName: Full=CENP-A histone chaperone scm3 {ECO:0000312|PomBase:SPAPB1A10.02};
+- **Gene Information:** Name=scm3 {ECO:0000312|PomBase:SPAPB1A10.02}; ORFNames=SPAPB1A10.02;
+- **Organism (full):** Schizosaccharomyces pombe (strain 972 / ATCC 24843) (Fission yeast).
+- **Protein Family:** Not specified in UniProt
+- **Key Domains:** Histone-fold. (IPR009072); Scm3/HJURP. (IPR018465); Scm3 (PF10384)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "scm3" matches the protein description above**
+2. **Verify the organism is correct:** Schizosaccharomyces pombe (strain 972 / ATCC 24843) (Fission yeast).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'scm3' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **scm3** (gene ID: scm3, UniProt: Q9HDY7) in SCHPO.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** Q9HDY7
+- **Protein Description:** RecName: Full=CENP-A histone chaperone scm3 {ECO:0000312|PomBase:SPAPB1A10.02};
+- **Gene Information:** Name=scm3 {ECO:0000312|PomBase:SPAPB1A10.02}; ORFNames=SPAPB1A10.02;
+- **Organism (full):** Schizosaccharomyces pombe (strain 972 / ATCC 24843) (Fission yeast).
+- **Protein Family:** Not specified in UniProt
+- **Key Domains:** Histone-fold. (IPR009072); Scm3/HJURP. (IPR018465); Scm3 (PF10384)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "scm3" matches the protein description above**
+2. **Verify the organism is correct:** Schizosaccharomyces pombe (strain 972 / ATCC 24843) (Fission yeast).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'scm3' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **scm3** (gene ID: scm3, UniProt: Q9HDY7) in SCHPO.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Research report: Functional annotation of *Schizosaccharomyces pombe* **scm3** (UniProt **Q9HDY7**, ORF **SPAPB1A10.02**)
+
+### 0) Target identity verification (mandatory)
+The gene symbol **scm3** in this report refers specifically to **SPAPB1A10.02** from *Schizosaccharomyces pombe* (strain 972), encoding a **336 aa** protein (predicted **~37.6 kDa**) that is a fungal ortholog of vertebrate **HJURP** and functions as a **CENP-A (Cnp1) histone chaperone/assembly factor** at centromeres. This is explicitly established in the foundational *S. pombe* Scm3 studies that map SPAPB1A10.02 to Scm3/Sim1 and characterize its role in Cnp1 deposition. (williams2009fissionyeastscm3 pages 1-2, pidoux2009fissionyeastscm3 pages 1-3, folco2024thecysteinerichdomain pages 1-2)
+
+---
+
+### 1) Key concepts and definitions (current understanding)
+
+#### 1.1 Centromere identity and CENP-A chromatin
+In most eukaryotes (including fission yeast), centromere identity is specified **epigenetically** by nucleosomes containing the histone H3 variant **CENP-A** (called **Cnp1** in *S. pombe*), which seeds kinetochore assembly and supports faithful chromosome segregation. (lim2024set2regulatesccp1 pages 1-2, salinasluypaert2024canonicalandnoncanonical pages 1-3)
+
+#### 1.2 CENP-A deposition requires dedicated chaperone pathways
+CENP-A deposition is not a passive histone replacement event; it requires **dedicated chaperones and licensing factors**. In metazoans, the central chaperone is **HJURP**, recruited by the **Mis18 complex** in a cell-cycle-regulated manner. A recent review emphasizes this “canonical” pathway as centered on **Mis18 complex + HJURP** (with CCAN components as readers of pre-existing CENP-A) and highlights multi-layered post-translational and cell-cycle regulation. (salinasluypaert2024canonicalandnoncanonical pages 1-3)
+
+#### 1.3 Scm3/HJURP family and role in fungi
+In fungi, **Scm3** is the functional counterpart of HJURP. In *S. pombe*, Scm3 is not interpreted as a constitutive nucleosome subunit; rather it behaves as a **CENP-A assembly/maintenance factor** whose centromeric association is **dynamic** across the cell cycle. (williams2009fissionyeastscm3 pages 1-2, williams2009fissionyeastscm3 pages 9-10, pidoux2009fissionyeastscm3 pages 5-6)
+
+---
+
+### 2) Molecular function of Scm3 in *S. pombe*
+
+#### 2.1 Primary molecular function
+**Scm3 is the dedicated CENP-A/Cnp1 assembly factor** required for stable enrichment/deposition of Cnp1 at the centromeric central domain. Loss or inactivation of Scm3 leads to loss of centromeric Cnp1 and replacement/encroachment of canonical histones (H3, H2B/H2A/H2B) into centromeric chromatin. (williams2009fissionyeastscm3 pages 1-2, williams2009fissionyeastscm3 pages 8-9)
+
+Williams et al. show Scm3 is required for centromeric Cnp1 localization, while Scm3 itself localizes to centromeres **independently of Cnp1**, consistent with an upstream assembly role. (williams2009fissionyeastscm3 pages 1-2, williams2009fissionyeastscm3 pages 7-8)
+
+#### 2.2 Scm3 is a receptor/assembly factor rather than a nucleosome core component
+Biochemical fractionation in Pidoux et al. supports the view that Scm3 is unlikely to be a stable stoichiometric nucleosome subunit: during MNase digestion, **most Cnp1 and bulk histones are released after 2–10 min**, whereas **Scm3 remains pellet-associated even after 20 min**, indicating distinct biochemical behavior from canonical nucleosomes. (pidoux2009fissionyeastscm3 pages 5-6)
+
+---
+
+### 3) Domain architecture and determinants of centromere targeting
+
+#### 3.1 Modular organization
+Scm3 exhibits modularity typical of Scm3/HJURP-family proteins:
+- An **N-terminal conserved region** responsible for **specific interaction with CENP-A/Cnp1**. (folco2024thecysteinerichdomain pages 1-2, pidoux2009fissionyeastscm3 pages 3-4)
+- A **C-terminal region** required for centromere targeting via interaction with upstream centromere licensing machinery, including a **Mis16-binding domain (Mis16-BD)** in fission yeast. (folco2024thecysteinerichdomain pages 1-2)
+
+Williams et al. map a Cnp1-interaction region within **Scm3 aa 1–194** and identify multiple temperature-sensitive alleles affecting Scm3 function (e.g., N100S, N50S). (williams2009fissionyeastscm3 pages 9-10)
+
+#### 3.2 Mis16-binding domain (Mis16-BD)
+Folco et al. summarize prior mapping that **residues ~270–305** comprise the **minimal Mis16-binding domain** (Mis16-BD) required for centromere targeting via the Mis18 holocomplex; the **S281L** mutation (sim1-15) in this region impairs Scm3 function, supporting its importance. (folco2024thecysteinerichdomain pages 1-2, pidoux2009fissionyeastscm3 pages 3-4)
+
+#### 3.3 2024 development: fungal-specific cysteine-rich CYS zinc-binding motif
+A major 2024 advance is the demonstration that fungal Scm3 proteins contain a **conserved cysteine-rich (CYS) motif** that **binds zinc in vitro** and is **essential for Scm3 centromere localization and kinetochore integrity** in *S. pombe*. Disrupting the zinc-binding motif prevents Scm3 localization and compromises kinetochore function. (folco2024thecysteinerichdomain pages 1-1, folco2024thecysteinerichdomain pages 1-2)
+
+Mechanistically, the CYS domain:
+- can **bind centromeric DNA fragments in vitro** using GST-fusion pull-downs, and
+- can **localize autonomously to centromeres** (weakly), but centromere targeting is **strongly enhanced when combined with Mis16-BD**, indicating cooperative targeting. (folco2024thecysteinerichdomain pages 7-8, folco2024thecysteinerichdomain pages 1-2)
+
+---
+
+### 4) Interaction partners and pathway placement
+
+#### 4.1 Direct binding partners supported by experiments
+**Cnp1/CENP-A:** Scm3 interacts with Cnp1 by yeast two-hybrid and via biochemical association/co-purification and in vitro binding (preferentially with GST-CENP-A vs GST-H3), supporting specificity for CENP-A. (williams2009fissionyeastscm3 pages 1-2, pidoux2009fissionyeastscm3 pages 7-8)
+
+**Mis16:** Scm3 shows a robust Y2H interaction with Mis16, requiring Scm3’s C-terminal region (C-terminal 141 aa in one mapping). (williams2009fissionyeastscm3 pages 7-8, williams2009fissionyeastscm3 pages 8-9)
+
+**Sim3 (NASP-like escort):** Pidoux et al. report that the Scm3–CENP-A interaction is disrupted in sim3Δ, consistent with a handover path in which Sim3 escorts nascent Cnp1 and facilitates transfer to Scm3 at centromeres. (pidoux2009fissionyeastscm3 pages 7-8)
+
+#### 4.2 Dependency relationships (targeting and assembly hierarchy)
+Both Williams et al. and Pidoux et al. show that **centromere localization of Scm3 requires** kinetochore/centromere factors including **Mis6/Sim4/Mis16/Mis18**, while Scm3 localization is largely **independent of Cnp1** (cnp1-1 does not displace Scm3). (williams2009fissionyeastscm3 pages 7-8, pidoux2009fissionyeastscm3 pages 7-8, pidoux2009fissionyeastscm3 pages 5-6)
+
+Conversely, Scm3 is required for stable centromeric enrichment of Cnp1. (williams2009fissionyeastscm3 pages 1-2, williams2009fissionyeastscm3 pages 8-9)
+
+#### 4.3 Structural context for recruitment machinery
+Structural/architectural work on the **Mis16–Mis18–Mis19** complex supports a recruitment model where Mis16 is positioned to recruit the **Scm3–Cnp1–H4** complex, while Mis19 bridges Mis16 and Mis18; importantly, *S. pombe* appears to lack a large Mis18BP1-like subunit and instead uses smaller partners (Mis19/Eic1, etc.). (korntnervetter2019subunitinteractionsand pages 1-2)
+
+---
+
+### 5) Cellular localization and cell-cycle regulation
+
+#### 5.1 Where Scm3 acts
+Scm3 functions in the **nucleus** at **centromeres**, specifically the **central centromere domain** (subkinetochore chromatin). (williams2009fissionyeastscm3 pages 7-8, pidoux2009fissionyeastscm3 pages 3-4)
+
+#### 5.2 Cell-cycle timing (Scm3 is dynamic)
+A defining feature of *S. pombe* Scm3 is cell-cycle-regulated centromere association:
+- Scm3 is present at centromeres in **interphase/G2**.
+- It **dissociates at mitotic onset/early mitosis** and
+- **reassociates in late anaphase/telophase**.
+This mirrors Mis16/Mis18 dynamics rather than the more constitutive presence of Cnp1. (williams2009fissionyeastscm3 pages 7-8, pidoux2009fissionyeastscm3 pages 3-4)
+
+Williams et al. used a metaphase arrest (nda3-KM311) at **20°C for 8 hr** and observed near-complete loss of Scm3 centromeric ChIP signal with little change in Cnp1, supporting the conclusion that Scm3 temporarily disengages while Cnp1 persists through mitosis. (williams2009fissionyeastscm3 pages 7-8, williams2009fissionyeastscm3 pages 9-10)
+
+---
+
+### 6) Phenotypes and quantitative data supporting functional annotation
+
+#### 6.1 Scm3 loss-of-function phenotypes
+Disrupting Scm3 disrupts CENP-A chromatin and leads to defective kinetochore assembly, chromosome segregation errors, and inviability/toxicity depending on the perturbation. (folco2024thecysteinerichdomain pages 1-1, williams2009fissionyeastscm3 pages 8-9)
+
+#### 6.2 Quantitative chromosome missegregation data (2024)
+Folco et al. report strong quantitative effects when mis-targeting Scm3 domains:
+- Control: **3.3% (4/121)** ChrII missegregation.
+- GFP-scm3FL: **4.5% (6/133)**.
+- Toxic C-terminal fragment (GFP-scm3-CT): **83.2% (94/113)**.
+- Zinc-motif mutant (GFP-scm3-CT4A): **2.4% (3/124)**.
+- CYS alone (GFP-scm3-CYS): **7.0% (10/143)**.
+These data support that the CYS zinc-binding motif and its proper regulatory context are critical for kinetochore integrity. (folco2024thecysteinerichdomain pages 9-10)
+
+The same study quantifies CENP-C focus intensity and chromosome II segregation with sample sizes and confidence intervals (see figure panels below). (folco2024thecysteinerichdomain pages 8-9, folco2024thecysteinerichdomain media 39b30728, folco2024thecysteinerichdomain media a784a709, folco2024thecysteinerichdomain media 6ed87ec6)
+
+---
+
+### 7) Recent developments (prioritizing 2023–2024)
+
+#### 7.1 2024: New centromere targeting mechanism (CYS zinc-binding + Mis16-BD cooperativity)
+Folco et al. (received 2023-05-11; accepted 2023-11-28; published in NAR 2024) establish that **fungal Scm3 proteins have an essential zinc-binding cysteine-rich CYS domain** and show it is required for centromere targeting and kinetochore integrity, adding a centromere-targeting determinant beyond the canonical Mis16/Mis18 pathway. (folco2024thecysteinerichdomain pages 1-2, folco2024thecysteinerichdomain pages 9-10)
+
+#### 7.2 2024: “Back-up” CENP-A retargeting pathway contextualizing Scm3 within broader homeostasis
+Lim et al. (Advance access publication date **5 March 2024**) report that **rDNA** can act as a sink for delocalized CENP-A in a temperature-sensitive **cnp1-1** mutant, and that **Set2 downregulation** can reverse aneuploidy by redirecting mislocalized CENP-A back to centromeres. This relocalization depends on canonical loaders **Mis16/Mis17/Mis18**, and the paper reiterates the early assembly handover in which newly synthesized CENP-A complexes with H4 and **Scm3**. (lim2024set2regulatesccp1 pages 1-2)
+
+---
+
+### 8) Current applications and real-world implementations
+
+#### 8.1 Model for conserved CENP-A chaperoning principles
+Although Scm3 itself is a yeast protein, it serves as a **high-tractability genetic and biochemical model** for the conserved logic of CENP-A deposition used in metazoans (HJURP + Mis18 licensing). The 2024 review literature frames this axis as central to centromere inheritance and genome stability, and fission yeast provides mechanistic dissection of recruitment and targeting determinants (e.g., Mis16-dependent targeting; fungal-specific DNA/zinc-binding motifs). (salinasluypaert2024canonicalandnoncanonical pages 1-3, folco2024thecysteinerichdomain pages 1-2)
+
+#### 8.2 Quantitative phenotype assays for centromere integrity
+Scm3 studies support widely used assays for centromere/kinetochore function in vivo, including:
+- chromosome missegregation quantification using lacO/tetO labeling,
+- minichromosome-loss assays (e.g., pNBg), and
+- fluorescence intensity quantification of kinetochore foci (CENP-A/CENP-C readouts). (folco2024thecysteinerichdomain pages 8-9)
+
+These assays are broadly implemented in centromere biology to measure stability, segregation fidelity, and epigenetic inheritance mechanisms.
+
+---
+
+### 9) Expert synthesis and mechanistic interpretation
+The combined evidence supports a mechanistic model for *S. pombe* Scm3 as a **centromere-localized CENP-A receptor/assembly factor** that is recruited/retained through a **multi-input targeting system**:
+1) **Mis16/Mis18/Mis6/Sim4-dependent licensing** is required to localize Scm3 to centromeres, positioning it upstream of stable Cnp1 deposition. (williams2009fissionyeastscm3 pages 7-8, pidoux2009fissionyeastscm3 pages 7-8)
+2) **Direct specificity for CENP-A** is supported by Scm3–Cnp1 binding (Y2H, in vitro specificity vs H3). (pidoux2009fissionyeastscm3 pages 7-8, williams2009fissionyeastscm3 pages 1-2)
+3) **Cell-cycle gating** (mitotic dissociation and late-anaphase return) likely functions to couple (re)loading competence to a specific cell-cycle window, analogous in principle (but not identical in timing) to the Mis18–HJURP regulation reviewed for metazoans. (williams2009fissionyeastscm3 pages 9-10, salinasluypaert2024canonicalandnoncanonical pages 1-3)
+4) The 2024 discovery of a **fungal-specific CYS zinc-binding motif** implies that fungal Scm3 proteins have evolved additional **DNA- and/or chromatin-interaction modules** that reinforce centromere targeting in organisms lacking sequence-specific centromere DNA-binding proteins like budding yeast Ndc10. (folco2024thecysteinerichdomain pages 1-2)
+
+---
+
+### 10) Evidence map (summary table)
+The following table provides a compact mapping from functional claims to assays, quantitative data, and sources.
+
+| Aspect | Key findings | Evidence type | Quantitative/statistical data if available | Primary source with year + URL |
+|---|---|---|---|---|
+| Molecular function | Scm3 is the dedicated CENP-A/Cnp1 assembly factor in *S. pombe*; it binds Cnp1 and is required for stable deposition/maintenance of Cnp1 chromatin at centromeres, while itself is not a stable nucleosome component (williams2009fissionyeastscm3 pages 1-2, pidoux2009fissionyeastscm3 pages 7-8, pidoux2009fissionyeastscm3 pages 5-6) | Y2H, co-IP/co-purification, in vitro binding, ChIP, genetics, MNase fractionation | In scm3-ts cells, Cnp1 enrichment at cnt1/imr1 is lost; H2B signal at centromeres increased ~3-fold in one assay after shift to restrictive conditions (williams2009fissionyeastscm3 pages 8-9) | Williams 2009 — https://doi.org/10.1016/j.molcel.2009.01.017; Pidoux 2009 — https://doi.org/10.1016/j.molcel.2009.01.019 |
+| Domain architecture | SPAPB1A10.02 encodes a 336 aa (~37.6 kDa) Scm3/HJURP-family protein with an N-terminal conserved CENP-A-binding region and a divergent C-terminus that mediates centromere targeting; the minimum Mis16-binding region maps to ~aa 270–305 (williams2009fissionyeastscm3 pages 1-2, folco2024thecysteinerichdomain pages 1-2, williams2009fissionyeastscm3 pages 9-10) | Sequence analysis, domain mapping, Y2H, mutational analysis | Protein length 336 aa; predicted mass 37.6 kDa; Mis16-BD mapped to residues ~270–305; Cnp1-interacting region reported within aa 1–194 (williams2009fissionyeastscm3 pages 1-2, folco2024thecysteinerichdomain pages 1-2, williams2009fissionyeastscm3 pages 9-10) | Williams 2009 — https://doi.org/10.1016/j.molcel.2009.01.017; Pidoux 2009 — https://doi.org/10.1016/j.molcel.2009.01.019; Folco 2024 — https://doi.org/10.1093/nar/gkad1182 |
+| Fungal-specific CYS domain | A conserved C-terminal cysteine-rich (CYS) zinc-binding motif is essential for efficient centromere localization and kinetochore integrity; CYS alone can weakly target centromeres and binds centromeric DNA in vitro, but acts best with Mis16-BD (folco2024thecysteinerichdomain pages 1-1, folco2024thecysteinerichdomain pages 7-8, folco2024thecysteinerichdomain pages 1-2) | In vitro zinc binding, GST-DNA pull-down, ChIP-qPCR, live-cell imaging, mutagenesis | CYS spans residues 303–336; a 34-aa CYS fragment was used in DNA-binding assays; ApoI centromeric fragments ranged 6–710 bp (folco2024thecysteinerichdomain pages 7-8, folco2024thecysteinerichdomain pages 1-2) | Folco 2024 — https://doi.org/10.1093/nar/gkad1182 |
+| Subcellular localization | Scm3 localizes to centromeric central domains/subkinetochore chromatin in interphase/G2 and is enriched across the central domain with other inner kinetochore proteins (williams2009fissionyeastscm3 pages 7-8, pidoux2009fissionyeastscm3 pages 3-4) | GFP imaging, IF, ChIP, ChIP-seq | Centromeric enrichment detected at cnt/imr regions; imaging quantified in multiple later studies (williams2009fissionyeastscm3 pages 7-8, pidoux2009fissionyeastscm3 pages 3-4) | Williams 2009 — https://doi.org/10.1016/j.molcel.2009.01.017; Pidoux 2009 — https://doi.org/10.1016/j.molcel.2009.01.019 |
+| Interaction partners | Scm3 interacts with Cnp1/CENP-A and Mis16; associates genetically/biochemically with Mis16-Mis18, Mis6 complex, and Sim3 escort pathway; Scm3 self-association has also been reported (williams2009fissionyeastscm3 pages 1-2, williams2009fissionyeastscm3 pages 7-8, pidoux2009fissionyeastscm3 pages 7-8) | Y2H, co-IP/co-purification, in vitro binding, genetics | Robust Y2H for Scm3–Mis16; Y2H interaction with Cnp1 seen in both bait/prey orientations; no Y2H detected for Scm3–Mis18 in Williams et al. (williams2009fissionyeastscm3 pages 7-8, williams2009fissionyeastscm3 pages 1-2) | Williams 2009 — https://doi.org/10.1016/j.molcel.2009.01.017; Pidoux 2009 — https://doi.org/10.1016/j.molcel.2009.01.019 |
+| Dependency relationships for centromere targeting | Scm3 centromere localization depends on Mis6, Sim4, Mis16, and Mis18, but not on Cnp1 itself; conversely, Scm3 is required for centromeric Cnp1 enrichment (williams2009fissionyeastscm3 pages 7-8, pidoux2009fissionyeastscm3 pages 7-8, pidoux2009fissionyeastscm3 pages 5-6) | Mutant analysis, ChIP, IF/imaging, genetics | Dependency tests used cnp1-1, mis6-302, sim4-193, mis16-53, mis18-262, typically after 36°C for 6 h (pidoux2009fissionyeastscm3 pages 7-8, pidoux2009fissionyeastscm3 pages 3-4) | Williams 2009 — https://doi.org/10.1016/j.molcel.2009.01.017; Pidoux 2009 — https://doi.org/10.1016/j.molcel.2009.01.019 |
+| Cell-cycle regulation | Scm3 dissociates from centromeres from mitotic onset/early mitosis and reassociates in late anaphase/telophase, paralleling Mis16/Mis18 rather than constitutive Cnp1 (williams2009fissionyeastscm3 pages 7-8, williams2009fissionyeastscm3 pages 8-9, pidoux2009fissionyeastscm3 pages 3-4) | Live-cell imaging, IF, ChIP, mitotic arrest experiments | nda3-KM311 metaphase arrest at 20°C for 8 h caused near-complete loss of Scm3 centromeric signal with little change in Cnp1 signal (williams2009fissionyeastscm3 pages 7-8, williams2009fissionyeastscm3 pages 9-10) | Williams 2009 — https://doi.org/10.1016/j.molcel.2009.01.017; Pidoux 2009 — https://doi.org/10.1016/j.molcel.2009.01.019 |
+| Biochemical behavior vs nucleosome core | Scm3 behaves differently from core histones/CENP-A nucleosomes in MNase fractionation, supporting a receptor/assembly-factor role rather than a stoichiometric nucleosome subunit (pidoux2009fissionyeastscm3 pages 5-6) | MNase digestion, chromatin fractionation | Most CENP-A and bulk histones released after 2–10 min MNase; Scm3 remained pellet-associated even after 20 min digestion (pidoux2009fissionyeastscm3 pages 5-6) | Pidoux 2009 — https://doi.org/10.1016/j.molcel.2009.01.019 |
+| Mutant/allelic evidence | Functional alleles include sim1-15/S281L in the Mis16-BD region and sim1-106/L73F, sim1-139/L56F in the conserved N-terminal Scm3 domain; Williams also isolated scm3-6/N100S and scm3-19/N50S ts alleles (pidoux2009fissionyeastscm3 pages 3-4, williams2009fissionyeastscm3 pages 9-10) | Genetics, temperature-sensitive phenotyping, ChIP, IF | Common restrictive condition: 36°C for 6 h (Pidoux); Williams selected ts mutants at 35.5°C and used semipermissive 30°C in survival assays (pidoux2009fissionyeastscm3 pages 3-4, williams2009fissionyeastscm3 pages 9-10) | Pidoux 2009 — https://doi.org/10.1016/j.molcel.2009.01.019; Williams 2009 — https://doi.org/10.1016/j.molcel.2009.01.017 |
+| Chromosome segregation/kinetochore phenotypes | Loss or disruption of Scm3 causes chromosome segregation defects, kinetochore loss, and inviability/strong toxicity depending on allele/construct; CYS motif mutants compromise kinetochore integrity even when bulk growth is modestly affected (folco2024thecysteinerichdomain pages 1-1, folco2024thecysteinerichdomain pages 5-6, folco2024thecysteinerichdomain pages 11-12) | Genetics, live-cell imaging, fluorescence quantification, minichromosome assay | Overexpressed GFP-scm3-CT caused 83.2% ChrII missegregation (94/113) versus 3.3% in control (4/121); GFP-scm3-CT4A reduced this to 2.4% (3/124); GFP-scm3-CYS gave 7.0% (10/143) (folco2024thecysteinerichdomain pages 9-10) | Folco 2024 — https://doi.org/10.1093/nar/gkad1182 |
+| Recent development (2024): centromere targeting mechanism | 2024 work added a new mechanistic layer: Scm3 targeting is not explained solely by Mis16-BD/Mis18; the fungal-specific zinc-binding CYS motif contributes independently and cooperatively to centromere targeting, likely via DNA interaction (folco2024thecysteinerichdomain pages 1-1, folco2024thecysteinerichdomain pages 7-8, folco2024thecysteinerichdomain pages 9-10) | In vitro zinc binding, DNA affinity assay, ChIP-qPCR, imaging, overexpression genetics | GFP-Scm3-CYS focus intensity was > half that of full-length Scm3; combined Mis16-BD + CYS gave near-full targeting; sample sizes in focus quantification included N=310, 275, 217 in one panel set (folco2024thecysteinerichdomain pages 7-8) | Folco 2024 — https://doi.org/10.1093/nar/gkad1182 |
+| Recent development (2024): CENP-A retargeting pathway context | A 2024 fission-yeast study on centromere stability places Scm3 within a broader correction pathway for mislocalized CENP-A: Set2 downregulation can retarget cnp1-1 from rDNA back to centromeres, requiring canonical loaders Mis16/Mis17/Mis18 and reiterating Scm3 as the CENP-A/H4 chaperone partner (lim2024set2regulatesccp1 pages 1-2) | Genetics, RNA-seq, ChIP, microscopy | RNA-seq DEG cutoff >1.5-fold; cells shifted from 22°C to 33°C for 4 h in some assays; cultures concentrated to 10^7 cells/ml for spotting (lim2024set2regulatesccp1 pages 2-3) | Lim 2024 — https://doi.org/10.1093/nar/gkae084 |
+| Structural recruitment context | Structural work on the Mis16–Mis18–Mis19 complex supports the recruitment framework in which Mis16 is positioned to recruit the Scm3–Cnp1–H4 complex, while Mis19 bridges Mis16 and Mis18 (korntnervetter2019subunitinteractionsand pages 1-2) | X-ray crystallography, structural/biochemical analysis | Mis19 residues 56–63 form a β-strand contact; residues 79–97 and 99–111 contribute additional Mis16 interfaces; Mis16–Mis19C structure solved at 2.0 Å (korntnervetter2019subunitinteractionsand pages 1-2) | Korntner-Vetter 2019 — https://doi.org/10.26508/lsa.201900408 |
+| Applications / real-world relevance | Scm3 is used as a model for conserved HJURP-family centromere licensing/chaperoning, informing how CENP-A is targeted, how ectopic CENP-A may be corrected, and how chromosome missegregation/aneuploidy can arise when centromere identity fails (salinasluypaert2024canonicalandnoncanonical pages 1-3, lim2024set2regulatesccp1 pages 1-2) | Comparative review, fission-yeast genetics, centromere biology applications | No direct translational metric for Scm3 itself, but related centromere misregulation is tied to aneuploidy/cancer risk in broader literature summarized in recent review/context (salinasluypaert2024canonicalandnoncanonical pages 1-3, lim2024set2regulatesccp1 pages 1-2) | Salinas-Luypaert & Fachinetti 2024 — https://doi.org/10.1016/j.ceb.2024.102396; Lim 2024 — https://doi.org/10.1093/nar/gkae084 |
+
+
+*Table: This table summarizes experimentally supported functional annotation for Schizosaccharomyces pombe Scm3/Q9HDY7, including mechanism, localization, interactions, domain organization, phenotypes, and recent 2023–2024 developments. It is useful as a compact evidence map linking each claim to methods, quantitative data, and primary sources.*
+
+---
+
+### 11) Key figure evidence (visual)
+Quantitative evidence for the functional requirement of the Scm3 CYS zinc-binding motif in kinetochore integrity and chromosome segregation is shown in Folco et al. Figure 4 panels (CENP-C focus intensity, minichromosome loss, and chromosome II missegregation). (folco2024thecysteinerichdomain media 39b30728, folco2024thecysteinerichdomain media a784a709, folco2024thecysteinerichdomain media 6ed87ec6)
+
+---
+
+## References (URLs and publication dates where available)
+- Williams JS, Hayashi T, Yanagida M, Russell P. **Fission yeast Scm3 mediates stable assembly of Cnp1/CENP-A into centromeric chromatin.** *Molecular Cell* (Feb 2009). https://doi.org/10.1016/j.molcel.2009.01.017 (williams2009fissionyeastscm3 pages 1-2)
+- Pidoux AL, Choi ES, Abbott JKR, et al. **Fission Yeast Scm3: A CENP-A Receptor Required for Integrity of Subkinetochore Chromatin.** *Molecular Cell* (Feb 2009). https://doi.org/10.1016/j.molcel.2009.01.019 (pidoux2009fissionyeastscm3 pages 1-3)
+- Folco HD, Xiao H, Wheeler D, et al. **The cysteine-rich domain in CENP-A chaperone Scm3/HJURP ensures centromere targeting and kinetochore integrity.** *Nucleic Acids Research* (2024; accepted 28 Nov 2023). https://doi.org/10.1093/nar/gkad1182 (folco2024thecysteinerichdomain pages 1-2)
+- Lim KK, Lam UTF, Li Y, et al. **Set2 regulates Ccp1 and Swc2 to ensure centromeric stability by retargeting CENP-A.** *Nucleic Acids Research* (Advance access publication date: **5 March 2024**). https://doi.org/10.1093/nar/gkae084 (lim2024set2regulatesccp1 pages 1-2)
+- Salinas-Luypaert C, Fachinetti D. **Canonical and noncanonical regulators of centromere assembly and maintenance.** *Current Opinion in Cell Biology* (Aug 2024). https://doi.org/10.1016/j.ceb.2024.102396 (salinasluypaert2024canonicalandnoncanonical pages 1-3)
+- Korntner-Vetter M, Lefèvre S, Hu X-W, et al. **Subunit interactions and arrangements in the fission yeast Mis16–Mis18–Mis19 complex.** *Life Science Alliance* (1 Aug 2019). https://doi.org/10.26508/lsa.201900408 (korntnervetter2019subunitinteractionsand pages 1-2)
+
+
+References
+
+1. (williams2009fissionyeastscm3 pages 1-2): Jessica S. Williams, Takeshi Hayashi, Mitsuhiro Yanagida, and Paul Russell. Fission yeast scm3 mediates stable assembly of cnp1/cenp-a into centromeric chromatin. Molecular cell, 33 3:287-98, Feb 2009. URL: https://doi.org/10.1016/j.molcel.2009.01.017, doi:10.1016/j.molcel.2009.01.017. This article has 237 citations and is from a highest quality peer-reviewed journal.
+
+2. (pidoux2009fissionyeastscm3 pages 1-3): Alison L. Pidoux, Eun Shik Choi, Johanna K.R. Abbott, Xingkun Liu, Alexander Kagansky, Araceli G. Castillo, Georgina L. Hamilton, William Richardson, Juri Rappsilber, Xiangwei He, and Robin C. Allshire. Fission yeast scm3: a cenp-a receptor required for integrity of subkinetochore chromatin. Molecular Cell, 33:299-311, Feb 2009. URL: https://doi.org/10.1016/j.molcel.2009.01.019, doi:10.1016/j.molcel.2009.01.019. This article has 221 citations and is from a highest quality peer-reviewed journal.
+
+3. (folco2024thecysteinerichdomain pages 1-2): H Diego Folco, Hua Xiao, David Wheeler, Hanqiao Feng, Yawen Bai, and Shiv I S Grewal. The cysteine-rich domain in cenp-a chaperone scm3hjurp ensures centromere targeting and kinetochore integrity. Nucleic acids research, 52:1688-1701, Dec 2024. URL: https://doi.org/10.1093/nar/gkad1182, doi:10.1093/nar/gkad1182. This article has 5 citations and is from a highest quality peer-reviewed journal.
+
+4. (lim2024set2regulatesccp1 pages 1-2): Kim Kiat Lim, Ulysses Tsz Fung Lam, Ying Li, Yi Bing Zeng, Henry Yang, and Ee Sin Chen. Set2 regulates ccp1 and swc2 to ensure centromeric stability by retargeting cenp-a. Nucleic Acids Research, 52:4198-4214, Mar 2024. URL: https://doi.org/10.1093/nar/gkae084, doi:10.1093/nar/gkae084. This article has 2 citations and is from a highest quality peer-reviewed journal.
+
+5. (salinasluypaert2024canonicalandnoncanonical pages 1-3): Catalina Salinas-Luypaert and Daniele Fachinetti. Canonical and noncanonical regulators of centromere assembly and maintenance. Current Opinion in Cell Biology, 89:102396, Aug 2024. URL: https://doi.org/10.1016/j.ceb.2024.102396, doi:10.1016/j.ceb.2024.102396. This article has 8 citations and is from a peer-reviewed journal.
+
+6. (williams2009fissionyeastscm3 pages 9-10): Jessica S. Williams, Takeshi Hayashi, Mitsuhiro Yanagida, and Paul Russell. Fission yeast scm3 mediates stable assembly of cnp1/cenp-a into centromeric chromatin. Molecular cell, 33 3:287-98, Feb 2009. URL: https://doi.org/10.1016/j.molcel.2009.01.017, doi:10.1016/j.molcel.2009.01.017. This article has 237 citations and is from a highest quality peer-reviewed journal.
+
+7. (pidoux2009fissionyeastscm3 pages 5-6): Alison L. Pidoux, Eun Shik Choi, Johanna K.R. Abbott, Xingkun Liu, Alexander Kagansky, Araceli G. Castillo, Georgina L. Hamilton, William Richardson, Juri Rappsilber, Xiangwei He, and Robin C. Allshire. Fission yeast scm3: a cenp-a receptor required for integrity of subkinetochore chromatin. Molecular Cell, 33:299-311, Feb 2009. URL: https://doi.org/10.1016/j.molcel.2009.01.019, doi:10.1016/j.molcel.2009.01.019. This article has 221 citations and is from a highest quality peer-reviewed journal.
+
+8. (williams2009fissionyeastscm3 pages 8-9): Jessica S. Williams, Takeshi Hayashi, Mitsuhiro Yanagida, and Paul Russell. Fission yeast scm3 mediates stable assembly of cnp1/cenp-a into centromeric chromatin. Molecular cell, 33 3:287-98, Feb 2009. URL: https://doi.org/10.1016/j.molcel.2009.01.017, doi:10.1016/j.molcel.2009.01.017. This article has 237 citations and is from a highest quality peer-reviewed journal.
+
+9. (williams2009fissionyeastscm3 pages 7-8): Jessica S. Williams, Takeshi Hayashi, Mitsuhiro Yanagida, and Paul Russell. Fission yeast scm3 mediates stable assembly of cnp1/cenp-a into centromeric chromatin. Molecular cell, 33 3:287-98, Feb 2009. URL: https://doi.org/10.1016/j.molcel.2009.01.017, doi:10.1016/j.molcel.2009.01.017. This article has 237 citations and is from a highest quality peer-reviewed journal.
+
+10. (pidoux2009fissionyeastscm3 pages 3-4): Alison L. Pidoux, Eun Shik Choi, Johanna K.R. Abbott, Xingkun Liu, Alexander Kagansky, Araceli G. Castillo, Georgina L. Hamilton, William Richardson, Juri Rappsilber, Xiangwei He, and Robin C. Allshire. Fission yeast scm3: a cenp-a receptor required for integrity of subkinetochore chromatin. Molecular Cell, 33:299-311, Feb 2009. URL: https://doi.org/10.1016/j.molcel.2009.01.019, doi:10.1016/j.molcel.2009.01.019. This article has 221 citations and is from a highest quality peer-reviewed journal.
+
+11. (folco2024thecysteinerichdomain pages 1-1): H Diego Folco, Hua Xiao, David Wheeler, Hanqiao Feng, Yawen Bai, and Shiv I S Grewal. The cysteine-rich domain in cenp-a chaperone scm3hjurp ensures centromere targeting and kinetochore integrity. Nucleic acids research, 52:1688-1701, Dec 2024. URL: https://doi.org/10.1093/nar/gkad1182, doi:10.1093/nar/gkad1182. This article has 5 citations and is from a highest quality peer-reviewed journal.
+
+12. (folco2024thecysteinerichdomain pages 7-8): H Diego Folco, Hua Xiao, David Wheeler, Hanqiao Feng, Yawen Bai, and Shiv I S Grewal. The cysteine-rich domain in cenp-a chaperone scm3hjurp ensures centromere targeting and kinetochore integrity. Nucleic acids research, 52:1688-1701, Dec 2024. URL: https://doi.org/10.1093/nar/gkad1182, doi:10.1093/nar/gkad1182. This article has 5 citations and is from a highest quality peer-reviewed journal.
+
+13. (pidoux2009fissionyeastscm3 pages 7-8): Alison L. Pidoux, Eun Shik Choi, Johanna K.R. Abbott, Xingkun Liu, Alexander Kagansky, Araceli G. Castillo, Georgina L. Hamilton, William Richardson, Juri Rappsilber, Xiangwei He, and Robin C. Allshire. Fission yeast scm3: a cenp-a receptor required for integrity of subkinetochore chromatin. Molecular Cell, 33:299-311, Feb 2009. URL: https://doi.org/10.1016/j.molcel.2009.01.019, doi:10.1016/j.molcel.2009.01.019. This article has 221 citations and is from a highest quality peer-reviewed journal.
+
+14. (korntnervetter2019subunitinteractionsand pages 1-2): Melanie Korntner-Vetter, Stéphane Lefèvre, Xiao-Wen Hu, Roger George, and Martin R Singleton. Subunit interactions and arrangements in the fission yeast mis16–mis18–mis19 complex. Life Science Alliance, 2:e201900408, Aug 2019. URL: https://doi.org/10.26508/lsa.201900408, doi:10.26508/lsa.201900408. This article has 5 citations and is from a peer-reviewed journal.
+
+15. (folco2024thecysteinerichdomain pages 9-10): H Diego Folco, Hua Xiao, David Wheeler, Hanqiao Feng, Yawen Bai, and Shiv I S Grewal. The cysteine-rich domain in cenp-a chaperone scm3hjurp ensures centromere targeting and kinetochore integrity. Nucleic acids research, 52:1688-1701, Dec 2024. URL: https://doi.org/10.1093/nar/gkad1182, doi:10.1093/nar/gkad1182. This article has 5 citations and is from a highest quality peer-reviewed journal.
+
+16. (folco2024thecysteinerichdomain pages 8-9): H Diego Folco, Hua Xiao, David Wheeler, Hanqiao Feng, Yawen Bai, and Shiv I S Grewal. The cysteine-rich domain in cenp-a chaperone scm3hjurp ensures centromere targeting and kinetochore integrity. Nucleic acids research, 52:1688-1701, Dec 2024. URL: https://doi.org/10.1093/nar/gkad1182, doi:10.1093/nar/gkad1182. This article has 5 citations and is from a highest quality peer-reviewed journal.
+
+17. (folco2024thecysteinerichdomain media 39b30728): H Diego Folco, Hua Xiao, David Wheeler, Hanqiao Feng, Yawen Bai, and Shiv I S Grewal. The cysteine-rich domain in cenp-a chaperone scm3hjurp ensures centromere targeting and kinetochore integrity. Nucleic acids research, 52:1688-1701, Dec 2024. URL: https://doi.org/10.1093/nar/gkad1182, doi:10.1093/nar/gkad1182. This article has 5 citations and is from a highest quality peer-reviewed journal.
+
+18. (folco2024thecysteinerichdomain media a784a709): H Diego Folco, Hua Xiao, David Wheeler, Hanqiao Feng, Yawen Bai, and Shiv I S Grewal. The cysteine-rich domain in cenp-a chaperone scm3hjurp ensures centromere targeting and kinetochore integrity. Nucleic acids research, 52:1688-1701, Dec 2024. URL: https://doi.org/10.1093/nar/gkad1182, doi:10.1093/nar/gkad1182. This article has 5 citations and is from a highest quality peer-reviewed journal.
+
+19. (folco2024thecysteinerichdomain media 6ed87ec6): H Diego Folco, Hua Xiao, David Wheeler, Hanqiao Feng, Yawen Bai, and Shiv I S Grewal. The cysteine-rich domain in cenp-a chaperone scm3hjurp ensures centromere targeting and kinetochore integrity. Nucleic acids research, 52:1688-1701, Dec 2024. URL: https://doi.org/10.1093/nar/gkad1182, doi:10.1093/nar/gkad1182. This article has 5 citations and is from a highest quality peer-reviewed journal.
+
+20. (folco2024thecysteinerichdomain pages 5-6): H Diego Folco, Hua Xiao, David Wheeler, Hanqiao Feng, Yawen Bai, and Shiv I S Grewal. The cysteine-rich domain in cenp-a chaperone scm3hjurp ensures centromere targeting and kinetochore integrity. Nucleic acids research, 52:1688-1701, Dec 2024. URL: https://doi.org/10.1093/nar/gkad1182, doi:10.1093/nar/gkad1182. This article has 5 citations and is from a highest quality peer-reviewed journal.
+
+21. (folco2024thecysteinerichdomain pages 11-12): H Diego Folco, Hua Xiao, David Wheeler, Hanqiao Feng, Yawen Bai, and Shiv I S Grewal. The cysteine-rich domain in cenp-a chaperone scm3hjurp ensures centromere targeting and kinetochore integrity. Nucleic acids research, 52:1688-1701, Dec 2024. URL: https://doi.org/10.1093/nar/gkad1182, doi:10.1093/nar/gkad1182. This article has 5 citations and is from a highest quality peer-reviewed journal.
+
+22. (lim2024set2regulatesccp1 pages 2-3): Kim Kiat Lim, Ulysses Tsz Fung Lam, Ying Li, Yi Bing Zeng, Henry Yang, and Ee Sin Chen. Set2 regulates ccp1 and swc2 to ensure centromeric stability by retargeting cenp-a. Nucleic Acids Research, 52:4198-4214, Mar 2024. URL: https://doi.org/10.1093/nar/gkae084, doi:10.1093/nar/gkae084. This article has 2 citations and is from a highest quality peer-reviewed journal.
+
+## Citations
+
+1. salinasluypaert2024canonicalandnoncanonical pages 1-3
+2. folco2024thecysteinerichdomain pages 1-2
+3. korntnervetter2019subunitinteractionsand pages 1-2
+4. folco2024thecysteinerichdomain pages 9-10
+5. folco2024thecysteinerichdomain pages 8-9
+6. folco2024thecysteinerichdomain pages 7-8
+7. folco2024thecysteinerichdomain pages 1-1
+8. folco2024thecysteinerichdomain pages 5-6
+9. folco2024thecysteinerichdomain pages 11-12
+10. https://doi.org/10.1016/j.molcel.2009.01.017;
+11. https://doi.org/10.1016/j.molcel.2009.01.019
+12. https://doi.org/10.1016/j.molcel.2009.01.019;
+13. https://doi.org/10.1093/nar/gkad1182
+14. https://doi.org/10.1016/j.molcel.2009.01.017
+15. https://doi.org/10.1093/nar/gkae084
+16. https://doi.org/10.26508/lsa.201900408
+17. https://doi.org/10.1016/j.ceb.2024.102396;
+18. https://doi.org/10.1016/j.ceb.2024.102396
+19. https://doi.org/10.1016/j.molcel.2009.01.017,
+20. https://doi.org/10.1016/j.molcel.2009.01.019,
+21. https://doi.org/10.1093/nar/gkad1182,
+22. https://doi.org/10.1093/nar/gkae084,
+23. https://doi.org/10.1016/j.ceb.2024.102396,
+24. https://doi.org/10.26508/lsa.201900408,

--- a/genes/yeast/ATG7/ATG7-ai-review.html
+++ b/genes/yeast/ATG7/ATG7-ai-review.html
@@ -671,33 +671,33 @@
     <div class="header">
         <h1>ATG7</h1>
         <div class="gene-info">
-            
+
             <div class="info-item">
-                
+
                 <span class="info-label">UniProt ID:</span>
                 <span>
                     <a href="https://www.uniprot.org/uniprotkb/P38862" target="_blank" class="term-link">
                         P38862
                     </a>
                 </span>
-                
+
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Organism:</span>
                 <span>Saccharomyces cerevisiae</span>
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
                 <span class="status-badge status-complete">
                     COMPLETE
                 </span>
             </div>
-            
-            
+
+
         </div>
         <div style="margin-top: 1rem; text-align: center;">
             <a id="feedback-form-link"
@@ -728,7 +728,7 @@
         </div>
     </div>
 
-    
+
     <div class="description-card">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <h2>Gene Description</h2>
@@ -739,13 +739,13 @@
         </div>
         <p>ATG7 (Ubiquitin-like modifier-activating enzyme ATG7, also known as Apg7p/Cvt2p) is an essential E1-like ubiquitin-activating enzyme that catalyzes the first step of the autophagy ubiquitin-like protein conjugation systems. ATG7 activates two distinct ubiquitin-like modifiers (ATG12 and ATG8/LC3) through adenylation and thioester bond formation at its catalytic cysteine (Cys507). It transfers these activated substrates to specific E2 enzymes (ATG10 for ATG12, ATG3 for ATG8), enabling their conjugation to target proteins (ATG5 and phosphatidylethanolamine, respectively). This function is essential for autophagosome formation, the Cvt (cytoplasm-to-vacuole targeting) pathway, and selective autophagy pathways including mitophagy and nucleophagy. ATG7 operates as a homodimer, and both dimerization and its catalytic activity are essential for ATP binding and substrate activation.</p>
     </div>
-    
 
-    
 
-    
 
-    
+
+
+
+
     <div class="section">
         <h2 class="section-title">Existing Annotations Review</h2>
         <table class="annotations-table">
@@ -758,32 +758,32 @@
                 </tr>
             </thead>
             <tbody>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000407" target="_blank" class="term-link">
                                     GO:0000407
                                 </a>
                             </span>
                             <span class="term-label">phagophore assembly site</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -795,64 +795,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Phylogenetic inference-based annotation (IBA) correctly assigns ATG7 to the phagophore assembly site based on ortholog curation. ATG7 localizes to the preautophagosomal/phagophore assembly site (PAS) where autophagosome biogenesis occurs.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Robust IBA annotation supported by experimental evidence showing ATG7 localization to the PAS (PMID:18497569). ATG7 is a core component of the autophagy machinery that functions at the phagophore assembly site. This is consistent with the UniProt annotation &#34;Preautophagosomal structure&#34; and represents a key subcellular localization.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/18497569" target="_blank" class="term-link">
                                         PMID:18497569
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">we localized these Atgp-vYFP chimeras during rapamycin-induced autophagy</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -864,46 +864,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> cytoplasm is consistent with the experimentally and phylogenetically supported ATG7 autophagy mechanism.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Accepted because this annotation aligns with established ATG7 E1-like function and autophagy pathway roles.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032446" target="_blank" class="term-link">
                                     GO:0032446
                                 </a>
                             </span>
                             <span class="term-label">protein modification by small protein conjugation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -915,46 +915,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> protein modification by small protein conjugation is consistent with the experimentally and phylogenetically supported ATG7 autophagy mechanism.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Accepted because this annotation aligns with established ATG7 E1-like function and autophagy pathway roles.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000423" target="_blank" class="term-link">
                                     GO:0000423
                                 </a>
                             </span>
                             <span class="term-label">mitophagy</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -966,46 +966,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> mitophagy is consistent with the experimentally and phylogenetically supported ATG7 autophagy mechanism.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Accepted because this annotation aligns with established ATG7 E1-like function and autophagy pathway roles.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000045" target="_blank" class="term-link">
                                     GO:0000045
                                 </a>
                             </span>
                             <span class="term-label">autophagosome assembly</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1017,46 +1017,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> autophagosome assembly is consistent with the experimentally and phylogenetically supported ATG7 autophagy mechanism.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Accepted because this annotation aligns with established ATG7 E1-like function and autophagy pathway roles.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019778" target="_blank" class="term-link">
                                     GO:0019778
                                 </a>
                             </span>
                             <span class="term-label">Atg12 activating enzyme activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1068,46 +1068,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Atg12 activating enzyme activity is consistent with the experimentally and phylogenetically supported ATG7 autophagy mechanism.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Accepted because this annotation aligns with established ATG7 E1-like function and autophagy pathway roles.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006995" target="_blank" class="term-link">
                                     GO:0006995
                                 </a>
                             </span>
                             <span class="term-label">cellular response to nitrogen starvation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1119,46 +1119,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> cellular response to nitrogen starvation is consistent with the experimentally and phylogenetically supported ATG7 autophagy mechanism.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Accepted because this annotation aligns with established ATG7 E1-like function and autophagy pathway roles.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019779" target="_blank" class="term-link">
                                     GO:0019779
                                 </a>
                             </span>
                             <span class="term-label">Atg8 activating enzyme activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1170,46 +1170,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Atg8 activating enzyme activity is consistent with the experimentally and phylogenetically supported ATG7 autophagy mechanism.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Accepted because this annotation aligns with established ATG7 E1-like function and autophagy pathway roles.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034727" target="_blank" class="term-link">
                                     GO:0034727
                                 </a>
                             </span>
                             <span class="term-label">piecemeal microautophagy of the nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1221,46 +1221,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> piecemeal microautophagy of the nucleus is consistent with the experimentally and phylogenetically supported ATG7 autophagy mechanism.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Accepted because this annotation aligns with established ATG7 E1-like function and autophagy pathway roles.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000407" target="_blank" class="term-link">
                                     GO:0000407
                                 </a>
                             </span>
                             <span class="term-label">phagophore assembly site</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1272,46 +1272,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> phagophore assembly site is consistent with the experimentally and phylogenetically supported ATG7 autophagy mechanism.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Accepted because this annotation aligns with established ATG7 E1-like function and autophagy pathway roles.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1323,46 +1323,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> cytoplasm is consistent with the experimentally and phylogenetically supported ATG7 autophagy mechanism.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Accepted because this annotation aligns with established ATG7 E1-like function and autophagy pathway roles.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006914" target="_blank" class="term-link">
                                     GO:0006914
                                 </a>
                             </span>
                             <span class="term-label">autophagy</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1374,46 +1374,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> autophagy is consistent with the experimentally and phylogenetically supported ATG7 autophagy mechanism.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Accepted because this annotation aligns with established ATG7 E1-like function and autophagy pathway roles.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008641" target="_blank" class="term-link">
                                     GO:0008641
                                 </a>
                             </span>
                             <span class="term-label">ubiquitin-like modifier activating enzyme activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1425,46 +1425,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> ubiquitin-like modifier activating enzyme activity is consistent with the experimentally and phylogenetically supported ATG7 autophagy mechanism.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Accepted because this annotation aligns with established ATG7 E1-like function and autophagy pathway roles.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015031" target="_blank" class="term-link">
                                     GO:0015031
                                 </a>
                             </span>
                             <span class="term-label">protein transport</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -1476,46 +1476,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> ATG7 functions in autophagy-specific trafficking pathways; this broad protein transport term is overly generic for its mechanism.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Removed because GO:0015031 does not capture the selective autophagy machinery role of ATG7, which is better represented by autophagy/Cvt/mitophagy terms.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016237" target="_blank" class="term-link">
                                     GO:0016237
                                 </a>
                             </span>
                             <span class="term-label">microautophagy</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1527,57 +1527,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> General microautophagy annotation is broader than the directly supported ATG7 microautophagy role.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Marked as over-annotated because ATG7 is strongly supported for nucleophagy (piecemeal microautophagy of nucleus), while generic microautophagy is less specifically evidenced.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10688190" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:10688190
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A comprehensive analysis of protein-protein interactions in ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -1589,86 +1589,86 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding is not sufficiently informative for ATG7, whose binding activity is substrate-specific in autophagy conjugation pathways.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Modified to a mechanistically informative binding term reflecting ATG7 interactions with ubiquitin-like modifiers used in autophagy conjugation.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0061664" target="_blank" class="term-link">
                                     ubiquitin-like protein binding
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10688190" target="_blank" class="term-link">
                                         PMID:10688190
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">A comprehensive analysis of protein-protein interactions in Saccharomyces cerevisiae.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/11100732" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:11100732
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A ubiquitin-like system mediates protein lipidation.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -1680,86 +1680,86 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding is not sufficiently informative for ATG7, whose binding activity is substrate-specific in autophagy conjugation pathways.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Modified to a mechanistically informative binding term reflecting ATG7 interactions with ubiquitin-like modifiers used in autophagy conjugation.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0061664" target="_blank" class="term-link">
                                     ubiquitin-like protein binding
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/11100732" target="_blank" class="term-link">
                                         PMID:11100732
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">A ubiquitin-like system mediates protein lipidation.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/12965207" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:12965207
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The carboxyl terminal 17 amino acids within Apg7 are essenti...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -1771,86 +1771,86 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding is not sufficiently informative for ATG7, whose binding activity is substrate-specific in autophagy conjugation pathways.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Modified to a mechanistically informative binding term reflecting ATG7 interactions with ubiquitin-like modifiers used in autophagy conjugation.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0061664" target="_blank" class="term-link">
                                     ubiquitin-like protein binding
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/12965207" target="_blank" class="term-link">
                                         PMID:12965207
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The carboxyl terminal 17 amino acids within Apg7 are essential for Apg8 lipidation, but not for Apg12 conjugation.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/18719252" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:18719252
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     High-quality binary protein interaction map of the yeast int...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -1862,86 +1862,86 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding is not sufficiently informative for ATG7, whose binding activity is substrate-specific in autophagy conjugation pathways.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Modified to a mechanistically informative binding term reflecting ATG7 interactions with ubiquitin-like modifiers used in autophagy conjugation.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0061664" target="_blank" class="term-link">
                                     ubiquitin-like protein binding
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/18719252" target="_blank" class="term-link">
                                         PMID:18719252
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Aug 21. High-quality binary protein interaction map of the yeast interactome network.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/22056771" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:22056771
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Insights into noncanonical E1 enzyme activation from the str...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -1953,86 +1953,86 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding is not sufficiently informative for ATG7, whose binding activity is substrate-specific in autophagy conjugation pathways.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Modified to a mechanistically informative binding term reflecting ATG7 interactions with ubiquitin-like modifiers used in autophagy conjugation.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0061664" target="_blank" class="term-link">
                                     ubiquitin-like protein binding
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/22056771" target="_blank" class="term-link">
                                         PMID:22056771
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Insights into noncanonical E1 enzyme activation from the structure of autophagic E1 Atg7 with Atg8.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23142976" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23142976
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Noncanonical E2 recruitment by the autophagy E1 revealed by ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -2044,86 +2044,86 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding is not sufficiently informative for ATG7, whose binding activity is substrate-specific in autophagy conjugation pathways.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Modified to a mechanistically informative binding term reflecting ATG7 interactions with ubiquitin-like modifiers used in autophagy conjugation.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0061664" target="_blank" class="term-link">
                                     ubiquitin-like protein binding
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/23142976" target="_blank" class="term-link">
                                         PMID:23142976
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Nov 11. Noncanonical E2 recruitment by the autophagy E1 revealed by Atg7-Atg3 and Atg7-Atg10 structures.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/25042851" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:25042851
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Autophagic clearance of polyQ proteins mediated by ubiquitin...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -2135,86 +2135,86 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic protein binding is not sufficiently informative for ATG7, whose binding activity is substrate-specific in autophagy conjugation pathways.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Modified to a mechanistically informative binding term reflecting ATG7 interactions with ubiquitin-like modifiers used in autophagy conjugation.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0061664" target="_blank" class="term-link">
                                     ubiquitin-like protein binding
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/25042851" target="_blank" class="term-link">
                                         PMID:25042851
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Jul 18. Autophagic clearance of polyQ proteins mediated by ubiquitin-Atg8 adaptors of the conserved CUET protein family.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
                                     GO:0042802
                                 </a>
                             </span>
                             <span class="term-label">identical protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/12965207" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:12965207
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The carboxyl terminal 17 amino acids within Apg7 are essenti...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2226,75 +2226,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> identical protein binding is consistent with the experimentally and phylogenetically supported ATG7 autophagy mechanism.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Accepted because this annotation aligns with established ATG7 E1-like function and autophagy pathway roles.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/12965207" target="_blank" class="term-link">
                                         PMID:12965207
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The carboxyl terminal 17 amino acids within Apg7 are essential for Apg8 lipidation, but not for Apg12 conjugation.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
                                     GO:0042802
                                 </a>
                             </span>
                             <span class="term-label">identical protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/22056771" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:22056771
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Insights into noncanonical E1 enzyme activation from the str...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2306,75 +2306,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> identical protein binding is consistent with the experimentally and phylogenetically supported ATG7 autophagy mechanism.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Accepted because this annotation aligns with established ATG7 E1-like function and autophagy pathway roles.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/22056771" target="_blank" class="term-link">
                                         PMID:22056771
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Insights into noncanonical E1 enzyme activation from the structure of autophagic E1 Atg7 with Atg8.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044804" target="_blank" class="term-link">
                                     GO:0044804
                                 </a>
                             </span>
                             <span class="term-label">nucleophagy</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/22768199" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:22768199
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A late form of nucleophagy in Saccharomyces cerevisiae.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2386,75 +2386,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> nucleophagy is consistent with the experimentally and phylogenetically supported ATG7 autophagy mechanism.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Accepted because this annotation aligns with established ATG7 E1-like function and autophagy pathway roles.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/22768199" target="_blank" class="term-link">
                                         PMID:22768199
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">A late form of nucleophagy in Saccharomyces cerevisiae.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008270" target="_blank" class="term-link">
                                     GO:0008270
                                 </a>
                             </span>
                             <span class="term-label">zinc ion binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">RCA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/30358795" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:30358795
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The cellular economy of the Saccharomyces cerevisiae zinc pr...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -2466,75 +2466,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Potential zinc-ion association is not a central, well-established molecular activity for ATG7.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Kept as non-core to retain computational signal without elevating to a core function pending stronger direct biochemical evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/30358795" target="_blank" class="term-link">
                                         PMID:30358795
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The cellular economy of the Saccharomyces cerevisiae zinc proteome.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/26928762" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:26928762
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     One library to make them all: streamlining the creation of y...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2546,75 +2546,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> cytosol is consistent with the experimentally and phylogenetically supported ATG7 autophagy mechanism.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Accepted because this annotation aligns with established ATG7 E1-like function and autophagy pathway roles.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/26928762" target="_blank" class="term-link">
                                         PMID:26928762
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">One library to make them all: streamlining the creation of yeast libraries via a SWAp-Tag strategy.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
                                     GO:0005739
                                 </a>
                             </span>
                             <span class="term-label">mitochondrion</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/14576278" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:14576278
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The proteome of Saccharomyces cerevisiae mitochondria.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -2626,75 +2626,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Mitochondrial localization from high-throughput datasets is not well supported for ATG7 as a resident compartment assignment.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Removed because ATG7 is primarily a cytosolic autophagy E1-like enzyme; its role in mitophagy does not require stable mitochondrial localization.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/14576278" target="_blank" class="term-link">
                                         PMID:14576278
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The proteome of Saccharomyces cerevisiae mitochondria.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
                                     GO:0005739
                                 </a>
                             </span>
                             <span class="term-label">mitochondrion</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16823961" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16823961
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Toward the complete yeast mitochondrial proteome: multidimen...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -2706,75 +2706,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Mitochondrial localization from high-throughput datasets is not well supported for ATG7 as a resident compartment assignment.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Removed because ATG7 is primarily a cytosolic autophagy E1-like enzyme; its role in mitophagy does not require stable mitochondrial localization.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/16823961" target="_blank" class="term-link">
                                         PMID:16823961
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Toward the complete yeast mitochondrial proteome: multidimensional separation techniques for mitochondrial proteomics.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006501" target="_blank" class="term-link">
                                     GO:0006501
                                 </a>
                             </span>
                             <span class="term-label">C-terminal protein lipidation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19398890" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19398890
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Mutation at the cargo-receptor binding site of Atg8 also aff...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -2786,86 +2786,86 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> The C-terminal protein lipidation label is mechanistically imprecise for ATG7.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> ATG7 catalyzes E1-like activation/transfer steps in Atg8 conjugation rather than direct lipidation chemistry; replacement term better captures the specific conjugation process.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0061683" target="_blank" class="term-link">
                                     Atg8 conjugation to phosphatidylethanolamine
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/19398890" target="_blank" class="term-link">
                                         PMID:19398890
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Mutation at the cargo-receptor binding site of Atg8 also affects its general autophagy regulation function.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0097632" target="_blank" class="term-link">
                                     GO:0097632
                                 </a>
                             </span>
                             <span class="term-label">extrinsic component of phagophore assembly site membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10233148" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:10233148
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Apg7p/Cvt2p is required for the cytoplasm-to-vacuole targeti...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2877,75 +2877,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> extrinsic component of phagophore assembly site membrane is consistent with the experimentally and phylogenetically supported ATG7 autophagy mechanism.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Accepted because this annotation aligns with established ATG7 E1-like function and autophagy pathway roles.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10233148" target="_blank" class="term-link">
                                         PMID:10233148
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Apg7p/Cvt2p is required for the cytoplasm-to-vacuole targeting, macroautophagy, and peroxisome degradation pathways.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000407" target="_blank" class="term-link">
                                     GO:0000407
                                 </a>
                             </span>
                             <span class="term-label">phagophore assembly site</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/18497569" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:18497569
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Localization of autophagy-related proteins in yeast using a ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2957,75 +2957,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> phagophore assembly site is consistent with the experimentally and phylogenetically supported ATG7 autophagy mechanism.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Accepted because this annotation aligns with established ATG7 E1-like function and autophagy pathway roles.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/18497569" target="_blank" class="term-link">
                                         PMID:18497569
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Localization of autophagy-related proteins in yeast using a versatile plasmid-based resource of fluorescent protein fusions.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000422" target="_blank" class="term-link">
                                     GO:0000422
                                 </a>
                             </span>
                             <span class="term-label">autophagy of mitochondrion</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19793921" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19793921
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A genomic screen for yeast mutants defective in selective mi...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3037,75 +3037,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> autophagy of mitochondrion is consistent with the experimentally and phylogenetically supported ATG7 autophagy mechanism.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Accepted because this annotation aligns with established ATG7 E1-like function and autophagy pathway roles.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/19793921" target="_blank" class="term-link">
                                         PMID:19793921
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Sep 30. A genomic screen for yeast mutants defective in selective mitochondria autophagy.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10233150" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:10233150
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Apg7p/Cvt2p: A novel protein-activating enzyme essential for...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3117,75 +3117,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> cytosol is consistent with the experimentally and phylogenetically supported ATG7 autophagy mechanism.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Accepted because this annotation aligns with established ATG7 E1-like function and autophagy pathway roles.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10233150" target="_blank" class="term-link">
                                         PMID:10233150
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Apg7p/Cvt2p: A novel protein-activating enzyme essential for autophagy.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006501" target="_blank" class="term-link">
                                     GO:0006501
                                 </a>
                             </span>
                             <span class="term-label">C-terminal protein lipidation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/11038174" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:11038174
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The reversible modification regulates the membrane-binding s...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -3197,86 +3197,86 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> The C-terminal protein lipidation label is mechanistically imprecise for ATG7.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> ATG7 catalyzes E1-like activation/transfer steps in Atg8 conjugation rather than direct lipidation chemistry; replacement term better captures the specific conjugation process.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0061683" target="_blank" class="term-link">
                                     Atg8 conjugation to phosphatidylethanolamine
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/11038174" target="_blank" class="term-link">
                                         PMID:11038174
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The reversible modification regulates the membrane-binding state of Apg8/Aut7 essential for autophagy and the cytoplasm to vacuole targeting pathway.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006501" target="_blank" class="term-link">
                                     GO:0006501
                                 </a>
                             </span>
                             <span class="term-label">C-terminal protein lipidation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/11100732" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:11100732
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A ubiquitin-like system mediates protein lipidation.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -3288,86 +3288,86 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> The C-terminal protein lipidation label is mechanistically imprecise for ATG7.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> ATG7 catalyzes E1-like activation/transfer steps in Atg8 conjugation rather than direct lipidation chemistry; replacement term better captures the specific conjugation process.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0061683" target="_blank" class="term-link">
                                     Atg8 conjugation to phosphatidylethanolamine
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/11100732" target="_blank" class="term-link">
                                         PMID:11100732
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">A ubiquitin-like system mediates protein lipidation.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006501" target="_blank" class="term-link">
                                     GO:0006501
                                 </a>
                             </span>
                             <span class="term-label">C-terminal protein lipidation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/12965207" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:12965207
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The carboxyl terminal 17 amino acids within Apg7 are essenti...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -3379,86 +3379,86 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> The C-terminal protein lipidation label is mechanistically imprecise for ATG7.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> ATG7 catalyzes E1-like activation/transfer steps in Atg8 conjugation rather than direct lipidation chemistry; replacement term better captures the specific conjugation process.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0061683" target="_blank" class="term-link">
                                     Atg8 conjugation to phosphatidylethanolamine
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/12965207" target="_blank" class="term-link">
                                         PMID:12965207
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The carboxyl terminal 17 amino acids within Apg7 are essential for Apg8 lipidation, but not for Apg12 conjugation.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006501" target="_blank" class="term-link">
                                     GO:0006501
                                 </a>
                             </span>
                             <span class="term-label">C-terminal protein lipidation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/15277523" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:15277523
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     In vivo and in vitro reconstitution of Atg8 conjugation esse...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -3470,86 +3470,86 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> The C-terminal protein lipidation label is mechanistically imprecise for ATG7.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> ATG7 catalyzes E1-like activation/transfer steps in Atg8 conjugation rather than direct lipidation chemistry; replacement term better captures the specific conjugation process.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0061683" target="_blank" class="term-link">
                                     Atg8 conjugation to phosphatidylethanolamine
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/15277523" target="_blank" class="term-link">
                                         PMID:15277523
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">2004 Jul 23. In vivo and in vitro reconstitution of Atg8 conjugation essential for autophagy.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006501" target="_blank" class="term-link">
                                     GO:0006501
                                 </a>
                             </span>
                             <span class="term-label">C-terminal protein lipidation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/15277523" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:15277523
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     In vivo and in vitro reconstitution of Atg8 conjugation esse...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -3561,86 +3561,86 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> The C-terminal protein lipidation label is mechanistically imprecise for ATG7.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> ATG7 catalyzes E1-like activation/transfer steps in Atg8 conjugation rather than direct lipidation chemistry; replacement term better captures the specific conjugation process.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0061683" target="_blank" class="term-link">
                                     Atg8 conjugation to phosphatidylethanolamine
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/15277523" target="_blank" class="term-link">
                                         PMID:15277523
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">2004 Jul 23. In vivo and in vitro reconstitution of Atg8 conjugation essential for autophagy.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006914" target="_blank" class="term-link">
                                     GO:0006914
                                 </a>
                             </span>
                             <span class="term-label">autophagy</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23382696" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23382696
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The role of autophagy in genome stability through suppressio...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3652,75 +3652,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> autophagy is consistent with the experimentally and phylogenetically supported ATG7 autophagy mechanism.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Accepted because this annotation aligns with established ATG7 E1-like function and autophagy pathway roles.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/23382696" target="_blank" class="term-link">
                                         PMID:23382696
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Jan 31. The role of autophagy in genome stability through suppression of abnormal mitosis under starvation.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
                                     GO:0016020
                                 </a>
                             </span>
                             <span class="term-label">membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10233148" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:10233148
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Apg7p/Cvt2p is required for the cytoplasm-to-vacuole targeti...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3732,75 +3732,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> membrane is consistent with the experimentally and phylogenetically supported ATG7 autophagy mechanism.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Accepted because this annotation aligns with established ATG7 E1-like function and autophagy pathway roles.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10233148" target="_blank" class="term-link">
                                         PMID:10233148
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Apg7p/Cvt2p is required for the cytoplasm-to-vacuole targeting, macroautophagy, and peroxisome degradation pathways.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016236" target="_blank" class="term-link">
                                     GO:0016236
                                 </a>
                             </span>
                             <span class="term-label">macroautophagy</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10233150" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:10233150
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Apg7p/Cvt2p: A novel protein-activating enzyme essential for...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3812,75 +3812,86 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> macroautophagy is consistent with the experimentally and phylogenetically supported ATG7 autophagy mechanism.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Accepted because this annotation aligns with established ATG7 E1-like function and autophagy pathway roles.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10233150" target="_blank" class="term-link">
                                         PMID:10233150
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Apg7p/Cvt2p: A novel protein-activating enzyme essential for autophagy.</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/ATG7/ATG7-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Atg7 activates the C-terminal glycine of Atg12 in an ATP-dependent reaction, forms an Atg12~Atg7 thioester, and transfers Atg12 onward for Atg12-Atg5 conjugation.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016236" target="_blank" class="term-link">
                                     GO:0016236
                                 </a>
                             </span>
                             <span class="term-label">macroautophagy</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/12965207" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:12965207
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The carboxyl terminal 17 amino acids within Apg7 are essenti...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3892,75 +3903,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> macroautophagy is consistent with the experimentally and phylogenetically supported ATG7 autophagy mechanism.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Accepted because this annotation aligns with established ATG7 E1-like function and autophagy pathway roles.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/12965207" target="_blank" class="term-link">
                                         PMID:12965207
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The carboxyl terminal 17 amino acids within Apg7 are essential for Apg8 lipidation, but not for Apg12 conjugation.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019778" target="_blank" class="term-link">
                                     GO:0019778
                                 </a>
                             </span>
                             <span class="term-label">Atg12 activating enzyme activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10233150" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:10233150
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Apg7p/Cvt2p: A novel protein-activating enzyme essential for...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3972,75 +3983,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Atg12 activating enzyme activity is consistent with the experimentally and phylogenetically supported ATG7 autophagy mechanism.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Accepted because this annotation aligns with established ATG7 E1-like function and autophagy pathway roles.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10233150" target="_blank" class="term-link">
                                         PMID:10233150
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Apg7p/Cvt2p: A novel protein-activating enzyme essential for autophagy.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019779" target="_blank" class="term-link">
                                     GO:0019779
                                 </a>
                             </span>
                             <span class="term-label">Atg8 activating enzyme activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/11100732" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:11100732
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A ubiquitin-like system mediates protein lipidation.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -4052,75 +4063,86 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Atg8 activating enzyme activity is consistent with the experimentally and phylogenetically supported ATG7 autophagy mechanism.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Accepted because this annotation aligns with established ATG7 E1-like function and autophagy pathway roles.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/11100732" target="_blank" class="term-link">
                                         PMID:11100732
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">A ubiquitin-like system mediates protein lipidation.</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/ATG7/ATG7-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Atg7 activates processed Atg8 and supports its transfer to the E2-like enzyme Atg3, ultimately yielding Atg8-PE on autophagy membranes.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032258" target="_blank" class="term-link">
                                     GO:0032258
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm to vacuole targeting by the Cvt pathway</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10233150" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:10233150
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Apg7p/Cvt2p: A novel protein-activating enzyme essential for...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -4132,75 +4154,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> cytoplasm to vacuole targeting by the Cvt pathway is consistent with the experimentally and phylogenetically supported ATG7 autophagy mechanism.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Accepted because this annotation aligns with established ATG7 E1-like function and autophagy pathway roles.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10233150" target="_blank" class="term-link">
                                         PMID:10233150
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Apg7p/Cvt2p: A novel protein-activating enzyme essential for autophagy.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032258" target="_blank" class="term-link">
                                     GO:0032258
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm to vacuole targeting by the Cvt pathway</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/12965207" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:12965207
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The carboxyl terminal 17 amino acids within Apg7 are essenti...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -4212,75 +4234,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> cytoplasm to vacuole targeting by the Cvt pathway is consistent with the experimentally and phylogenetically supported ATG7 autophagy mechanism.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Accepted because this annotation aligns with established ATG7 E1-like function and autophagy pathway roles.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/12965207" target="_blank" class="term-link">
                                         PMID:12965207
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The carboxyl terminal 17 amino acids within Apg7 are essential for Apg8 lipidation, but not for Apg12 conjugation.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032446" target="_blank" class="term-link">
                                     GO:0032446
                                 </a>
                             </span>
                             <span class="term-label">protein modification by small protein conjugation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10233150" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:10233150
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Apg7p/Cvt2p: A novel protein-activating enzyme essential for...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -4292,75 +4314,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> protein modification by small protein conjugation is consistent with the experimentally and phylogenetically supported ATG7 autophagy mechanism.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Accepted because this annotation aligns with established ATG7 E1-like function and autophagy pathway roles.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10233150" target="_blank" class="term-link">
                                         PMID:10233150
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Apg7p/Cvt2p: A novel protein-activating enzyme essential for autophagy.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034727" target="_blank" class="term-link">
                                     GO:0034727
                                 </a>
                             </span>
                             <span class="term-label">piecemeal microautophagy of the nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/18701704" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:18701704
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Piecemeal microautophagy of the nucleus requires the core ma...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -4372,50 +4394,50 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> piecemeal microautophagy of the nucleus is consistent with the experimentally and phylogenetically supported ATG7 autophagy mechanism.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Accepted because this annotation aligns with established ATG7 E1-like function and autophagy pathway roles.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/18701704" target="_blank" class="term-link">
                                         PMID:18701704
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">2008 Aug 13. Piecemeal microautophagy of the nucleus requires the core macroautophagy genes.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
             </tbody>
         </table>
     </div>
-    
 
-    
+
+
     <div class="section">
         <h2 class="section-title">Core Functions</h2>
-        
+
         <div class="core-function-card">
-            
+
             <div style="display: flex; justify-content: space-between; align-items: center;">
                 <h3>ATG7 is the E1-like enzyme that activates Atg12 for transfer into the autophagy conjugation pathway required for autophagosome biogenesis and Cvt trafficking.</h3>
                 <span class="vote-buttons" data-g="P38862" data-a="FUNCTION: ATG7 is the E1-like enzyme that activates Atg12 fo..." data-r="" data-act="CORE_FUNCTION">
@@ -4423,10 +4445,10 @@
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
             </div>
-            
+
 
             <div class="core-function-terms">
-                
+
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
@@ -4435,66 +4457,84 @@
                         </a>
                     </span>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Directly Involved In:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032446" target="_blank" class="term-link">
                                 protein modification by small protein conjugation
                             </a>
                         </span>
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016236" target="_blank" class="term-link">
                                 macroautophagy
                             </a>
                         </span>
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032258" target="_blank" class="term-link">
                                 cytoplasm to vacuole targeting by the Cvt pathway
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Cellular Locations:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                 cytosol
                             </a>
                         </span>
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000407" target="_blank" class="term-link">
                                 phagophore assembly site
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
 
-                
+
+
+
             </div>
 
-            
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:yeast/ATG7/ATG7-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">Atg7 activates the C-terminal glycine of Atg12 in an ATP-dependent reaction, forms an Atg12~Atg7 thioester, and transfers Atg12 onward for Atg12-Atg5 conjugation.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
         </div>
-        
+
         <div class="core-function-card">
-            
+
             <div style="display: flex; justify-content: space-between; align-items: center;">
                 <h3>ATG7 activates Atg8 in the ubiquitin-like conjugation cascade, enabling downstream membrane-coupled autophagy functions including selective autophagy pathways.</h3>
                 <span class="vote-buttons" data-g="P38862" data-a="FUNCTION: ATG7 activates Atg8 in the ubiquitin-like conjugat..." data-r="" data-act="CORE_FUNCTION">
@@ -4502,10 +4542,10 @@
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
             </div>
-            
+
 
             <div class="core-function-terms">
-                
+
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
@@ -4514,523 +4554,920 @@
                         </a>
                     </span>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Directly Involved In:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000045" target="_blank" class="term-link">
                                 autophagosome assembly
                             </a>
                         </span>
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000422" target="_blank" class="term-link">
                                 autophagy of mitochondrion
                             </a>
                         </span>
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034727" target="_blank" class="term-link">
                                 piecemeal microautophagy of the nucleus
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Cellular Locations:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                 cytosol
                             </a>
                         </span>
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0097632" target="_blank" class="term-link">
                                 extrinsic component of phagophore assembly site membrane
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
 
-                
+
+
+
             </div>
 
-            
-        </div>
-        
-    </div>
-    
 
-    
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:yeast/ATG7/ATG7-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">Atg7 activates processed Atg8 and supports its transfer to the E2-like enzyme Atg3, ultimately yielding Atg8-PE on autophagy membranes.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class="section">
         <h2 class="section-title collapsible">References</h2>
         <div class="collapse-content">
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
+                        file:yeast/ATG7/ATG7-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research report for ATG7</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Falcon supports ATG7 as the E1-like activating enzyme for both Atg12 and Atg8 ubiquitin-like conjugation systems in yeast autophagy.</div>
+
+                        <div class="finding-text">"Atg7 is the E1 enzyme for the autophagy conjugation machinery. It activates Atg12 and also functions as the E1 for Atg8 in the Atg8-PE lipidation pathway."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
                             GO_REF:0000002
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
                             GO_REF:0000033
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Annotation inferences using phylogenetic trees</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000043.md" target="_blank" class="term-link">
                             GO_REF:0000043
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
                             GO_REF:0000044
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
                             GO_REF:0000117
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
                             GO_REF:0000120
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/10233148" target="_blank" class="term-link">
                             PMID:10233148
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Apg7p/Cvt2p is required for the cytoplasm-to-vacuole targeting, macroautophagy, and peroxisome degradation pathways.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/10233150" target="_blank" class="term-link">
                             PMID:10233150
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Apg7p/Cvt2p: A novel protein-activating enzyme essential for autophagy.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/10688190" target="_blank" class="term-link">
                             PMID:10688190
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A comprehensive analysis of protein-protein interactions in Saccharomyces cerevisiae.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/11038174" target="_blank" class="term-link">
                             PMID:11038174
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The reversible modification regulates the membrane-binding state of Apg8/Aut7 essential for autophagy and the cytoplasm to vacuole targeting pathway.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/11100732" target="_blank" class="term-link">
                             PMID:11100732
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A ubiquitin-like system mediates protein lipidation.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/12965207" target="_blank" class="term-link">
                             PMID:12965207
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The carboxyl terminal 17 amino acids within Apg7 are essential for Apg8 lipidation, but not for Apg12 conjugation.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/14576278" target="_blank" class="term-link">
                             PMID:14576278
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The proteome of Saccharomyces cerevisiae mitochondria.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/15277523" target="_blank" class="term-link">
                             PMID:15277523
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">In vivo and in vitro reconstitution of Atg8 conjugation essential for autophagy.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/16823961" target="_blank" class="term-link">
                             PMID:16823961
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Toward the complete yeast mitochondrial proteome: multidimensional separation techniques for mitochondrial proteomics.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/18497569" target="_blank" class="term-link">
                             PMID:18497569
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Localization of autophagy-related proteins in yeast using a versatile plasmid-based resource of fluorescent protein fusions.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/18701704" target="_blank" class="term-link">
                             PMID:18701704
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Piecemeal microautophagy of the nucleus requires the core macroautophagy genes.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/18719252" target="_blank" class="term-link">
                             PMID:18719252
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">High-quality binary protein interaction map of the yeast interactome network.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/19398890" target="_blank" class="term-link">
                             PMID:19398890
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Mutation at the cargo-receptor binding site of Atg8 also affects its general autophagy regulation function.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/19793921" target="_blank" class="term-link">
                             PMID:19793921
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A genomic screen for yeast mutants defective in selective mitochondria autophagy.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/22056771" target="_blank" class="term-link">
                             PMID:22056771
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Insights into noncanonical E1 enzyme activation from the structure of autophagic E1 Atg7 with Atg8.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/22768199" target="_blank" class="term-link">
                             PMID:22768199
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A late form of nucleophagy in Saccharomyces cerevisiae.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/23142976" target="_blank" class="term-link">
                             PMID:23142976
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Noncanonical E2 recruitment by the autophagy E1 revealed by Atg7-Atg3 and Atg7-Atg10 structures.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/23382696" target="_blank" class="term-link">
                             PMID:23382696
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The role of autophagy in genome stability through suppression of abnormal mitosis under starvation.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/25042851" target="_blank" class="term-link">
                             PMID:25042851
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Autophagic clearance of polyQ proteins mediated by ubiquitin-Atg8 adaptors of the conserved CUET protein family.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/26928762" target="_blank" class="term-link">
                             PMID:26928762
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">One library to make them all: streamlining the creation of yeast libraries via a SWAp-Tag strategy.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/30358795" target="_blank" class="term-link">
                             PMID:30358795
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The cellular economy of the Saccharomyces cerevisiae zinc proteome.</div>
-                
-                
+
+
             </div>
-            
+
         </div>
     </div>
-    
 
 
-    
 
-    
 
-    
+
+
+
+
 
     <!-- Computational Predictions Section -->
-    
+
 
     <!-- Additional Documentation Sections -->
-    
+
     <div class="section">
         <h2 class="section-title">📚 Additional Documentation</h2>
-        
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Deep Research Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(ATG7-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P38862" data-a="DOC: Deep Research Falcon" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <hr />
+<p>provider: falcon<br />
+model: Edison Scientific Literature<br />
+cached: false<br />
+start_time: '2026-05-11T06:56:33.457320'<br />
+end_time: '2026-05-11T07:04:53.417634'<br />
+duration_seconds: 499.96<br />
+template_file: templates/gene_research_go_focused.md<br />
+template_variables:<br />
+  organism: yeast<br />
+  gene_id: ATG7<br />
+  gene_symbol: ATG7<br />
+  uniprot_accession: P38862<br />
+  protein_description: 'RecName: Full=Ubiquitin-like modifier-activating enzyme ATG7;<br />
+    AltName: Full=ATG12-activating enzyme E1 ATG7; AltName: Full=Autophagy-related<br />
+    protein 7; AltName: Full=Cytoplasm to vacuole targeting protein 2;'<br />
+  gene_info: Name=ATG7; Synonyms=APG7, CVT2; OrderedLocusNames=YHR171W;<br />
+  organism_full: Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).<br />
+  protein_family: Belongs to the ATG7 family. .<br />
+  protein_domains: Atg7. (IPR006285); Atg7_N. (IPR032197); Atg7_N_1. (IPR042522);<br />
+    Atg7_N_2. (IPR042523); ThiF/MoeB/HesA. (IPR045886)<br />
+provider_config:<br />
+  timeout: 600<br />
+  max_retries: 3<br />
+  parameters:<br />
+    allowed_domains: []<br />
+    temperature: 0.1<br />
+citation_count: 30</p>
+<hr />
+<h2 id="question">Question</h2>
+<h1 id="gene-research-for-functional-annotation">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> P38862</li>
+<li><strong>Protein Description:</strong> RecName: Full=Ubiquitin-like modifier-activating enzyme ATG7; AltName: Full=ATG12-activating enzyme E1 ATG7; AltName: Full=Autophagy-related protein 7; AltName: Full=Cytoplasm to vacuole targeting protein 2;</li>
+<li><strong>Gene Information:</strong> Name=ATG7; Synonyms=APG7, CVT2; OrderedLocusNames=YHR171W;</li>
+<li><strong>Organism (full):</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Protein Family:</strong> Belongs to the ATG7 family. .</li>
+<li><strong>Key Domains:</strong> Atg7. (IPR006285); Atg7_N. (IPR032197); Atg7_N_1. (IPR042522); Atg7_N_2. (IPR042523); ThiF/MoeB/HesA. (IPR045886)</li>
+</ul>
+<h3 id="mandatory-verification-steps">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "ATG7" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'ATG7' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>ATG7</strong> (gene ID: ATG7, UniProt: P38862) in yeast.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="output">Output</h2>
+<p>Question: You are an expert researcher providing comprehensive, well-cited information.</p>
+<p>Provide detailed information focusing on:<br />
+1. Key concepts and definitions with current understanding<br />
+2. Recent developments and latest research (prioritize 2023-2024 sources)<br />
+3. Current applications and real-world implementations<br />
+4. Expert opinions and analysis from authoritative sources<br />
+5. Relevant statistics and data from recent studies</p>
+<p>Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.<br />
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.</p>
+<h1 id="gene-research-for-functional-annotation_1">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context_1">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot_1">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> P38862</li>
+<li><strong>Protein Description:</strong> RecName: Full=Ubiquitin-like modifier-activating enzyme ATG7; AltName: Full=ATG12-activating enzyme E1 ATG7; AltName: Full=Autophagy-related protein 7; AltName: Full=Cytoplasm to vacuole targeting protein 2;</li>
+<li><strong>Gene Information:</strong> Name=ATG7; Synonyms=APG7, CVT2; OrderedLocusNames=YHR171W;</li>
+<li><strong>Organism (full):</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Protein Family:</strong> Belongs to the ATG7 family. .</li>
+<li><strong>Key Domains:</strong> Atg7. (IPR006285); Atg7_N. (IPR032197); Atg7_N_1. (IPR042522); Atg7_N_2. (IPR042523); ThiF/MoeB/HesA. (IPR045886)</li>
+</ul>
+<h3 id="mandatory-verification-steps_1">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "ATG7" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature_1">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'ATG7' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target_1">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>ATG7</strong> (gene ID: ATG7, UniProt: P38862) in yeast.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="research-report-functional-annotation-of-saccharomyces-cerevisiae-atg7-uniprot-p38862-gene-atg7apg7cvt2-orf-yhr171w">Research Report: Functional Annotation of <em>Saccharomyces cerevisiae</em> ATG7 (UniProt P38862; gene ATG7/APG7/CVT2; ORF YHR171W)</h2>
+<h3 id="scope-and-identity-verification-critical-disambiguation">Scope and identity verification (critical disambiguation)</h3>
+<p>The UniProt accession <strong>P38862</strong> corresponds to the budding yeast (<em>Saccharomyces cerevisiae</em> S288c) gene historically named <strong>APG7/CVT2</strong> and now referred to as <strong>ATG7</strong>, and it is explicitly mapped to <strong>ORF YHR171W</strong> in primary yeast literature (Tanida et al., 1999; Molecular Biology of the Cell; published May 1999; https://doi.org/10.1091/mbc.10.5.1367) (tanida1999apg7pcvt2panovel pages 2-3). The same work and related yeast genetics papers describe Apg7/Cvt2 as essential for core autophagy and the Cvt pathway in yeast, consistent with the UniProt description provided by the user (tanida1999apg7pcvt2panovel pages 1-2, kim1999apg7pcvt2pisrequired pages 1-2).</p>
+<h3 id="1-key-concepts-and-definitions-current-understanding">1) Key concepts and definitions (current understanding)</h3>
+<h4 id="autophagy-and-the-cvt-pathway">Autophagy and the Cvt pathway</h4>
+<p>In yeast, <strong>macroautophagy</strong> is a vacuole-directed degradative pathway in which cytoplasmic components are sequestered into double-membrane autophagosomes that fuse with the vacuole for breakdown. The <strong>cytoplasm-to-vacuole targeting (Cvt) pathway</strong> is a related biosynthetic trafficking pathway that uses overlapping machinery but typically delivers specific cargo such as precursor aminopeptidase I (Ape1/API) to the vacuole (tanida1999apg7pcvt2panovel pages 1-2, kim1999apg7pcvt2pisrequired pages 1-2).</p>
+<h4 id="two-ubiquitin-like-ubl-conjugation-systems-in-autophagy">Two ubiquitin-like (UBL) conjugation systems in autophagy</h4>
+<p>A central mechanistic concept in autophagosome biogenesis is that the core machinery contains <strong>two ubiquitin-like conjugation systems</strong>:<br />
+1) the <strong>Atg12–Atg5</strong> conjugation system, and<br />
+2) the <strong>Atg8–phosphatidylethanolamine (PE)</strong> lipidation system.</p>
+<p>ATG7/Atg7 acts as the <strong>E1-like (activating) enzyme</strong> for these UBL systems, functioning analogously to ubiquitin E1 enzymes but dedicated to autophagy-related UBL substrates (yorimitsu2005autophagymolecularmachinery pages 4-5, hanada2005structurefunctionrelationshipof pages 1-2).</p>
+<h3 id="2-primary-biochemical-function-of-atg7-reaction-catalyzed-and-substrate-specificity">2) Primary biochemical function of Atg7: reaction catalyzed and substrate specificity</h3>
+<h4 id="atg7-is-an-e1-like-activating-enzyme-for-atg12-direct-yeast-experimental-evidence">Atg7 is an E1-like activating enzyme for Atg12 (direct yeast experimental evidence)</h4>
+<p>Classic yeast biochemical genetics established that Apg7/Cvt2 (Atg7) is an <strong>E1-like “protein-activating enzyme”</strong> essential for autophagy, and specifically an <strong>Apg12 (Atg12)-activating enzyme</strong> (tanida1999apg7pcvt2panovel pages 1-2). The key biochemical steps supported by yeast evidence include:</p>
+<ul>
+<li><strong>ATP-dependent activation</strong> of the C-terminal glycine of Atg12/Apg12 (tanida1999apg7pcvt2panovel pages 8-9).</li>
+<li>Formation of an <strong>Atg12~Atg7 thioester intermediate</strong> (i.e., a thioester conjugate between Atg12 and Atg7) (tanida1999apg7pcvt2panovel pages 8-9, tanida1999apg7pcvt2panovel pages 1-2).</li>
+<li>Dependence on an <strong>active-site cysteine (Cys507)</strong> in Atg7 for thioester formation and downstream conjugation; mutation of this cysteine disrupts Atg12–Atg5 conjugation and causes autophagy/Cvt defects (tanida1999apg7pcvt2panovel pages 8-9, tanida1999apg7pcvt2panovel pages 1-2).</li>
+</ul>
+<p>These findings establish substrate specificity for <strong>Atg12</strong> and a canonical E1-like thioester chemistry.</p>
+<h4 id="atg7-is-shared-by-the-atg8-lipidation-pathway-atg8-atg8-pe">Atg7 is shared by the Atg8 lipidation pathway (Atg8 → Atg8-PE)</h4>
+<p>Authoritative mechanistic literature and yeast-focused reviews describe Atg7 as the <strong>E1-like enzyme shared by both UBL systems</strong>, including the Atg8 lipidation pathway (hanada2005structurefunctionrelationshipof pages 1-2, marquardt2023autophagicandnonautophagic pages 1-2). In this pathway, Atg7 activates processed Atg8 and supports its transfer to the E2-like enzyme Atg3, ultimately yielding <strong>Atg8–PE</strong> on autophagy membranes (hanada2005structurefunctionrelationshipof pages 1-2, marquardt2023autophagicandnonautophagic pages 1-2).</p>
+<h4 id="e2-partners-and-downstream-enzymology">E2 partners and downstream enzymology</h4>
+<p>Evidence supports that Atg7 transfers:<br />
+- <strong>Atg12 to Atg10</strong> (E2-like enzyme) (hanada2005structurefunctionrelationshipof pages 1-2), and<br />
+- <strong>Atg8 to Atg3</strong> (E2-like enzyme) in the Atg8 lipidation cascade (hanada2005structurefunctionrelationshipof pages 1-2, marquardt2023autophagicandnonautophagic pages 1-2).</p>
+<p>The Atg12–Atg5 conjugate assembles with Atg16 to form an <strong>E3-like complex</strong> that promotes Atg8 lipidation, and this machinery is spatially organized at the phagophore/PAS in yeast (marquardt2023autophagicandnonautophagic pages 1-2).</p>
+<h3 id="3-biological-processes-and-pathways-requiring-atg7-genetic-pathway-level-roles">3) Biological processes and pathways requiring Atg7 (genetic pathway-level roles)</h3>
+<h4 id="required-for-cvt-macroautophagy-and-peroxisome-degradation-pexophagy">Required for Cvt, macroautophagy, and peroxisome degradation (pexophagy)</h4>
+<p>Yeast genetic evidence shows Apg7/Cvt2 is required for:<br />
+- the <strong>Cvt pathway</strong>, <br />
+- <strong>macroautophagy</strong>, and<br />
+- <strong>peroxisome degradation</strong> (often discussed as pexophagy) (Kim et al., 1999; Molecular Biology of the Cell; May 1999; https://doi.org/10.1091/mbc.10.5.1337) (kim1999apg7pcvt2pisrequired pages 1-2, kim1999apg7pcvt2pisrequired pages 2-3).</p>
+<p>This is consistent with Atg7 acting at a conserved “sequestration” step and enabling UBL conjugation events needed for autophagosome/Cvt vesicle formation (kim1999apg7pcvt2pisrequired pages 1-2).</p>
+<h3 id="4-subcellular-localization-and-site-of-action">4) Subcellular localization and site of action</h3>
+<h4 id="cytosolic-predominance-with-conditional-membrane-association">Cytosolic predominance with conditional membrane association</h4>
+<p>Tanida et al. (1999) report Atg7/Apg7 is <strong>mainly cytosolic</strong>, and suggest the Atg12–Atg7 interaction can occur in the cytosol or on the cytoplasmic face of an Atg12-associated compartment (tanida1999apg7pcvt2panovel pages 8-9). Kim et al. (1999) further note that <strong>a fraction of Apg7 becomes membrane-associated</strong> in an Atg12-dependent manner (kim1999apg7pcvt2pisrequired pages 1-2).</p>
+<h4 id="pas-centric-view-of-the-lipidation-machinery-current-models">PAS-centric view of the lipidation machinery (current models)</h4>
+<p>Later yeast-centric mechanistic synthesis places the Atg8 lipidation machinery—including Atg7’s role as E1—at the <strong>phagophore assembly site (PAS)</strong> and on the growing phagophore membrane, where Atg8–PE becomes distributed over the phagophore and is later delipidated from the outer surface after closure (marquardt2023autophagicandnonautophagic pages 1-2, fujioka2025mechanismsofautophagosome pages 1-3).</p>
+<h3 id="5-recent-developments-prioritizing-20232024">5) Recent developments (prioritizing 2023–2024)</h3>
+<h4 id="2023-organization-of-the-atg8-lipidation-machinery-at-phagophorevacuole-contacts">2023: Organization of the Atg8 lipidation machinery at phagophore/vacuole contacts</h4>
+<p>A 2023 yeast-focused review emphasizes that Atg21 organizes part of the Atg8 lipidation machinery at the vacuole–phagophore contact and explicitly reiterates the enzymatic cascade: Atg8 is activated by <strong>E1 Atg7</strong>, transferred to <strong>E2 Atg3</strong>, and requires an <strong>E3 complex</strong> formed by Atg12–Atg5 (with Atg16) (Marquardt &amp; Thumm, 2023; Biological Chemistry; May 2023; https://doi.org/10.1515/hsz-2023-0126) (marquardt2023autophagicandnonautophagic pages 1-2).</p>
+<h4 id="2024-phase-separation-as-a-mechanistic-enhancer-of-atg8-lipidation-in-vitro-reconstitution">2024: Phase separation as a mechanistic enhancer of Atg8 lipidation (in vitro reconstitution)</h4>
+<p>A 2024 preprint reports that an early PAS-like compartment formed by <strong>phase separation</strong> can promote Atg8 lipidation by concentrating the E3-like Atg12–Atg5–Atg16 complex and excluding the deconjugase Atg4, thereby favoring net Atg8–PE formation; Atg7 is explicitly included as the E1 for both Atg8 and Atg12 in the reconstituted cascade (Fujioka et al., 2024; bioRxiv; Aug 2024; https://doi.org/10.1101/2024.08.29.610189) (fujioka2024phaseseparationpromotes pages 1-5). This work represents a contemporary direction in the field: using reconstitution and mesoscale organization (condensates) to explain how enzymatic reactions are spatially tuned in autophagy.</p>
+<h4 id="2024-real-world-yeast-method-developmenttemporal-proximity-labeling-for-autophagy-interactomes">2024: Real-world yeast method development—temporal proximity labeling for autophagy interactomes</h4>
+<p>A 2024 methods paper introduces an <strong>APEX2-based proximity labeling</strong> protocol adapted to <em>S. cerevisiae</em> that preserves temporal specificity during autophagy induction, demonstrated with Atg8 and Atg9 as baits (Filali-Mouncef et al., 2024; Autophagy; Jul 2024; https://doi.org/10.1080/15548627.2024.2366749). Notably, their proof-of-concept datasets did not identify Atg7 in that particular setup, which the authors mention as an example of proteins not recovered (fujioka2024phaseseparationpromotes pages 24-26). While not an Atg7 paper per se, this is a current implementation relevant to mapping Atg7-adjacent networks in yeast.</p>
+<h4 id="2024-yeast-applicationscore-atg-genes-tested-in-lipophagy-context">2024: Yeast applications—core ATG genes tested in lipophagy context</h4>
+<p>A 2024 yeast study on lipophagy reports testing a panel of <strong>core autophagy-related yeast genes</strong> (including ATG mutants) under different conditions to parse ATG-dependent and ATG-independent contributions to overall lipophagy (Kang et al., 2024; Autophagy; Mar 2024; https://doi.org/10.1080/15548627.2024.2325297). The retrieved snippet does not isolate an Atg7-specific quantitative result, but it supports the ongoing use of core ATG mutants (including atg7Δ in many designs) as implementation tools in yeast cell biology (ohsumi2006proteindegradation pages 53-57).</p>
+<h3 id="6-expert-opinions-and-analysis-authoritative-synthesis">6) Expert opinions and analysis (authoritative synthesis)</h3>
+<p>Across authoritative autophagy literature, the consensus interpretation is that Atg7 serves as a pathway-specifying E1-like enzyme whose principal biological role is to <strong>enable autophagosome/Cvt vesicle biogenesis by driving UBL conjugation chemistry</strong> (not proteasome-directed ubiquitination). High-citation reviews frame Atg7 as homologous to canonical E1 ubiquitin-activating enzymes and emphasize its formation of a thioester intermediate with Atg12 via an active site cysteine (Yorimitsu &amp; Klionsky, 2005; Cell Death &amp; Differentiation; Nov 2005; https://doi.org/10.1038/sj.cdd.4401765) (yorimitsu2005autophagymolecularmachinery pages 4-5). More recent yeast-centric synthesis integrates this enzymology with spatial organization at the PAS/phagophore and with contact-site factors (e.g., Atg21) that help position the lipidation machinery where Atg8–PE functions (marquardt2023autophagicandnonautophagic pages 1-2).</p>
+<h3 id="7-statistics-and-quantitative-data-from-recent-studies-limitations-of-retrieved-evidence">7) Statistics and quantitative data from recent studies (limitations of retrieved evidence)</h3>
+<p>The retrieved evidence includes well-supported <strong>qualitative</strong> requirements (e.g., atg7 mutants block Ape1/API processing, autophagy, and peroxisome degradation; Cys507 is required for thioester formation and function) (tanida1999apg7pcvt2panovel pages 1-2, kim1999apg7pcvt2pisrequired pages 1-2). It also identifies commonly used <strong>quantitative flux assays</strong> used in yeast autophagy research, including <strong>GFP-Atg8 vacuolar delivery</strong> and the <strong>Pho8Δ60 alkaline phosphatase assay</strong> (ohsumi2006proteindegradation pages 53-57). However, the excerpts retrieved here do <strong>not</strong> contain specific numeric values (e.g., percent flux reduction, fold-changes, kinetic constants) for ATG7-dependent phenotypes in 2023–2024 studies. Therefore, no numerical statistics are reported in this answer to avoid over-interpretation beyond the provided evidence (ohsumi2006proteindegradation pages 53-57).</p>
+<h3 id="summary-table-evidence-map">Summary table (evidence map)</h3>
+<p>The following table consolidates identity, enzymatic mechanism, pathways, localization, phenotypes, and 2023–2024 developments with dates and URLs.</p>
+<table>
+<thead>
+<tr>
+<th>Aspect</th>
+<th>Key points</th>
+<th>Best supporting citations</th>
+<th>Primary sources/reviews (short ref)</th>
+<th>URL</th>
+<th>Publication date</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>identity</td>
+<td>The target matches <strong>Saccharomyces cerevisiae ATG7</strong>, also called <strong>Apg7/Cvt2</strong>; the APG7 locus is explicitly identified as <strong>ORF YHR171W</strong>. It is essential for autophagy and the Cvt pathway.</td>
+<td>(tanida1999apg7pcvt2panovel pages 2-3, tanida1999apg7pcvt2panovel pages 1-2)</td>
+<td>Tanida et al. 1999</td>
+<td>https://doi.org/10.1091/mbc.10.5.1367</td>
+<td>May 1999</td>
+</tr>
+<tr>
+<td>domains/family</td>
+<td>Atg7 is described as an <strong>E1-like/ubiquitin-activating-enzyme homolog</strong> in the autophagy ubiquitin-like conjugation systems; evidence snippets support family-level classification as an E1-like activating enzyme, but do not provide domain architecture details.</td>
+<td>(yorimitsu2005autophagymolecularmachinery pages 4-5, tanida1999apg7pcvt2panovel pages 1-2)</td>
+<td>Yorimitsu &amp; Klionsky 2005; Tanida et al. 1999</td>
+<td>https://doi.org/10.1038/sj.cdd.4401765; https://doi.org/10.1091/mbc.10.5.1367</td>
+<td>Nov 2005; May 1999</td>
+</tr>
+<tr>
+<td>enzymatic role</td>
+<td>Atg7 is the <strong>E1 enzyme</strong> for the autophagy conjugation machinery. It activates <strong>Atg12</strong> and also functions as the E1 for <strong>Atg8</strong> in the Atg8-PE lipidation pathway.</td>
+<td>(hanada2005structurefunctionrelationshipof pages 1-2, marquardt2023autophagicandnonautophagic pages 1-2, fujioka2025mechanismsofautophagosome pages 1-3)</td>
+<td>Hanada &amp; Ohsumi 2005; Marquardt &amp; Thumm 2023; Fujioka &amp; Noda 2025</td>
+<td>https://doi.org/10.4161/auto.1.2.1858; https://doi.org/10.1515/hsz-2023-0126; https://doi.org/10.2183/pjab.101.005</td>
+<td>Jul 2005; May 2023; Jan 2025</td>
+</tr>
+<tr>
+<td>substrates</td>
+<td>Supported substrates are <strong>Atg12</strong> and <strong>Atg8</strong>. For Atg8, the pathway culminates in conjugation to <strong>phosphatidylethanolamine (PE)</strong>; the Atg12 system yields Atg12 transfer onward for Atg12-Atg5 conjugation.</td>
+<td>(hanada2005structurefunctionrelationshipof pages 1-2, fujioka2024phaseseparationpromotes pages 1-5)</td>
+<td>Hanada &amp; Ohsumi 2005; Fujioka et al. 2024</td>
+<td>https://doi.org/10.4161/auto.1.2.1858; https://doi.org/10.1101/2024.08.29.610189</td>
+<td>Jul 2005; Aug 2024</td>
+</tr>
+<tr>
+<td>reaction steps</td>
+<td>For <strong>Atg12</strong>: Atg7 activates the C-terminal glycine in an <strong>ATP-dependent</strong> reaction, forms an <strong>Atg12~Atg7 thioester</strong>, then transfers Atg12 to <strong>Atg10</strong> for eventual Atg12-Atg5 conjugation. For <strong>Atg8</strong>: Atg7 activates Atg8, transfers it to <strong>Atg3</strong>, and the <strong>Atg12-Atg5-Atg16</strong> complex promotes Atg8-PE formation.</td>
+<td>(tanida1999apg7pcvt2panovel pages 8-9, hanada2005structurefunctionrelationshipof pages 1-2, yorimitsu2005autophagymolecularmachinery pages 4-5, marquardt2023autophagicandnonautophagic pages 1-2)</td>
+<td>Tanida et al. 1999; Hanada &amp; Ohsumi 2005; Yorimitsu &amp; Klionsky 2005; Marquardt &amp; Thumm 2023</td>
+<td>https://doi.org/10.1091/mbc.10.5.1367; https://doi.org/10.4161/auto.1.2.1858; https://doi.org/10.1038/sj.cdd.4401765; https://doi.org/10.1515/hsz-2023-0126</td>
+<td>May 1999; Jul 2005; Nov 2005; May 2023</td>
+</tr>
+<tr>
+<td>key catalytic residue</td>
+<td><strong>Cys507</strong> is the active-site cysteine required for Atg7 function. Mutation of this residue disrupts conjugation activity and autophagy/Cvt readouts.</td>
+<td>(tanida1999apg7pcvt2panovel pages 8-9, tanida1999apg7pcvt2panovel pages 1-2)</td>
+<td>Tanida et al. 1999</td>
+<td>https://doi.org/10.1091/mbc.10.5.1367</td>
+<td>May 1999</td>
+</tr>
+<tr>
+<td>E2 partners</td>
+<td>Atg7 transfers <strong>Atg12 to Atg10</strong> and <strong>Atg8 to Atg3</strong>; thus the cognate E2 partners supported in the evidence are <strong>Atg10</strong> and <strong>Atg3</strong>.</td>
+<td>(hanada2005structurefunctionrelationshipof pages 1-2, marquardt2023autophagicandnonautophagic pages 1-2)</td>
+<td>Hanada &amp; Ohsumi 2005; Marquardt &amp; Thumm 2023</td>
+<td>https://doi.org/10.4161/auto.1.2.1858; https://doi.org/10.1515/hsz-2023-0126</td>
+<td>Jul 2005; May 2023</td>
+</tr>
+<tr>
+<td>pathways</td>
+<td>Atg7 is required for <strong>cytoplasm-to-vacuole targeting (Cvt)</strong>, <strong>macroautophagy</strong>, and <strong>peroxisome degradation/pexophagy</strong>; later reviews also place it in the core Atg8/Atg12 conjugation systems that drive autophagosome biogenesis.</td>
+<td>(kim1999apg7pcvt2pisrequired pages 1-2, kim1999apg7pcvt2pisrequired pages 2-3, hanada2005structurefunctionrelationshipof pages 1-2)</td>
+<td>Kim et al. 1999; Hanada &amp; Ohsumi 2005</td>
+<td>https://doi.org/10.1091/mbc.10.5.1337; https://doi.org/10.4161/auto.1.2.1858</td>
+<td>May 1999; Jul 2005</td>
+</tr>
+<tr>
+<td>localization</td>
+<td>Evidence supports Atg7 as <strong>mainly cytosolic</strong>, with interaction/conjugation occurring in the cytosol or on the <strong>cytoplasmic face of an Atg12-associated compartment</strong>; a fraction can be <strong>membrane-associated</strong> in an Atg12-dependent manner. In current models of Atg8 lipidation, the machinery functions at the <strong>PAS/phagophore membrane</strong>.</td>
+<td>(tanida1999apg7pcvt2panovel pages 8-9, kim1999apg7pcvt2pisrequired pages 1-2, marquardt2023autophagicandnonautophagic pages 1-2, fujioka2025mechanismsofautophagosome pages 1-3)</td>
+<td>Tanida et al. 1999; Kim et al. 1999; Marquardt &amp; Thumm 2023; Fujioka &amp; Noda 2025</td>
+<td>https://doi.org/10.1091/mbc.10.5.1367; https://doi.org/10.1091/mbc.10.5.1337; https://doi.org/10.1515/hsz-2023-0126; https://doi.org/10.2183/pjab.101.005</td>
+<td>May 1999; May 1999; May 2023; Jan 2025</td>
+</tr>
+<tr>
+<td>phenotypes</td>
+<td><strong>atg7/apg7/cvt2 mutants</strong> show defects in <strong>Ape1/API processing</strong>, autophagy, Cvt transport, and peroxisome degradation. Mutation of the ATP-binding region or <strong>C507A</strong> impairs Atg12-Apg5 conjugation and autophagy/Cvt function.</td>
+<td>(tanida1999apg7pcvt2panovel pages 1-2, kim1999apg7pcvt2pisrequired pages 1-2, kim1999apg7pcvt2pisrequired pages 2-3)</td>
+<td>Tanida et al. 1999; Kim et al. 1999</td>
+<td>https://doi.org/10.1091/mbc.10.5.1367; https://doi.org/10.1091/mbc.10.5.1337</td>
+<td>May 1999</td>
+</tr>
+<tr>
+<td>recent 2023-2024 developments/methods</td>
+<td>Recent yeast-focused work places Atg7 in <strong>PAS/phagophore-localized Atg8 lipidation organization</strong> and in <strong>in vitro reconstitution</strong> systems. A <strong>2024 APEX2 proximity-labeling</strong> protocol was introduced for temporal mapping of autophagy interactions in yeast, though Atg7 was not recovered in the proof-of-concept dataset. A <strong>2024 lipophagy</strong> study assessed core ATG mutants in yeast. A <strong>2024 preprint</strong> reported that <strong>phase separation of early PAS droplets promotes Atg8 lipidation</strong>, with Atg7 included as the E1 in the reconstituted cascade.</td>
+<td>(marquardt2023autophagicandnonautophagic pages 1-2, fujioka2024phaseseparationpromotes pages 1-5, fujioka2024phaseseparationpromotes pages 24-26)</td>
+<td>Marquardt &amp; Thumm 2023; Fujioka et al. 2024; Filali-Mouncef et al. 2024</td>
+<td>https://doi.org/10.1515/hsz-2023-0126; https://doi.org/10.1101/2024.08.29.610189; https://doi.org/10.1080/15548627.2024.2366749</td>
+<td>May 2023; Aug 2024; Jul 2024</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes identity, mechanism, pathways, localization, phenotypes, and recent developments for Saccharomyces cerevisiae ATG7/YHR171W using only facts supported by the cited evidence snippets. It is useful as a compact evidence map for functional annotation of UniProt P38862.</em></p>
+<h3 id="key-take-home-functional-annotation-for-uniprot-style-summary">Key take-home functional annotation (for UniProt-style summary)</h3>
+<p>In <em>S. cerevisiae</em>, <strong>Atg7 (Apg7/Cvt2; YHR171W)</strong> is an <strong>E1-like ubiquitin-like modifier–activating enzyme</strong> that catalyzes ATP-dependent activation of autophagy UBL substrates and forms thioester intermediates via an essential active-site cysteine (<strong>Cys507</strong>). Its primary substrates are <strong>Atg12</strong> (activation and transfer to Atg10 for Atg12–Atg5 conjugation) and <strong>Atg8</strong> (activation and transfer to Atg3 to ultimately form <strong>Atg8–PE</strong> on autophagy membranes). Through these reactions, Atg7 is required for vesicle formation steps shared by the <strong>Cvt pathway</strong>, <strong>macroautophagy</strong>, and <strong>peroxisome degradation</strong> pathways, acting mainly in the cytosol but functionally organized at the <strong>PAS/phagophore</strong> where lipidation occurs (tanida1999apg7pcvt2panovel pages 2-3, tanida1999apg7pcvt2panovel pages 8-9, hanada2005structurefunctionrelationshipof pages 1-2, kim1999apg7pcvt2pisrequired pages 1-2, marquardt2023autophagicandnonautophagic pages 1-2).</p>
+<p>References</p>
+<ol>
+<li>
+<p>(tanida1999apg7pcvt2panovel pages 2-3): Isei Tanida, Noboru Mizushima, Miho Kiyooka, Mariko Ohsumi, Takashi Ueno, Yoshinori Ohsumi, and Eiki Kominami. Apg7p/cvt2p: a novel protein-activating enzyme essential for autophagy. Molecular biology of the cell, 10 5:1367-79, May 1999. URL: https://doi.org/10.1091/mbc.10.5.1367, doi:10.1091/mbc.10.5.1367. This article has 545 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(tanida1999apg7pcvt2panovel pages 1-2): Isei Tanida, Noboru Mizushima, Miho Kiyooka, Mariko Ohsumi, Takashi Ueno, Yoshinori Ohsumi, and Eiki Kominami. Apg7p/cvt2p: a novel protein-activating enzyme essential for autophagy. Molecular biology of the cell, 10 5:1367-79, May 1999. URL: https://doi.org/10.1091/mbc.10.5.1367, doi:10.1091/mbc.10.5.1367. This article has 545 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(kim1999apg7pcvt2pisrequired pages 1-2): John Kim, Valerie M. Dalton, Kimberly P. Eggerton, Sidney V. Scott, and Daniel J. Klionsky. Apg7p/cvt2p is required for the cytoplasm-to-vacuole targeting, macroautophagy, and peroxisome degradation pathways. Molecular biology of the cell, 10 5:1337-51, May 1999. URL: https://doi.org/10.1091/mbc.10.5.1337, doi:10.1091/mbc.10.5.1337. This article has 284 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(yorimitsu2005autophagymolecularmachinery pages 4-5): Tomohiro Yorimitsu and D. Klionsky. Autophagy: molecular machinery for self-eating. Cell Death and Differentiation, 12:1542-1552, Nov 2005. URL: https://doi.org/10.1038/sj.cdd.4401765, doi:10.1038/sj.cdd.4401765. This article has 2107 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(hanada2005structurefunctionrelationshipof pages 1-2): Takao Hanada and Yoshinori Ohsumi. Structure-function relationship of atg12, a ubiquitin-like modifier essential for autophagy. Autophagy, 1:110-118, Jul 2005. URL: https://doi.org/10.4161/auto.1.2.1858, doi:10.4161/auto.1.2.1858. This article has 88 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(tanida1999apg7pcvt2panovel pages 8-9): Isei Tanida, Noboru Mizushima, Miho Kiyooka, Mariko Ohsumi, Takashi Ueno, Yoshinori Ohsumi, and Eiki Kominami. Apg7p/cvt2p: a novel protein-activating enzyme essential for autophagy. Molecular biology of the cell, 10 5:1367-79, May 1999. URL: https://doi.org/10.1091/mbc.10.5.1367, doi:10.1091/mbc.10.5.1367. This article has 545 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(marquardt2023autophagicandnonautophagic pages 1-2): Lisa Marquardt and Michael Thumm. Autophagic and non-autophagic functions of the saccharomyces cerevisiae proppins atg18, atg21 and hsv2. Biological Chemistry, 0:813-819, May 2023. URL: https://doi.org/10.1515/hsz-2023-0126, doi:10.1515/hsz-2023-0126. This article has 11 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(kim1999apg7pcvt2pisrequired pages 2-3): John Kim, Valerie M. Dalton, Kimberly P. Eggerton, Sidney V. Scott, and Daniel J. Klionsky. Apg7p/cvt2p is required for the cytoplasm-to-vacuole targeting, macroautophagy, and peroxisome degradation pathways. Molecular biology of the cell, 10 5:1337-51, May 1999. URL: https://doi.org/10.1091/mbc.10.5.1337, doi:10.1091/mbc.10.5.1337. This article has 284 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(fujioka2025mechanismsofautophagosome pages 1-3): Yuko FUJIOKA and Nobuo N. NODA. Mechanisms of autophagosome formation. Proceedings of the Japan Academy. Series B, Physical and Biological Sciences, 101:32-40, Jan 2025. URL: https://doi.org/10.2183/pjab.101.005, doi:10.2183/pjab.101.005. This article has 10 citations.</p>
+</li>
+<li>
+<p>(fujioka2024phaseseparationpromotes pages 1-5): Yuko Fujioka, Takuma Tsuji, Tetsuya Kotani, Hiroyuki Kumeta, Chika Kakuta, Toyoshi Fujimoto, Hitoshi Nakatogawa, and Nobuo N. Noda. Phase separation promotes atg8 lipidation for autophagy progression. bioRxiv, Aug 2024. URL: https://doi.org/10.1101/2024.08.29.610189, doi:10.1101/2024.08.29.610189. This article has 4 citations.</p>
+</li>
+<li>
+<p>(fujioka2024phaseseparationpromotes pages 24-26): Yuko Fujioka, Takuma Tsuji, Tetsuya Kotani, Hiroyuki Kumeta, Chika Kakuta, Toyoshi Fujimoto, Hitoshi Nakatogawa, and Nobuo N. Noda. Phase separation promotes atg8 lipidation for autophagy progression. bioRxiv, Aug 2024. URL: https://doi.org/10.1101/2024.08.29.610189, doi:10.1101/2024.08.29.610189. This article has 4 citations.</p>
+</li>
+<li>
+<p>(ohsumi2006proteindegradation pages 53-57): Y Ohsumi. Protein Degradation. Wiley, Dec 2006. URL: https://doi.org/10.1002/9783527620210, doi:10.1002/9783527620210.</p>
+</li>
+</ol>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>hanada2005structurefunctionrelationshipof pages 1-2</li>
+<li>marquardt2023autophagicandnonautophagic pages 1-2</li>
+<li>fujioka2024phaseseparationpromotes pages 1-5</li>
+<li>fujioka2024phaseseparationpromotes pages 24-26</li>
+<li>ohsumi2006proteindegradation pages 53-57</li>
+<li>yorimitsu2005autophagymolecularmachinery pages 4-5</li>
+<li>fujioka2025mechanismsofautophagosome pages 1-3</li>
+<li>https://doi.org/10.1091/mbc.10.5.1367</li>
+<li>https://doi.org/10.1091/mbc.10.5.1337</li>
+<li>https://doi.org/10.1515/hsz-2023-0126</li>
+<li>https://doi.org/10.1101/2024.08.29.610189</li>
+<li>https://doi.org/10.1080/15548627.2024.2366749</li>
+<li>https://doi.org/10.1080/15548627.2024.2325297</li>
+<li>https://doi.org/10.1038/sj.cdd.4401765</li>
+<li>https://doi.org/10.1038/sj.cdd.4401765;</li>
+<li>https://doi.org/10.4161/auto.1.2.1858;</li>
+<li>https://doi.org/10.1515/hsz-2023-0126;</li>
+<li>https://doi.org/10.2183/pjab.101.005</li>
+<li>https://doi.org/10.1091/mbc.10.5.1367;</li>
+<li>https://doi.org/10.1091/mbc.10.5.1337;</li>
+<li>https://doi.org/10.4161/auto.1.2.1858</li>
+<li>https://doi.org/10.1101/2024.08.29.610189;</li>
+<li>https://doi.org/10.1091/mbc.10.5.1367,</li>
+<li>https://doi.org/10.1091/mbc.10.5.1337,</li>
+<li>https://doi.org/10.1038/sj.cdd.4401765,</li>
+<li>https://doi.org/10.4161/auto.1.2.1858,</li>
+<li>https://doi.org/10.1515/hsz-2023-0126,</li>
+<li>https://doi.org/10.2183/pjab.101.005,</li>
+<li>https://doi.org/10.1101/2024.08.29.610189,</li>
+<li>https://doi.org/10.1002/9783527620210,</li>
+</ol>
+            </div>
+        </details>
+
         <details class="markdown-section">
             <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
                 <div style="flex: 1;">
@@ -5995,9 +6432,9 @@
 - Domain section describes functional regions (C-terminal 40 aa for homodimerization and E2 recruitment)</p>
             </div>
         </details>
-        
+
     </div>
-    
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -6515,6 +6952,11 @@ existing_annotations:
     supported_by:
     - reference_id: PMID:10233150
       supporting_text: &#39;Apg7p/Cvt2p: A novel protein-activating enzyme essential for autophagy.&#39;
+    - reference_id: file:yeast/ATG7/ATG7-deep-research-falcon.md
+      supporting_text: &gt;-
+        Atg7 activates the C-terminal glycine of Atg12 in an ATP-dependent
+        reaction, forms an Atg12~Atg7 thioester, and transfers Atg12 onward for
+        Atg12-Atg5 conjugation.
     reason: Accepted because this annotation aligns with established ATG7 E1-like function and autophagy pathway roles.
 - term:
     id: GO:0016236
@@ -6551,6 +6993,10 @@ existing_annotations:
     supported_by:
     - reference_id: PMID:11100732
       supporting_text: A ubiquitin-like system mediates protein lipidation.
+    - reference_id: file:yeast/ATG7/ATG7-deep-research-falcon.md
+      supporting_text: &gt;-
+        Atg7 activates processed Atg8 and supports its transfer to the E2-like
+        enzyme Atg3, ultimately yielding Atg8-PE on autophagy membranes.
     reason: Accepted because this annotation aligns with established ATG7 E1-like function and autophagy pathway roles.
 - term:
     id: GO:0032258
@@ -6601,6 +7047,16 @@ existing_annotations:
       supporting_text: 2008 Aug 13. Piecemeal microautophagy of the nucleus requires the core macroautophagy genes.
     reason: Accepted because this annotation aligns with established ATG7 E1-like function and autophagy pathway roles.
 references:
+- id: file:yeast/ATG7/ATG7-deep-research-falcon.md
+  title: Falcon deep research report for ATG7
+  findings:
+  - statement: &gt;-
+      Falcon supports ATG7 as the E1-like activating enzyme for both Atg12 and
+      Atg8 ubiquitin-like conjugation systems in yeast autophagy.
+    supporting_text: &gt;-
+      Atg7 is the E1 enzyme for the autophagy conjugation machinery. It
+      activates Atg12 and also functions as the E1 for Atg8 in the Atg8-PE
+      lipidation pathway.
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO terms
   findings: []
@@ -6699,6 +7155,12 @@ core_functions:
   - id: GO:0000407
     label: phagophore assembly site
   description: ATG7 is the E1-like enzyme that activates Atg12 for transfer into the autophagy conjugation pathway required for autophagosome biogenesis and Cvt trafficking.
+  supported_by:
+  - reference_id: file:yeast/ATG7/ATG7-deep-research-falcon.md
+    supporting_text: &gt;-
+      Atg7 activates the C-terminal glycine of Atg12 in an ATP-dependent
+      reaction, forms an Atg12~Atg7 thioester, and transfers Atg12 onward for
+      Atg12-Atg5 conjugation.
 - molecular_function:
     id: GO:0019779
     label: Atg8 activating enzyme activity
@@ -6715,13 +7177,18 @@ core_functions:
   - id: GO:0097632
     label: extrinsic component of phagophore assembly site membrane
   description: ATG7 activates Atg8 in the ubiquitin-like conjugation cascade, enabling downstream membrane-coupled autophagy functions including selective autophagy pathways.
+  supported_by:
+  - reference_id: file:yeast/ATG7/ATG7-deep-research-falcon.md
+    supporting_text: &gt;-
+      Atg7 activates processed Atg8 and supports its transfer to the E2-like
+      enzyme Atg3, ultimately yielding Atg8-PE on autophagy membranes.
 </code></pre>
             </div>
         </details>
     </div>
 
     <!-- Pathway Visualization Link -->
-    
+
 
     <style>
         /* Markdown Section Styles */

--- a/genes/yeast/ATG7/ATG7-ai-review.yaml
+++ b/genes/yeast/ATG7/ATG7-ai-review.yaml
@@ -507,6 +507,11 @@ existing_annotations:
     supported_by:
     - reference_id: PMID:10233150
       supporting_text: 'Apg7p/Cvt2p: A novel protein-activating enzyme essential for autophagy.'
+    - reference_id: file:yeast/ATG7/ATG7-deep-research-falcon.md
+      supporting_text: >-
+        Atg7 activates the C-terminal glycine of Atg12 in an ATP-dependent
+        reaction, forms an Atg12~Atg7 thioester, and transfers Atg12 onward for
+        Atg12-Atg5 conjugation.
     reason: Accepted because this annotation aligns with established ATG7 E1-like function and autophagy pathway roles.
 - term:
     id: GO:0016236
@@ -543,6 +548,10 @@ existing_annotations:
     supported_by:
     - reference_id: PMID:11100732
       supporting_text: A ubiquitin-like system mediates protein lipidation.
+    - reference_id: file:yeast/ATG7/ATG7-deep-research-falcon.md
+      supporting_text: >-
+        Atg7 activates processed Atg8 and supports its transfer to the E2-like
+        enzyme Atg3, ultimately yielding Atg8-PE on autophagy membranes.
     reason: Accepted because this annotation aligns with established ATG7 E1-like function and autophagy pathway roles.
 - term:
     id: GO:0032258
@@ -593,6 +602,16 @@ existing_annotations:
       supporting_text: 2008 Aug 13. Piecemeal microautophagy of the nucleus requires the core macroautophagy genes.
     reason: Accepted because this annotation aligns with established ATG7 E1-like function and autophagy pathway roles.
 references:
+- id: file:yeast/ATG7/ATG7-deep-research-falcon.md
+  title: Falcon deep research report for ATG7
+  findings:
+  - statement: >-
+      Falcon supports ATG7 as the E1-like activating enzyme for both Atg12 and
+      Atg8 ubiquitin-like conjugation systems in yeast autophagy.
+    supporting_text: >-
+      Atg7 is the E1 enzyme for the autophagy conjugation machinery. It
+      activates Atg12 and also functions as the E1 for Atg8 in the Atg8-PE
+      lipidation pathway.
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO terms
   findings: []
@@ -691,6 +710,12 @@ core_functions:
   - id: GO:0000407
     label: phagophore assembly site
   description: ATG7 is the E1-like enzyme that activates Atg12 for transfer into the autophagy conjugation pathway required for autophagosome biogenesis and Cvt trafficking.
+  supported_by:
+  - reference_id: file:yeast/ATG7/ATG7-deep-research-falcon.md
+    supporting_text: >-
+      Atg7 activates the C-terminal glycine of Atg12 in an ATP-dependent
+      reaction, forms an Atg12~Atg7 thioester, and transfers Atg12 onward for
+      Atg12-Atg5 conjugation.
 - molecular_function:
     id: GO:0019779
     label: Atg8 activating enzyme activity
@@ -707,3 +732,8 @@ core_functions:
   - id: GO:0097632
     label: extrinsic component of phagophore assembly site membrane
   description: ATG7 activates Atg8 in the ubiquitin-like conjugation cascade, enabling downstream membrane-coupled autophagy functions including selective autophagy pathways.
+  supported_by:
+  - reference_id: file:yeast/ATG7/ATG7-deep-research-falcon.md
+    supporting_text: >-
+      Atg7 activates processed Atg8 and supports its transfer to the E2-like
+      enzyme Atg3, ultimately yielding Atg8-PE on autophagy membranes.

--- a/genes/yeast/ATG7/ATG7-deep-research-falcon.md
+++ b/genes/yeast/ATG7/ATG7-deep-research-falcon.md
@@ -1,0 +1,295 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-11T06:56:33.457320'
+end_time: '2026-05-11T07:04:53.417634'
+duration_seconds: 499.96
+template_file: templates/gene_research_go_focused.md
+template_variables:
+  organism: yeast
+  gene_id: ATG7
+  gene_symbol: ATG7
+  uniprot_accession: P38862
+  protein_description: 'RecName: Full=Ubiquitin-like modifier-activating enzyme ATG7;
+    AltName: Full=ATG12-activating enzyme E1 ATG7; AltName: Full=Autophagy-related
+    protein 7; AltName: Full=Cytoplasm to vacuole targeting protein 2;'
+  gene_info: Name=ATG7; Synonyms=APG7, CVT2; OrderedLocusNames=YHR171W;
+  organism_full: Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+  protein_family: Belongs to the ATG7 family. .
+  protein_domains: Atg7. (IPR006285); Atg7_N. (IPR032197); Atg7_N_1. (IPR042522);
+    Atg7_N_2. (IPR042523); ThiF/MoeB/HesA. (IPR045886)
+provider_config:
+  timeout: 600
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 30
+---
+
+## Question
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** P38862
+- **Protein Description:** RecName: Full=Ubiquitin-like modifier-activating enzyme ATG7; AltName: Full=ATG12-activating enzyme E1 ATG7; AltName: Full=Autophagy-related protein 7; AltName: Full=Cytoplasm to vacuole targeting protein 2;
+- **Gene Information:** Name=ATG7; Synonyms=APG7, CVT2; OrderedLocusNames=YHR171W;
+- **Organism (full):** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+- **Protein Family:** Belongs to the ATG7 family. .
+- **Key Domains:** Atg7. (IPR006285); Atg7_N. (IPR032197); Atg7_N_1. (IPR042522); Atg7_N_2. (IPR042523); ThiF/MoeB/HesA. (IPR045886)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "ATG7" matches the protein description above**
+2. **Verify the organism is correct:** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'ATG7' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **ATG7** (gene ID: ATG7, UniProt: P38862) in yeast.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** P38862
+- **Protein Description:** RecName: Full=Ubiquitin-like modifier-activating enzyme ATG7; AltName: Full=ATG12-activating enzyme E1 ATG7; AltName: Full=Autophagy-related protein 7; AltName: Full=Cytoplasm to vacuole targeting protein 2;
+- **Gene Information:** Name=ATG7; Synonyms=APG7, CVT2; OrderedLocusNames=YHR171W;
+- **Organism (full):** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+- **Protein Family:** Belongs to the ATG7 family. .
+- **Key Domains:** Atg7. (IPR006285); Atg7_N. (IPR032197); Atg7_N_1. (IPR042522); Atg7_N_2. (IPR042523); ThiF/MoeB/HesA. (IPR045886)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "ATG7" matches the protein description above**
+2. **Verify the organism is correct:** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'ATG7' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **ATG7** (gene ID: ATG7, UniProt: P38862) in yeast.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Research Report: Functional Annotation of *Saccharomyces cerevisiae* ATG7 (UniProt P38862; gene ATG7/APG7/CVT2; ORF YHR171W)
+
+### Scope and identity verification (critical disambiguation)
+The UniProt accession **P38862** corresponds to the budding yeast (*Saccharomyces cerevisiae* S288c) gene historically named **APG7/CVT2** and now referred to as **ATG7**, and it is explicitly mapped to **ORF YHR171W** in primary yeast literature (Tanida et al., 1999; Molecular Biology of the Cell; published May 1999; https://doi.org/10.1091/mbc.10.5.1367) (tanida1999apg7pcvt2panovel pages 2-3). The same work and related yeast genetics papers describe Apg7/Cvt2 as essential for core autophagy and the Cvt pathway in yeast, consistent with the UniProt description provided by the user (tanida1999apg7pcvt2panovel pages 1-2, kim1999apg7pcvt2pisrequired pages 1-2).
+
+### 1) Key concepts and definitions (current understanding)
+
+#### Autophagy and the Cvt pathway
+In yeast, **macroautophagy** is a vacuole-directed degradative pathway in which cytoplasmic components are sequestered into double-membrane autophagosomes that fuse with the vacuole for breakdown. The **cytoplasm-to-vacuole targeting (Cvt) pathway** is a related biosynthetic trafficking pathway that uses overlapping machinery but typically delivers specific cargo such as precursor aminopeptidase I (Ape1/API) to the vacuole (tanida1999apg7pcvt2panovel pages 1-2, kim1999apg7pcvt2pisrequired pages 1-2).
+
+#### Two ubiquitin-like (UBL) conjugation systems in autophagy
+A central mechanistic concept in autophagosome biogenesis is that the core machinery contains **two ubiquitin-like conjugation systems**:
+1) the **Atg12–Atg5** conjugation system, and
+2) the **Atg8–phosphatidylethanolamine (PE)** lipidation system.
+
+ATG7/Atg7 acts as the **E1-like (activating) enzyme** for these UBL systems, functioning analogously to ubiquitin E1 enzymes but dedicated to autophagy-related UBL substrates (yorimitsu2005autophagymolecularmachinery pages 4-5, hanada2005structurefunctionrelationshipof pages 1-2).
+
+### 2) Primary biochemical function of Atg7: reaction catalyzed and substrate specificity
+
+#### Atg7 is an E1-like activating enzyme for Atg12 (direct yeast experimental evidence)
+Classic yeast biochemical genetics established that Apg7/Cvt2 (Atg7) is an **E1-like “protein-activating enzyme”** essential for autophagy, and specifically an **Apg12 (Atg12)-activating enzyme** (tanida1999apg7pcvt2panovel pages 1-2). The key biochemical steps supported by yeast evidence include:
+
+- **ATP-dependent activation** of the C-terminal glycine of Atg12/Apg12 (tanida1999apg7pcvt2panovel pages 8-9).
+- Formation of an **Atg12~Atg7 thioester intermediate** (i.e., a thioester conjugate between Atg12 and Atg7) (tanida1999apg7pcvt2panovel pages 8-9, tanida1999apg7pcvt2panovel pages 1-2).
+- Dependence on an **active-site cysteine (Cys507)** in Atg7 for thioester formation and downstream conjugation; mutation of this cysteine disrupts Atg12–Atg5 conjugation and causes autophagy/Cvt defects (tanida1999apg7pcvt2panovel pages 8-9, tanida1999apg7pcvt2panovel pages 1-2).
+
+These findings establish substrate specificity for **Atg12** and a canonical E1-like thioester chemistry.
+
+#### Atg7 is shared by the Atg8 lipidation pathway (Atg8 → Atg8-PE)
+Authoritative mechanistic literature and yeast-focused reviews describe Atg7 as the **E1-like enzyme shared by both UBL systems**, including the Atg8 lipidation pathway (hanada2005structurefunctionrelationshipof pages 1-2, marquardt2023autophagicandnonautophagic pages 1-2). In this pathway, Atg7 activates processed Atg8 and supports its transfer to the E2-like enzyme Atg3, ultimately yielding **Atg8–PE** on autophagy membranes (hanada2005structurefunctionrelationshipof pages 1-2, marquardt2023autophagicandnonautophagic pages 1-2).
+
+#### E2 partners and downstream enzymology
+Evidence supports that Atg7 transfers:
+- **Atg12 to Atg10** (E2-like enzyme) (hanada2005structurefunctionrelationshipof pages 1-2), and
+- **Atg8 to Atg3** (E2-like enzyme) in the Atg8 lipidation cascade (hanada2005structurefunctionrelationshipof pages 1-2, marquardt2023autophagicandnonautophagic pages 1-2).
+
+The Atg12–Atg5 conjugate assembles with Atg16 to form an **E3-like complex** that promotes Atg8 lipidation, and this machinery is spatially organized at the phagophore/PAS in yeast (marquardt2023autophagicandnonautophagic pages 1-2).
+
+### 3) Biological processes and pathways requiring Atg7 (genetic pathway-level roles)
+
+#### Required for Cvt, macroautophagy, and peroxisome degradation (pexophagy)
+Yeast genetic evidence shows Apg7/Cvt2 is required for:
+- the **Cvt pathway**, 
+- **macroautophagy**, and
+- **peroxisome degradation** (often discussed as pexophagy) (Kim et al., 1999; Molecular Biology of the Cell; May 1999; https://doi.org/10.1091/mbc.10.5.1337) (kim1999apg7pcvt2pisrequired pages 1-2, kim1999apg7pcvt2pisrequired pages 2-3).
+
+This is consistent with Atg7 acting at a conserved “sequestration” step and enabling UBL conjugation events needed for autophagosome/Cvt vesicle formation (kim1999apg7pcvt2pisrequired pages 1-2).
+
+### 4) Subcellular localization and site of action
+
+#### Cytosolic predominance with conditional membrane association
+Tanida et al. (1999) report Atg7/Apg7 is **mainly cytosolic**, and suggest the Atg12–Atg7 interaction can occur in the cytosol or on the cytoplasmic face of an Atg12-associated compartment (tanida1999apg7pcvt2panovel pages 8-9). Kim et al. (1999) further note that **a fraction of Apg7 becomes membrane-associated** in an Atg12-dependent manner (kim1999apg7pcvt2pisrequired pages 1-2).
+
+#### PAS-centric view of the lipidation machinery (current models)
+Later yeast-centric mechanistic synthesis places the Atg8 lipidation machinery—including Atg7’s role as E1—at the **phagophore assembly site (PAS)** and on the growing phagophore membrane, where Atg8–PE becomes distributed over the phagophore and is later delipidated from the outer surface after closure (marquardt2023autophagicandnonautophagic pages 1-2, fujioka2025mechanismsofautophagosome pages 1-3).
+
+### 5) Recent developments (prioritizing 2023–2024)
+
+#### 2023: Organization of the Atg8 lipidation machinery at phagophore/vacuole contacts
+A 2023 yeast-focused review emphasizes that Atg21 organizes part of the Atg8 lipidation machinery at the vacuole–phagophore contact and explicitly reiterates the enzymatic cascade: Atg8 is activated by **E1 Atg7**, transferred to **E2 Atg3**, and requires an **E3 complex** formed by Atg12–Atg5 (with Atg16) (Marquardt & Thumm, 2023; Biological Chemistry; May 2023; https://doi.org/10.1515/hsz-2023-0126) (marquardt2023autophagicandnonautophagic pages 1-2).
+
+#### 2024: Phase separation as a mechanistic enhancer of Atg8 lipidation (in vitro reconstitution)
+A 2024 preprint reports that an early PAS-like compartment formed by **phase separation** can promote Atg8 lipidation by concentrating the E3-like Atg12–Atg5–Atg16 complex and excluding the deconjugase Atg4, thereby favoring net Atg8–PE formation; Atg7 is explicitly included as the E1 for both Atg8 and Atg12 in the reconstituted cascade (Fujioka et al., 2024; bioRxiv; Aug 2024; https://doi.org/10.1101/2024.08.29.610189) (fujioka2024phaseseparationpromotes pages 1-5). This work represents a contemporary direction in the field: using reconstitution and mesoscale organization (condensates) to explain how enzymatic reactions are spatially tuned in autophagy.
+
+#### 2024: Real-world yeast method development—temporal proximity labeling for autophagy interactomes
+A 2024 methods paper introduces an **APEX2-based proximity labeling** protocol adapted to *S. cerevisiae* that preserves temporal specificity during autophagy induction, demonstrated with Atg8 and Atg9 as baits (Filali-Mouncef et al., 2024; Autophagy; Jul 2024; https://doi.org/10.1080/15548627.2024.2366749). Notably, their proof-of-concept datasets did not identify Atg7 in that particular setup, which the authors mention as an example of proteins not recovered (fujioka2024phaseseparationpromotes pages 24-26). While not an Atg7 paper per se, this is a current implementation relevant to mapping Atg7-adjacent networks in yeast.
+
+#### 2024: Yeast applications—core ATG genes tested in lipophagy context
+A 2024 yeast study on lipophagy reports testing a panel of **core autophagy-related yeast genes** (including ATG mutants) under different conditions to parse ATG-dependent and ATG-independent contributions to overall lipophagy (Kang et al., 2024; Autophagy; Mar 2024; https://doi.org/10.1080/15548627.2024.2325297). The retrieved snippet does not isolate an Atg7-specific quantitative result, but it supports the ongoing use of core ATG mutants (including atg7Δ in many designs) as implementation tools in yeast cell biology (ohsumi2006proteindegradation pages 53-57).
+
+### 6) Expert opinions and analysis (authoritative synthesis)
+Across authoritative autophagy literature, the consensus interpretation is that Atg7 serves as a pathway-specifying E1-like enzyme whose principal biological role is to **enable autophagosome/Cvt vesicle biogenesis by driving UBL conjugation chemistry** (not proteasome-directed ubiquitination). High-citation reviews frame Atg7 as homologous to canonical E1 ubiquitin-activating enzymes and emphasize its formation of a thioester intermediate with Atg12 via an active site cysteine (Yorimitsu & Klionsky, 2005; Cell Death & Differentiation; Nov 2005; https://doi.org/10.1038/sj.cdd.4401765) (yorimitsu2005autophagymolecularmachinery pages 4-5). More recent yeast-centric synthesis integrates this enzymology with spatial organization at the PAS/phagophore and with contact-site factors (e.g., Atg21) that help position the lipidation machinery where Atg8–PE functions (marquardt2023autophagicandnonautophagic pages 1-2).
+
+### 7) Statistics and quantitative data from recent studies (limitations of retrieved evidence)
+The retrieved evidence includes well-supported **qualitative** requirements (e.g., atg7 mutants block Ape1/API processing, autophagy, and peroxisome degradation; Cys507 is required for thioester formation and function) (tanida1999apg7pcvt2panovel pages 1-2, kim1999apg7pcvt2pisrequired pages 1-2). It also identifies commonly used **quantitative flux assays** used in yeast autophagy research, including **GFP-Atg8 vacuolar delivery** and the **Pho8Δ60 alkaline phosphatase assay** (ohsumi2006proteindegradation pages 53-57). However, the excerpts retrieved here do **not** contain specific numeric values (e.g., percent flux reduction, fold-changes, kinetic constants) for ATG7-dependent phenotypes in 2023–2024 studies. Therefore, no numerical statistics are reported in this answer to avoid over-interpretation beyond the provided evidence (ohsumi2006proteindegradation pages 53-57).
+
+### Summary table (evidence map)
+The following table consolidates identity, enzymatic mechanism, pathways, localization, phenotypes, and 2023–2024 developments with dates and URLs.
+
+| Aspect | Key points | Best supporting citations | Primary sources/reviews (short ref) | URL | Publication date |
+|---|---|---|---|---|---|
+| identity | The target matches **Saccharomyces cerevisiae ATG7**, also called **Apg7/Cvt2**; the APG7 locus is explicitly identified as **ORF YHR171W**. It is essential for autophagy and the Cvt pathway. | (tanida1999apg7pcvt2panovel pages 2-3, tanida1999apg7pcvt2panovel pages 1-2) | Tanida et al. 1999 | https://doi.org/10.1091/mbc.10.5.1367 | May 1999 |
+| domains/family | Atg7 is described as an **E1-like/ubiquitin-activating-enzyme homolog** in the autophagy ubiquitin-like conjugation systems; evidence snippets support family-level classification as an E1-like activating enzyme, but do not provide domain architecture details. | (yorimitsu2005autophagymolecularmachinery pages 4-5, tanida1999apg7pcvt2panovel pages 1-2) | Yorimitsu & Klionsky 2005; Tanida et al. 1999 | https://doi.org/10.1038/sj.cdd.4401765; https://doi.org/10.1091/mbc.10.5.1367 | Nov 2005; May 1999 |
+| enzymatic role | Atg7 is the **E1 enzyme** for the autophagy conjugation machinery. It activates **Atg12** and also functions as the E1 for **Atg8** in the Atg8-PE lipidation pathway. | (hanada2005structurefunctionrelationshipof pages 1-2, marquardt2023autophagicandnonautophagic pages 1-2, fujioka2025mechanismsofautophagosome pages 1-3) | Hanada & Ohsumi 2005; Marquardt & Thumm 2023; Fujioka & Noda 2025 | https://doi.org/10.4161/auto.1.2.1858; https://doi.org/10.1515/hsz-2023-0126; https://doi.org/10.2183/pjab.101.005 | Jul 2005; May 2023; Jan 2025 |
+| substrates | Supported substrates are **Atg12** and **Atg8**. For Atg8, the pathway culminates in conjugation to **phosphatidylethanolamine (PE)**; the Atg12 system yields Atg12 transfer onward for Atg12-Atg5 conjugation. | (hanada2005structurefunctionrelationshipof pages 1-2, fujioka2024phaseseparationpromotes pages 1-5) | Hanada & Ohsumi 2005; Fujioka et al. 2024 | https://doi.org/10.4161/auto.1.2.1858; https://doi.org/10.1101/2024.08.29.610189 | Jul 2005; Aug 2024 |
+| reaction steps | For **Atg12**: Atg7 activates the C-terminal glycine in an **ATP-dependent** reaction, forms an **Atg12~Atg7 thioester**, then transfers Atg12 to **Atg10** for eventual Atg12-Atg5 conjugation. For **Atg8**: Atg7 activates Atg8, transfers it to **Atg3**, and the **Atg12-Atg5-Atg16** complex promotes Atg8-PE formation. | (tanida1999apg7pcvt2panovel pages 8-9, hanada2005structurefunctionrelationshipof pages 1-2, yorimitsu2005autophagymolecularmachinery pages 4-5, marquardt2023autophagicandnonautophagic pages 1-2) | Tanida et al. 1999; Hanada & Ohsumi 2005; Yorimitsu & Klionsky 2005; Marquardt & Thumm 2023 | https://doi.org/10.1091/mbc.10.5.1367; https://doi.org/10.4161/auto.1.2.1858; https://doi.org/10.1038/sj.cdd.4401765; https://doi.org/10.1515/hsz-2023-0126 | May 1999; Jul 2005; Nov 2005; May 2023 |
+| key catalytic residue | **Cys507** is the active-site cysteine required for Atg7 function. Mutation of this residue disrupts conjugation activity and autophagy/Cvt readouts. | (tanida1999apg7pcvt2panovel pages 8-9, tanida1999apg7pcvt2panovel pages 1-2) | Tanida et al. 1999 | https://doi.org/10.1091/mbc.10.5.1367 | May 1999 |
+| E2 partners | Atg7 transfers **Atg12 to Atg10** and **Atg8 to Atg3**; thus the cognate E2 partners supported in the evidence are **Atg10** and **Atg3**. | (hanada2005structurefunctionrelationshipof pages 1-2, marquardt2023autophagicandnonautophagic pages 1-2) | Hanada & Ohsumi 2005; Marquardt & Thumm 2023 | https://doi.org/10.4161/auto.1.2.1858; https://doi.org/10.1515/hsz-2023-0126 | Jul 2005; May 2023 |
+| pathways | Atg7 is required for **cytoplasm-to-vacuole targeting (Cvt)**, **macroautophagy**, and **peroxisome degradation/pexophagy**; later reviews also place it in the core Atg8/Atg12 conjugation systems that drive autophagosome biogenesis. | (kim1999apg7pcvt2pisrequired pages 1-2, kim1999apg7pcvt2pisrequired pages 2-3, hanada2005structurefunctionrelationshipof pages 1-2) | Kim et al. 1999; Hanada & Ohsumi 2005 | https://doi.org/10.1091/mbc.10.5.1337; https://doi.org/10.4161/auto.1.2.1858 | May 1999; Jul 2005 |
+| localization | Evidence supports Atg7 as **mainly cytosolic**, with interaction/conjugation occurring in the cytosol or on the **cytoplasmic face of an Atg12-associated compartment**; a fraction can be **membrane-associated** in an Atg12-dependent manner. In current models of Atg8 lipidation, the machinery functions at the **PAS/phagophore membrane**. | (tanida1999apg7pcvt2panovel pages 8-9, kim1999apg7pcvt2pisrequired pages 1-2, marquardt2023autophagicandnonautophagic pages 1-2, fujioka2025mechanismsofautophagosome pages 1-3) | Tanida et al. 1999; Kim et al. 1999; Marquardt & Thumm 2023; Fujioka & Noda 2025 | https://doi.org/10.1091/mbc.10.5.1367; https://doi.org/10.1091/mbc.10.5.1337; https://doi.org/10.1515/hsz-2023-0126; https://doi.org/10.2183/pjab.101.005 | May 1999; May 1999; May 2023; Jan 2025 |
+| phenotypes | **atg7/apg7/cvt2 mutants** show defects in **Ape1/API processing**, autophagy, Cvt transport, and peroxisome degradation. Mutation of the ATP-binding region or **C507A** impairs Atg12-Apg5 conjugation and autophagy/Cvt function. | (tanida1999apg7pcvt2panovel pages 1-2, kim1999apg7pcvt2pisrequired pages 1-2, kim1999apg7pcvt2pisrequired pages 2-3) | Tanida et al. 1999; Kim et al. 1999 | https://doi.org/10.1091/mbc.10.5.1367; https://doi.org/10.1091/mbc.10.5.1337 | May 1999 |
+| recent 2023-2024 developments/methods | Recent yeast-focused work places Atg7 in **PAS/phagophore-localized Atg8 lipidation organization** and in **in vitro reconstitution** systems. A **2024 APEX2 proximity-labeling** protocol was introduced for temporal mapping of autophagy interactions in yeast, though Atg7 was not recovered in the proof-of-concept dataset. A **2024 lipophagy** study assessed core ATG mutants in yeast. A **2024 preprint** reported that **phase separation of early PAS droplets promotes Atg8 lipidation**, with Atg7 included as the E1 in the reconstituted cascade. | (marquardt2023autophagicandnonautophagic pages 1-2, fujioka2024phaseseparationpromotes pages 1-5, fujioka2024phaseseparationpromotes pages 24-26) | Marquardt & Thumm 2023; Fujioka et al. 2024; Filali-Mouncef et al. 2024 | https://doi.org/10.1515/hsz-2023-0126; https://doi.org/10.1101/2024.08.29.610189; https://doi.org/10.1080/15548627.2024.2366749 | May 2023; Aug 2024; Jul 2024 |
+
+
+*Table: This table summarizes identity, mechanism, pathways, localization, phenotypes, and recent developments for Saccharomyces cerevisiae ATG7/YHR171W using only facts supported by the cited evidence snippets. It is useful as a compact evidence map for functional annotation of UniProt P38862.*
+
+### Key take-home functional annotation (for UniProt-style summary)
+In *S. cerevisiae*, **Atg7 (Apg7/Cvt2; YHR171W)** is an **E1-like ubiquitin-like modifier–activating enzyme** that catalyzes ATP-dependent activation of autophagy UBL substrates and forms thioester intermediates via an essential active-site cysteine (**Cys507**). Its primary substrates are **Atg12** (activation and transfer to Atg10 for Atg12–Atg5 conjugation) and **Atg8** (activation and transfer to Atg3 to ultimately form **Atg8–PE** on autophagy membranes). Through these reactions, Atg7 is required for vesicle formation steps shared by the **Cvt pathway**, **macroautophagy**, and **peroxisome degradation** pathways, acting mainly in the cytosol but functionally organized at the **PAS/phagophore** where lipidation occurs (tanida1999apg7pcvt2panovel pages 2-3, tanida1999apg7pcvt2panovel pages 8-9, hanada2005structurefunctionrelationshipof pages 1-2, kim1999apg7pcvt2pisrequired pages 1-2, marquardt2023autophagicandnonautophagic pages 1-2).
+
+References
+
+1. (tanida1999apg7pcvt2panovel pages 2-3): Isei Tanida, Noboru Mizushima, Miho Kiyooka, Mariko Ohsumi, Takashi Ueno, Yoshinori Ohsumi, and Eiki Kominami. Apg7p/cvt2p: a novel protein-activating enzyme essential for autophagy. Molecular biology of the cell, 10 5:1367-79, May 1999. URL: https://doi.org/10.1091/mbc.10.5.1367, doi:10.1091/mbc.10.5.1367. This article has 545 citations and is from a domain leading peer-reviewed journal.
+
+2. (tanida1999apg7pcvt2panovel pages 1-2): Isei Tanida, Noboru Mizushima, Miho Kiyooka, Mariko Ohsumi, Takashi Ueno, Yoshinori Ohsumi, and Eiki Kominami. Apg7p/cvt2p: a novel protein-activating enzyme essential for autophagy. Molecular biology of the cell, 10 5:1367-79, May 1999. URL: https://doi.org/10.1091/mbc.10.5.1367, doi:10.1091/mbc.10.5.1367. This article has 545 citations and is from a domain leading peer-reviewed journal.
+
+3. (kim1999apg7pcvt2pisrequired pages 1-2): John Kim, Valerie M. Dalton, Kimberly P. Eggerton, Sidney V. Scott, and Daniel J. Klionsky. Apg7p/cvt2p is required for the cytoplasm-to-vacuole targeting, macroautophagy, and peroxisome degradation pathways. Molecular biology of the cell, 10 5:1337-51, May 1999. URL: https://doi.org/10.1091/mbc.10.5.1337, doi:10.1091/mbc.10.5.1337. This article has 284 citations and is from a domain leading peer-reviewed journal.
+
+4. (yorimitsu2005autophagymolecularmachinery pages 4-5): Tomohiro Yorimitsu and D. Klionsky. Autophagy: molecular machinery for self-eating. Cell Death and Differentiation, 12:1542-1552, Nov 2005. URL: https://doi.org/10.1038/sj.cdd.4401765, doi:10.1038/sj.cdd.4401765. This article has 2107 citations and is from a domain leading peer-reviewed journal.
+
+5. (hanada2005structurefunctionrelationshipof pages 1-2): Takao Hanada and Yoshinori Ohsumi. Structure-function relationship of atg12, a ubiquitin-like modifier essential for autophagy. Autophagy, 1:110-118, Jul 2005. URL: https://doi.org/10.4161/auto.1.2.1858, doi:10.4161/auto.1.2.1858. This article has 88 citations and is from a domain leading peer-reviewed journal.
+
+6. (tanida1999apg7pcvt2panovel pages 8-9): Isei Tanida, Noboru Mizushima, Miho Kiyooka, Mariko Ohsumi, Takashi Ueno, Yoshinori Ohsumi, and Eiki Kominami. Apg7p/cvt2p: a novel protein-activating enzyme essential for autophagy. Molecular biology of the cell, 10 5:1367-79, May 1999. URL: https://doi.org/10.1091/mbc.10.5.1367, doi:10.1091/mbc.10.5.1367. This article has 545 citations and is from a domain leading peer-reviewed journal.
+
+7. (marquardt2023autophagicandnonautophagic pages 1-2): Lisa Marquardt and Michael Thumm. Autophagic and non-autophagic functions of the saccharomyces cerevisiae proppins atg18, atg21 and hsv2. Biological Chemistry, 0:813-819, May 2023. URL: https://doi.org/10.1515/hsz-2023-0126, doi:10.1515/hsz-2023-0126. This article has 11 citations and is from a peer-reviewed journal.
+
+8. (kim1999apg7pcvt2pisrequired pages 2-3): John Kim, Valerie M. Dalton, Kimberly P. Eggerton, Sidney V. Scott, and Daniel J. Klionsky. Apg7p/cvt2p is required for the cytoplasm-to-vacuole targeting, macroautophagy, and peroxisome degradation pathways. Molecular biology of the cell, 10 5:1337-51, May 1999. URL: https://doi.org/10.1091/mbc.10.5.1337, doi:10.1091/mbc.10.5.1337. This article has 284 citations and is from a domain leading peer-reviewed journal.
+
+9. (fujioka2025mechanismsofautophagosome pages 1-3): Yuko FUJIOKA and Nobuo N. NODA. Mechanisms of autophagosome formation. Proceedings of the Japan Academy. Series B, Physical and Biological Sciences, 101:32-40, Jan 2025. URL: https://doi.org/10.2183/pjab.101.005, doi:10.2183/pjab.101.005. This article has 10 citations.
+
+10. (fujioka2024phaseseparationpromotes pages 1-5): Yuko Fujioka, Takuma Tsuji, Tetsuya Kotani, Hiroyuki Kumeta, Chika Kakuta, Toyoshi Fujimoto, Hitoshi Nakatogawa, and Nobuo N. Noda. Phase separation promotes atg8 lipidation for autophagy progression. bioRxiv, Aug 2024. URL: https://doi.org/10.1101/2024.08.29.610189, doi:10.1101/2024.08.29.610189. This article has 4 citations.
+
+11. (fujioka2024phaseseparationpromotes pages 24-26): Yuko Fujioka, Takuma Tsuji, Tetsuya Kotani, Hiroyuki Kumeta, Chika Kakuta, Toyoshi Fujimoto, Hitoshi Nakatogawa, and Nobuo N. Noda. Phase separation promotes atg8 lipidation for autophagy progression. bioRxiv, Aug 2024. URL: https://doi.org/10.1101/2024.08.29.610189, doi:10.1101/2024.08.29.610189. This article has 4 citations.
+
+12. (ohsumi2006proteindegradation pages 53-57): Y Ohsumi. Protein Degradation. Wiley, Dec 2006. URL: https://doi.org/10.1002/9783527620210, doi:10.1002/9783527620210.
+
+## Citations
+
+1. hanada2005structurefunctionrelationshipof pages 1-2
+2. marquardt2023autophagicandnonautophagic pages 1-2
+3. fujioka2024phaseseparationpromotes pages 1-5
+4. fujioka2024phaseseparationpromotes pages 24-26
+5. ohsumi2006proteindegradation pages 53-57
+6. yorimitsu2005autophagymolecularmachinery pages 4-5
+7. fujioka2025mechanismsofautophagosome pages 1-3
+8. https://doi.org/10.1091/mbc.10.5.1367
+9. https://doi.org/10.1091/mbc.10.5.1337
+10. https://doi.org/10.1515/hsz-2023-0126
+11. https://doi.org/10.1101/2024.08.29.610189
+12. https://doi.org/10.1080/15548627.2024.2366749
+13. https://doi.org/10.1080/15548627.2024.2325297
+14. https://doi.org/10.1038/sj.cdd.4401765
+15. https://doi.org/10.1038/sj.cdd.4401765;
+16. https://doi.org/10.4161/auto.1.2.1858;
+17. https://doi.org/10.1515/hsz-2023-0126;
+18. https://doi.org/10.2183/pjab.101.005
+19. https://doi.org/10.1091/mbc.10.5.1367;
+20. https://doi.org/10.1091/mbc.10.5.1337;
+21. https://doi.org/10.4161/auto.1.2.1858
+22. https://doi.org/10.1101/2024.08.29.610189;
+23. https://doi.org/10.1091/mbc.10.5.1367,
+24. https://doi.org/10.1091/mbc.10.5.1337,
+25. https://doi.org/10.1038/sj.cdd.4401765,
+26. https://doi.org/10.4161/auto.1.2.1858,
+27. https://doi.org/10.1515/hsz-2023-0126,
+28. https://doi.org/10.2183/pjab.101.005,
+29. https://doi.org/10.1101/2024.08.29.610189,
+30. https://doi.org/10.1002/9783527620210,

--- a/genes/yeast/CYC1/CYC1-ai-review.html
+++ b/genes/yeast/CYC1/CYC1-ai-review.html
@@ -671,44 +671,44 @@
     <div class="header">
         <h1>CYC1</h1>
         <div class="gene-info">
-            
+
             <div class="info-item">
-                
+
                 <span class="info-label">UniProt ID:</span>
                 <span>
                     <a href="https://www.uniprot.org/uniprotkb/P00044" target="_blank" class="term-link">
                         P00044
                     </a>
                 </span>
-                
+
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Organism:</span>
                 <span>Saccharomyces cerevisiae</span>
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
                 <span class="status-badge status-complete">
                     COMPLETE
                 </span>
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Aliases:</span>
                 <div class="aliases">
-                    
+
                     <span class="badge">YJR048W</span>
-                    
+
                     <span class="badge">J1653</span>
-                    
+
                 </div>
             </div>
-            
+
         </div>
         <div style="margin-top: 1rem; text-align: center;">
             <a id="feedback-form-link"
@@ -739,7 +739,7 @@
         </div>
     </div>
 
-    
+
     <div class="description-card">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <h2>Gene Description</h2>
@@ -750,13 +750,13 @@
         </div>
         <p>Cytochrome c isoform 1 is a small heme-containing electron carrier protein central to mitochondrial aerobic respiration. It functions as the critical link between Complex III and Complex IV in the electron transport chain. CYC1 is predominantly expressed during aerobic growth, with its heme-bound iron center accepting electrons from Complex III and donating them to Complex IV, driving oxidative phosphorylation and ATP synthesis. Secondary roles include interaction with cardiolipin and involvement in apoptotic signaling pathways.</p>
     </div>
-    
 
-    
 
-    
 
-    
+
+
+
+
     <div class="section">
         <h2 class="section-title">Existing Annotations Review</h2>
         <table class="annotations-table">
@@ -769,32 +769,32 @@
                 </tr>
             </thead>
             <tbody>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009055" target="_blank" class="term-link">
                                     GO:0009055
                                 </a>
                             </span>
                             <span class="term-label">electron transfer activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -806,77 +806,88 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Cytochrome c is a core electron carrier protein that shuttles electrons between Complex III and Complex IV in the mitochondrial electron transport chain. The IBA evidence is appropriate for this molecular function annotation.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This is the quintessential function of cytochrome c. UniProt describes CYC1 as an electron carrier protein where the heme group accepts electrons from cytochrome c1 and transfers them to cytochrome c oxidase. Both IDA evidence from PMID:7851399 and PMID:18975895 directly support electron transfer activity through kinetic measurements and electrochemical analysis. IBA annotation is appropriate given the highly conserved nature of this function across cytochrome c family members (PTHR11961). This represents a core primary metabolic role.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/7851399" target="_blank" class="term-link">
                                         PMID:7851399
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The purified enzyme had a turnover number of 1500 s-1 and the ionic-strength dependence of the Km value for cytochrome-c was similar to that described for other preparations of cytochrome-c oxidase.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/18975895" target="_blank" class="term-link">
                                         PMID:18975895
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The apparent electron transfer rate constants of YCC on MUA/MU and MU/MH at pH 6.0 were determined to be 8 and 18 s(-1), respectively.</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/CYC1/CYC1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Cyc1p&#39;s precise biochemical role is single-electron transfer between the bc1 complex and cytochrome c oxidase.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006122" target="_blank" class="term-link">
                                     GO:0006122
                                 </a>
                             </span>
                             <span class="term-label">mitochondrial electron transport, ubiquinol to cytochrome c</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -888,64 +899,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Cytochrome c is the direct electron acceptor from Complex III, receiving electrons from ubiquinol and transferring them to Complex IV. This biological process annotation accurately describes CYC1&#39;s participation in the electron transport chain.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This annotation correctly identifies CYC1&#39;s specific role in mitochondrial electron transport. CYC1 is the electron acceptor from ubiquinol-cytochrome c oxidoreductase (Complex III, the cytochrome bc1 complex). UniProt FUNCTION states CYC1 accepts electrons from the heme group of cytochrome c1 of ubiquinol-cytochrome c oxidoreductase. IDA evidence from PMID:7851399 characterizes the kinetic properties of cytochrome c as a substrate, demonstrating this electron transport step. This is a core primary metabolic function.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/7851399" target="_blank" class="term-link">
                                         PMID:7851399
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The purified enzyme had a turnover number of 1500 s-1 and the ionic-strength dependence of the Km value for cytochrome-c was similar to that described for other preparations of cytochrome-c oxidase.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005758" target="_blank" class="term-link">
                                     GO:0005758
                                 </a>
                             </span>
                             <span class="term-label">mitochondrial intermembrane space</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -957,64 +968,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Cytochrome c is localized to the mitochondrial intermembrane space (IMS), the aqueous compartment between the inner and outer mitochondrial membranes, where it functions as an electron shuttle between membrane-bound protein complexes.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This is the correct cellular compartment localization for CYC1. UniProt explicitly states SUBCELLULAR LOCATION is Mitochondrion intermembrane space. PMID:9866716 describes the purification of intermembrane space fractions with cytochrome c as a key marker protein. IBA annotation is appropriate given the universal localization of cytochrome c to the IMS across eukaryotes.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9866716" target="_blank" class="term-link">
                                         PMID:9866716
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Two distinct fractions were obtained: a soluble IMS with cytochrome b2 as key marker and a salt-extractable IMS with cytochrome c as key marker.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006123" target="_blank" class="term-link">
                                     GO:0006123
                                 </a>
                             </span>
                             <span class="term-label">mitochondrial electron transport, cytochrome c to oxygen</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1026,64 +1037,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Cytochrome c donates electrons to Complex IV (cytochrome c oxidase), where oxygen serves as the final electron acceptor. This biological process annotation describes the second major step of CYC1&#39;s participation in the electron transport chain.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This annotation correctly identifies CYC1&#39;s specific role as the electron donor to cytochrome c oxidase (Complex IV). UniProt states CYC1 transfers electrons to the dinuclear copper A center of the COX2 subunit of cytochrome oxidase, the final protein carrier in the mitochondrial electron-transport chain. PMID:7851399 provides kinetic evidence for this interaction. IBA annotation is appropriate. This is a core primary metabolic function.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/7851399" target="_blank" class="term-link">
                                         PMID:7851399
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The purified enzyme had a turnover number of 1500 s-1 and the ionic-strength dependence of the Km value for cytochrome-c was similar to that described for other preparations of cytochrome-c oxidase.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005758" target="_blank" class="term-link">
                                     GO:0005758
                                 </a>
                             </span>
                             <span class="term-label">mitochondrial intermembrane space</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1095,64 +1106,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation of mitochondrial intermembrane space localization derived from automated sequence analysis and subcellular location databases. Consistent with experimental evidence.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> IEA annotation correctly predicts CYC1 localization based on UniProt subcellular location annotations. This is fully supported by experimental IDA evidence (PMID:9866716). Redundant with other mitochondrial intermembrane space annotations but acceptable as it represents automated annotation pipelines that independently confirm the localization.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9866716" target="_blank" class="term-link">
                                         PMID:9866716
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Two distinct fractions were obtained: a soluble IMS with cytochrome b2 as key marker and a salt-extractable IMS with cytochrome c as key marker.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006122" target="_blank" class="term-link">
                                     GO:0006122
                                 </a>
                             </span>
                             <span class="term-label">mitochondrial electron transport, ubiquinol to cytochrome c</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1164,64 +1175,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation by ARBA machine learning model predicting CYC1 involvement in ubiquinol-to-cytochrome c electron transport. Consistent with experimental evidence and core function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> IEA annotation correctly predicts this core metabolic process based on sequence homology and association rules. Fully consistent with experimental IDA evidence (PMID:7851399) and IBA annotations. ARBA models are trained on well-characterized annotations, and this prediction is mechanistically sound for the cytochrome c family.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/7851399" target="_blank" class="term-link">
                                         PMID:7851399
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The purified enzyme had a turnover number of 1500 s-1 and the ionic-strength dependence of the Km value for cytochrome-c was similar to that described for other preparations of cytochrome-c oxidase.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006123" target="_blank" class="term-link">
                                     GO:0006123
                                 </a>
                             </span>
                             <span class="term-label">mitochondrial electron transport, cytochrome c to oxygen</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1233,64 +1244,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation by ARBA machine learning model predicting CYC1 involvement in cytochrome c-to-oxygen electron transport. Consistent with experimental evidence and core function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> IEA annotation correctly predicts this core metabolic process based on sequence homology and association rules. Fully consistent with experimental IDA evidence (PMID:7851399) and IBA annotations. ARBA models work well for well-characterized metabolic processes like the electron transport chain.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/7851399" target="_blank" class="term-link">
                                         PMID:7851399
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The purified enzyme had a turnover number of 1500 s-1 and the ionic-strength dependence of the Km value for cytochrome-c was similar to that described for other preparations of cytochrome-c oxidase.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009055" target="_blank" class="term-link">
                                     GO:0009055
                                 </a>
                             </span>
                             <span class="term-label">electron transfer activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1302,64 +1313,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation of electron transfer activity derived from combined automated methods and InterPro domain analysis. Represents predicted molecular function based on heme-binding domain membership.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> IEA annotation correctly predicts electron transfer activity based on InterPro domain membership (IPR002327, IPR009056, IPR036909 - cytochrome c domains). This is the most direct inference from sequence structure. Fully supported by multiple IDA evidence entries. IEA based on protein family membership is appropriate for such well-characterized functions.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/18975895" target="_blank" class="term-link">
                                         PMID:18975895
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The apparent electron transfer rate constants of YCC on MUA/MU and MU/MH at pH 6.0 were determined to be 8 and 18 s(-1), respectively.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0020037" target="_blank" class="term-link">
                                     GO:0020037
                                 </a>
                             </span>
                             <span class="term-label">heme binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1371,64 +1382,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Heme binding activity inferred from InterPro domain analysis of cytochrome c protein structure. CYC1 contains covalent heme c group essential for electron transfer.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> IEA annotation based on InterPro domain membership correctly identifies heme binding as a molecular function of CYC1. UniProt explicitly states CYC1 binds 1 heme c group covalently per subunit, with covalent binding at His-18 and His-81 and axial iron coordination by His-86 and Met-80. This molecular function is fundamental to the redox chemistry enabling electron transfer. IEA from protein family annotation is appropriate for this well-characterized feature.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/18390544" target="_blank" class="term-link">
                                         PMID:18390544
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Structure of complex III with bound cytochrome c in reduced state and definition of a minimal core interface for electron transfer.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0022904" target="_blank" class="term-link">
                                     GO:0022904
                                 </a>
                             </span>
                             <span class="term-label">respiratory electron transport chain</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1440,64 +1451,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Respiratory electron transport chain participation inferred from UniProtKB keyword mapping. CYC1 is a component of the electron transport chain that couples redox reactions to ATP synthesis.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> IEA annotation based on UniProtKB-KW (keyword) mapping correctly identifies CYC1 as a component of the respiratory electron transport chain. UniProt keywords include Respiratory chain and Electron transport, reflecting CYC1&#39;s role as a central hub between Complexes III and IV. This is appropriate for identifying participation in the broader pathway context while more specific electron transport processes are annotated separately.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/7851399" target="_blank" class="term-link">
                                         PMID:7851399
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The purified enzyme had a turnover number of 1500 s-1 and the ionic-strength dependence of the Km value for cytochrome-c was similar to that described for other preparations of cytochrome-c oxidase.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046872" target="_blank" class="term-link">
                                     GO:0046872
                                 </a>
                             </span>
                             <span class="term-label">metal ion binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1509,75 +1520,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Metal ion binding inferred from UniProtKB keyword mapping (KW-0479) reflecting the iron coordination in CYC1&#39;s heme c group. The Fe center is essential for redox cycling.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> IEA annotation based on UniProtKB keyword mapping correctly identifies metal ion binding as a molecular function. CYC1 binds iron (Fe) as the central atom of heme c through axial coordination by His-86 and Met-80, as documented in UniProt feature annotation. This is a more general annotation than GO:0020037 (heme binding) but appropriately identifies the metal cofactor requirement. For a protein with such well-characterized iron coordination, IEA from keyword mapping is justified.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/18390544" target="_blank" class="term-link">
                                         PMID:18390544
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Structure of complex III with bound cytochrome c in reduced state and definition of a minimal core interface for electron transfer.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/15071191" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:15071191
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Crystal structure and characterization of a cytochrome c per...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1589,75 +1600,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Cytochrome c peroxidase (CCP) interaction demonstrated through structural and kinetic studies of the electron transfer complex. This represents a secondary protein-protein interaction not central to CYC1&#39;s primary metabolic role.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> While CYC1 does interact with cytochrome c peroxidase (CCP) as demonstrated by PMID:15071191, the generic term protein binding is not informative and represents an over-annotation. The CCP interaction is a non-physiological interaction used for research purposes. More importantly, the physiological protein interactions with Complex III (cytochrome c1) and Complex IV (cytochrome c oxidase subunit IV) are far more significant but already captured by the electron transport process annotations. A vague protein binding term obscures rather than clarifies the functional role. For a protein with such well-defined biochemistry, more specific binding terms would be preferable if capturing this interaction is important. CCP interaction should not be prioritized over the core metabolic functions.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/15071191" target="_blank" class="term-link">
                                         PMID:15071191
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">A specific covalently cross-linked complex between redox partners yeast cytochrome c peroxidase (CCP) and cytochrome c (cyt. c) has been made by engineering cysteines into CCP and cyt. c that form an intermolecular disulfide bond in high yield.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/15339156" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:15339156
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Electron transfer between cytochrome c and cytochome c perox...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1669,75 +1680,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Electron transfer between cytochrome c and cytochrome c peroxidase in single crystals. IPI evidence for protein-protein interaction with CCP.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> PMID:15339156 studies electron transfer kinetics between CYC1 and CCP in single crystal systems, demonstrating physical interaction. However, as with PMID:15071191, this CCP interaction is not central to CYC1&#39;s primary physiological role. The generic term protein binding is uninformative and represents an over-annotation. The critical physiological interactions are with Complex III and Complex IV proteins, already captured by process annotations. CCP is a research tool for studying electron transfer kinetics, not a core functional partner. This annotation should be deprioritized in favor of core metabolic functions.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/15339156" target="_blank" class="term-link">
                                         PMID:15339156
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Electron transfer between cytochrome c and cytochome c peroxidase in single crystals</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17146057" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:17146057
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Solution structure and dynamics of the complex between cytoc...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1749,75 +1760,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Solution structure and dynamics of the complex between cytochrome c and cytochrome c peroxidase by paramagnetic NMR spectroscopy. IPI evidence for protein-protein interaction.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> PMID:17146057 characterizes the complex between CYC1 and CCP using structural biology methods. However, this represents a non-physiological research interaction rather than a core functional interaction. The CCP is not a natural substrate or cofactor partner in yeast metabolism. The generic term protein binding is uninformative. More significant physiological protein interactions (Complex III and IV) are already represented in the electron transport process annotations. This annotation over-represents peripheral research interactions at the expense of core functions.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/17146057" target="_blank" class="term-link">
                                         PMID:17146057
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Solution structure and dynamics of the complex between cytochrome c and cytochrome c peroxidase determined by paramagnetic NMR.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24726731" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:24726731
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The cytochrome c peroxidase and cytochrome c encounter compl...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1829,75 +1840,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Cytochrome c peroxidase and cytochrome c encounter complex characterized through structural and kinetic studies.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> PMID:24726731 characterizes the CCP-cytochrome c encounter complex. However, this remains a non-physiological research interaction with CCP, not a core functional partner. The generic protein binding term lacks specificity and represents peripheral rather than core function. CCP interactions, while scientifically interesting for studying electron transfer mechanisms, should not dominate the annotation profile of CYC1. The primary physiological interactions with Complex III (cytochrome c1) and Complex IV are more important and already captured in process annotations. This is over-annotation that dilutes focus on core metabolic role.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/24726731" target="_blank" class="term-link">
                                         PMID:24726731
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The cytochrome c peroxidase and cytochrome c encounter complex: the other side of the story.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1901612" target="_blank" class="term-link">
                                     GO:1901612
                                 </a>
                             </span>
                             <span class="term-label">cardiolipin binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/30182710" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:30182710
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Electrostatic Constituents of the Interaction of Cardiolipin...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -1909,75 +1920,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> CYC1 binds to cardiolipin (CL), an anionic mitochondrial lipid, through electrostatic interactions mediated by lysine residues at site A. This interaction is relevant during apoptosis when CYC1 oxidizes CL.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> PMID:30182710 provides direct experimental evidence (IDA) that CYC1 binds cardiolipin at multiple lysine residues (positions 72, 73, 86, 87). Cardiolipin binding is well-documented and mechanistically characterized. However, this represents a secondary function associated with apoptotic signaling rather than the primary aerobic metabolic role. In yeast under normal aerobic growth, cardiolipin binding relates to apoptotic peroxidase activity, not the primary electron transport function. For a primarily metabolic protein, this should be retained as a supported annotation but marked as non-core to distinguish from the central electron transport functions. The apoptotic role of CYC1 is less central in yeast compared to mammals.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/30182710" target="_blank" class="term-link">
                                         PMID:30182710
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">A set of single, double, and quadruple lysine to alanine variants of yeast iso-1-cytochrome c, at sequence positions 72, 73, 86, and 87, show that all contribute to the site A-mediated interaction with CL.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
                                     GO:0005739
                                 </a>
                             </span>
                             <span class="term-label">mitochondrion</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16823961" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16823961
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Toward the complete yeast mitochondrial proteome - multidime...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1989,75 +2000,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> CYC1 is a mitochondrial protein identified through large-scale mitochondrial proteomics analysis. HDA (homology-derived assertion) evidence from PMID:16823961 contributes to broader cellular component annotation.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> HDA annotation correctly identifies CYC1 as a mitochondrial protein. PMID:16823961 is a large-scale proteomic analysis of the yeast mitochondrial proteome that identified CYC1 among intermembrane space proteins. However, GO:0005758 (mitochondrial intermembrane space) is more specific and informative than the broader GO:0005739 (mitochondrion). Both are technically correct, but the more specific localization is more useful. HDA annotation is appropriate for broad compartment classification, though the intermembrane space annotations are more precise and should be prioritized.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/16823961" target="_blank" class="term-link">
                                         PMID:16823961
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Toward the complete yeast mitochondrial proteome: multidimensional separation techniques for mitochondrial proteomics</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005758" target="_blank" class="term-link">
                                     GO:0005758
                                 </a>
                             </span>
                             <span class="term-label">mitochondrial intermembrane space</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9866716" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:9866716
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The yeast mitochondrial intermembrane space - purification a...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2069,75 +2080,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Direct experimental evidence that CYC1 is localized to the mitochondrial intermembrane space. PMID:9866716 describes the purification of distinct IMS fractions with CYC1 as a key marker protein.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> IDA annotation provides direct experimental evidence for CYC1 localization. PMID:9866716 is a landmark study that fractionally purified mitochondrial intermembrane space content, identifying CYC1 as a defining marker of the salt-extractable IMS fraction. This is the most specific and accurate cellular localization, superior to the broader mitochondrion (GO:0005739) annotation. This is a core, well-supported annotation of CYC1&#39;s subcellular localization.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9866716" target="_blank" class="term-link">
                                         PMID:9866716
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Two distinct fractions were obtained: a soluble IMS with cytochrome b2 as key marker and a salt-extractable IMS with cytochrome c as key marker.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006122" target="_blank" class="term-link">
                                     GO:0006122
                                 </a>
                             </span>
                             <span class="term-label">mitochondrial electron transport, ubiquinol to cytochrome c</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/7851399" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:7851399
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Kinetic properties and ligand binding of the eleven-subunit ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2149,75 +2160,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Direct kinetic and biochemical evidence that CYC1 functions in mitochondrial electron transport from ubiquinol to the final electron acceptor at Complex IV. PMID:7851399 characterizes kinetic properties of cytochrome c as a substrate for cytochrome c oxidase.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> IDA annotation provides direct experimental evidence for CYC1&#39;s role in electron transport. PMID:7851399 is a seminal biochemical study characterizing the purified eleven-subunit cytochrome c oxidase complex with kinetic analysis of cytochrome c as a substrate. The demonstrated Km values and turnover numbers (1500 s-1) represent direct functional evidence that CYC1 participates in this electron transport step. This is a core primary metabolic function with the highest quality evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/7851399" target="_blank" class="term-link">
                                         PMID:7851399
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The purified enzyme had a turnover number of 1500 s-1 and the ionic-strength dependence of the Km value for cytochrome-c was similar to that described for other preparations of cytochrome-c oxidase.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006123" target="_blank" class="term-link">
                                     GO:0006123
                                 </a>
                             </span>
                             <span class="term-label">mitochondrial electron transport, cytochrome c to oxygen</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/7851399" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:7851399
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Kinetic properties and ligand binding of the eleven-subunit ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2229,75 +2240,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Direct kinetic and biochemical evidence that CYC1 functions in mitochondrial electron transport from cytochrome c to the final electron acceptor (oxygen). PMID:7851399 characterizes kinetic properties of cytochrome c oxidase interaction with cytochrome c.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> IDA annotation provides direct experimental evidence for CYC1&#39;s role as electron donor to cytochrome c oxidase. PMID:7851399 demonstrates quantitatively that cytochrome c is a substrate for Complex IV (cytochrome c oxidase), with measured kinetic parameters reflecting true enzyme kinetics. This electron transfer to oxygen is the final step in the respiratory chain and a core primary metabolic function of CYC1. This is one of the most important functional annotations for this protein.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/7851399" target="_blank" class="term-link">
                                         PMID:7851399
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The purified enzyme had a turnover number of 1500 s-1 and the ionic-strength dependence of the Km value for cytochrome-c was similar to that described for other preparations of cytochrome-c oxidase.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009055" target="_blank" class="term-link">
                                     GO:0009055
                                 </a>
                             </span>
                             <span class="term-label">electron transfer activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/18975895" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:18975895
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Gated electron transfer of yeast iso-1 cytochrome c on self-...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2309,75 +2320,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Direct electrochemical evidence demonstrating electron transfer activity of yeast CYC1. PMID:18975895 measures electron transfer rate constants using surface-enhanced resonance Raman spectroscopy.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> IDA annotation provides direct biophysical evidence for CYC1&#39;s electron transfer activity. PMID:18975895 employs sophisticated electrochemical methods to measure electron transfer rate constants (8-18 s-1) and demonstrates that protein reorientation is rate-limiting for interfacial electron transfer. This represents direct, quantitative molecular evidence of the electron transfer mechanism central to CYC1&#39;s function. This is a core primary molecular function with excellent experimental support.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/18975895" target="_blank" class="term-link">
                                         PMID:18975895
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The apparent electron transfer rate constants of YCC on MUA/MU and MU/MH at pH 6.0 were determined to be 8 and 18 s(-1), respectively.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009055" target="_blank" class="term-link">
                                     GO:0009055
                                 </a>
                             </span>
                             <span class="term-label">electron transfer activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/7851399" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:7851399
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Kinetic properties and ligand binding of the eleven-subunit ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2389,50 +2400,50 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Direct biochemical evidence for electron transfer activity through kinetic characterization of cytochrome c as a functional substrate in electron transport chain complexes.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> IDA annotation provides direct biochemical evidence for electron transfer activity from a landmark kinetic analysis. PMID:7851399 demonstrates that cytochrome c functions as a true kinetic substrate for both Complex III (ubiquinol-cytochrome c oxidoreductase) and Complex IV (cytochrome c oxidase), with measured turnover numbers and Km values reflecting physiological kinetics. This dual IDA evidence from different experimental approaches (electrochemistry and enzyme kinetics) provides robust support for this fundamental molecular function.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/7851399" target="_blank" class="term-link">
                                         PMID:7851399
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The purified enzyme had a turnover number of 1500 s-1 and the ionic-strength dependence of the Km value for cytochrome-c was similar to that described for other preparations of cytochrome-c oxidase.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
             </tbody>
         </table>
     </div>
-    
 
-    
+
+
     <div class="section">
         <h2 class="section-title">Core Functions</h2>
-        
+
         <div class="core-function-card">
-            
+
             <div style="display: flex; justify-content: space-between; align-items: center;">
                 <h3>Electron transfer between Complex III and Complex IV in mitochondrial electron transport chain via redox cycling of heme-bound iron center</h3>
                 <span class="vote-buttons" data-g="P00044" data-a="FUNCTION: Electron transfer between Complex III and Complex ..." data-r="" data-act="CORE_FUNCTION">
@@ -2440,10 +2451,10 @@
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
             </div>
-            
+
 
             <div class="core-function-terms">
-                
+
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
@@ -2452,314 +2463,357 @@
                         </a>
                     </span>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Directly Involved In:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006122" target="_blank" class="term-link">
                                 mitochondrial electron transport, ubiquinol to cytochrome c
                             </a>
                         </span>
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006123" target="_blank" class="term-link">
                                 mitochondrial electron transport, cytochrome c to oxygen
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Cellular Locations:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005758" target="_blank" class="term-link">
                                 mitochondrial intermembrane space
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
 
-                
+
+
+
             </div>
 
-            
-        </div>
-        
-    </div>
-    
 
-    
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:yeast/CYC1/CYC1-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">CYC1 encodes iso-1-cytochrome c, the major soluble c-type cytochrome in yeast mitochondria, shuttling electrons from complex III to complex IV.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class="section">
         <h2 class="section-title collapsible">References</h2>
         <div class="collapse-content">
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
+                        file:yeast/CYC1/CYC1-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research report for CYC1</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Falcon supports CYC1 as yeast iso-1-cytochrome c, the principal mobile electron carrier between respiratory complexes III and IV.</div>
+
+                        <div class="finding-text">"Cyc1p&#39;s precise biochemical role is single-electron transfer between the bc1 complex and cytochrome c oxidase."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
                             GO_REF:0000002
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
                             GO_REF:0000033
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Annotation inferences using phylogenetic trees</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000043.md" target="_blank" class="term-link">
                             GO_REF:0000043
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
                             GO_REF:0000117
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
                             GO_REF:0000120
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/15071191" target="_blank" class="term-link">
                             PMID:15071191
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Crystal structure and characterization of a cytochrome c peroxidase-cytochrome c site-specific cross-link.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/15339156" target="_blank" class="term-link">
                             PMID:15339156
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Electron transfer between cytochrome c and cytochome c peroxidase in single crystals.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/16823961" target="_blank" class="term-link">
                             PMID:16823961
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Toward the complete yeast mitochondrial proteome - multidimensional separation techniques for mitochondrial proteomics.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/17146057" target="_blank" class="term-link">
                             PMID:17146057
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Solution structure and dynamics of the complex between cytochrome c and cytochrome c peroxidase determined by paramagnetic NMR.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/18390544" target="_blank" class="term-link">
                             PMID:18390544
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Structure of complex III with bound cytochrome c in reduced state and definition of a minimal core interface for electron transfer.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/18975895" target="_blank" class="term-link">
                             PMID:18975895
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gated electron transfer of yeast iso-1 cytochrome c on self-assembled monolayer-coated electrodes.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/24726731" target="_blank" class="term-link">
                             PMID:24726731
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The cytochrome c peroxidase and cytochrome c encounter complex - the other side of the story.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/30182710" target="_blank" class="term-link">
                             PMID:30182710
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Electrostatic Constituents of the Interaction of Cardiolipin with Site A of Cytochrome c.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/7851399" target="_blank" class="term-link">
                             PMID:7851399
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Kinetic properties and ligand binding of the eleven-subunit cytochrome-c oxidase from Saccharomyces cerevisiae isolated with a novel large-scale purification method.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/9866716" target="_blank" class="term-link">
                             PMID:9866716
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The yeast mitochondrial intermembrane space - purification and analysis of two distinct fractions.</div>
-                
-                
+
+
             </div>
-            
+
         </div>
     </div>
-    
 
 
-    
+
+
     <div class="section">
         <h2 class="section-title">Suggested Questions for Experts</h2>
-        
+
         <div class="question-card">
             <div style="display: flex; justify-content: space-between; align-items: start;">
                 <div style="flex: 1;">
                     <p><strong>Q:</strong> Does CYC1 have distinct redox potential states in different microenvironments (membrane-bound vs. soluble) that affect electron transfer efficiency?</p>
-                    
+
                 </div>
                 <span class="vote-buttons" data-g="P00044" data-a="Q: Does CYC1 have distinct redox potential states in ..." data-r="" data-act="QUESTION">
                     <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
@@ -2767,12 +2821,12 @@
                 </span>
             </div>
         </div>
-        
+
         <div class="question-card">
             <div style="display: flex; justify-content: space-between; align-items: start;">
                 <div style="flex: 1;">
                     <p><strong>Q:</strong> What is the functional significance of CYC1&#39;s methylation at lysines 78-79 in regulating its apoptotic signaling role versus its metabolic role?</p>
-                    
+
                 </div>
                 <span class="vote-buttons" data-g="P00044" data-a="Q: What is the functional significance of CYC1&#39;s meth..." data-r="" data-act="QUESTION">
                     <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
@@ -2780,12 +2834,12 @@
                 </span>
             </div>
         </div>
-        
+
         <div class="question-card">
             <div style="display: flex; justify-content: space-between; align-items: start;">
                 <div style="flex: 1;">
                     <p><strong>Q:</strong> Are there regulatory post-translational modifications of CYC1 that modulate its interaction with Complex III or Complex IV during metabolic transitions?</p>
-                    
+
                 </div>
                 <span class="vote-buttons" data-g="P00044" data-a="Q: Are there regulatory post-translational modificati..." data-r="" data-act="QUESTION">
                     <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
@@ -2793,22 +2847,22 @@
                 </span>
             </div>
         </div>
-        
-    </div>
-    
 
-    
+    </div>
+
+
+
     <div class="section">
         <h2 class="section-title">Suggested Experiments</h2>
-        
+
         <div class="experiment-card">
             <div style="display: flex; justify-content: space-between; align-items: start;">
                 <div style="flex: 1;">
-                    
+
                     <p><strong>Experiment:</strong> Measure electron transfer kinetics between purified Complex III and Complex IV using reconstituted CYC1 in liposomes to establish turnover rates in a membrane context</p>
-                    
-                    
-                    
+
+
+
                 </div>
                 <span class="vote-buttons" data-g="P00044" data-a="EXPERIMENT: Measure electron transfer kinetics between purifie..." data-r="" data-act="EXPERIMENT">
                     <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
@@ -2816,15 +2870,15 @@
                 </span>
             </div>
         </div>
-        
+
         <div class="experiment-card">
             <div style="display: flex; justify-content: space-between; align-items: start;">
                 <div style="flex: 1;">
-                    
+
                     <p><strong>Experiment:</strong> Characterize how mutations affecting cardiolipin-binding lysines (K72, K73, K86, K87) impact aerobic growth and respiration rates</p>
-                    
-                    
-                    
+
+
+
                 </div>
                 <span class="vote-buttons" data-g="P00044" data-a="EXPERIMENT: Characterize how mutations affecting cardiolipin-b..." data-r="" data-act="EXPERIMENT">
                     <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
@@ -2832,15 +2886,15 @@
                 </span>
             </div>
         </div>
-        
+
         <div class="experiment-card">
             <div style="display: flex; justify-content: space-between; align-items: start;">
                 <div style="flex: 1;">
-                    
+
                     <p><strong>Experiment:</strong> Investigate whether CYC1 undergoes conformational changes upon binding to cardiolipin that influence its peroxidase activity during apoptosis</p>
-                    
-                    
-                    
+
+
+
                 </div>
                 <span class="vote-buttons" data-g="P00044" data-a="EXPERIMENT: Investigate whether CYC1 undergoes conformational ..." data-r="" data-act="EXPERIMENT">
                     <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
@@ -2848,17 +2902,410 @@
                 </span>
             </div>
         </div>
-        
-    </div>
-    
 
-    
+    </div>
+
+
+
 
     <!-- Computational Predictions Section -->
-    
+
 
     <!-- Additional Documentation Sections -->
-    
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Deep Research Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(CYC1-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P00044" data-a="DOC: Deep Research Falcon" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <hr />
+<p>provider: falcon<br />
+model: Edison Scientific Literature<br />
+cached: false<br />
+start_time: '2026-05-11T06:56:33.457315'<br />
+end_time: '2026-05-11T07:26:53.656454'<br />
+duration_seconds: 1820.2<br />
+template_file: templates/gene_research_go_focused.md<br />
+template_variables:<br />
+  organism: yeast<br />
+  gene_id: CYC1<br />
+  gene_symbol: CYC1<br />
+  uniprot_accession: P00044<br />
+  protein_description: 'RecName: Full=Cytochrome c isoform 1; Short=Iso-1-cytochrome<br />
+    c; AltName: Full=Cytochrome c aerobic isoform;'<br />
+  gene_info: Name=CYC1; OrderedLocusNames=YJR048W; ORFNames=J1653;<br />
+  organism_full: Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).<br />
+  protein_family: Belongs to the cytochrome c family. .<br />
+  protein_domains: Cyt_c-like_dom. (IPR009056); Cyt_c-like_dom_sf. (IPR036909); Cyt_c_1A/1B.<br />
+    (IPR002327); Cytochrom_C (PF00034)<br />
+provider_config:<br />
+  timeout: 600<br />
+  max_retries: 3<br />
+  parameters:<br />
+    allowed_domains: []<br />
+    temperature: 0.1<br />
+citation_count: 52</p>
+<hr />
+<h2 id="question">Question</h2>
+<h1 id="gene-research-for-functional-annotation">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> P00044</li>
+<li><strong>Protein Description:</strong> RecName: Full=Cytochrome c isoform 1; Short=Iso-1-cytochrome c; AltName: Full=Cytochrome c aerobic isoform;</li>
+<li><strong>Gene Information:</strong> Name=CYC1; OrderedLocusNames=YJR048W; ORFNames=J1653;</li>
+<li><strong>Organism (full):</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Protein Family:</strong> Belongs to the cytochrome c family. .</li>
+<li><strong>Key Domains:</strong> Cyt_c-like_dom. (IPR009056); Cyt_c-like_dom_sf. (IPR036909); Cyt_c_1A/1B. (IPR002327); Cytochrom_C (PF00034)</li>
+</ul>
+<h3 id="mandatory-verification-steps">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "CYC1" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'CYC1' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>CYC1</strong> (gene ID: CYC1, UniProt: P00044) in yeast.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="output">Output</h2>
+<p>Question: You are an expert researcher providing comprehensive, well-cited information.</p>
+<p>Provide detailed information focusing on:<br />
+1. Key concepts and definitions with current understanding<br />
+2. Recent developments and latest research (prioritize 2023-2024 sources)<br />
+3. Current applications and real-world implementations<br />
+4. Expert opinions and analysis from authoritative sources<br />
+5. Relevant statistics and data from recent studies</p>
+<p>Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.<br />
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.</p>
+<h1 id="gene-research-for-functional-annotation_1">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context_1">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot_1">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> P00044</li>
+<li><strong>Protein Description:</strong> RecName: Full=Cytochrome c isoform 1; Short=Iso-1-cytochrome c; AltName: Full=Cytochrome c aerobic isoform;</li>
+<li><strong>Gene Information:</strong> Name=CYC1; OrderedLocusNames=YJR048W; ORFNames=J1653;</li>
+<li><strong>Organism (full):</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Protein Family:</strong> Belongs to the cytochrome c family. .</li>
+<li><strong>Key Domains:</strong> Cyt_c-like_dom. (IPR009056); Cyt_c-like_dom_sf. (IPR036909); Cyt_c_1A/1B. (IPR002327); Cytochrom_C (PF00034)</li>
+</ul>
+<h3 id="mandatory-verification-steps_1">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "CYC1" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature_1">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'CYC1' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target_1">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>CYC1</strong> (gene ID: CYC1, UniProt: P00044) in yeast.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="research-report-saccharomyces-cerevisiae-cyc1-uniprot-p00044-functional-annotation-of-iso-1-cytochrome-c">Research Report: <em>Saccharomyces cerevisiae</em> <strong>CYC1</strong> (UniProt <strong>P00044</strong>) — Functional Annotation of Iso-1 Cytochrome c</h1>
+<h2 id="executive-summary">Executive summary</h2>
+<p><em>Saccharomyces cerevisiae</em> <strong>CYC1</strong> encodes <strong>iso-1-cytochrome c (Cyc1p)</strong>, the major soluble c-type cytochrome in yeast mitochondria (≈95% of total cellular cytochrome c). Its primary function is to act as a <strong>mobile electron carrier</strong> in the mitochondrial intermembrane space (IMS), shuttling electrons from <strong>complex III (bc1; via cytochrome c1)</strong> to <strong>complex IV (cytochrome c oxidase)</strong> during oxidative phosphorylation. Cyc1p is produced as an apoprotein in the cytosol, imported into the IMS, and converted into holocytochrome c by <strong>System III holocytochrome c synthase / cytochrome c heme lyase</strong> (CCHL/HCCS; encoded by <strong>CYC3</strong>) with support from accessory factors such as <strong>Cyc2p</strong>. Recent (2023–2024) work emphasizes cytochrome c’s role in <strong>respiratory III–IV supercomplex organization</strong>, including lipid dependence (cardiolipin vs phosphatidylglycerol) and engineered supercomplex configurations that alter respiratory performance and substrate use.</p>
+<h2 id="0-target-verification-mandatory">0) Target verification (mandatory)</h2>
+<h3 id="01-gene-symbol-protein-description-organism-match">0.1 Gene symbol, protein description, organism match</h3>
+<p>The literature surveyed matches the UniProt description provided: <strong>CYC1</strong> in <em>S. cerevisiae</em> encodes <strong>iso-1-cytochrome c (Cyc1p)</strong>, while <strong>CYC7</strong> encodes the minor <strong>iso-2</strong> cytochrome c (Cyc7p). This explicitly resolves symbol ambiguity for yeast CYC1 in the current context (wang1996sequencerequirementsfor pages 4-4).</p>
+<h3 id="02-isoforms-and-abundance">0.2 Isoforms and abundance</h3>
+<p>Classic biochemical-genetic analysis shows that <strong>iso-1</strong> (CYC1) and <strong>iso-2</strong> (CYC7) constitute, respectively, <strong>95% and 5%</strong> of total cellular cytochrome c in normal yeast, though CYC7 expression can be engineered (CYC7-H3 allele) to increase iso-2 to ~iso-1 levels (wang1996sequencerequirementsfor pages 4-4).</p>
+<h2 id="1-key-concepts-and-definitions-current-understanding">1) Key concepts and definitions (current understanding)</h2>
+<h3 id="11-what-is-cytochrome-c-c-type-cytochrome">1.1 What is cytochrome c (c-type cytochrome)?</h3>
+<p>c-type cytochromes are defined by <strong>covalent heme attachment</strong>: heme vinyl groups form thioether bonds with cysteine thiols, usually at a <strong>CxxCH</strong> motif where the histidine serves as an axial ligand to the heme iron. In mitochondria there are two c-type cytochromes: <strong>cytochrome c</strong> and <strong>cytochrome c1</strong> (allen2011cytochromecbiogenesis pages 1-2).</p>
+<h3 id="12-cyc1p-biochemical-role-in-respiration-reaction-level-description">1.2 Cyc1p biochemical role in respiration (reaction-level description)</h3>
+<p>Cyc1p’s precise biochemical role is <strong>single-electron transfer</strong> between the bc1 complex and cytochrome c oxidase. Cytochrome c’s “classical function” is electron transfer between <strong>cytochrome c1 (complex III)</strong> and the <strong>CuA center of complex IV</strong>, a key step in oxidative phosphorylation (allen2011cytochromecbiogenesis pages 1-2). In the yeast respiratory chain, reduced ubiquinol (QH2) donates electrons to <strong>complex III</strong>, which transfers electrons to <strong>water-soluble cytochrome c</strong> in the IMS; reduced cytochrome c then donates electrons to <strong>complex IV</strong>, which reduces O2 to water (brzezinski2021structureandmechanism pages 2-3).</p>
+<h3 id="13-cellular-localization-and-diffusion-regime">1.3 Cellular localization and diffusion regime</h3>
+<p>In <em>S. cerevisiae</em>, cytochrome c is <strong>water soluble</strong> and resides in the <strong>intermembrane/intercristae space</strong>, where it can diffuse to connect complexes III and IV (brzezinski2021structureandmechanism pages 2-3). Quantitatively, the <strong>cyt. c:CytcO ratio is 2–4</strong>, corresponding to an average concentration of ~<strong>100 μM</strong> cytochrome c in the intercristae space (brzezinski2021structureandmechanism pages 2-3).</p>
+<h2 id="2-cyc1p-biogenesis-and-maturation-in-mitochondria">2) Cyc1p biogenesis and maturation in mitochondria</h2>
+<h3 id="21-import-as-apocytochrome-and-coupling-to-maturation">2.1 Import as apocytochrome and coupling to maturation</h3>
+<p>Yeast cytochrome c is <strong>nuclear encoded</strong>, synthesized on cytosolic ribosomes as an <strong>apoprotein</strong>, and imported to the IMS via the TOM pathway (Tom40/Tom22 emphasized in review). In the IMS, apocytochrome c forms a tight complex with <strong>HCCS/CCHL (System III)</strong>, which catalyzes covalent attachment of <strong>ferrous heme [Fe(II)]</strong> to the CxxCH motif; heme attachment drives folding and <strong>irreversibly traps</strong> cytochrome c in the IMS (allen2011cytochromecbiogenesis pages 9-11).</p>
+<h3 id="22-the-enzymology-system-iii-hccscchl-and-accessory-cyc2">2.2 The enzymology: System III (HCCS/CCHL) and accessory Cyc2</h3>
+<p>System III is the mitochondrial pathway in fungi/animals: <strong>holocytochrome c synthase (HCCS), also called cytochrome c heme lyase (CCHL)</strong>, performs the covalent heme ligation reaction (allen2011cytochromecbiogenesis pages 1-2). In yeast, <strong>Cyc2p</strong> is a mitochondrial inner-membrane protein with a C-terminal FAD domain exposed to the IMS; recombinant Cyc2p shows <strong>NAD(P)H-dependent reductase activity</strong>, and genetic analysis supports a role dedicated to the CCHL pathway (important in sensitized cytochrome c1 mutants) (corvest2010ctypecytochromeassembly pages 2-3). Independent work also describes Cyc2p as a <strong>mitochondrial cytochrome c assembly factor</strong> and <strong>NAD(P)H-dependent haem reductase</strong> (verissimo2012engineeringaprokaryotic pages 6-8).</p>
+<h3 id="23-evidence-of-heme-attachment-as-a-defining-functional-feature">2.3 Evidence of heme attachment as a defining functional feature</h3>
+<p>A study using an ADP/ATP carrier–iso-1 cytochrome c fusion reports that <strong>heme is present</strong> in isolated fusion protein preparations (“red color”), reinforcing that heme attachment is intrinsic to functional cytochrome c polypeptide contexts (dassa2005functionalcharacterizationand pages 1-2).</p>
+<h2 id="3-transcriptional-regulation-and-gene-circuit-relevance-of-cyc1-regulatory-elements">3) Transcriptional regulation and gene-circuit relevance of <strong>CYC1</strong> regulatory elements</h2>
+<h3 id="31-native-regulation-themes-respiration-linked-activation-and-catabolite-repression">3.1 Native regulation themes: respiration-linked activation and catabolite repression</h3>
+<p>A promoter-engineering review compiles extensive classical genetics showing that the <strong>CYC1 promoter</strong> contains upstream activation sequences responsive to respiratory regulators (e.g., HAP2/HAP3-responsive elements) and tandem activation sites involved in <strong>catabolite (glucose) repression</strong>; promoter architecture includes multiple TATA elements affecting transcription start site usage (feng2021saccharomycescerevisiaepromoter pages 15-16).</p>
+<h3 id="32-cyc1-promoter-as-a-standardized-engineering-part">3.2 CYC1 promoter as a standardized engineering part</h3>
+<p>CYC1 regulatory sequences are widely repurposed:<br />
+- A <strong>minimal CYC1 core promoter</strong> retaining the TATA box has served as a backbone for synthetic promoters by adding operator sites (e.g., 1–8 lexO copies) and driving inducible expression with LexA-based synthetic activators (feng2021saccharomycescerevisiaepromoter pages 6-8).<br />
+- In standardized parts and high-throughput characterization, <strong>pCYC1</strong> is used as a <strong>reference/normalization standard</strong>; YeastFab included a pCYC1 strain in every 96-well plate for promoter activity calibration (guo2015yeastfabthedesign pages 2-3).<br />
+- CYC1-derived promoter backbones are used in yeast biosensor designs (operator insertions such as metO-CYC1 and P8x.CYC1 hybrids) (qiu2019biosensorsdesignin pages 27-27).</p>
+<h3 id="33-cyc1-terminator-as-a-baseline-part-quantitative-benchmarking">3.3 CYC1 terminator as a baseline part; quantitative benchmarking</h3>
+<p>The endogenous <strong>CYC1 terminator</strong> is a very common baseline in synthetic biology. A highly cited study of short synthetic terminators reports the best synthetic terminator yielded <strong>3.7-fold more fluorescent protein output</strong> and <strong>4.4-fold increased transcript level</strong> compared to the commonly used CYC1 terminator (Published <strong>Feb 2015</strong>, URL: https://doi.org/10.1021/sb5003357) (curran2015shortsyntheticterminators pages 1-2). The same work reports a variant (Tsynth3) achieving ~<strong>3.3-fold</strong> higher protein output than the CYC1 terminator (curran2015shortsyntheticterminators pages 4-5).</p>
+<h2 id="4-recent-developments-prioritizing-20232024">4) Recent developments (prioritizing 2023–2024)</h2>
+<h3 id="41-2023-lipid-dependence-and-supercomplex-architecture-peer-reviewed">4.1 2023: Lipid dependence and supercomplex architecture (peer-reviewed)</h3>
+<p>A 2023 <em>Nature Communications</em> cryo-EM study solved yeast respiratory supercomplex structures at high resolution and directly linked lipid composition to supercomplex organization. Specifically:<br />
+- WT yeast supercomplex (<strong>III2IV2</strong>) was solved to <strong>3.2 Å</strong> resolution, and a cardiolipin-deficient CRD1Δ-derived supercomplex (<strong>III2IV1</strong>) to <strong>3.3 Å</strong> resolution (Published <strong>May 2023</strong>, URL: https://doi.org/10.1038/s41467-023-38441-5) (hryc2023structuralinsightsinto pages 2-3).<br />
+- WT digitonin extracts show predominantly tetrameric <strong>III2IV2</strong>, whereas CRD1Δ shifts toward <strong>III2IV1</strong> plus free complexes; phosphatidylglycerol (PG) replaces cardiolipin (CL) in the mutant and can occupy similar structural positions, but altered interactions plausibly underlie the assembly/stability shift (hryc2023structuralinsightsinto pages 2-3).<br />
+- Functionally, NADH-driven oxygen consumption was higher in WT mitochondria (<strong>0.730 ± 0.052 µmol O2/min/mg</strong>) than in CRD1Δ (<strong>0.360 ± 0.047 µmol O2/min/mg</strong>; three determinations), consistent with reduced respiratory capacity in CL deficiency (hryc2023structuralinsightsinto pages 2-3).</p>
+<h3 id="42-2024-cytochrome-c-isoforms-as-modulators-of-supercomplex-assembly-preprint">4.2 2024: Cytochrome c isoforms as modulators of supercomplex assembly (preprint)</h3>
+<p>A 2024 bioRxiv preprint focuses on how yeast cytochrome c isoforms influence III–IV supercomplex assembly and respiratory chain rate. It emphasizes that cytochrome c is a <strong>mobile electron carrier</strong> between complexes III and IV and reports that both cytochrome c isoforms contribute to supercomplex assembly, with iso-2 associated with improved electron-transfer efficiency and reduced ROS production in their experimental framework (Posted <strong>Jul 2024</strong>, URL: https://doi.org/10.1101/2024.07.13.603375) (guerracastellano2024unveilingtherole pages 1-3).</p>
+<h3 id="43-2024-engineered-tethered-supercomplexes-and-substrate-utilization-preprint">4.3 2024: Engineered tethered supercomplexes and substrate utilization (preprint)</h3>
+<p>A 2024 bioRxiv study reports an engineered yeast strain expressing a <strong>covalently linked III2IV2 supercomplex</strong> to isolate the physiological role of supercomplex plasticity. The authors argue that SCs can facilitate cytochrome c diffusion along the SC surface and enhance rates, and they report that tethering preserves robust respiration but can selectively affect respiration from cytosol-derived NADH via differential association with mitochondrial NADH dehydrogenases (Posted <strong>Dec 2024</strong>, URL: https://doi.org/10.1101/2024.12.19.629262) (eldeeb2024bioengineeredyeasttethered pages 1-4).</p>
+<h3 id="44-2024-updated-transcriptional-regulatory-context-for-respiration-programs-peer-reviewed">4.4 2024: Updated transcriptional-regulatory context for respiration programs (peer-reviewed)</h3>
+<p>A 2024 <em>Nucleic Acids Research</em> study on fermentation-to-respiration switching shows that the zinc-cluster factor <strong>Rds2</strong> controls expression of <strong>HAP4</strong>, a regulatory subunit gene of the Hap2/3/4/5 complex involved in activating respiration genes, and reveals promoter-specific interdependency/cooperativity among Rds2, Ert1, and Gsm1 during the metabolic shift (Published <strong>Dec 2024</strong>, URL: https://doi.org/10.1093/nar/gkad1185) (martinez2024yeastzinccluster pages 1-2).</p>
+<h2 id="5-current-applications-and-real-world-implementations">5) Current applications and real-world implementations</h2>
+<h3 id="51-research-applications-leveraging-cyc1-coding-sequence-and-cytochrome-c-function">5.1 Research applications leveraging CYC1 coding sequence and cytochrome c function</h3>
+<p>Because cytochrome c is central to electron transfer between complexes III and IV and supercomplex function, it is repeatedly used as a functional readout component in mitochondrial bioenergetics studies and perturbations (e.g., lipid mutants or engineered tethered supercomplexes) (brzezinski2021structureandmechanism pages 2-3, hryc2023structuralinsightsinto pages 2-3, eldeeb2024bioengineeredyeasttethered pages 1-4). Although not “industrial” in the product sense, these approaches are real-world implementations in respiratory physiology research, providing engineered systems to parse bioenergetic mechanisms.</p>
+<h3 id="52-synthetic-biology-and-biotechnology-cyc1-promoterterminator-as-standard-parts">5.2 Synthetic biology and biotechnology: CYC1 promoter/terminator as standard parts</h3>
+<p>CYC1 regulatory elements are deeply embedded in yeast engineering workflows:<br />
+- <strong>pCYC1</strong> as a calibration standard in promoter part libraries (YeastFab) (Published <strong>May 2015</strong>, URL: https://doi.org/10.1093/nar/gkv464) (guo2015yeastfabthedesign pages 2-3).<br />
+- <strong>Minimal CYC1 promoter</strong> as a modular scaffold for orthogonal regulation by operator-site insertion and synthetic TFs (feng2021saccharomycescerevisiaepromoter pages 6-8).<br />
+- <strong>CYC1 terminator</strong> as a benchmark baseline for designing compact, high-performance synthetic terminators; synthetic terminators with multi-fold improvements have direct utility in metabolic engineering and heterologous expression (curran2015shortsyntheticterminators pages 1-2).</p>
+<h2 id="6-expert-opinions-authoritative-synthesis">6) Expert opinions / authoritative synthesis</h2>
+<h3 id="61-supercomplexes-and-cytochrome-c-diffusion-as-an-organizing-principle">6.1 Supercomplexes and cytochrome c diffusion as an organizing principle</h3>
+<p>An authoritative Chemical Reviews article frames the yeast III–IV supercomplex landscape and emphasizes that mobile carriers (QH2 and cytochrome c) can diffuse freely, so physical linkage is not strictly required, but supercomplexes are widely observed and actively debated regarding functional advantages (e.g., channeling/diffusion constraints) (Published <strong>Jun 2021</strong>, URL: https://doi.org/10.1021/acs.chemrev.1c00140) (brzezinski2021structureandmechanism pages 2-3).</p>
+<h3 id="62-cytochrome-c-biogenesis-as-tightly-coupled-importmaturation">6.2 Cytochrome c biogenesis as tightly coupled import–maturation</h3>
+<p>A highly cited FEBS Journal review emphasizes that in System III organisms (including fungi), cytochrome c heme attachment is a post-translational modification mediated by HCCS/CCHL and is tightly integrated with import and retention in the IMS, with Cyc2 highlighted as a fungal accessory factor (Published <strong>Nov 2011</strong>, URL: https://doi.org/10.1111/j.1742-4658.2011.08231.x) (allen2011cytochromecbiogenesis pages 1-2).</p>
+<h2 id="7-key-quantitativestatistical-takeaways">7) Key quantitative/statistical takeaways</h2>
+<ul>
+<li>Isoform abundance: <strong>CYC1/iso-1 ≈95%</strong> and <strong>CYC7/iso-2 ≈5%</strong> of total cytochrome c (wang1996sequencerequirementsfor pages 4-4).</li>
+<li>IMS abundance: cyt c:CytcO ratio <strong>2–4</strong> → ~<strong>100 μM</strong> cytochrome c in intercristae space (brzezinski2021structureandmechanism pages 2-3).</li>
+<li>Structural/functional 2023 supercomplex data: cryo-EM <strong>3.2 Å (WT III2IV2)</strong> and <strong>3.3 Å (CRD1Δ III2IV1)</strong>; NADH-driven O2 consumption <strong>0.730 ± 0.052</strong> vs <strong>0.360 ± 0.047 µmol O2/min/mg</strong> (WT vs CRD1Δ) (hryc2023structuralinsightsinto pages 2-3).</li>
+<li>Synthetic biology benchmarks: best short synthetic terminator yields <strong>3.7×</strong> more protein output and <strong>4.4×</strong> more transcript than <strong>CYC1 terminator</strong>; Tsynth3 yields ~<strong>3.3×</strong> higher protein output vs CYC1 terminator (curran2015shortsyntheticterminators pages 1-2, curran2015shortsyntheticterminators pages 4-5).</li>
+</ul>
+<h2 id="8-evidence-summary-table">8) Evidence summary table</h2>
+<table>
+<thead>
+<tr>
+<th>Category</th>
+<th>Evidence-backed details (1-3 sentences)</th>
+<th>Key quantitative data</th>
+<th>Key sources (include URLs + publication month/year)</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Gene/protein identity</td>
+<td>In <em>Saccharomyces cerevisiae</em>, <strong>CYC1</strong> encodes <strong>iso-1-cytochrome c (Cyc1p)</strong>, the major soluble mitochondrial c-type cytochrome; this matches the UniProt target P00044. Classic yeast genetics distinguishes <strong>CYC1/iso-1</strong> from <strong>CYC7/iso-2</strong>, resolving symbol ambiguity for this report (dassa2005functionalcharacterizationand pages 1-2, wang1996sequencerequirementsfor pages 4-4).</td>
+<td>Iso-1 ≈ <strong>95%</strong> and iso-2 ≈ <strong>5%</strong> of total cellular cytochrome c; engineered <strong>CYC7-H3</strong> can overproduce iso-2 to about iso-1 levels (wang1996sequencerequirementsfor pages 4-4).</td>
+<td>Wang et al., <em>J. Biol. Chem.</em> <strong>Mar 1996</strong>. https://doi.org/10.1074/jbc.271.12.6594 ; Dassa et al., <em>Protein Expr. Purif.</em> <strong>Apr 2005</strong>. https://doi.org/10.1016/j.pep.2004.12.019</td>
+</tr>
+<tr>
+<td>Localization</td>
+<td>Cytochrome c is a <strong>soluble protein in the mitochondrial intermembrane/intercristae space (IMS)</strong>, peripherally associated with the inner membrane and positioned to shuttle electrons between respiratory complexes. Reviews and import studies consistently place apocytochrome/holocytochrome c maturation and retention in the IMS (brzezinski2021structureandmechanism pages 2-3, wang1996sequencerequirementsfor pages 1-2, allen2011cytochromecbiogenesis pages 1-2, allen2011cytochromecbiogenesis pages 9-11).</td>
+<td>Cyt. c:CytcO ratio in <em>S. cerevisiae</em> ≈ <strong>2-4</strong>, corresponding to an average cyt. c concentration of ~<strong>100 μM</strong> in the intercristae space (brzezinski2021structureandmechanism pages 2-3).</td>
+<td>Brzezinski et al., <em>Chem. Rev.</em> <strong>Jun 2021</strong>. https://doi.org/10.1021/acs.chemrev.1c00140 ; Allen, <em>FEBS J.</em> <strong>Nov 2011</strong>. https://doi.org/10.1111/j.1742-4658.2011.08231.x ; Wang et al., <em>J. Biol. Chem.</em> <strong>Mar 1996</strong>. https://doi.org/10.1074/jbc.271.12.6594</td>
+</tr>
+<tr>
+<td>Biochemical function (electron transfer)</td>
+<td>Cyc1p is the canonical <strong>mobile electron carrier</strong> of the mitochondrial respiratory chain, accepting electrons downstream of complex III (via cytochrome c1 in the bc1 complex) and donating them to <strong>cytochrome c oxidase/complex IV</strong> for O2 reduction to water. This is its primary, precise biochemical role in yeast respiration (brzezinski2021structureandmechanism pages 2-3, allen2011cytochromecbiogenesis pages 1-2, zhang2015substraterecognitionby pages 39-44).</td>
+<td>Soluble carrier linking <strong>complex III → complex IV</strong>; cytochrome c is estimated at ~<strong>100 μM</strong> in IMS, supporting rapid diffusion-based transfer (brzezinski2021structureandmechanism pages 2-3).</td>
+<td>Brzezinski et al., <em>Chem. Rev.</em> <strong>Jun 2021</strong>. https://doi.org/10.1021/acs.chemrev.1c00140 ; Allen, <em>FEBS J.</em> <strong>Nov 2011</strong>. https://doi.org/10.1111/j.1742-4658.2011.08231.x</td>
+</tr>
+<tr>
+<td>Maturation / biogenesis</td>
+<td>CYC1 is nuclear-encoded and synthesized as <strong>apocytochrome c</strong> in the cytosol, then imported through the TOM pathway into the IMS, where <strong>holocytochrome c synthase / cytochrome c heme lyase (HCCS/CCHL; System III, encoded by CYC3)</strong> catalyzes covalent heme attachment at the CxxCH motif; heme ligation drives folding and traps the holoprotein in the IMS. <strong>Cyc2p</strong> is an IMS-facing inner-membrane flavoprotein with NAD(P)H-dependent reductase activity that supports/augments CCHL-dependent maturation, especially in sensitized genetic contexts (allen2011cytochromecbiogenesis pages 9-11, verissimo2012engineeringaprokaryotic pages 6-8, corvest2010ctypecytochromeassembly pages 2-3, wang1996sequencerequirementsfor pages 4-4).</td>
+<td>Cytochrome c is ~<strong>12 kDa</strong>; HCCS in yeast is reported as ~<strong>31 kDa</strong> in one mechanistic study/dissertation (allen2011cytochromecbiogenesis pages 1-2, zhang2015substraterecognitionby pages 39-44).</td>
+<td>Allen, <em>FEBS J.</em> <strong>Nov 2011</strong>. https://doi.org/10.1111/j.1742-4658.2011.08231.x ; Corvest et al., <em>Genetics</em> <strong>Oct 2010</strong>. https://doi.org/10.1534/genetics.110.120022 ; Verissimo et al., <em>BBRC</em> <strong>Jul 2012</strong>. https://doi.org/10.1016/j.bbrc.2012.06.088</td>
+</tr>
+<tr>
+<td>Isoforms (CYC1 vs CYC7)</td>
+<td>Yeast has two cytochrome c isoforms: <strong>CYC1 = iso-1</strong> and <strong>CYC7 = iso-2</strong>. Both can support electron transport, but recent work suggests the isoforms are not fully equivalent in respiratory-chain organization: both contribute to supercomplex assembly, while iso-2 may enhance electron-transfer efficiency and reduce ROS in some contexts (wang1996sequencerequirementsfor pages 4-4, guerracastellano2024unveilingtherole pages 1-3).</td>
+<td>Approximate fraction of total cytochrome c: <strong>95% iso-1 / 5% iso-2</strong> (wang1996sequencerequirementsfor pages 4-4).</td>
+<td>Wang et al., <em>J. Biol. Chem.</em> <strong>Mar 1996</strong>. https://doi.org/10.1074/jbc.271.12.6594 ; Guerra-Castellano et al., <em>bioRxiv</em> <strong>Jul 2024</strong>. https://doi.org/10.1101/2024.07.13.603375</td>
+</tr>
+<tr>
+<td>Regulation / promoter</td>
+<td>The <strong>CYC1 promoter</strong> is a classic yeast regulatory model: mutational analyses identified HAP2/HAP3-responsive upstream activation sequences, consistent with <strong>heme/respiration-linked activation</strong>, and tandem UAS elements involved in <strong>catabolite (glucose) repression</strong>. It has therefore been used extensively to dissect promoter architecture, TATA usage, transcription start-site selection, and promoter occupancy under repressed vs active states (feng2021saccharomycescerevisiaepromoter pages 15-16).</td>
+<td>No single absolute native promoter-strength value was retrieved here, but promoter studies document multiple TATA elements and glucose-responsive repression circuitry; Rds2 binding expands from <strong>7 promoters in glucose to 43 in ethanol</strong> in a 2024 study of the fermentative-to-respiratory transition (context for respiratory gene control) (feng2021saccharomycescerevisiaepromoter pages 15-16, martinez2024yeastzinccluster pages 2-3).</td>
+<td>Feng &amp; Marchisio, <em>Biology</em> <strong>Jun 2021</strong>. https://doi.org/10.3390/biology10060504 ; Martinez et al., <em>Nucleic Acids Res.</em> <strong>Dec 2024</strong>. https://doi.org/10.1093/nar/gkad1185</td>
+</tr>
+<tr>
+<td>Recent 2023-2024 findings</td>
+<td>A 2023 cryo-EM study showed that in cardiolipin-deficient yeast respiratory supercomplexes, <strong>phosphatidylglycerol can occupy cardiolipin-like positions</strong>, but supercomplex organization shifts from predominantly <strong>III2IV2</strong> toward <strong>III2IV1 + free CIII/CIV</strong>, supporting a lipid-dependent role in respiratory-chain architecture. 2024 preprints further report that cytochrome c isoforms modulate supercomplex assembly and that engineered tethered <strong>III2IV2</strong> supercomplexes can preserve strong respiration while altering substrate utilization, especially for cytosol-derived NADH (hryc2023structuralinsightsinto pages 1-2, hryc2023structuralinsightsinto pages 2-3, eldeeb2024bioengineeredyeasttethered pages 1-4, guerracastellano2024unveilingtherole pages 1-3).</td>
+<td>Cryo-EM resolutions: WT <strong>3.2 Å</strong>, CRD1Δ <strong>3.3 Å</strong>; NADH-driven O2 consumption WT <strong>0.730 ± 0.052</strong> vs CRD1Δ <strong>0.360 ± 0.047 μmol O2/min/mg</strong> (three determinations) (hryc2023structuralinsightsinto pages 2-3).</td>
+<td>Hryc et al., <em>Nat. Commun.</em> <strong>May 2023</strong>. https://doi.org/10.1038/s41467-023-38441-5 ; Guerra-Castellano et al., <em>bioRxiv</em> <strong>Jul 2024</strong>. https://doi.org/10.1101/2024.07.13.603375 ; Eldeeb et al., <em>bioRxiv</em> <strong>Dec 2024</strong>. https://doi.org/10.1101/2024.12.19.629262</td>
+</tr>
+<tr>
+<td>Applications (promoter/terminator in synthetic biology; respiration studies)</td>
+<td><strong>CYC1 regulatory elements</strong> are widely used in practice: the promoter serves as a constitutive reference or core scaffold in standardized part libraries, hybrid promoters, biosensors, and orthogonal inducible circuits, while the <strong>CYC1 terminator</strong> is a standard baseline for expression-cassette benchmarking. The cytochrome c protein itself is also central to mitochondrial respiration assays and supercomplex engineering studies that probe electron-transfer kinetics and membrane organization (guo2015yeastfabthedesign pages 2-3, qiu2019biosensorsdesignin pages 27-27, feng2021saccharomycescerevisiaepromoter pages 6-8, curran2015shortsyntheticterminators pages 1-2, eldeeb2024bioengineeredyeasttethered pages 33-35).</td>
+<td>In YeastFab, <strong>pCYC1</strong> was included on every 96-well plate as a normalization standard (guo2015yeastfabthedesign pages 2-3). Synthetic terminators yielded up to <strong>3.7-fold</strong> higher fluorescent output and <strong>4.4-fold</strong> higher transcript levels than the commonly used <strong>CYC1 terminator</strong>; Tsynth3 gave ~<strong>3.3-fold</strong> higher protein output than CYC1 terminator (curran2015shortsyntheticterminators pages 1-2, curran2015shortsyntheticterminators pages 4-5).</td>
+<td>Guo et al., <em>Nucleic Acids Res.</em> <strong>May 2015</strong>. https://doi.org/10.1093/nar/gkv464 ; Qiu et al., <em>FEMS Yeast Res.</em> <strong>Nov 2019</strong>. https://doi.org/10.1093/femsyr/foz082 ; Feng &amp; Marchisio, <em>Biology</em> <strong>Jun 2021</strong>. https://doi.org/10.3390/biology10060504 ; Curran et al., <em>ACS Synth. Biol.</em> <strong>Feb 2015</strong>. https://doi.org/10.1021/sb5003357</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the evidence-backed functional annotation of yeast CYC1/iso-1-cytochrome c, including identity, localization, biochemical role, maturation, regulation, recent 2023-2024 findings, and practical applications. It condenses key mechanistic points, quantitative values, and source links into a single reference artifact.</em></p>
+<h2 id="visual-evidence-figure">Visual evidence (figure)</h2>
+<p>Figure showing cryo-EM supercomplex maps/models comparing WT and cardiolipin-deficient yeast supercomplexes is provided from the 2023 <em>Nature Communications</em> paper (hryc2023structuralinsightsinto media ef369fac).</p>
+<h2 id="references-urls-and-publication-dates-emphasized">References (URLs and publication dates emphasized)</h2>
+<p>Key works used directly for evidence (non-exhaustive; see in-text citations):<br />
+- Hryc et al. <em>Nature Communications</em> (May 2023). https://doi.org/10.1038/s41467-023-38441-5 (hryc2023structuralinsightsinto pages 2-3, hryc2023structuralinsightsinto media ef369fac)<br />
+- Guerra-Castellano et al. <em>bioRxiv</em> (Jul 2024). https://doi.org/10.1101/2024.07.13.603375 (guerracastellano2024unveilingtherole pages 1-3)<br />
+- Eldeeb et al. <em>bioRxiv</em> (Dec 2024). https://doi.org/10.1101/2024.12.19.629262 (eldeeb2024bioengineeredyeasttethered pages 1-4)<br />
+- Martinez et al. <em>Nucleic Acids Research</em> (Dec 2024). https://doi.org/10.1093/nar/gkad1185 (martinez2024yeastzinccluster pages 1-2)<br />
+- Brzezinski et al. <em>Chemical Reviews</em> (Jun 2021). https://doi.org/10.1021/acs.chemrev.1c00140 (brzezinski2021structureandmechanism pages 2-3)<br />
+- Allen. <em>The FEBS Journal</em> (Nov 2011). https://doi.org/10.1111/j.1742-4658.2011.08231.x (allen2011cytochromecbiogenesis pages 9-11, allen2011cytochromecbiogenesis pages 1-2)<br />
+- Wang et al. <em>Journal of Biological Chemistry</em> (Mar 1996). https://doi.org/10.1074/jbc.271.12.6594 (wang1996sequencerequirementsfor pages 4-4)<br />
+- Guo et al. <em>Nucleic Acids Research</em> (May 2015). https://doi.org/10.1093/nar/gkv464 (guo2015yeastfabthedesign pages 2-3)<br />
+- Curran et al. <em>ACS Synthetic Biology</em> (Feb 2015). https://doi.org/10.1021/sb5003357 (curran2015shortsyntheticterminators pages 1-2, curran2015shortsyntheticterminators pages 4-5)</p>
+<p>References</p>
+<ol>
+<li>
+<p>(wang1996sequencerequirementsfor pages 4-4): Xiaoye Wang, Mark E. Dumont, and Fred Sherman. Sequence requirements for mitochondrial import of yeast cytochrome c(*). The Journal of Biological Chemistry, 271:6594-6604, Mar 1996. URL: https://doi.org/10.1074/jbc.271.12.6594, doi:10.1074/jbc.271.12.6594. This article has 46 citations.</p>
+</li>
+<li>
+<p>(allen2011cytochromecbiogenesis pages 1-2): James W. A. Allen. Cytochrome c biogenesis in mitochondria – systems iii and v. The FEBS Journal, Nov 2011. URL: https://doi.org/10.1111/j.1742-4658.2011.08231.x, doi:10.1111/j.1742-4658.2011.08231.x. This article has 98 citations.</p>
+</li>
+<li>
+<p>(brzezinski2021structureandmechanism pages 2-3): Peter Brzezinski, Agnes Moe, and Pia Ädelroth. Structure and mechanism of respiratory iii–iv supercomplexes in bioenergetic membranes. Chemical Reviews, 121:9644-9673, Jun 2021. URL: https://doi.org/10.1021/acs.chemrev.1c00140, doi:10.1021/acs.chemrev.1c00140. This article has 116 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(allen2011cytochromecbiogenesis pages 9-11): James W. A. Allen. Cytochrome c biogenesis in mitochondria – systems iii and v. The FEBS Journal, Nov 2011. URL: https://doi.org/10.1111/j.1742-4658.2011.08231.x, doi:10.1111/j.1742-4658.2011.08231.x. This article has 98 citations.</p>
+</li>
+<li>
+<p>(corvest2010ctypecytochromeassembly pages 2-3): Vincent Corvest, Darren A Murrey, Delphine G Bernard, David B Knaff, Bernard Guiard, and Patrice P Hamel. C-type cytochrome assembly in saccharomyces cerevisiae: a key residue for apocytochrome c1/lyase interaction. Genetics, 186:561-571, Oct 2010. URL: https://doi.org/10.1534/genetics.110.120022, doi:10.1534/genetics.110.120022. This article has 19 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(verissimo2012engineeringaprokaryotic pages 6-8): Andreia F. Verissimo, Joohee Sanders, Fevzi Daldal, and Carsten Sanders. Engineering a prokaryotic apocytochrome c as an efficient substrate for saccharomyces cerevisiae cytochrome c heme lyase. Biochemical and Biophysical Research Communications, 424:130-135, Jul 2012. URL: https://doi.org/10.1016/j.bbrc.2012.06.088, doi:10.1016/j.bbrc.2012.06.088. This article has 18 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(dassa2005functionalcharacterizationand pages 1-2): Emmanuel Philippe Dassa, Cécile Dahout-Gonzalez, Anne-Christine Dianoux, and Gérard Brandolin. Functional characterization and purification of a saccharomyces cerevisiae adp/atp carrier-iso 1 cytochrome c fusion protein. Protein expression and purification, 40 2:358-69, Apr 2005. URL: https://doi.org/10.1016/j.pep.2004.12.019, doi:10.1016/j.pep.2004.12.019. This article has 9 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(feng2021saccharomycescerevisiaepromoter pages 15-16): Xiaofan Feng and Mario Marchisio. Saccharomyces cerevisiae promoter engineering before and during the synthetic biology era. Biology, 10:504, Jun 2021. URL: https://doi.org/10.3390/biology10060504, doi:10.3390/biology10060504. This article has 35 citations.</p>
+</li>
+<li>
+<p>(feng2021saccharomycescerevisiaepromoter pages 6-8): Xiaofan Feng and Mario Marchisio. Saccharomyces cerevisiae promoter engineering before and during the synthetic biology era. Biology, 10:504, Jun 2021. URL: https://doi.org/10.3390/biology10060504, doi:10.3390/biology10060504. This article has 35 citations.</p>
+</li>
+<li>
+<p>(guo2015yeastfabthedesign pages 2-3): Yakun Guo, Junkai Dong, Tong Zhou, Jamie Auxillos, Tianyi Li, Wei-Meng Zhang, Lihui Wang, Yue Shen, Yisha Luo, Yijing Zheng, Jiwei Lin, Guoqiang Chen, Qingyu Wu, Yizhi Cai, and Junbiao Dai. Yeastfab: the design and construction of standard biological parts for metabolic engineering in saccharomyces cerevisiae. Nucleic Acids Research, 43:e88-e88, May 2015. URL: https://doi.org/10.1093/nar/gkv464, doi:10.1093/nar/gkv464. This article has 177 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(qiu2019biosensorsdesignin pages 27-27): Chenxi Qiu, Haotian Zhai, and Jin Hou. Biosensors design in yeast and applications in metabolic engineering. FEMS yeast research, Nov 2019. URL: https://doi.org/10.1093/femsyr/foz082, doi:10.1093/femsyr/foz082. This article has 54 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(curran2015shortsyntheticterminators pages 1-2): Kathleen A. Curran, Nicholas J. Morse, Kelly A. Markham, Allison M. Wagman, Akash Gupta, and Hal S. Alper. Short synthetic terminators for improved heterologous gene expression in yeast. ACS synthetic biology, 4 7:824-32, Feb 2015. URL: https://doi.org/10.1021/sb5003357, doi:10.1021/sb5003357. This article has 282 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(curran2015shortsyntheticterminators pages 4-5): Kathleen A. Curran, Nicholas J. Morse, Kelly A. Markham, Allison M. Wagman, Akash Gupta, and Hal S. Alper. Short synthetic terminators for improved heterologous gene expression in yeast. ACS synthetic biology, 4 7:824-32, Feb 2015. URL: https://doi.org/10.1021/sb5003357, doi:10.1021/sb5003357. This article has 282 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(hryc2023structuralinsightsinto pages 2-3): Corey F. Hryc, Venkata K. P. S. Mallampalli, Evgeniy I. Bovshik, Stavros Azinas, Guizhen Fan, Irina I. Serysheva, Genevieve C. Sparagna, Matthew L. Baker, Eugenia Mileykovskaya, and William Dowhan. Structural insights into cardiolipin replacement by phosphatidylglycerol in a cardiolipin-lacking yeast respiratory supercomplex. Nature Communications, May 2023. URL: https://doi.org/10.1038/s41467-023-38441-5, doi:10.1038/s41467-023-38441-5. This article has 34 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(guerracastellano2024unveilingtherole pages 1-3): Alejandra Guerra-Castellano, Manuel Aneas, Joaquin Tamargo-Azpilicueta, Inmaculada Marquez, Jose Luis Olloqui-Sariego, Juan Jose Calvente, Miguel A. De la Rosa, and Irene Diaz Moreno. Unveiling the role of yeast cytochrome c isoforms in the assembly of mitochondrial supercomplexes and the control of respiratory chain rate. bioRxiv, Jul 2024. URL: https://doi.org/10.1101/2024.07.13.603375, doi:10.1101/2024.07.13.603375. This article has 1 citations.</p>
+</li>
+<li>
+<p>(eldeeb2024bioengineeredyeasttethered pages 1-4): Mazzen H. Eldeeb, Zoe Cosner, Andreas Carlstrom, Jeffri-Noelle Mays, Gabriella F. Rodriguez, Jens Berndtsson, Martin Ott, and Flavia Fontanesi. Bioengineered yeast tethered respiratory supercomplexes reveal mechanisms governing efficient substrate utilization. bioRxiv, Dec 2024. URL: https://doi.org/10.1101/2024.12.19.629262, doi:10.1101/2024.12.19.629262. This article has 0 citations.</p>
+</li>
+<li>
+<p>(martinez2024yeastzinccluster pages 1-2): Karla Páez Martinez, Najla Gasmi, Célia Jeronimo, Natalia Klimova, François Robert, and Bernard Turcotte. Yeast zinc cluster transcription factors involved in the switch from fermentation to respiration show interdependency for dna binding revealing a novel type of dna recognition. Nucleic Acids Research, 52:2242-2259, Dec 2024. URL: https://doi.org/10.1093/nar/gkad1185, doi:10.1093/nar/gkad1185. This article has 7 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(wang1996sequencerequirementsfor pages 1-2): Xiaoye Wang, Mark E. Dumont, and Fred Sherman. Sequence requirements for mitochondrial import of yeast cytochrome c(*). The Journal of Biological Chemistry, 271:6594-6604, Mar 1996. URL: https://doi.org/10.1074/jbc.271.12.6594, doi:10.1074/jbc.271.12.6594. This article has 46 citations.</p>
+</li>
+<li>
+<p>(zhang2015substraterecognitionby pages 39-44): Yulin Zhang. Substrate recognition by holocytochrome c synthase in cytochrome c biogenesis system iii. Dissertation, Jan 2015. URL: https://doi.org/10.5287/ora-jnoyq87ry, doi:10.5287/ora-jnoyq87ry. This article has 0 citations.</p>
+</li>
+<li>
+<p>(martinez2024yeastzinccluster pages 2-3): Karla Páez Martinez, Najla Gasmi, Célia Jeronimo, Natalia Klimova, François Robert, and Bernard Turcotte. Yeast zinc cluster transcription factors involved in the switch from fermentation to respiration show interdependency for dna binding revealing a novel type of dna recognition. Nucleic Acids Research, 52:2242-2259, Dec 2024. URL: https://doi.org/10.1093/nar/gkad1185, doi:10.1093/nar/gkad1185. This article has 7 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(hryc2023structuralinsightsinto pages 1-2): Corey F. Hryc, Venkata K. P. S. Mallampalli, Evgeniy I. Bovshik, Stavros Azinas, Guizhen Fan, Irina I. Serysheva, Genevieve C. Sparagna, Matthew L. Baker, Eugenia Mileykovskaya, and William Dowhan. Structural insights into cardiolipin replacement by phosphatidylglycerol in a cardiolipin-lacking yeast respiratory supercomplex. Nature Communications, May 2023. URL: https://doi.org/10.1038/s41467-023-38441-5, doi:10.1038/s41467-023-38441-5. This article has 34 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(eldeeb2024bioengineeredyeasttethered pages 33-35): Mazzen H. Eldeeb, Zoe Cosner, Andreas Carlstrom, Jeffri-Noelle Mays, Gabriella F. Rodriguez, Jens Berndtsson, Martin Ott, and Flavia Fontanesi. Bioengineered yeast tethered respiratory supercomplexes reveal mechanisms governing efficient substrate utilization. bioRxiv, Dec 2024. URL: https://doi.org/10.1101/2024.12.19.629262, doi:10.1101/2024.12.19.629262. This article has 0 citations.</p>
+</li>
+<li>
+<p>(hryc2023structuralinsightsinto media ef369fac): Corey F. Hryc, Venkata K. P. S. Mallampalli, Evgeniy I. Bovshik, Stavros Azinas, Guizhen Fan, Irina I. Serysheva, Genevieve C. Sparagna, Matthew L. Baker, Eugenia Mileykovskaya, and William Dowhan. Structural insights into cardiolipin replacement by phosphatidylglycerol in a cardiolipin-lacking yeast respiratory supercomplex. Nature Communications, May 2023. URL: https://doi.org/10.1038/s41467-023-38441-5, doi:10.1038/s41467-023-38441-5. This article has 34 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>wang1996sequencerequirementsfor pages 4-4</li>
+<li>allen2011cytochromecbiogenesis pages 1-2</li>
+<li>brzezinski2021structureandmechanism pages 2-3</li>
+<li>allen2011cytochromecbiogenesis pages 9-11</li>
+<li>corvest2010ctypecytochromeassembly pages 2-3</li>
+<li>verissimo2012engineeringaprokaryotic pages 6-8</li>
+<li>dassa2005functionalcharacterizationand pages 1-2</li>
+<li>feng2021saccharomycescerevisiaepromoter pages 15-16</li>
+<li>feng2021saccharomycescerevisiaepromoter pages 6-8</li>
+<li>guo2015yeastfabthedesign pages 2-3</li>
+<li>qiu2019biosensorsdesignin pages 27-27</li>
+<li>curran2015shortsyntheticterminators pages 1-2</li>
+<li>curran2015shortsyntheticterminators pages 4-5</li>
+<li>hryc2023structuralinsightsinto pages 2-3</li>
+<li>guerracastellano2024unveilingtherole pages 1-3</li>
+<li>eldeeb2024bioengineeredyeasttethered pages 1-4</li>
+<li>martinez2024yeastzinccluster pages 1-2</li>
+<li>wang1996sequencerequirementsfor pages 1-2</li>
+<li>zhang2015substraterecognitionby pages 39-44</li>
+<li>martinez2024yeastzinccluster pages 2-3</li>
+<li>hryc2023structuralinsightsinto pages 1-2</li>
+<li>eldeeb2024bioengineeredyeasttethered pages 33-35</li>
+<li>Fe(II)</li>
+<li>https://doi.org/10.1021/sb5003357</li>
+<li>https://doi.org/10.1038/s41467-023-38441-5</li>
+<li>https://doi.org/10.1101/2024.07.13.603375</li>
+<li>https://doi.org/10.1101/2024.12.19.629262</li>
+<li>https://doi.org/10.1093/nar/gkad1185</li>
+<li>https://doi.org/10.1093/nar/gkv464</li>
+<li>https://doi.org/10.1021/acs.chemrev.1c00140</li>
+<li>https://doi.org/10.1111/j.1742-4658.2011.08231.x</li>
+<li>https://doi.org/10.1074/jbc.271.12.6594</li>
+<li>https://doi.org/10.1016/j.pep.2004.12.019</li>
+<li>https://doi.org/10.1534/genetics.110.120022</li>
+<li>https://doi.org/10.1016/j.bbrc.2012.06.088</li>
+<li>https://doi.org/10.3390/biology10060504</li>
+<li>https://doi.org/10.1093/femsyr/foz082</li>
+<li>https://doi.org/10.1074/jbc.271.12.6594,</li>
+<li>https://doi.org/10.1111/j.1742-4658.2011.08231.x,</li>
+<li>https://doi.org/10.1021/acs.chemrev.1c00140,</li>
+<li>https://doi.org/10.1534/genetics.110.120022,</li>
+<li>https://doi.org/10.1016/j.bbrc.2012.06.088,</li>
+<li>https://doi.org/10.1016/j.pep.2004.12.019,</li>
+<li>https://doi.org/10.3390/biology10060504,</li>
+<li>https://doi.org/10.1093/nar/gkv464,</li>
+<li>https://doi.org/10.1093/femsyr/foz082,</li>
+<li>https://doi.org/10.1021/sb5003357,</li>
+<li>https://doi.org/10.1038/s41467-023-38441-5,</li>
+<li>https://doi.org/10.1101/2024.07.13.603375,</li>
+<li>https://doi.org/10.1101/2024.12.19.629262,</li>
+<li>https://doi.org/10.1093/nar/gkad1185,</li>
+<li>https://doi.org/10.5287/ora-jnoyq87ry,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -2877,17 +3324,17 @@ status: COMPLETE
 taxon:
   id: NCBITaxon:559292
   label: Saccharomyces cerevisiae
-description: Cytochrome c isoform 1 is a small heme-containing electron carrier 
-  protein central to mitochondrial aerobic respiration. It functions as the 
-  critical link between Complex III and Complex IV in the electron transport 
-  chain. CYC1 is predominantly expressed during aerobic growth, with its 
-  heme-bound iron center accepting electrons from Complex III and donating them 
-  to Complex IV, driving oxidative phosphorylation and ATP synthesis. Secondary 
-  roles include interaction with cardiolipin and involvement in apoptotic 
+description: Cytochrome c isoform 1 is a small heme-containing electron carrier
+  protein central to mitochondrial aerobic respiration. It functions as the
+  critical link between Complex III and Complex IV in the electron transport
+  chain. CYC1 is predominantly expressed during aerobic growth, with its
+  heme-bound iron center accepting electrons from Complex III and donating them
+  to Complex IV, driving oxidative phosphorylation and ATP synthesis. Secondary
+  roles include interaction with cardiolipin and involvement in apoptotic
   signaling pathways.
 core_functions:
-- description: Electron transfer between Complex III and Complex IV in 
-    mitochondrial electron transport chain via redox cycling of heme-bound iron 
+- description: Electron transfer between Complex III and Complex IV in
+    mitochondrial electron transport chain via redox cycling of heme-bound iron
     center
   molecular_function:
     id: GO:0009055
@@ -2900,6 +3347,11 @@ core_functions:
   locations:
   - id: GO:0005758
     label: mitochondrial intermembrane space
+  supported_by:
+  - reference_id: file:yeast/CYC1/CYC1-deep-research-falcon.md
+    supporting_text: &gt;-
+      CYC1 encodes iso-1-cytochrome c, the major soluble c-type cytochrome in
+      yeast mitochondria, shuttling electrons from complex III to complex IV.
 existing_annotations:
 - term:
     id: GO:0009055
@@ -2907,53 +3359,57 @@ existing_annotations:
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: Cytochrome c is a core electron carrier protein that shuttles 
+    summary: Cytochrome c is a core electron carrier protein that shuttles
       electrons between Complex III and Complex IV in the mitochondrial electron
-      transport chain. The IBA evidence is appropriate for this molecular 
+      transport chain. The IBA evidence is appropriate for this molecular
       function annotation.
     action: ACCEPT
-    reason: This is the quintessential function of cytochrome c. UniProt 
+    reason: This is the quintessential function of cytochrome c. UniProt
       describes CYC1 as an electron carrier protein where the heme group accepts
-      electrons from cytochrome c1 and transfers them to cytochrome c oxidase. 
-      Both IDA evidence from PMID:7851399 and PMID:18975895 directly support 
-      electron transfer activity through kinetic measurements and 
-      electrochemical analysis. IBA annotation is appropriate given the highly 
-      conserved nature of this function across cytochrome c family members 
+      electrons from cytochrome c1 and transfers them to cytochrome c oxidase.
+      Both IDA evidence from PMID:7851399 and PMID:18975895 directly support
+      electron transfer activity through kinetic measurements and
+      electrochemical analysis. IBA annotation is appropriate given the highly
+      conserved nature of this function across cytochrome c family members
       (PTHR11961). This represents a core primary metabolic role.
     supported_by:
     - reference_id: PMID:7851399
       supporting_text: The purified enzyme had a turnover number of 1500 s-1 and
-        the ionic-strength dependence of the Km value for cytochrome-c was 
-        similar to that described for other preparations of cytochrome-c 
+        the ionic-strength dependence of the Km value for cytochrome-c was
+        similar to that described for other preparations of cytochrome-c
         oxidase.
     - reference_id: PMID:18975895
-      supporting_text: The apparent electron transfer rate constants of YCC on 
-        MUA/MU and MU/MH at pH 6.0 were determined to be 8 and 18 s(-1), 
+      supporting_text: The apparent electron transfer rate constants of YCC on
+        MUA/MU and MU/MH at pH 6.0 were determined to be 8 and 18 s(-1),
         respectively.
+    - reference_id: file:yeast/CYC1/CYC1-deep-research-falcon.md
+      supporting_text: &gt;-
+        Cyc1p&#39;s precise biochemical role is single-electron transfer between
+        the bc1 complex and cytochrome c oxidase.
 - term:
     id: GO:0006122
     label: mitochondrial electron transport, ubiquinol to cytochrome c
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: Cytochrome c is the direct electron acceptor from Complex III, 
-      receiving electrons from ubiquinol and transferring them to Complex IV. 
-      This biological process annotation accurately describes CYC1&#39;s 
+    summary: Cytochrome c is the direct electron acceptor from Complex III,
+      receiving electrons from ubiquinol and transferring them to Complex IV.
+      This biological process annotation accurately describes CYC1&#39;s
       participation in the electron transport chain.
     action: ACCEPT
-    reason: This annotation correctly identifies CYC1&#39;s specific role in 
-      mitochondrial electron transport. CYC1 is the electron acceptor from 
-      ubiquinol-cytochrome c oxidoreductase (Complex III, the cytochrome bc1 
-      complex). UniProt FUNCTION states CYC1 accepts electrons from the heme 
-      group of cytochrome c1 of ubiquinol-cytochrome c oxidoreductase. IDA 
-      evidence from PMID:7851399 characterizes the kinetic properties of 
-      cytochrome c as a substrate, demonstrating this electron transport step. 
+    reason: This annotation correctly identifies CYC1&#39;s specific role in
+      mitochondrial electron transport. CYC1 is the electron acceptor from
+      ubiquinol-cytochrome c oxidoreductase (Complex III, the cytochrome bc1
+      complex). UniProt FUNCTION states CYC1 accepts electrons from the heme
+      group of cytochrome c1 of ubiquinol-cytochrome c oxidoreductase. IDA
+      evidence from PMID:7851399 characterizes the kinetic properties of
+      cytochrome c as a substrate, demonstrating this electron transport step.
       This is a core primary metabolic function.
     supported_by:
     - reference_id: PMID:7851399
       supporting_text: The purified enzyme had a turnover number of 1500 s-1 and
-        the ionic-strength dependence of the Km value for cytochrome-c was 
-        similar to that described for other preparations of cytochrome-c 
+        the ionic-strength dependence of the Km value for cytochrome-c was
+        similar to that described for other preparations of cytochrome-c
         oxidase.
 - term:
     id: GO:0005758
@@ -2961,16 +3417,16 @@ existing_annotations:
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: Cytochrome c is localized to the mitochondrial intermembrane space 
-      (IMS), the aqueous compartment between the inner and outer mitochondrial 
-      membranes, where it functions as an electron shuttle between 
+    summary: Cytochrome c is localized to the mitochondrial intermembrane space
+      (IMS), the aqueous compartment between the inner and outer mitochondrial
+      membranes, where it functions as an electron shuttle between
       membrane-bound protein complexes.
     action: ACCEPT
-    reason: This is the correct cellular compartment localization for CYC1. 
-      UniProt explicitly states SUBCELLULAR LOCATION is Mitochondrion 
-      intermembrane space. PMID:9866716 describes the purification of 
-      intermembrane space fractions with cytochrome c as a key marker protein. 
-      IBA annotation is appropriate given the universal localization of 
+    reason: This is the correct cellular compartment localization for CYC1.
+      UniProt explicitly states SUBCELLULAR LOCATION is Mitochondrion
+      intermembrane space. PMID:9866716 describes the purification of
+      intermembrane space fractions with cytochrome c as a key marker protein.
+      IBA annotation is appropriate given the universal localization of
       cytochrome c to the IMS across eukaryotes.
     supported_by:
     - reference_id: PMID:9866716
@@ -2982,23 +3438,23 @@ existing_annotations:
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: Cytochrome c donates electrons to Complex IV (cytochrome c 
-      oxidase), where oxygen serves as the final electron acceptor. This 
-      biological process annotation describes the second major step of CYC1&#39;s 
+    summary: Cytochrome c donates electrons to Complex IV (cytochrome c
+      oxidase), where oxygen serves as the final electron acceptor. This
+      biological process annotation describes the second major step of CYC1&#39;s
       participation in the electron transport chain.
     action: ACCEPT
-    reason: This annotation correctly identifies CYC1&#39;s specific role as the 
-      electron donor to cytochrome c oxidase (Complex IV). UniProt states CYC1 
-      transfers electrons to the dinuclear copper A center of the COX2 subunit 
-      of cytochrome oxidase, the final protein carrier in the mitochondrial 
-      electron-transport chain. PMID:7851399 provides kinetic evidence for this 
-      interaction. IBA annotation is appropriate. This is a core primary 
+    reason: This annotation correctly identifies CYC1&#39;s specific role as the
+      electron donor to cytochrome c oxidase (Complex IV). UniProt states CYC1
+      transfers electrons to the dinuclear copper A center of the COX2 subunit
+      of cytochrome oxidase, the final protein carrier in the mitochondrial
+      electron-transport chain. PMID:7851399 provides kinetic evidence for this
+      interaction. IBA annotation is appropriate. This is a core primary
       metabolic function.
     supported_by:
     - reference_id: PMID:7851399
       supporting_text: The purified enzyme had a turnover number of 1500 s-1 and
-        the ionic-strength dependence of the Km value for cytochrome-c was 
-        similar to that described for other preparations of cytochrome-c 
+        the ionic-strength dependence of the Km value for cytochrome-c was
+        similar to that described for other preparations of cytochrome-c
         oxidase.
 - term:
     id: GO:0005758
@@ -3006,14 +3462,14 @@ existing_annotations:
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
   review:
-    summary: IEA annotation of mitochondrial intermembrane space localization 
-      derived from automated sequence analysis and subcellular location 
+    summary: IEA annotation of mitochondrial intermembrane space localization
+      derived from automated sequence analysis and subcellular location
       databases. Consistent with experimental evidence.
     action: ACCEPT
     reason: IEA annotation correctly predicts CYC1 localization based on UniProt
-      subcellular location annotations. This is fully supported by experimental 
-      IDA evidence (PMID:9866716). Redundant with other mitochondrial 
-      intermembrane space annotations but acceptable as it represents automated 
+      subcellular location annotations. This is fully supported by experimental
+      IDA evidence (PMID:9866716). Redundant with other mitochondrial
+      intermembrane space annotations but acceptable as it represents automated
       annotation pipelines that independently confirm the localization.
     supported_by:
     - reference_id: PMID:9866716
@@ -3025,20 +3481,20 @@ existing_annotations:
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
   review:
-    summary: IEA annotation by ARBA machine learning model predicting CYC1 
-      involvement in ubiquinol-to-cytochrome c electron transport. Consistent 
+    summary: IEA annotation by ARBA machine learning model predicting CYC1
+      involvement in ubiquinol-to-cytochrome c electron transport. Consistent
       with experimental evidence and core function.
     action: ACCEPT
-    reason: IEA annotation correctly predicts this core metabolic process based 
-      on sequence homology and association rules. Fully consistent with 
-      experimental IDA evidence (PMID:7851399) and IBA annotations. ARBA models 
-      are trained on well-characterized annotations, and this prediction is 
+    reason: IEA annotation correctly predicts this core metabolic process based
+      on sequence homology and association rules. Fully consistent with
+      experimental IDA evidence (PMID:7851399) and IBA annotations. ARBA models
+      are trained on well-characterized annotations, and this prediction is
       mechanistically sound for the cytochrome c family.
     supported_by:
     - reference_id: PMID:7851399
       supporting_text: The purified enzyme had a turnover number of 1500 s-1 and
-        the ionic-strength dependence of the Km value for cytochrome-c was 
-        similar to that described for other preparations of cytochrome-c 
+        the ionic-strength dependence of the Km value for cytochrome-c was
+        similar to that described for other preparations of cytochrome-c
         oxidase.
 - term:
     id: GO:0006123
@@ -3046,20 +3502,20 @@ existing_annotations:
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
   review:
-    summary: IEA annotation by ARBA machine learning model predicting CYC1 
-      involvement in cytochrome c-to-oxygen electron transport. Consistent with 
+    summary: IEA annotation by ARBA machine learning model predicting CYC1
+      involvement in cytochrome c-to-oxygen electron transport. Consistent with
       experimental evidence and core function.
     action: ACCEPT
-    reason: IEA annotation correctly predicts this core metabolic process based 
-      on sequence homology and association rules. Fully consistent with 
-      experimental IDA evidence (PMID:7851399) and IBA annotations. ARBA models 
-      work well for well-characterized metabolic processes like the electron 
+    reason: IEA annotation correctly predicts this core metabolic process based
+      on sequence homology and association rules. Fully consistent with
+      experimental IDA evidence (PMID:7851399) and IBA annotations. ARBA models
+      work well for well-characterized metabolic processes like the electron
       transport chain.
     supported_by:
     - reference_id: PMID:7851399
       supporting_text: The purified enzyme had a turnover number of 1500 s-1 and
-        the ionic-strength dependence of the Km value for cytochrome-c was 
-        similar to that described for other preparations of cytochrome-c 
+        the ionic-strength dependence of the Km value for cytochrome-c was
+        similar to that described for other preparations of cytochrome-c
         oxidase.
 - term:
     id: GO:0009055
@@ -3067,20 +3523,20 @@ existing_annotations:
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
   review:
-    summary: IEA annotation of electron transfer activity derived from combined 
-      automated methods and InterPro domain analysis. Represents predicted 
+    summary: IEA annotation of electron transfer activity derived from combined
+      automated methods and InterPro domain analysis. Represents predicted
       molecular function based on heme-binding domain membership.
     action: ACCEPT
-    reason: IEA annotation correctly predicts electron transfer activity based 
-      on InterPro domain membership (IPR002327, IPR009056, IPR036909 - 
-      cytochrome c domains). This is the most direct inference from sequence 
-      structure. Fully supported by multiple IDA evidence entries. IEA based on 
-      protein family membership is appropriate for such well-characterized 
+    reason: IEA annotation correctly predicts electron transfer activity based
+      on InterPro domain membership (IPR002327, IPR009056, IPR036909 -
+      cytochrome c domains). This is the most direct inference from sequence
+      structure. Fully supported by multiple IDA evidence entries. IEA based on
+      protein family membership is appropriate for such well-characterized
       functions.
     supported_by:
     - reference_id: PMID:18975895
-      supporting_text: The apparent electron transfer rate constants of YCC on 
-        MUA/MU and MU/MH at pH 6.0 were determined to be 8 and 18 s(-1), 
+      supporting_text: The apparent electron transfer rate constants of YCC on
+        MUA/MU and MU/MH at pH 6.0 were determined to be 8 and 18 s(-1),
         respectively.
 - term:
     id: GO:0020037
@@ -3088,21 +3544,21 @@ existing_annotations:
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
   review:
-    summary: Heme binding activity inferred from InterPro domain analysis of 
-      cytochrome c protein structure. CYC1 contains covalent heme c group 
+    summary: Heme binding activity inferred from InterPro domain analysis of
+      cytochrome c protein structure. CYC1 contains covalent heme c group
       essential for electron transfer.
     action: ACCEPT
-    reason: IEA annotation based on InterPro domain membership correctly 
-      identifies heme binding as a molecular function of CYC1. UniProt 
-      explicitly states CYC1 binds 1 heme c group covalently per subunit, with 
-      covalent binding at His-18 and His-81 and axial iron coordination by 
-      His-86 and Met-80. This molecular function is fundamental to the redox 
-      chemistry enabling electron transfer. IEA from protein family annotation 
+    reason: IEA annotation based on InterPro domain membership correctly
+      identifies heme binding as a molecular function of CYC1. UniProt
+      explicitly states CYC1 binds 1 heme c group covalently per subunit, with
+      covalent binding at His-18 and His-81 and axial iron coordination by
+      His-86 and Met-80. This molecular function is fundamental to the redox
+      chemistry enabling electron transfer. IEA from protein family annotation
       is appropriate for this well-characterized feature.
     supported_by:
     - reference_id: PMID:18390544
-      supporting_text: Structure of complex III with bound cytochrome c in 
-        reduced state and definition of a minimal core interface for electron 
+      supporting_text: Structure of complex III with bound cytochrome c in
+        reduced state and definition of a minimal core interface for electron
         transfer.
 - term:
     id: GO:0022904
@@ -3110,22 +3566,22 @@ existing_annotations:
   evidence_type: IEA
   original_reference_id: GO_REF:0000043
   review:
-    summary: Respiratory electron transport chain participation inferred from 
-      UniProtKB keyword mapping. CYC1 is a component of the electron transport 
+    summary: Respiratory electron transport chain participation inferred from
+      UniProtKB keyword mapping. CYC1 is a component of the electron transport
       chain that couples redox reactions to ATP synthesis.
     action: ACCEPT
-    reason: IEA annotation based on UniProtKB-KW (keyword) mapping correctly 
-      identifies CYC1 as a component of the respiratory electron transport 
-      chain. UniProt keywords include Respiratory chain and Electron transport, 
+    reason: IEA annotation based on UniProtKB-KW (keyword) mapping correctly
+      identifies CYC1 as a component of the respiratory electron transport
+      chain. UniProt keywords include Respiratory chain and Electron transport,
       reflecting CYC1&#39;s role as a central hub between Complexes III and IV. This
-      is appropriate for identifying participation in the broader pathway 
-      context while more specific electron transport processes are annotated 
+      is appropriate for identifying participation in the broader pathway
+      context while more specific electron transport processes are annotated
       separately.
     supported_by:
     - reference_id: PMID:7851399
       supporting_text: The purified enzyme had a turnover number of 1500 s-1 and
-        the ionic-strength dependence of the Km value for cytochrome-c was 
-        similar to that described for other preparations of cytochrome-c 
+        the ionic-strength dependence of the Km value for cytochrome-c was
+        similar to that described for other preparations of cytochrome-c
         oxidase.
 - term:
     id: GO:0046872
@@ -3134,21 +3590,21 @@ existing_annotations:
   original_reference_id: GO_REF:0000043
   review:
     summary: Metal ion binding inferred from UniProtKB keyword mapping (KW-0479)
-      reflecting the iron coordination in CYC1&#39;s heme c group. The Fe center is 
+      reflecting the iron coordination in CYC1&#39;s heme c group. The Fe center is
       essential for redox cycling.
     action: ACCEPT
-    reason: IEA annotation based on UniProtKB keyword mapping correctly 
+    reason: IEA annotation based on UniProtKB keyword mapping correctly
       identifies metal ion binding as a molecular function. CYC1 binds iron (Fe)
-      as the central atom of heme c through axial coordination by His-86 and 
-      Met-80, as documented in UniProt feature annotation. This is a more 
-      general annotation than GO:0020037 (heme binding) but appropriately 
-      identifies the metal cofactor requirement. For a protein with such 
-      well-characterized iron coordination, IEA from keyword mapping is 
+      as the central atom of heme c through axial coordination by His-86 and
+      Met-80, as documented in UniProt feature annotation. This is a more
+      general annotation than GO:0020037 (heme binding) but appropriately
+      identifies the metal cofactor requirement. For a protein with such
+      well-characterized iron coordination, IEA from keyword mapping is
       justified.
     supported_by:
     - reference_id: PMID:18390544
-      supporting_text: Structure of complex III with bound cytochrome c in 
-        reduced state and definition of a minimal core interface for electron 
+      supporting_text: Structure of complex III with bound cytochrome c in
+        reduced state and definition of a minimal core interface for electron
         transfer.
 - term:
     id: GO:0005515
@@ -3156,28 +3612,28 @@ existing_annotations:
   evidence_type: IPI
   original_reference_id: PMID:15071191
   review:
-    summary: Cytochrome c peroxidase (CCP) interaction demonstrated through 
-      structural and kinetic studies of the electron transfer complex. This 
-      represents a secondary protein-protein interaction not central to CYC1&#39;s 
+    summary: Cytochrome c peroxidase (CCP) interaction demonstrated through
+      structural and kinetic studies of the electron transfer complex. This
+      represents a secondary protein-protein interaction not central to CYC1&#39;s
       primary metabolic role.
     action: MARK_AS_OVER_ANNOTATED
-    reason: While CYC1 does interact with cytochrome c peroxidase (CCP) as 
-      demonstrated by PMID:15071191, the generic term protein binding is not 
-      informative and represents an over-annotation. The CCP interaction is a 
-      non-physiological interaction used for research purposes. More 
-      importantly, the physiological protein interactions with Complex III 
-      (cytochrome c1) and Complex IV (cytochrome c oxidase subunit IV) are far 
-      more significant but already captured by the electron transport process 
-      annotations. A vague protein binding term obscures rather than clarifies 
-      the functional role. For a protein with such well-defined biochemistry, 
-      more specific binding terms would be preferable if capturing this 
-      interaction is important. CCP interaction should not be prioritized over 
+    reason: While CYC1 does interact with cytochrome c peroxidase (CCP) as
+      demonstrated by PMID:15071191, the generic term protein binding is not
+      informative and represents an over-annotation. The CCP interaction is a
+      non-physiological interaction used for research purposes. More
+      importantly, the physiological protein interactions with Complex III
+      (cytochrome c1) and Complex IV (cytochrome c oxidase subunit IV) are far
+      more significant but already captured by the electron transport process
+      annotations. A vague protein binding term obscures rather than clarifies
+      the functional role. For a protein with such well-defined biochemistry,
+      more specific binding terms would be preferable if capturing this
+      interaction is important. CCP interaction should not be prioritized over
       the core metabolic functions.
     supported_by:
     - reference_id: PMID:15071191
-      supporting_text: A specific covalently cross-linked complex between redox 
-        partners yeast cytochrome c peroxidase (CCP) and cytochrome c (cyt. c) 
-        has been made by engineering cysteines into CCP and cyt. c that form an 
+      supporting_text: A specific covalently cross-linked complex between redox
+        partners yeast cytochrome c peroxidase (CCP) and cytochrome c (cyt. c)
+        has been made by engineering cysteines into CCP and cyt. c that form an
         intermolecular disulfide bond in high yield.
 - term:
     id: GO:0005515
@@ -3185,17 +3641,17 @@ existing_annotations:
   evidence_type: IPI
   original_reference_id: PMID:15339156
   review:
-    summary: Electron transfer between cytochrome c and cytochrome c peroxidase 
+    summary: Electron transfer between cytochrome c and cytochrome c peroxidase
       in single crystals. IPI evidence for protein-protein interaction with CCP.
     action: MARK_AS_OVER_ANNOTATED
-    reason: PMID:15339156 studies electron transfer kinetics between CYC1 and 
-      CCP in single crystal systems, demonstrating physical interaction. 
-      However, as with PMID:15071191, this CCP interaction is not central to 
-      CYC1&#39;s primary physiological role. The generic term protein binding is 
-      uninformative and represents an over-annotation. The critical 
-      physiological interactions are with Complex III and Complex IV proteins, 
-      already captured by process annotations. CCP is a research tool for 
-      studying electron transfer kinetics, not a core functional partner. This 
+    reason: PMID:15339156 studies electron transfer kinetics between CYC1 and
+      CCP in single crystal systems, demonstrating physical interaction.
+      However, as with PMID:15071191, this CCP interaction is not central to
+      CYC1&#39;s primary physiological role. The generic term protein binding is
+      uninformative and represents an over-annotation. The critical
+      physiological interactions are with Complex III and Complex IV proteins,
+      already captured by process annotations. CCP is a research tool for
+      studying electron transfer kinetics, not a core functional partner. This
       annotation should be deprioritized in favor of core metabolic functions.
     supported_by:
     - reference_id: PMID:15339156
@@ -3211,18 +3667,18 @@ existing_annotations:
       and cytochrome c peroxidase by paramagnetic NMR spectroscopy. IPI evidence
       for protein-protein interaction.
     action: MARK_AS_OVER_ANNOTATED
-    reason: PMID:17146057 characterizes the complex between CYC1 and CCP using 
-      structural biology methods. However, this represents a non-physiological 
+    reason: PMID:17146057 characterizes the complex between CYC1 and CCP using
+      structural biology methods. However, this represents a non-physiological
       research interaction rather than a core functional interaction. The CCP is
-      not a natural substrate or cofactor partner in yeast metabolism. The 
-      generic term protein binding is uninformative. More significant 
-      physiological protein interactions (Complex III and IV) are already 
+      not a natural substrate or cofactor partner in yeast metabolism. The
+      generic term protein binding is uninformative. More significant
+      physiological protein interactions (Complex III and IV) are already
       represented in the electron transport process annotations. This annotation
-      over-represents peripheral research interactions at the expense of core 
+      over-represents peripheral research interactions at the expense of core
       functions.
     supported_by:
     - reference_id: PMID:17146057
-      supporting_text: Solution structure and dynamics of the complex between 
+      supporting_text: Solution structure and dynamics of the complex between
         cytochrome c and cytochrome c peroxidase determined by paramagnetic NMR.
 - term:
     id: GO:0005515
@@ -3230,18 +3686,18 @@ existing_annotations:
   evidence_type: IPI
   original_reference_id: PMID:24726731
   review:
-    summary: Cytochrome c peroxidase and cytochrome c encounter complex 
+    summary: Cytochrome c peroxidase and cytochrome c encounter complex
       characterized through structural and kinetic studies.
     action: MARK_AS_OVER_ANNOTATED
-    reason: PMID:24726731 characterizes the CCP-cytochrome c encounter complex. 
-      However, this remains a non-physiological research interaction with CCP, 
-      not a core functional partner. The generic protein binding term lacks 
-      specificity and represents peripheral rather than core function. CCP 
-      interactions, while scientifically interesting for studying electron 
-      transfer mechanisms, should not dominate the annotation profile of CYC1. 
-      The primary physiological interactions with Complex III (cytochrome c1) 
-      and Complex IV are more important and already captured in process 
-      annotations. This is over-annotation that dilutes focus on core metabolic 
+    reason: PMID:24726731 characterizes the CCP-cytochrome c encounter complex.
+      However, this remains a non-physiological research interaction with CCP,
+      not a core functional partner. The generic protein binding term lacks
+      specificity and represents peripheral rather than core function. CCP
+      interactions, while scientifically interesting for studying electron
+      transfer mechanisms, should not dominate the annotation profile of CYC1.
+      The primary physiological interactions with Complex III (cytochrome c1)
+      and Complex IV are more important and already captured in process
+      annotations. This is over-annotation that dilutes focus on core metabolic
       role.
     supported_by:
     - reference_id: PMID:24726731
@@ -3253,25 +3709,25 @@ existing_annotations:
   evidence_type: IDA
   original_reference_id: PMID:30182710
   review:
-    summary: CYC1 binds to cardiolipin (CL), an anionic mitochondrial lipid, 
-      through electrostatic interactions mediated by lysine residues at site A. 
+    summary: CYC1 binds to cardiolipin (CL), an anionic mitochondrial lipid,
+      through electrostatic interactions mediated by lysine residues at site A.
       This interaction is relevant during apoptosis when CYC1 oxidizes CL.
     action: KEEP_AS_NON_CORE
-    reason: PMID:30182710 provides direct experimental evidence (IDA) that CYC1 
-      binds cardiolipin at multiple lysine residues (positions 72, 73, 86, 87). 
-      Cardiolipin binding is well-documented and mechanistically characterized. 
-      However, this represents a secondary function associated with apoptotic 
-      signaling rather than the primary aerobic metabolic role. In yeast under 
+    reason: PMID:30182710 provides direct experimental evidence (IDA) that CYC1
+      binds cardiolipin at multiple lysine residues (positions 72, 73, 86, 87).
+      Cardiolipin binding is well-documented and mechanistically characterized.
+      However, this represents a secondary function associated with apoptotic
+      signaling rather than the primary aerobic metabolic role. In yeast under
       normal aerobic growth, cardiolipin binding relates to apoptotic peroxidase
-      activity, not the primary electron transport function. For a primarily 
-      metabolic protein, this should be retained as a supported annotation but 
-      marked as non-core to distinguish from the central electron transport 
+      activity, not the primary electron transport function. For a primarily
+      metabolic protein, this should be retained as a supported annotation but
+      marked as non-core to distinguish from the central electron transport
       functions. The apoptotic role of CYC1 is less central in yeast compared to
       mammals.
     supported_by:
     - reference_id: PMID:30182710
-      supporting_text: A set of single, double, and quadruple lysine to alanine 
-        variants of yeast iso-1-cytochrome c, at sequence positions 72, 73, 86, 
+      supporting_text: A set of single, double, and quadruple lysine to alanine
+        variants of yeast iso-1-cytochrome c, at sequence positions 72, 73, 86,
         and 87, show that all contribute to the site A-mediated interaction with
         CL.
 - term:
@@ -3280,19 +3736,19 @@ existing_annotations:
   evidence_type: HDA
   original_reference_id: PMID:16823961
   review:
-    summary: CYC1 is a mitochondrial protein identified through large-scale 
-      mitochondrial proteomics analysis. HDA (homology-derived assertion) 
-      evidence from PMID:16823961 contributes to broader cellular component 
+    summary: CYC1 is a mitochondrial protein identified through large-scale
+      mitochondrial proteomics analysis. HDA (homology-derived assertion)
+      evidence from PMID:16823961 contributes to broader cellular component
       annotation.
     action: ACCEPT
     reason: HDA annotation correctly identifies CYC1 as a mitochondrial protein.
-      PMID:16823961 is a large-scale proteomic analysis of the yeast 
-      mitochondrial proteome that identified CYC1 among intermembrane space 
-      proteins. However, GO:0005758 (mitochondrial intermembrane space) is more 
+      PMID:16823961 is a large-scale proteomic analysis of the yeast
+      mitochondrial proteome that identified CYC1 among intermembrane space
+      proteins. However, GO:0005758 (mitochondrial intermembrane space) is more
       specific and informative than the broader GO:0005739 (mitochondrion). Both
-      are technically correct, but the more specific localization is more 
-      useful. HDA annotation is appropriate for broad compartment 
-      classification, though the intermembrane space annotations are more 
+      are technically correct, but the more specific localization is more
+      useful. HDA annotation is appropriate for broad compartment
+      classification, though the intermembrane space annotations are more
       precise and should be prioritized.
     supported_by:
     - reference_id: PMID:16823961
@@ -3304,16 +3760,16 @@ existing_annotations:
   evidence_type: IDA
   original_reference_id: PMID:9866716
   review:
-    summary: Direct experimental evidence that CYC1 is localized to the 
+    summary: Direct experimental evidence that CYC1 is localized to the
       mitochondrial intermembrane space. PMID:9866716 describes the purification
       of distinct IMS fractions with CYC1 as a key marker protein.
     action: ACCEPT
-    reason: IDA annotation provides direct experimental evidence for CYC1 
-      localization. PMID:9866716 is a landmark study that fractionally purified 
-      mitochondrial intermembrane space content, identifying CYC1 as a defining 
+    reason: IDA annotation provides direct experimental evidence for CYC1
+      localization. PMID:9866716 is a landmark study that fractionally purified
+      mitochondrial intermembrane space content, identifying CYC1 as a defining
       marker of the salt-extractable IMS fraction. This is the most specific and
-      accurate cellular localization, superior to the broader mitochondrion 
-      (GO:0005739) annotation. This is a core, well-supported annotation of 
+      accurate cellular localization, superior to the broader mitochondrion
+      (GO:0005739) annotation. This is a core, well-supported annotation of
       CYC1&#39;s subcellular localization.
     supported_by:
     - reference_id: PMID:9866716
@@ -3325,23 +3781,23 @@ existing_annotations:
   evidence_type: IDA
   original_reference_id: PMID:7851399
   review:
-    summary: Direct kinetic and biochemical evidence that CYC1 functions in 
-      mitochondrial electron transport from ubiquinol to the final electron 
-      acceptor at Complex IV. PMID:7851399 characterizes kinetic properties of 
+    summary: Direct kinetic and biochemical evidence that CYC1 functions in
+      mitochondrial electron transport from ubiquinol to the final electron
+      acceptor at Complex IV. PMID:7851399 characterizes kinetic properties of
       cytochrome c as a substrate for cytochrome c oxidase.
     action: ACCEPT
     reason: IDA annotation provides direct experimental evidence for CYC1&#39;s role
-      in electron transport. PMID:7851399 is a seminal biochemical study 
-      characterizing the purified eleven-subunit cytochrome c oxidase complex 
-      with kinetic analysis of cytochrome c as a substrate. The demonstrated Km 
-      values and turnover numbers (1500 s-1) represent direct functional 
+      in electron transport. PMID:7851399 is a seminal biochemical study
+      characterizing the purified eleven-subunit cytochrome c oxidase complex
+      with kinetic analysis of cytochrome c as a substrate. The demonstrated Km
+      values and turnover numbers (1500 s-1) represent direct functional
       evidence that CYC1 participates in this electron transport step. This is a
       core primary metabolic function with the highest quality evidence.
     supported_by:
     - reference_id: PMID:7851399
       supporting_text: The purified enzyme had a turnover number of 1500 s-1 and
-        the ionic-strength dependence of the Km value for cytochrome-c was 
-        similar to that described for other preparations of cytochrome-c 
+        the ionic-strength dependence of the Km value for cytochrome-c was
+        similar to that described for other preparations of cytochrome-c
         oxidase.
 - term:
     id: GO:0006123
@@ -3349,23 +3805,23 @@ existing_annotations:
   evidence_type: IDA
   original_reference_id: PMID:7851399
   review:
-    summary: Direct kinetic and biochemical evidence that CYC1 functions in 
-      mitochondrial electron transport from cytochrome c to the final electron 
-      acceptor (oxygen). PMID:7851399 characterizes kinetic properties of 
+    summary: Direct kinetic and biochemical evidence that CYC1 functions in
+      mitochondrial electron transport from cytochrome c to the final electron
+      acceptor (oxygen). PMID:7851399 characterizes kinetic properties of
       cytochrome c oxidase interaction with cytochrome c.
     action: ACCEPT
     reason: IDA annotation provides direct experimental evidence for CYC1&#39;s role
-      as electron donor to cytochrome c oxidase. PMID:7851399 demonstrates 
+      as electron donor to cytochrome c oxidase. PMID:7851399 demonstrates
       quantitatively that cytochrome c is a substrate for Complex IV (cytochrome
-      c oxidase), with measured kinetic parameters reflecting true enzyme 
-      kinetics. This electron transfer to oxygen is the final step in the 
-      respiratory chain and a core primary metabolic function of CYC1. This is 
+      c oxidase), with measured kinetic parameters reflecting true enzyme
+      kinetics. This electron transfer to oxygen is the final step in the
+      respiratory chain and a core primary metabolic function of CYC1. This is
       one of the most important functional annotations for this protein.
     supported_by:
     - reference_id: PMID:7851399
       supporting_text: The purified enzyme had a turnover number of 1500 s-1 and
-        the ionic-strength dependence of the Km value for cytochrome-c was 
-        similar to that described for other preparations of cytochrome-c 
+        the ionic-strength dependence of the Km value for cytochrome-c was
+        similar to that described for other preparations of cytochrome-c
         oxidase.
 - term:
     id: GO:0009055
@@ -3373,22 +3829,22 @@ existing_annotations:
   evidence_type: IDA
   original_reference_id: PMID:18975895
   review:
-    summary: Direct electrochemical evidence demonstrating electron transfer 
-      activity of yeast CYC1. PMID:18975895 measures electron transfer rate 
+    summary: Direct electrochemical evidence demonstrating electron transfer
+      activity of yeast CYC1. PMID:18975895 measures electron transfer rate
       constants using surface-enhanced resonance Raman spectroscopy.
     action: ACCEPT
-    reason: IDA annotation provides direct biophysical evidence for CYC1&#39;s 
-      electron transfer activity. PMID:18975895 employs sophisticated 
-      electrochemical methods to measure electron transfer rate constants (8-18 
-      s-1) and demonstrates that protein reorientation is rate-limiting for 
-      interfacial electron transfer. This represents direct, quantitative 
-      molecular evidence of the electron transfer mechanism central to CYC1&#39;s 
-      function. This is a core primary molecular function with excellent 
+    reason: IDA annotation provides direct biophysical evidence for CYC1&#39;s
+      electron transfer activity. PMID:18975895 employs sophisticated
+      electrochemical methods to measure electron transfer rate constants (8-18
+      s-1) and demonstrates that protein reorientation is rate-limiting for
+      interfacial electron transfer. This represents direct, quantitative
+      molecular evidence of the electron transfer mechanism central to CYC1&#39;s
+      function. This is a core primary molecular function with excellent
       experimental support.
     supported_by:
     - reference_id: PMID:18975895
-      supporting_text: The apparent electron transfer rate constants of YCC on 
-        MUA/MU and MU/MH at pH 6.0 were determined to be 8 and 18 s(-1), 
+      supporting_text: The apparent electron transfer rate constants of YCC on
+        MUA/MU and MU/MH at pH 6.0 were determined to be 8 and 18 s(-1),
         respectively.
 - term:
     id: GO:0009055
@@ -3396,27 +3852,36 @@ existing_annotations:
   evidence_type: IDA
   original_reference_id: PMID:7851399
   review:
-    summary: Direct biochemical evidence for electron transfer activity through 
-      kinetic characterization of cytochrome c as a functional substrate in 
+    summary: Direct biochemical evidence for electron transfer activity through
+      kinetic characterization of cytochrome c as a functional substrate in
       electron transport chain complexes.
     action: ACCEPT
-    reason: IDA annotation provides direct biochemical evidence for electron 
-      transfer activity from a landmark kinetic analysis. PMID:7851399 
-      demonstrates that cytochrome c functions as a true kinetic substrate for 
-      both Complex III (ubiquinol-cytochrome c oxidoreductase) and Complex IV 
-      (cytochrome c oxidase), with measured turnover numbers and Km values 
-      reflecting physiological kinetics. This dual IDA evidence from different 
-      experimental approaches (electrochemistry and enzyme kinetics) provides 
+    reason: IDA annotation provides direct biochemical evidence for electron
+      transfer activity from a landmark kinetic analysis. PMID:7851399
+      demonstrates that cytochrome c functions as a true kinetic substrate for
+      both Complex III (ubiquinol-cytochrome c oxidoreductase) and Complex IV
+      (cytochrome c oxidase), with measured turnover numbers and Km values
+      reflecting physiological kinetics. This dual IDA evidence from different
+      experimental approaches (electrochemistry and enzyme kinetics) provides
       robust support for this fundamental molecular function.
     supported_by:
     - reference_id: PMID:7851399
       supporting_text: The purified enzyme had a turnover number of 1500 s-1 and
-        the ionic-strength dependence of the Km value for cytochrome-c was 
-        similar to that described for other preparations of cytochrome-c 
+        the ionic-strength dependence of the Km value for cytochrome-c was
+        similar to that described for other preparations of cytochrome-c
         oxidase.
 references:
+- id: file:yeast/CYC1/CYC1-deep-research-falcon.md
+  title: Falcon deep research report for CYC1
+  findings:
+  - statement: &gt;-
+      Falcon supports CYC1 as yeast iso-1-cytochrome c, the principal mobile
+      electron carrier between respiratory complexes III and IV.
+    supporting_text: &gt;-
+      Cyc1p&#39;s precise biochemical role is single-electron transfer between the
+      bc1 complex and cytochrome c oxidase.
 - id: GO_REF:0000002
-  title: Gene Ontology annotation through association of InterPro records with 
+  title: Gene Ontology annotation through association of InterPro records with
     GO terms
   findings: []
 - id: GO_REF:0000033
@@ -3426,22 +3891,22 @@ references:
   title: Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping
   findings: []
 - id: GO_REF:0000117
-  title: Electronic Gene Ontology annotations created by ARBA machine learning 
+  title: Electronic Gene Ontology annotations created by ARBA machine learning
     models
   findings: []
 - id: GO_REF:0000120
   title: Combined Automated Annotation using Multiple IEA Methods
   findings: []
 - id: PMID:15071191
-  title: Crystal structure and characterization of a cytochrome c 
+  title: Crystal structure and characterization of a cytochrome c
     peroxidase-cytochrome c site-specific cross-link.
   findings: []
 - id: PMID:15339156
-  title: Electron transfer between cytochrome c and cytochome c peroxidase in 
+  title: Electron transfer between cytochrome c and cytochome c peroxidase in
     single crystals.
   findings: []
 - id: PMID:16823961
-  title: Toward the complete yeast mitochondrial proteome - multidimensional 
+  title: Toward the complete yeast mitochondrial proteome - multidimensional
     separation techniques for mitochondrial proteomics.
   findings: []
 - id: PMID:17146057
@@ -3449,24 +3914,24 @@ references:
     cytochrome c peroxidase determined by paramagnetic NMR.
   findings: []
 - id: PMID:18390544
-  title: Structure of complex III with bound cytochrome c in reduced state and 
+  title: Structure of complex III with bound cytochrome c in reduced state and
     definition of a minimal core interface for electron transfer.
   findings: []
 - id: PMID:18975895
-  title: Gated electron transfer of yeast iso-1 cytochrome c on self-assembled 
+  title: Gated electron transfer of yeast iso-1 cytochrome c on self-assembled
     monolayer-coated electrodes.
   findings: []
 - id: PMID:24726731
-  title: The cytochrome c peroxidase and cytochrome c encounter complex - the 
+  title: The cytochrome c peroxidase and cytochrome c encounter complex - the
     other side of the story.
   findings: []
 - id: PMID:30182710
-  title: Electrostatic Constituents of the Interaction of Cardiolipin with Site 
+  title: Electrostatic Constituents of the Interaction of Cardiolipin with Site
     A of Cytochrome c.
   findings: []
 - id: PMID:7851399
-  title: Kinetic properties and ligand binding of the eleven-subunit 
-    cytochrome-c oxidase from Saccharomyces cerevisiae isolated with a novel 
+  title: Kinetic properties and ligand binding of the eleven-subunit
+    cytochrome-c oxidase from Saccharomyces cerevisiae isolated with a novel
     large-scale purification method.
   findings: []
 - id: PMID:9866716
@@ -3475,22 +3940,22 @@ references:
   findings: []
 proposed_new_terms: []
 suggested_questions:
-- question: Does CYC1 have distinct redox potential states in different 
+- question: Does CYC1 have distinct redox potential states in different
     microenvironments (membrane-bound vs. soluble) that affect electron transfer
     efficiency?
 - question: What is the functional significance of CYC1&#39;s methylation at lysines
     78-79 in regulating its apoptotic signaling role versus its metabolic role?
-- question: Are there regulatory post-translational modifications of CYC1 that 
-    modulate its interaction with Complex III or Complex IV during metabolic 
+- question: Are there regulatory post-translational modifications of CYC1 that
+    modulate its interaction with Complex III or Complex IV during metabolic
     transitions?
 suggested_experiments:
-- description: Measure electron transfer kinetics between purified Complex III 
-    and Complex IV using reconstituted CYC1 in liposomes to establish turnover 
+- description: Measure electron transfer kinetics between purified Complex III
+    and Complex IV using reconstituted CYC1 in liposomes to establish turnover
     rates in a membrane context
-- description: Characterize how mutations affecting cardiolipin-binding lysines 
+- description: Characterize how mutations affecting cardiolipin-binding lysines
     (K72, K73, K86, K87) impact aerobic growth and respiration rates
-- description: Investigate whether CYC1 undergoes conformational changes upon 
-    binding to cardiolipin that influence its peroxidase activity during 
+- description: Investigate whether CYC1 undergoes conformational changes upon
+    binding to cardiolipin that influence its peroxidase activity during
     apoptosis
 </code></pre>
             </div>
@@ -3498,7 +3963,7 @@ suggested_experiments:
     </div>
 
     <!-- Pathway Visualization Link -->
-    
+
 
     <style>
         /* Markdown Section Styles */

--- a/genes/yeast/CYC1/CYC1-ai-review.yaml
+++ b/genes/yeast/CYC1/CYC1-ai-review.yaml
@@ -31,6 +31,11 @@ core_functions:
   locations:
   - id: GO:0005758
     label: mitochondrial intermembrane space
+  supported_by:
+  - reference_id: file:yeast/CYC1/CYC1-deep-research-falcon.md
+    supporting_text: >-
+      CYC1 encodes iso-1-cytochrome c, the major soluble c-type cytochrome in
+      yeast mitochondria, shuttling electrons from complex III to complex IV.
 existing_annotations:
 - term:
     id: GO:0009055
@@ -61,6 +66,10 @@ existing_annotations:
       supporting_text: The apparent electron transfer rate constants of YCC on 
         MUA/MU and MU/MH at pH 6.0 were determined to be 8 and 18 s(-1), 
         respectively.
+    - reference_id: file:yeast/CYC1/CYC1-deep-research-falcon.md
+      supporting_text: >-
+        Cyc1p's precise biochemical role is single-electron transfer between
+        the bc1 complex and cytochrome c oxidase.
 - term:
     id: GO:0006122
     label: mitochondrial electron transport, ubiquinol to cytochrome c
@@ -546,6 +555,15 @@ existing_annotations:
         similar to that described for other preparations of cytochrome-c 
         oxidase.
 references:
+- id: file:yeast/CYC1/CYC1-deep-research-falcon.md
+  title: Falcon deep research report for CYC1
+  findings:
+  - statement: >-
+      Falcon supports CYC1 as yeast iso-1-cytochrome c, the principal mobile
+      electron carrier between respiratory complexes III and IV.
+    supporting_text: >-
+      Cyc1p's precise biochemical role is single-electron transfer between the
+      bc1 complex and cytochrome c oxidase.
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with 
     GO terms

--- a/genes/yeast/CYC1/CYC1-deep-research-falcon.md
+++ b/genes/yeast/CYC1/CYC1-deep-research-falcon.md
@@ -1,0 +1,362 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-11T06:56:33.457315'
+end_time: '2026-05-11T07:26:53.656454'
+duration_seconds: 1820.2
+template_file: templates/gene_research_go_focused.md
+template_variables:
+  organism: yeast
+  gene_id: CYC1
+  gene_symbol: CYC1
+  uniprot_accession: P00044
+  protein_description: 'RecName: Full=Cytochrome c isoform 1; Short=Iso-1-cytochrome
+    c; AltName: Full=Cytochrome c aerobic isoform;'
+  gene_info: Name=CYC1; OrderedLocusNames=YJR048W; ORFNames=J1653;
+  organism_full: Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+  protein_family: Belongs to the cytochrome c family. .
+  protein_domains: Cyt_c-like_dom. (IPR009056); Cyt_c-like_dom_sf. (IPR036909); Cyt_c_1A/1B.
+    (IPR002327); Cytochrom_C (PF00034)
+provider_config:
+  timeout: 600
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 52
+---
+
+## Question
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** P00044
+- **Protein Description:** RecName: Full=Cytochrome c isoform 1; Short=Iso-1-cytochrome c; AltName: Full=Cytochrome c aerobic isoform;
+- **Gene Information:** Name=CYC1; OrderedLocusNames=YJR048W; ORFNames=J1653;
+- **Organism (full):** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+- **Protein Family:** Belongs to the cytochrome c family. .
+- **Key Domains:** Cyt_c-like_dom. (IPR009056); Cyt_c-like_dom_sf. (IPR036909); Cyt_c_1A/1B. (IPR002327); Cytochrom_C (PF00034)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "CYC1" matches the protein description above**
+2. **Verify the organism is correct:** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'CYC1' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **CYC1** (gene ID: CYC1, UniProt: P00044) in yeast.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** P00044
+- **Protein Description:** RecName: Full=Cytochrome c isoform 1; Short=Iso-1-cytochrome c; AltName: Full=Cytochrome c aerobic isoform;
+- **Gene Information:** Name=CYC1; OrderedLocusNames=YJR048W; ORFNames=J1653;
+- **Organism (full):** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+- **Protein Family:** Belongs to the cytochrome c family. .
+- **Key Domains:** Cyt_c-like_dom. (IPR009056); Cyt_c-like_dom_sf. (IPR036909); Cyt_c_1A/1B. (IPR002327); Cytochrom_C (PF00034)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "CYC1" matches the protein description above**
+2. **Verify the organism is correct:** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'CYC1' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **CYC1** (gene ID: CYC1, UniProt: P00044) in yeast.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+# Research Report: *Saccharomyces cerevisiae* **CYC1** (UniProt **P00044**) — Functional Annotation of Iso-1 Cytochrome c
+
+## Executive summary
+*Saccharomyces cerevisiae* **CYC1** encodes **iso-1-cytochrome c (Cyc1p)**, the major soluble c-type cytochrome in yeast mitochondria (≈95% of total cellular cytochrome c). Its primary function is to act as a **mobile electron carrier** in the mitochondrial intermembrane space (IMS), shuttling electrons from **complex III (bc1; via cytochrome c1)** to **complex IV (cytochrome c oxidase)** during oxidative phosphorylation. Cyc1p is produced as an apoprotein in the cytosol, imported into the IMS, and converted into holocytochrome c by **System III holocytochrome c synthase / cytochrome c heme lyase** (CCHL/HCCS; encoded by **CYC3**) with support from accessory factors such as **Cyc2p**. Recent (2023–2024) work emphasizes cytochrome c’s role in **respiratory III–IV supercomplex organization**, including lipid dependence (cardiolipin vs phosphatidylglycerol) and engineered supercomplex configurations that alter respiratory performance and substrate use.
+
+## 0) Target verification (mandatory)
+
+### 0.1 Gene symbol, protein description, organism match
+The literature surveyed matches the UniProt description provided: **CYC1** in *S. cerevisiae* encodes **iso-1-cytochrome c (Cyc1p)**, while **CYC7** encodes the minor **iso-2** cytochrome c (Cyc7p). This explicitly resolves symbol ambiguity for yeast CYC1 in the current context (wang1996sequencerequirementsfor pages 4-4).
+
+### 0.2 Isoforms and abundance
+Classic biochemical-genetic analysis shows that **iso-1** (CYC1) and **iso-2** (CYC7) constitute, respectively, **95% and 5%** of total cellular cytochrome c in normal yeast, though CYC7 expression can be engineered (CYC7-H3 allele) to increase iso-2 to ~iso-1 levels (wang1996sequencerequirementsfor pages 4-4).
+
+## 1) Key concepts and definitions (current understanding)
+
+### 1.1 What is cytochrome c (c-type cytochrome)?
+c-type cytochromes are defined by **covalent heme attachment**: heme vinyl groups form thioether bonds with cysteine thiols, usually at a **CxxCH** motif where the histidine serves as an axial ligand to the heme iron. In mitochondria there are two c-type cytochromes: **cytochrome c** and **cytochrome c1** (allen2011cytochromecbiogenesis pages 1-2).
+
+### 1.2 Cyc1p biochemical role in respiration (reaction-level description)
+Cyc1p’s precise biochemical role is **single-electron transfer** between the bc1 complex and cytochrome c oxidase. Cytochrome c’s “classical function” is electron transfer between **cytochrome c1 (complex III)** and the **CuA center of complex IV**, a key step in oxidative phosphorylation (allen2011cytochromecbiogenesis pages 1-2). In the yeast respiratory chain, reduced ubiquinol (QH2) donates electrons to **complex III**, which transfers electrons to **water-soluble cytochrome c** in the IMS; reduced cytochrome c then donates electrons to **complex IV**, which reduces O2 to water (brzezinski2021structureandmechanism pages 2-3).
+
+### 1.3 Cellular localization and diffusion regime
+In *S. cerevisiae*, cytochrome c is **water soluble** and resides in the **intermembrane/intercristae space**, where it can diffuse to connect complexes III and IV (brzezinski2021structureandmechanism pages 2-3). Quantitatively, the **cyt. c:CytcO ratio is 2–4**, corresponding to an average concentration of ~**100 μM** cytochrome c in the intercristae space (brzezinski2021structureandmechanism pages 2-3).
+
+## 2) Cyc1p biogenesis and maturation in mitochondria
+
+### 2.1 Import as apocytochrome and coupling to maturation
+Yeast cytochrome c is **nuclear encoded**, synthesized on cytosolic ribosomes as an **apoprotein**, and imported to the IMS via the TOM pathway (Tom40/Tom22 emphasized in review). In the IMS, apocytochrome c forms a tight complex with **HCCS/CCHL (System III)**, which catalyzes covalent attachment of **ferrous heme [Fe(II)]** to the CxxCH motif; heme attachment drives folding and **irreversibly traps** cytochrome c in the IMS (allen2011cytochromecbiogenesis pages 9-11).
+
+### 2.2 The enzymology: System III (HCCS/CCHL) and accessory Cyc2
+System III is the mitochondrial pathway in fungi/animals: **holocytochrome c synthase (HCCS), also called cytochrome c heme lyase (CCHL)**, performs the covalent heme ligation reaction (allen2011cytochromecbiogenesis pages 1-2). In yeast, **Cyc2p** is a mitochondrial inner-membrane protein with a C-terminal FAD domain exposed to the IMS; recombinant Cyc2p shows **NAD(P)H-dependent reductase activity**, and genetic analysis supports a role dedicated to the CCHL pathway (important in sensitized cytochrome c1 mutants) (corvest2010ctypecytochromeassembly pages 2-3). Independent work also describes Cyc2p as a **mitochondrial cytochrome c assembly factor** and **NAD(P)H-dependent haem reductase** (verissimo2012engineeringaprokaryotic pages 6-8).
+
+### 2.3 Evidence of heme attachment as a defining functional feature
+A study using an ADP/ATP carrier–iso-1 cytochrome c fusion reports that **heme is present** in isolated fusion protein preparations (“red color”), reinforcing that heme attachment is intrinsic to functional cytochrome c polypeptide contexts (dassa2005functionalcharacterizationand pages 1-2).
+
+## 3) Transcriptional regulation and gene-circuit relevance of **CYC1** regulatory elements
+
+### 3.1 Native regulation themes: respiration-linked activation and catabolite repression
+A promoter-engineering review compiles extensive classical genetics showing that the **CYC1 promoter** contains upstream activation sequences responsive to respiratory regulators (e.g., HAP2/HAP3-responsive elements) and tandem activation sites involved in **catabolite (glucose) repression**; promoter architecture includes multiple TATA elements affecting transcription start site usage (feng2021saccharomycescerevisiaepromoter pages 15-16).
+
+### 3.2 CYC1 promoter as a standardized engineering part
+CYC1 regulatory sequences are widely repurposed:
+- A **minimal CYC1 core promoter** retaining the TATA box has served as a backbone for synthetic promoters by adding operator sites (e.g., 1–8 lexO copies) and driving inducible expression with LexA-based synthetic activators (feng2021saccharomycescerevisiaepromoter pages 6-8).
+- In standardized parts and high-throughput characterization, **pCYC1** is used as a **reference/normalization standard**; YeastFab included a pCYC1 strain in every 96-well plate for promoter activity calibration (guo2015yeastfabthedesign pages 2-3).
+- CYC1-derived promoter backbones are used in yeast biosensor designs (operator insertions such as metO-CYC1 and P8x.CYC1 hybrids) (qiu2019biosensorsdesignin pages 27-27).
+
+### 3.3 CYC1 terminator as a baseline part; quantitative benchmarking
+The endogenous **CYC1 terminator** is a very common baseline in synthetic biology. A highly cited study of short synthetic terminators reports the best synthetic terminator yielded **3.7-fold more fluorescent protein output** and **4.4-fold increased transcript level** compared to the commonly used CYC1 terminator (Published **Feb 2015**, URL: https://doi.org/10.1021/sb5003357) (curran2015shortsyntheticterminators pages 1-2). The same work reports a variant (Tsynth3) achieving ~**3.3-fold** higher protein output than the CYC1 terminator (curran2015shortsyntheticterminators pages 4-5).
+
+## 4) Recent developments (prioritizing 2023–2024)
+
+### 4.1 2023: Lipid dependence and supercomplex architecture (peer-reviewed)
+A 2023 *Nature Communications* cryo-EM study solved yeast respiratory supercomplex structures at high resolution and directly linked lipid composition to supercomplex organization. Specifically:
+- WT yeast supercomplex (**III2IV2**) was solved to **3.2 Å** resolution, and a cardiolipin-deficient CRD1Δ-derived supercomplex (**III2IV1**) to **3.3 Å** resolution (Published **May 2023**, URL: https://doi.org/10.1038/s41467-023-38441-5) (hryc2023structuralinsightsinto pages 2-3).
+- WT digitonin extracts show predominantly tetrameric **III2IV2**, whereas CRD1Δ shifts toward **III2IV1** plus free complexes; phosphatidylglycerol (PG) replaces cardiolipin (CL) in the mutant and can occupy similar structural positions, but altered interactions plausibly underlie the assembly/stability shift (hryc2023structuralinsightsinto pages 2-3).
+- Functionally, NADH-driven oxygen consumption was higher in WT mitochondria (**0.730 ± 0.052 µmol O2/min/mg**) than in CRD1Δ (**0.360 ± 0.047 µmol O2/min/mg**; three determinations), consistent with reduced respiratory capacity in CL deficiency (hryc2023structuralinsightsinto pages 2-3).
+
+### 4.2 2024: Cytochrome c isoforms as modulators of supercomplex assembly (preprint)
+A 2024 bioRxiv preprint focuses on how yeast cytochrome c isoforms influence III–IV supercomplex assembly and respiratory chain rate. It emphasizes that cytochrome c is a **mobile electron carrier** between complexes III and IV and reports that both cytochrome c isoforms contribute to supercomplex assembly, with iso-2 associated with improved electron-transfer efficiency and reduced ROS production in their experimental framework (Posted **Jul 2024**, URL: https://doi.org/10.1101/2024.07.13.603375) (guerracastellano2024unveilingtherole pages 1-3).
+
+### 4.3 2024: Engineered tethered supercomplexes and substrate utilization (preprint)
+A 2024 bioRxiv study reports an engineered yeast strain expressing a **covalently linked III2IV2 supercomplex** to isolate the physiological role of supercomplex plasticity. The authors argue that SCs can facilitate cytochrome c diffusion along the SC surface and enhance rates, and they report that tethering preserves robust respiration but can selectively affect respiration from cytosol-derived NADH via differential association with mitochondrial NADH dehydrogenases (Posted **Dec 2024**, URL: https://doi.org/10.1101/2024.12.19.629262) (eldeeb2024bioengineeredyeasttethered pages 1-4).
+
+### 4.4 2024: Updated transcriptional-regulatory context for respiration programs (peer-reviewed)
+A 2024 *Nucleic Acids Research* study on fermentation-to-respiration switching shows that the zinc-cluster factor **Rds2** controls expression of **HAP4**, a regulatory subunit gene of the Hap2/3/4/5 complex involved in activating respiration genes, and reveals promoter-specific interdependency/cooperativity among Rds2, Ert1, and Gsm1 during the metabolic shift (Published **Dec 2024**, URL: https://doi.org/10.1093/nar/gkad1185) (martinez2024yeastzinccluster pages 1-2).
+
+## 5) Current applications and real-world implementations
+
+### 5.1 Research applications leveraging CYC1 coding sequence and cytochrome c function
+Because cytochrome c is central to electron transfer between complexes III and IV and supercomplex function, it is repeatedly used as a functional readout component in mitochondrial bioenergetics studies and perturbations (e.g., lipid mutants or engineered tethered supercomplexes) (brzezinski2021structureandmechanism pages 2-3, hryc2023structuralinsightsinto pages 2-3, eldeeb2024bioengineeredyeasttethered pages 1-4). Although not “industrial” in the product sense, these approaches are real-world implementations in respiratory physiology research, providing engineered systems to parse bioenergetic mechanisms.
+
+### 5.2 Synthetic biology and biotechnology: CYC1 promoter/terminator as standard parts
+CYC1 regulatory elements are deeply embedded in yeast engineering workflows:
+- **pCYC1** as a calibration standard in promoter part libraries (YeastFab) (Published **May 2015**, URL: https://doi.org/10.1093/nar/gkv464) (guo2015yeastfabthedesign pages 2-3).
+- **Minimal CYC1 promoter** as a modular scaffold for orthogonal regulation by operator-site insertion and synthetic TFs (feng2021saccharomycescerevisiaepromoter pages 6-8).
+- **CYC1 terminator** as a benchmark baseline for designing compact, high-performance synthetic terminators; synthetic terminators with multi-fold improvements have direct utility in metabolic engineering and heterologous expression (curran2015shortsyntheticterminators pages 1-2).
+
+## 6) Expert opinions / authoritative synthesis
+
+### 6.1 Supercomplexes and cytochrome c diffusion as an organizing principle
+An authoritative Chemical Reviews article frames the yeast III–IV supercomplex landscape and emphasizes that mobile carriers (QH2 and cytochrome c) can diffuse freely, so physical linkage is not strictly required, but supercomplexes are widely observed and actively debated regarding functional advantages (e.g., channeling/diffusion constraints) (Published **Jun 2021**, URL: https://doi.org/10.1021/acs.chemrev.1c00140) (brzezinski2021structureandmechanism pages 2-3).
+
+### 6.2 Cytochrome c biogenesis as tightly coupled import–maturation
+A highly cited FEBS Journal review emphasizes that in System III organisms (including fungi), cytochrome c heme attachment is a post-translational modification mediated by HCCS/CCHL and is tightly integrated with import and retention in the IMS, with Cyc2 highlighted as a fungal accessory factor (Published **Nov 2011**, URL: https://doi.org/10.1111/j.1742-4658.2011.08231.x) (allen2011cytochromecbiogenesis pages 1-2).
+
+## 7) Key quantitative/statistical takeaways
+- Isoform abundance: **CYC1/iso-1 ≈95%** and **CYC7/iso-2 ≈5%** of total cytochrome c (wang1996sequencerequirementsfor pages 4-4).
+- IMS abundance: cyt c:CytcO ratio **2–4** → ~**100 μM** cytochrome c in intercristae space (brzezinski2021structureandmechanism pages 2-3).
+- Structural/functional 2023 supercomplex data: cryo-EM **3.2 Å (WT III2IV2)** and **3.3 Å (CRD1Δ III2IV1)**; NADH-driven O2 consumption **0.730 ± 0.052** vs **0.360 ± 0.047 µmol O2/min/mg** (WT vs CRD1Δ) (hryc2023structuralinsightsinto pages 2-3).
+- Synthetic biology benchmarks: best short synthetic terminator yields **3.7×** more protein output and **4.4×** more transcript than **CYC1 terminator**; Tsynth3 yields ~**3.3×** higher protein output vs CYC1 terminator (curran2015shortsyntheticterminators pages 1-2, curran2015shortsyntheticterminators pages 4-5).
+
+## 8) Evidence summary table
+| Category | Evidence-backed details (1-3 sentences) | Key quantitative data | Key sources (include URLs + publication month/year) |
+|---|---|---|---|
+| Gene/protein identity | In *Saccharomyces cerevisiae*, **CYC1** encodes **iso-1-cytochrome c (Cyc1p)**, the major soluble mitochondrial c-type cytochrome; this matches the UniProt target P00044. Classic yeast genetics distinguishes **CYC1/iso-1** from **CYC7/iso-2**, resolving symbol ambiguity for this report (dassa2005functionalcharacterizationand pages 1-2, wang1996sequencerequirementsfor pages 4-4). | Iso-1 ≈ **95%** and iso-2 ≈ **5%** of total cellular cytochrome c; engineered **CYC7-H3** can overproduce iso-2 to about iso-1 levels (wang1996sequencerequirementsfor pages 4-4). | Wang et al., *J. Biol. Chem.* **Mar 1996**. https://doi.org/10.1074/jbc.271.12.6594 ; Dassa et al., *Protein Expr. Purif.* **Apr 2005**. https://doi.org/10.1016/j.pep.2004.12.019 |
+| Localization | Cytochrome c is a **soluble protein in the mitochondrial intermembrane/intercristae space (IMS)**, peripherally associated with the inner membrane and positioned to shuttle electrons between respiratory complexes. Reviews and import studies consistently place apocytochrome/holocytochrome c maturation and retention in the IMS (brzezinski2021structureandmechanism pages 2-3, wang1996sequencerequirementsfor pages 1-2, allen2011cytochromecbiogenesis pages 1-2, allen2011cytochromecbiogenesis pages 9-11). | Cyt. c:CytcO ratio in *S. cerevisiae* ≈ **2-4**, corresponding to an average cyt. c concentration of ~**100 μM** in the intercristae space (brzezinski2021structureandmechanism pages 2-3). | Brzezinski et al., *Chem. Rev.* **Jun 2021**. https://doi.org/10.1021/acs.chemrev.1c00140 ; Allen, *FEBS J.* **Nov 2011**. https://doi.org/10.1111/j.1742-4658.2011.08231.x ; Wang et al., *J. Biol. Chem.* **Mar 1996**. https://doi.org/10.1074/jbc.271.12.6594 |
+| Biochemical function (electron transfer) | Cyc1p is the canonical **mobile electron carrier** of the mitochondrial respiratory chain, accepting electrons downstream of complex III (via cytochrome c1 in the bc1 complex) and donating them to **cytochrome c oxidase/complex IV** for O2 reduction to water. This is its primary, precise biochemical role in yeast respiration (brzezinski2021structureandmechanism pages 2-3, allen2011cytochromecbiogenesis pages 1-2, zhang2015substraterecognitionby pages 39-44). | Soluble carrier linking **complex III → complex IV**; cytochrome c is estimated at ~**100 μM** in IMS, supporting rapid diffusion-based transfer (brzezinski2021structureandmechanism pages 2-3). | Brzezinski et al., *Chem. Rev.* **Jun 2021**. https://doi.org/10.1021/acs.chemrev.1c00140 ; Allen, *FEBS J.* **Nov 2011**. https://doi.org/10.1111/j.1742-4658.2011.08231.x |
+| Maturation / biogenesis | CYC1 is nuclear-encoded and synthesized as **apocytochrome c** in the cytosol, then imported through the TOM pathway into the IMS, where **holocytochrome c synthase / cytochrome c heme lyase (HCCS/CCHL; System III, encoded by CYC3)** catalyzes covalent heme attachment at the CxxCH motif; heme ligation drives folding and traps the holoprotein in the IMS. **Cyc2p** is an IMS-facing inner-membrane flavoprotein with NAD(P)H-dependent reductase activity that supports/augments CCHL-dependent maturation, especially in sensitized genetic contexts (allen2011cytochromecbiogenesis pages 9-11, verissimo2012engineeringaprokaryotic pages 6-8, corvest2010ctypecytochromeassembly pages 2-3, wang1996sequencerequirementsfor pages 4-4). | Cytochrome c is ~**12 kDa**; HCCS in yeast is reported as ~**31 kDa** in one mechanistic study/dissertation (allen2011cytochromecbiogenesis pages 1-2, zhang2015substraterecognitionby pages 39-44). | Allen, *FEBS J.* **Nov 2011**. https://doi.org/10.1111/j.1742-4658.2011.08231.x ; Corvest et al., *Genetics* **Oct 2010**. https://doi.org/10.1534/genetics.110.120022 ; Verissimo et al., *BBRC* **Jul 2012**. https://doi.org/10.1016/j.bbrc.2012.06.088 |
+| Isoforms (CYC1 vs CYC7) | Yeast has two cytochrome c isoforms: **CYC1 = iso-1** and **CYC7 = iso-2**. Both can support electron transport, but recent work suggests the isoforms are not fully equivalent in respiratory-chain organization: both contribute to supercomplex assembly, while iso-2 may enhance electron-transfer efficiency and reduce ROS in some contexts (wang1996sequencerequirementsfor pages 4-4, guerracastellano2024unveilingtherole pages 1-3). | Approximate fraction of total cytochrome c: **95% iso-1 / 5% iso-2** (wang1996sequencerequirementsfor pages 4-4). | Wang et al., *J. Biol. Chem.* **Mar 1996**. https://doi.org/10.1074/jbc.271.12.6594 ; Guerra-Castellano et al., *bioRxiv* **Jul 2024**. https://doi.org/10.1101/2024.07.13.603375 |
+| Regulation / promoter | The **CYC1 promoter** is a classic yeast regulatory model: mutational analyses identified HAP2/HAP3-responsive upstream activation sequences, consistent with **heme/respiration-linked activation**, and tandem UAS elements involved in **catabolite (glucose) repression**. It has therefore been used extensively to dissect promoter architecture, TATA usage, transcription start-site selection, and promoter occupancy under repressed vs active states (feng2021saccharomycescerevisiaepromoter pages 15-16). | No single absolute native promoter-strength value was retrieved here, but promoter studies document multiple TATA elements and glucose-responsive repression circuitry; Rds2 binding expands from **7 promoters in glucose to 43 in ethanol** in a 2024 study of the fermentative-to-respiratory transition (context for respiratory gene control) (feng2021saccharomycescerevisiaepromoter pages 15-16, martinez2024yeastzinccluster pages 2-3). | Feng & Marchisio, *Biology* **Jun 2021**. https://doi.org/10.3390/biology10060504 ; Martinez et al., *Nucleic Acids Res.* **Dec 2024**. https://doi.org/10.1093/nar/gkad1185 |
+| Recent 2023-2024 findings | A 2023 cryo-EM study showed that in cardiolipin-deficient yeast respiratory supercomplexes, **phosphatidylglycerol can occupy cardiolipin-like positions**, but supercomplex organization shifts from predominantly **III2IV2** toward **III2IV1 + free CIII/CIV**, supporting a lipid-dependent role in respiratory-chain architecture. 2024 preprints further report that cytochrome c isoforms modulate supercomplex assembly and that engineered tethered **III2IV2** supercomplexes can preserve strong respiration while altering substrate utilization, especially for cytosol-derived NADH (hryc2023structuralinsightsinto pages 1-2, hryc2023structuralinsightsinto pages 2-3, eldeeb2024bioengineeredyeasttethered pages 1-4, guerracastellano2024unveilingtherole pages 1-3). | Cryo-EM resolutions: WT **3.2 Å**, CRD1Δ **3.3 Å**; NADH-driven O2 consumption WT **0.730 ± 0.052** vs CRD1Δ **0.360 ± 0.047 μmol O2/min/mg** (three determinations) (hryc2023structuralinsightsinto pages 2-3). | Hryc et al., *Nat. Commun.* **May 2023**. https://doi.org/10.1038/s41467-023-38441-5 ; Guerra-Castellano et al., *bioRxiv* **Jul 2024**. https://doi.org/10.1101/2024.07.13.603375 ; Eldeeb et al., *bioRxiv* **Dec 2024**. https://doi.org/10.1101/2024.12.19.629262 |
+| Applications (promoter/terminator in synthetic biology; respiration studies) | **CYC1 regulatory elements** are widely used in practice: the promoter serves as a constitutive reference or core scaffold in standardized part libraries, hybrid promoters, biosensors, and orthogonal inducible circuits, while the **CYC1 terminator** is a standard baseline for expression-cassette benchmarking. The cytochrome c protein itself is also central to mitochondrial respiration assays and supercomplex engineering studies that probe electron-transfer kinetics and membrane organization (guo2015yeastfabthedesign pages 2-3, qiu2019biosensorsdesignin pages 27-27, feng2021saccharomycescerevisiaepromoter pages 6-8, curran2015shortsyntheticterminators pages 1-2, eldeeb2024bioengineeredyeasttethered pages 33-35). | In YeastFab, **pCYC1** was included on every 96-well plate as a normalization standard (guo2015yeastfabthedesign pages 2-3). Synthetic terminators yielded up to **3.7-fold** higher fluorescent output and **4.4-fold** higher transcript levels than the commonly used **CYC1 terminator**; Tsynth3 gave ~**3.3-fold** higher protein output than CYC1 terminator (curran2015shortsyntheticterminators pages 1-2, curran2015shortsyntheticterminators pages 4-5). | Guo et al., *Nucleic Acids Res.* **May 2015**. https://doi.org/10.1093/nar/gkv464 ; Qiu et al., *FEMS Yeast Res.* **Nov 2019**. https://doi.org/10.1093/femsyr/foz082 ; Feng & Marchisio, *Biology* **Jun 2021**. https://doi.org/10.3390/biology10060504 ; Curran et al., *ACS Synth. Biol.* **Feb 2015**. https://doi.org/10.1021/sb5003357 |
+
+
+*Table: This table summarizes the evidence-backed functional annotation of yeast CYC1/iso-1-cytochrome c, including identity, localization, biochemical role, maturation, regulation, recent 2023-2024 findings, and practical applications. It condenses key mechanistic points, quantitative values, and source links into a single reference artifact.*
+
+## Visual evidence (figure)
+Figure showing cryo-EM supercomplex maps/models comparing WT and cardiolipin-deficient yeast supercomplexes is provided from the 2023 *Nature Communications* paper (hryc2023structuralinsightsinto media ef369fac).
+
+## References (URLs and publication dates emphasized)
+Key works used directly for evidence (non-exhaustive; see in-text citations):
+- Hryc et al. *Nature Communications* (May 2023). https://doi.org/10.1038/s41467-023-38441-5 (hryc2023structuralinsightsinto pages 2-3, hryc2023structuralinsightsinto media ef369fac)
+- Guerra-Castellano et al. *bioRxiv* (Jul 2024). https://doi.org/10.1101/2024.07.13.603375 (guerracastellano2024unveilingtherole pages 1-3)
+- Eldeeb et al. *bioRxiv* (Dec 2024). https://doi.org/10.1101/2024.12.19.629262 (eldeeb2024bioengineeredyeasttethered pages 1-4)
+- Martinez et al. *Nucleic Acids Research* (Dec 2024). https://doi.org/10.1093/nar/gkad1185 (martinez2024yeastzinccluster pages 1-2)
+- Brzezinski et al. *Chemical Reviews* (Jun 2021). https://doi.org/10.1021/acs.chemrev.1c00140 (brzezinski2021structureandmechanism pages 2-3)
+- Allen. *The FEBS Journal* (Nov 2011). https://doi.org/10.1111/j.1742-4658.2011.08231.x (allen2011cytochromecbiogenesis pages 9-11, allen2011cytochromecbiogenesis pages 1-2)
+- Wang et al. *Journal of Biological Chemistry* (Mar 1996). https://doi.org/10.1074/jbc.271.12.6594 (wang1996sequencerequirementsfor pages 4-4)
+- Guo et al. *Nucleic Acids Research* (May 2015). https://doi.org/10.1093/nar/gkv464 (guo2015yeastfabthedesign pages 2-3)
+- Curran et al. *ACS Synthetic Biology* (Feb 2015). https://doi.org/10.1021/sb5003357 (curran2015shortsyntheticterminators pages 1-2, curran2015shortsyntheticterminators pages 4-5)
+
+
+
+References
+
+1. (wang1996sequencerequirementsfor pages 4-4): Xiaoye Wang, Mark E. Dumont, and Fred Sherman. Sequence requirements for mitochondrial import of yeast cytochrome c(*). The Journal of Biological Chemistry, 271:6594-6604, Mar 1996. URL: https://doi.org/10.1074/jbc.271.12.6594, doi:10.1074/jbc.271.12.6594. This article has 46 citations.
+
+2. (allen2011cytochromecbiogenesis pages 1-2): James W. A. Allen. Cytochrome c biogenesis in mitochondria – systems iii and v. The FEBS Journal, Nov 2011. URL: https://doi.org/10.1111/j.1742-4658.2011.08231.x, doi:10.1111/j.1742-4658.2011.08231.x. This article has 98 citations.
+
+3. (brzezinski2021structureandmechanism pages 2-3): Peter Brzezinski, Agnes Moe, and Pia Ädelroth. Structure and mechanism of respiratory iii–iv supercomplexes in bioenergetic membranes. Chemical Reviews, 121:9644-9673, Jun 2021. URL: https://doi.org/10.1021/acs.chemrev.1c00140, doi:10.1021/acs.chemrev.1c00140. This article has 116 citations and is from a highest quality peer-reviewed journal.
+
+4. (allen2011cytochromecbiogenesis pages 9-11): James W. A. Allen. Cytochrome c biogenesis in mitochondria – systems iii and v. The FEBS Journal, Nov 2011. URL: https://doi.org/10.1111/j.1742-4658.2011.08231.x, doi:10.1111/j.1742-4658.2011.08231.x. This article has 98 citations.
+
+5. (corvest2010ctypecytochromeassembly pages 2-3): Vincent Corvest, Darren A Murrey, Delphine G Bernard, David B Knaff, Bernard Guiard, and Patrice P Hamel. C-type cytochrome assembly in saccharomyces cerevisiae: a key residue for apocytochrome c1/lyase interaction. Genetics, 186:561-571, Oct 2010. URL: https://doi.org/10.1534/genetics.110.120022, doi:10.1534/genetics.110.120022. This article has 19 citations and is from a domain leading peer-reviewed journal.
+
+6. (verissimo2012engineeringaprokaryotic pages 6-8): Andreia F. Verissimo, Joohee Sanders, Fevzi Daldal, and Carsten Sanders. Engineering a prokaryotic apocytochrome c as an efficient substrate for saccharomyces cerevisiae cytochrome c heme lyase. Biochemical and Biophysical Research Communications, 424:130-135, Jul 2012. URL: https://doi.org/10.1016/j.bbrc.2012.06.088, doi:10.1016/j.bbrc.2012.06.088. This article has 18 citations and is from a peer-reviewed journal.
+
+7. (dassa2005functionalcharacterizationand pages 1-2): Emmanuel Philippe Dassa, Cécile Dahout-Gonzalez, Anne-Christine Dianoux, and Gérard Brandolin. Functional characterization and purification of a saccharomyces cerevisiae adp/atp carrier-iso 1 cytochrome c fusion protein. Protein expression and purification, 40 2:358-69, Apr 2005. URL: https://doi.org/10.1016/j.pep.2004.12.019, doi:10.1016/j.pep.2004.12.019. This article has 9 citations and is from a peer-reviewed journal.
+
+8. (feng2021saccharomycescerevisiaepromoter pages 15-16): Xiaofan Feng and Mario Marchisio. Saccharomyces cerevisiae promoter engineering before and during the synthetic biology era. Biology, 10:504, Jun 2021. URL: https://doi.org/10.3390/biology10060504, doi:10.3390/biology10060504. This article has 35 citations.
+
+9. (feng2021saccharomycescerevisiaepromoter pages 6-8): Xiaofan Feng and Mario Marchisio. Saccharomyces cerevisiae promoter engineering before and during the synthetic biology era. Biology, 10:504, Jun 2021. URL: https://doi.org/10.3390/biology10060504, doi:10.3390/biology10060504. This article has 35 citations.
+
+10. (guo2015yeastfabthedesign pages 2-3): Yakun Guo, Junkai Dong, Tong Zhou, Jamie Auxillos, Tianyi Li, Wei-Meng Zhang, Lihui Wang, Yue Shen, Yisha Luo, Yijing Zheng, Jiwei Lin, Guoqiang Chen, Qingyu Wu, Yizhi Cai, and Junbiao Dai. Yeastfab: the design and construction of standard biological parts for metabolic engineering in saccharomyces cerevisiae. Nucleic Acids Research, 43:e88-e88, May 2015. URL: https://doi.org/10.1093/nar/gkv464, doi:10.1093/nar/gkv464. This article has 177 citations and is from a highest quality peer-reviewed journal.
+
+11. (qiu2019biosensorsdesignin pages 27-27): Chenxi Qiu, Haotian Zhai, and Jin Hou. Biosensors design in yeast and applications in metabolic engineering. FEMS yeast research, Nov 2019. URL: https://doi.org/10.1093/femsyr/foz082, doi:10.1093/femsyr/foz082. This article has 54 citations and is from a peer-reviewed journal.
+
+12. (curran2015shortsyntheticterminators pages 1-2): Kathleen A. Curran, Nicholas J. Morse, Kelly A. Markham, Allison M. Wagman, Akash Gupta, and Hal S. Alper. Short synthetic terminators for improved heterologous gene expression in yeast. ACS synthetic biology, 4 7:824-32, Feb 2015. URL: https://doi.org/10.1021/sb5003357, doi:10.1021/sb5003357. This article has 282 citations and is from a domain leading peer-reviewed journal.
+
+13. (curran2015shortsyntheticterminators pages 4-5): Kathleen A. Curran, Nicholas J. Morse, Kelly A. Markham, Allison M. Wagman, Akash Gupta, and Hal S. Alper. Short synthetic terminators for improved heterologous gene expression in yeast. ACS synthetic biology, 4 7:824-32, Feb 2015. URL: https://doi.org/10.1021/sb5003357, doi:10.1021/sb5003357. This article has 282 citations and is from a domain leading peer-reviewed journal.
+
+14. (hryc2023structuralinsightsinto pages 2-3): Corey F. Hryc, Venkata K. P. S. Mallampalli, Evgeniy I. Bovshik, Stavros Azinas, Guizhen Fan, Irina I. Serysheva, Genevieve C. Sparagna, Matthew L. Baker, Eugenia Mileykovskaya, and William Dowhan. Structural insights into cardiolipin replacement by phosphatidylglycerol in a cardiolipin-lacking yeast respiratory supercomplex. Nature Communications, May 2023. URL: https://doi.org/10.1038/s41467-023-38441-5, doi:10.1038/s41467-023-38441-5. This article has 34 citations and is from a highest quality peer-reviewed journal.
+
+15. (guerracastellano2024unveilingtherole pages 1-3): Alejandra Guerra-Castellano, Manuel Aneas, Joaquin Tamargo-Azpilicueta, Inmaculada Marquez, Jose Luis Olloqui-Sariego, Juan Jose Calvente, Miguel A. De la Rosa, and Irene Diaz Moreno. Unveiling the role of yeast cytochrome c isoforms in the assembly of mitochondrial supercomplexes and the control of respiratory chain rate. bioRxiv, Jul 2024. URL: https://doi.org/10.1101/2024.07.13.603375, doi:10.1101/2024.07.13.603375. This article has 1 citations.
+
+16. (eldeeb2024bioengineeredyeasttethered pages 1-4): Mazzen H. Eldeeb, Zoe Cosner, Andreas Carlstrom, Jeffri-Noelle Mays, Gabriella F. Rodriguez, Jens Berndtsson, Martin Ott, and Flavia Fontanesi. Bioengineered yeast tethered respiratory supercomplexes reveal mechanisms governing efficient substrate utilization. bioRxiv, Dec 2024. URL: https://doi.org/10.1101/2024.12.19.629262, doi:10.1101/2024.12.19.629262. This article has 0 citations.
+
+17. (martinez2024yeastzinccluster pages 1-2): Karla Páez Martinez, Najla Gasmi, Célia Jeronimo, Natalia Klimova, François Robert, and Bernard Turcotte. Yeast zinc cluster transcription factors involved in the switch from fermentation to respiration show interdependency for dna binding revealing a novel type of dna recognition. Nucleic Acids Research, 52:2242-2259, Dec 2024. URL: https://doi.org/10.1093/nar/gkad1185, doi:10.1093/nar/gkad1185. This article has 7 citations and is from a highest quality peer-reviewed journal.
+
+18. (wang1996sequencerequirementsfor pages 1-2): Xiaoye Wang, Mark E. Dumont, and Fred Sherman. Sequence requirements for mitochondrial import of yeast cytochrome c(*). The Journal of Biological Chemistry, 271:6594-6604, Mar 1996. URL: https://doi.org/10.1074/jbc.271.12.6594, doi:10.1074/jbc.271.12.6594. This article has 46 citations.
+
+19. (zhang2015substraterecognitionby pages 39-44): Yulin Zhang. Substrate recognition by holocytochrome c synthase in cytochrome c biogenesis system iii. Dissertation, Jan 2015. URL: https://doi.org/10.5287/ora-jnoyq87ry, doi:10.5287/ora-jnoyq87ry. This article has 0 citations.
+
+20. (martinez2024yeastzinccluster pages 2-3): Karla Páez Martinez, Najla Gasmi, Célia Jeronimo, Natalia Klimova, François Robert, and Bernard Turcotte. Yeast zinc cluster transcription factors involved in the switch from fermentation to respiration show interdependency for dna binding revealing a novel type of dna recognition. Nucleic Acids Research, 52:2242-2259, Dec 2024. URL: https://doi.org/10.1093/nar/gkad1185, doi:10.1093/nar/gkad1185. This article has 7 citations and is from a highest quality peer-reviewed journal.
+
+21. (hryc2023structuralinsightsinto pages 1-2): Corey F. Hryc, Venkata K. P. S. Mallampalli, Evgeniy I. Bovshik, Stavros Azinas, Guizhen Fan, Irina I. Serysheva, Genevieve C. Sparagna, Matthew L. Baker, Eugenia Mileykovskaya, and William Dowhan. Structural insights into cardiolipin replacement by phosphatidylglycerol in a cardiolipin-lacking yeast respiratory supercomplex. Nature Communications, May 2023. URL: https://doi.org/10.1038/s41467-023-38441-5, doi:10.1038/s41467-023-38441-5. This article has 34 citations and is from a highest quality peer-reviewed journal.
+
+22. (eldeeb2024bioengineeredyeasttethered pages 33-35): Mazzen H. Eldeeb, Zoe Cosner, Andreas Carlstrom, Jeffri-Noelle Mays, Gabriella F. Rodriguez, Jens Berndtsson, Martin Ott, and Flavia Fontanesi. Bioengineered yeast tethered respiratory supercomplexes reveal mechanisms governing efficient substrate utilization. bioRxiv, Dec 2024. URL: https://doi.org/10.1101/2024.12.19.629262, doi:10.1101/2024.12.19.629262. This article has 0 citations.
+
+23. (hryc2023structuralinsightsinto media ef369fac): Corey F. Hryc, Venkata K. P. S. Mallampalli, Evgeniy I. Bovshik, Stavros Azinas, Guizhen Fan, Irina I. Serysheva, Genevieve C. Sparagna, Matthew L. Baker, Eugenia Mileykovskaya, and William Dowhan. Structural insights into cardiolipin replacement by phosphatidylglycerol in a cardiolipin-lacking yeast respiratory supercomplex. Nature Communications, May 2023. URL: https://doi.org/10.1038/s41467-023-38441-5, doi:10.1038/s41467-023-38441-5. This article has 34 citations and is from a highest quality peer-reviewed journal.
+
+## Citations
+
+1. wang1996sequencerequirementsfor pages 4-4
+2. allen2011cytochromecbiogenesis pages 1-2
+3. brzezinski2021structureandmechanism pages 2-3
+4. allen2011cytochromecbiogenesis pages 9-11
+5. corvest2010ctypecytochromeassembly pages 2-3
+6. verissimo2012engineeringaprokaryotic pages 6-8
+7. dassa2005functionalcharacterizationand pages 1-2
+8. feng2021saccharomycescerevisiaepromoter pages 15-16
+9. feng2021saccharomycescerevisiaepromoter pages 6-8
+10. guo2015yeastfabthedesign pages 2-3
+11. qiu2019biosensorsdesignin pages 27-27
+12. curran2015shortsyntheticterminators pages 1-2
+13. curran2015shortsyntheticterminators pages 4-5
+14. hryc2023structuralinsightsinto pages 2-3
+15. guerracastellano2024unveilingtherole pages 1-3
+16. eldeeb2024bioengineeredyeasttethered pages 1-4
+17. martinez2024yeastzinccluster pages 1-2
+18. wang1996sequencerequirementsfor pages 1-2
+19. zhang2015substraterecognitionby pages 39-44
+20. martinez2024yeastzinccluster pages 2-3
+21. hryc2023structuralinsightsinto pages 1-2
+22. eldeeb2024bioengineeredyeasttethered pages 33-35
+23. Fe(II)
+24. https://doi.org/10.1021/sb5003357
+25. https://doi.org/10.1038/s41467-023-38441-5
+26. https://doi.org/10.1101/2024.07.13.603375
+27. https://doi.org/10.1101/2024.12.19.629262
+28. https://doi.org/10.1093/nar/gkad1185
+29. https://doi.org/10.1093/nar/gkv464
+30. https://doi.org/10.1021/acs.chemrev.1c00140
+31. https://doi.org/10.1111/j.1742-4658.2011.08231.x
+32. https://doi.org/10.1074/jbc.271.12.6594
+33. https://doi.org/10.1016/j.pep.2004.12.019
+34. https://doi.org/10.1534/genetics.110.120022
+35. https://doi.org/10.1016/j.bbrc.2012.06.088
+36. https://doi.org/10.3390/biology10060504
+37. https://doi.org/10.1093/femsyr/foz082
+38. https://doi.org/10.1074/jbc.271.12.6594,
+39. https://doi.org/10.1111/j.1742-4658.2011.08231.x,
+40. https://doi.org/10.1021/acs.chemrev.1c00140,
+41. https://doi.org/10.1534/genetics.110.120022,
+42. https://doi.org/10.1016/j.bbrc.2012.06.088,
+43. https://doi.org/10.1016/j.pep.2004.12.019,
+44. https://doi.org/10.3390/biology10060504,
+45. https://doi.org/10.1093/nar/gkv464,
+46. https://doi.org/10.1093/femsyr/foz082,
+47. https://doi.org/10.1021/sb5003357,
+48. https://doi.org/10.1038/s41467-023-38441-5,
+49. https://doi.org/10.1101/2024.07.13.603375,
+50. https://doi.org/10.1101/2024.12.19.629262,
+51. https://doi.org/10.1093/nar/gkad1185,
+52. https://doi.org/10.5287/ora-jnoyq87ry,

--- a/genes/yeast/HSP26/HSP26-ai-review.html
+++ b/genes/yeast/HSP26/HSP26-ai-review.html
@@ -671,33 +671,33 @@
     <div class="header">
         <h1>HSP26</h1>
         <div class="gene-info">
-            
+
             <div class="info-item">
-                
+
                 <span class="info-label">UniProt ID:</span>
                 <span>
                     <a href="https://www.uniprot.org/uniprotkb/P15992" target="_blank" class="term-link">
                         P15992
                     </a>
                 </span>
-                
+
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Organism:</span>
                 <span>Saccharomyces cerevisiae</span>
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
                 <span class="status-badge status-complete">
                     COMPLETE
                 </span>
             </div>
-            
-            
+
+
         </div>
         <div style="margin-top: 1rem; text-align: center;">
             <a id="feedback-form-link"
@@ -728,7 +728,7 @@
         </div>
     </div>
 
-    
+
     <div class="description-card">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <h2>Gene Description</h2>
@@ -739,14 +739,14 @@
         </div>
         <p>HSP26 is the sole small heat shock protein (sHSP) of Saccharomyces cerevisiae, belonging to the conserved HSP20/alpha-crystallin superfamily. It functions as a temperature-regulated molecular chaperone with holdase activity: at heat shock temperatures, the 24-mer oligomeric storage complex dissociates, and the resulting smaller species bind non-native proteins to prevent their irreversible aggregation (PMID:10581247). This holdase activity is ATP-independent and mechanistically distinct from foldase chaperones (e.g., HSP70, GroEL). HSP26 does not actively refold substrates or escort them between compartments; rather, it maintains client proteins in a soluble, folding-competent state in situ until ATP-dependent chaperones (HSP70/HSP104) can mediate refolding. HSP26 forms large oligomeric complexes (&gt;500 kD) and is induced by heat shock and other stress conditions. Its intracellular localization (cytoplasm vs. nucleus) varies with the metabolic state of the cell (PMID:2645298). HSP26 also localizes to stress granules during severe heat stress (PMID:24291094). Unexpectedly, Hsp26 was identified as a novel RNA-binding protein that co-purifies with a small set of specific mRNAs (PMID:20844764), though this activity is likely moonlighting rather than a core function.</p>
     </div>
-    
 
-    
 
-    
+
+
+
     <div class="section">
         <h2 class="section-title">Proposed New Ontology Terms</h2>
-        
+
         <div class="proposed-term">
             <div style="display: flex; justify-content: space-between; align-items: center;">
                 <h3>holdase chaperone activity</h3>
@@ -756,41 +756,41 @@
                 </span>
             </div>
 
-            
+
             <p><strong>Definition:</strong> Binding to an unfolded or misfolded protein to prevent its aggregation without actively catalyzing refolding. The holdase maintains the client protein in a soluble, folding-competent state. This is mechanistically distinct from foldase activity (GO:0044183) and from carrier- holdase activity (GO:0140309).</p>
-            
 
-            
+
+
             <p><strong>Justification:</strong> HSP26 and other sHSPs (CRYAA, CRYAB, HSPB6 in human) are canonical in-situ holdases that cannot be properly annotated with existing GO terms. GO:0051082 is proposed for obsoletion, GO:0044183 implies active refolding, and GO:0140309 is carrier-specific. See UPB project and go-ontology#30552.</p>
-            
 
-            
 
-            
 
-            
+
+
+
+
             <p><strong>Supporting Evidence:</strong></p>
             <ul style="margin-left: 1rem;">
-                
+
                 <li>
-                    
+
                     <a href="https://pubmed.ncbi.nlm.nih.gov/10581247" target="_blank" class="term-link">
                         PMID:10581247
                     </a>
-                    
-                    
-                    : Several sHsps have been shown to exhibit chaperone activity and protect proteins from irreversible aggregation in vitro. Here we show that Hsp26, an sHsp from Saccharomyces cerevisiae, is a temperature-regulated molecular chaperone.
-                    
-                </li>
-                
-            </ul>
-            
-        </div>
-        
-    </div>
-    
 
-    
+
+                    : Several sHsps have been shown to exhibit chaperone activity and protect proteins from irreversible aggregation in vitro. Here we show that Hsp26, an sHsp from Saccharomyces cerevisiae, is a temperature-regulated molecular chaperone.
+
+                </li>
+
+            </ul>
+
+        </div>
+
+    </div>
+
+
+
     <div class="section">
         <h2 class="section-title">Existing Annotations Review</h2>
         <table class="annotations-table">
@@ -803,32 +803,32 @@
                 </tr>
             </thead>
             <tbody>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                     GO:0006457
                                 </a>
                             </span>
                             <span class="term-label">protein folding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -840,75 +840,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation from ARBA machine learning models mapping HSP26 to protein folding. HSP26 is an sHSP holdase that prevents aggregation of unfolded proteins but does not actively assist protein folding (refolding requires the HSP70/HSP104 disaggregase system). The term &#34;protein folding&#34; (GO:0006457) implies active assistance in acquiring correct tertiary structure, which does not match HSP26 holdase mechanism. However, this IEA is broader than the IDA annotation for the same term (see below), and both share the same concern.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> HSP26 is a holdase, not a foldase. It prevents aggregation of non-native proteins but does not actively catalyze protein folding. The GO:0006457 definition states &#34;assisting in the covalent and noncovalent assembly of single chain polypeptides or multisubunit complexes into the correct tertiary structure,&#34; which better describes ATP-dependent foldase chaperones like GroEL/ES or HSP70. HSP26 maintains substrates in a folding-competent state for later refolding by other chaperones. The IEA mapping is too generous here. A more appropriate BP annotation would be to a process term reflecting prevention of protein aggregation under stress.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10581247" target="_blank" class="term-link">
                                         PMID:10581247
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Hsp26, an sHsp from Saccharomyces cerevisiae, is a temperature-regulated molecular chaperone. Like other sHsps, Hsp26 forms large oligomeric complexes. At heat shock temperatures, however, the 24mer chaperone complex dissociates. ... Binding of non-native proteins to dissociated Hsp26 produces large globular assemblies</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16429126" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16429126
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Proteome survey reveals modularity of the yeast cell machine...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -920,75 +920,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Protein binding annotation from the Gavin et al. (2006) large-scale TAP-tag affinity purification/mass spectrometry study of yeast protein complexes. HSP26 was identified as co-purifying with SSA2 (P10592) and VMA2 (P16140) in this study. While HSP26 does physically interact with proteins (both substrates and other chaperones), GO:0005515 &#34;protein binding&#34; is uninformative and does not capture the mechanistic nature of these interactions.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 &#34;protein binding&#34; is too vague. For a chaperone like HSP26, the relevant molecular function is its holdase activity -- binding unfolded/misfolded proteins to prevent aggregation. The interactions detected in large-scale co-purification studies may reflect chaperone-substrate relationships (e.g., with SSA2, an HSP70 family member) or other associations. A more informative annotation would capture the holdase mechanism. Per curation guidelines, &#34;protein binding&#34; should be avoided in favor of more specific terms.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/16429126" target="_blank" class="term-link">
                                         PMID:16429126
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Protein complexes are key molecular entities that integrate multiple gene products to perform cellular functions. Here we report the first genome-wide screen for complexes in an organism, budding yeast, using affinity purification and mass spectrometry.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16554755" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16554755
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Global landscape of protein complexes in the yeast Saccharom...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1000,75 +1000,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Protein binding annotation from Krogan et al. (2006) large-scale TAP-tag study of yeast protein complexes. Multiple interaction partners were detected (ADH3, EMW1, FUS3, NEW1, POL32, RNR1, RTT101, SGV1, SME1, TFB4, UPC2, VMA2). As a chaperone, HSP26 is expected to interact with many proteins, but GO:0005515 does not meaningfully describe the nature of these interactions.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Same rationale as above. GO:0005515 is uninformative for a chaperone. Many of these interaction partners may represent chaperone substrates or indirect associations from large-scale co-purification. HSP26 was classified as a &#34;specific chaperone&#34; with fewer than 200 non-chaperone interactors in the comprehensive chaperone atlas (PMID:19536198), consistent with its selective holdase function.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/19536198" target="_blank" class="term-link">
                                         PMID:19536198
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">the specific chaperones are (ordered from low to high number of interactors): Hsp32, Sno4, Hsp33, Tim14, Mdj2, Jac1, Cwc23, Jid1, Mcx1, Mdj1, Jjj2, Hlj1, Jjj3, Erj5, Ssc3, Kar2, Lhs1, Hsp26, Jem1, Jjj1, Xdj1, Hsp12, Hsp60</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19536198" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19536198
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     An atlas of chaperone-protein interactions in Saccharomyces ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1080,75 +1080,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Protein binding annotation from Gong et al. (2009), a comprehensive TAP-tag based chaperone interaction atlas covering all 63 yeast chaperones. HSP26 was classified as a &#34;specific chaperone&#34; with fewer than 200 interactors. Multiple interaction partners were detected. This study provides excellent systems-level context for HSP26 as a chaperone but GO:0005515 remains uninformative.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0005515 does not capture the chaperone-substrate nature of these interactions. This study specifically characterizes HSP26 as a molecular chaperone with selective substrate binding. A more specific MF term reflecting holdase activity would be more appropriate.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/19536198" target="_blank" class="term-link">
                                         PMID:19536198
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Molecular chaperones are defined as a group of highly interactive proteins that modulate the folding and unfolding of other proteins ... We expect that most of the chaperone interactors represent putative substrates whose conformational stability is modulated by molecular chaperones</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
                                     GO:0042802
                                 </a>
                             </span>
                             <span class="term-label">identical protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16843901" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16843901
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Multiple distinct assemblies reveal conformational flexibili...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1160,88 +1160,88 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Identical protein binding annotation based on White et al. (2006), which used cryo-EM to characterize Hsp26 oligomeric assemblies. The study demonstrated that Hsp26 forms 24-subunit assemblies with tetrahedral symmetry, composed of asymmetric dimers, confirming self-association. This homo-oligomerization is integral to Hsp26 chaperone function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> HSP26 homo-oligomerization is well-established and functionally critical. The 24-mer complex is the storage form that dissociates at heat shock temperatures to become the active holdase species. The cryo-EM structural data directly demonstrates identical protein binding through dimer and trimer contacts. While GO:0042802 is somewhat generic, it correctly captures the self-association that is a defining structural feature of sHSPs.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/16843901" target="_blank" class="term-link">
                                         PMID:16843901
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Cryo-electron microscopy of yeast Hsp26 reveals two distinct forms, each comprising 24 subunits arranged in a porous shell with tetrahedral symmetry. The subunits form elongated, asymmetric dimers that assemble via trimeric contacts.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10581247" target="_blank" class="term-link">
                                         PMID:10581247
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Like other sHsps, Hsp26 forms large oligomeric complexes. At heat shock temperatures, however, the 24mer chaperone complex dissociates.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
                                     GO:0042802
                                 </a>
                             </span>
                             <span class="term-label">identical protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/18719252" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:18719252
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     High-quality binary protein interaction map of the yeast int...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1253,75 +1253,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Identical protein binding annotation from Yu et al. (2008), a high-quality binary yeast interactome study. HSP26-HSP26 self-interaction was detected, consistent with the known oligomeric nature of Hsp26.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This binary interaction study independently confirms HSP26 homo-oligomerization, which is consistent with the well-characterized 24-mer structure from cryo-EM (PMID:16843901). Duplicate evidence for the same GO term is appropriate when from independent experimental sources.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/16843901" target="_blank" class="term-link">
                                         PMID:16843901
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Cryo-electron microscopy of yeast Hsp26 reveals two distinct forms, each comprising 24 subunits arranged in a porous shell with tetrahedral symmetry.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0010494" target="_blank" class="term-link">
                                     GO:0010494
                                 </a>
                             </span>
                             <span class="term-label">cytoplasmic stress granule</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/26777405" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:26777405
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     ATPase-Modulated Stress Granules Contain a Diverse Proteome ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1333,75 +1333,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HDA annotation from Jain et al. (2016) large-scale proteomic analysis of stress granule cores. This study used super-resolution microscopy and mass spectrometry to characterize stress granule composition, identifying molecular chaperones as conserved stress granule components.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Stress granule localization is consistent with HSP26 function as a stress-responsive chaperone. The Jain et al. study is a rigorous proteomic analysis of stress granule composition, and the finding is independently supported by direct IDA evidence from Cherkasov et al. (PMID:24291094), which showed heat stress granules contain molecular chaperones that coassemble with aggregates of misfolded proteins.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/26777405" target="_blank" class="term-link">
                                         PMID:26777405
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Proteomic analysis of stress granule cores reveals a dense network of protein-protein interactions and links between stress granules and human diseases and identifies ATP-dependent helicases and protein remodelers as conserved stress granule components.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
                                     GO:0005739
                                 </a>
                             </span>
                             <span class="term-label">mitochondrion</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24769239" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:24769239
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Quantitative variations of the mitochondrial proteome and ph...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -1413,88 +1413,88 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HDA annotation from Renvoise et al. (2014) quantitative mitochondrial proteomics study. HSP26 was detected in isolated mitochondrial fractions by mass spectrometry. However, HSP26 is primarily a cytoplasmic protein, and mitochondrial detection in large-scale proteomics may reflect contamination or transient association rather than bona fide mitochondrial localization.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> HSP26 is primarily cytoplasmic and nuclear (PMID:2645298), with stress granule localization under heat stress. Detection in mitochondrial fractions from a quantitative proteomics study could represent genuine low-level mitochondrial association (e.g., chaperoning mitochondrial surface proteins during stress) or co-purification artifact. UniProt does not list mitochondrial localization. This is not a core localization but may represent a minor or transient association, so it should be kept as non-core rather than removed.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/24769239" target="_blank" class="term-link">
                                         PMID:24769239
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Label free quantitative analysis of protein accumulation revealed significant variation of 176 mitochondrial proteins</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/2645298" target="_blank" class="term-link">
                                         PMID:2645298
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">When log-phase cells growing in glucose were heat shocked, hsp26 concentrated in nuclei ... in early stationary-phase cells hsp26 is induced at normal growth temperatures. This protein was generally distributed throughout the cells</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/11914276" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:11914276
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Subcellular localization of the yeast proteome.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1506,88 +1506,88 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HDA annotation from Kumar et al. (2002) proteome-wide subcellular localization study using epitope-tagged proteins and immunolocalization. HSP26 was detected in the cytoplasm.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytoplasmic localization is well-established for HSP26 and is its primary localization. This is confirmed by multiple independent studies including direct IDA evidence (PMID:2645298) and the UniProt record. The large-scale localization study provides additional support.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/11914276" target="_blank" class="term-link">
                                         PMID:11914276
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Here, we report the first proteome-scale analysis of protein localization within any eukaryote. ... we have determined the subcellular localization of 2744 yeast proteins.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/2645298" target="_blank" class="term-link">
                                         PMID:2645298
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">in early stationary-phase cells hsp26 is induced at normal growth temperatures. This protein was generally distributed throughout the cells</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0010494" target="_blank" class="term-link">
                                     GO:0010494
                                 </a>
                             </span>
                             <span class="term-label">cytoplasmic stress granule</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24291094" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:24291094
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Coordination of translational control and protein homeostasi...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1599,75 +1599,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation from Cherkasov et al. (2013), which demonstrated that yeast heat stress granules contain molecular chaperones and coassemble with aggregates of misfolded proteins. The study showed that heat-SG disassembly requires Hsp104 and Hsp70 activity.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Direct experimental evidence for HSP26 localization to stress granules during severe heat stress. This is mechanistically coherent with HSP26 holdase function, as stress granules form under conditions where protein aggregation occurs and translation is inhibited. The colocalization with misfolded protein aggregates is especially relevant to HSP26 chaperone activity.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/24291094" target="_blank" class="term-link">
                                         PMID:24291094
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">both S. cerevisiae and D. melanogaster heat-SGs contain mRNA, translation machinery components (excluding ribosomes), and molecular chaperones and that heat-SGs coassemble with aggregates of misfolded, heat-labile proteins</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034605" target="_blank" class="term-link">
                                     GO:0034605
                                 </a>
                             </span>
                             <span class="term-label">cellular response to heat</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10581247" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:10581247
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Hsp26: a temperature-regulated chaperone.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1679,75 +1679,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation from Haslbeck et al. (1999), the seminal study demonstrating HSP26 is a temperature-regulated chaperone. The study showed that Hsp26 chaperone activity is temperature-dependent: the 24-mer dissociates at heat shock temperatures, and this dissociation is a prerequisite for efficient chaperone activity.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> HSP26 is one of the major proteins produced on heat shock (UniProt) and its chaperone activity is directly activated by elevated temperature through oligomer dissociation. This is a core biological process for HSP26 -- it is a heat shock protein whose functional activation is temperature-regulated. The evidence directly demonstrates temperature-dependent functional changes.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10581247" target="_blank" class="term-link">
                                         PMID:10581247
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Hsp26, an sHsp from Saccharomyces cerevisiae, is a temperature-regulated molecular chaperone. ... the dissociation of the Hsp26 complex at heat shock temperatures is a prerequisite for efficient chaperone activity</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003729" target="_blank" class="term-link">
                                     GO:0003729
                                 </a>
                             </span>
                             <span class="term-label">mRNA binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20844764" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20844764
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Proteome-wide search reveals unexpected RNA-binding proteins...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -1759,75 +1759,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation from Tsvetanova et al. (2010), a proteome-wide search for RNA-binding proteins using protein microarrays and IP-microarray validation. HSP26 was identified as a novel RBP that co-purified with 279 specific mRNAs (FDR less than 0.01%). The study describes HSP26 as a &#34;chaperone; heat shock response&#34; protein and notes it &#34;co-purified with smaller sets of mRNAs, but these small sets of putative mRNA targets shared distinct functional and/or cytotopical themes.&#34; HSP26 lacks any known RNA-binding domain.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> While the experimental evidence is sound (validated by IP-microarray with replicate experiments and stringent FDR cutoffs), mRNA binding is likely a moonlighting activity rather than a core function of HSP26. HSP26 lacks canonical RNA-binding domains, and the authors themselves describe it among &#34;unexpected&#34; RNA-binding proteins. The primary function of HSP26 is as a holdase chaperone for unfolded proteins. The mRNA binding may reflect the broad substrate-binding properties of chaperones, or a secondary regulatory role. Many chaperones have been found to associate with RNA in proteome-wide screens.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/20844764" target="_blank" class="term-link">
                                         PMID:20844764
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Other candidate RBPs (Vtc1, Arc15, Hsp26, Arp8, Gis2) co-purified with smaller sets of mRNAs, but these small sets of putative mRNA targets shared distinct functional and/or cytotopical themes, increasing our confidence that the RNA-protein interactions we observed were genuine.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/2645298" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:2645298
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The intracellular location of yeast heat-shock protein 26 va...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -1839,88 +1839,88 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation from Rossi and Lindquist (1989), which showed that HSP26 intracellular localization varies with the metabolic state of the cell. In log-phase cells growing in glucose after heat shock, HSP26 concentrated in nuclei. However, this nuclear concentration was condition-dependent and did not occur in cells grown in galactose or acetate, or in mitochondrial mutants.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Nuclear localization of HSP26 is condition-dependent rather than constitutive. HSP26 concentrates in nuclei only in log-phase glucose-grown cells after heat shock; under other metabolic conditions it remains generally distributed throughout the cell. This represents a conditional localization rather than a core cellular component, so it should be retained but marked as non-core.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/2645298" target="_blank" class="term-link">
                                         PMID:2645298
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">When log-phase cells growing in glucose were heat shocked, hsp26 concentrated in nuclei and continued to concentrate in nuclei when these cells were returned to normal temperatures for recovery. However, hsp26 did not concentrate in nuclei under a variety of other conditions.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/2645298" target="_blank" class="term-link">
                                         PMID:2645298
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">We conclude that the intracellular location of hsp26 in yeast depends upon the physiological state of the cell and not simply upon the presence or absence of heat stress.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/2645298" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:2645298
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The intracellular location of yeast heat-shock protein 26 va...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1932,75 +1932,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation from Rossi and Lindquist (1989) demonstrating cytoplasmic localization of HSP26. The protein was generally distributed throughout the cytoplasm, particularly in stationary-phase cells and under most metabolic conditions.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytoplasm is the primary and constitutive localization of HSP26. Under most physiological conditions, HSP26 is distributed throughout the cytoplasm. This is the core cellular component for HSP26 function as a cytoplasmic holdase chaperone.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/2645298" target="_blank" class="term-link">
                                         PMID:2645298
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">in early stationary-phase cells hsp26 is induced at normal growth temperatures. This protein was generally distributed throughout the cells, even after heat shock.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                     GO:0006457
                                 </a>
                             </span>
                             <span class="term-label">protein folding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10581247" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:10581247
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Hsp26: a temperature-regulated chaperone.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -2012,86 +2012,86 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation from Haslbeck et al. (1999) based on in vitro chaperone assays demonstrating that Hsp26 protects proteins from irreversible aggregation. The term &#34;protein folding&#34; is applied here, but the actual experimental evidence shows holdase activity (aggregation prevention), not active refolding. sHSPs maintain substrates in a folding-competent state but require HSP70/HSP104 for actual refolding.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The experimental evidence in PMID:10581247 demonstrates that HSP26 prevents irreversible aggregation of non-native proteins. This is holdase activity, not protein folding per se. GO:0006457 &#34;protein folding&#34; implies active assistance in acquiring correct tertiary structure, which better describes ATP-dependent foldases. HSP26 functions upstream of refolding by maintaining substrates in a soluble, folding-competent state. A more accurate BP annotation would be &#34;chaperone-mediated protein complex assembly&#34; (GO:0051131) or ideally a BP term for &#34;prevention of protein aggregation,&#34; though no such specific term currently exists. As an interim measure, &#34;protein folding&#34; is overly generous but not entirely wrong since HSP26 participates in the broader proteostasis pathway that includes folding.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051131" target="_blank" class="term-link">
                                     chaperone-mediated protein complex assembly
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10581247" target="_blank" class="term-link">
                                         PMID:10581247
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Several sHsps have been shown to exhibit chaperone activity and protect proteins from irreversible aggregation in vitro. ... Binding of non-native proteins to dissociated Hsp26 produces large globular assemblies ... In this complex one monomer of substrate is bound per Hsp26 dimer.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10581247" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:10581247
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Hsp26: a temperature-regulated chaperone.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -2103,87 +2103,98 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA annotation from Haslbeck et al. (1999), the key study demonstrating HSP26 chaperone activity. The study showed that at heat shock temperatures, Hsp26 24-mer dissociates and the resulting active species binds non-native proteins, forming large chaperone-substrate complexes with a 1:2 substrate:Hsp26 stoichiometry. This is canonical holdase activity: binding unfolded/misfolded proteins to prevent their irreversible aggregation, without actively catalyzing refolding. HSP26 is ATP-independent and does not escort substrates between cellular compartments. Per the UPB project, GO:0051082 is proposed for obsoletion (go-ontology#30962). The appropriate replacement is a general &#34;holdase chaperone activity&#34; NTR. GO:0140309 &#34;unfolded protein carrier activity&#34; does NOT fit because it was created specifically for TIM carrier-holdases that escort proteins between compartments (go-ontology#30552), and HSP26 is an in-situ holdase.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> HSP26 is a canonical in-situ holdase chaperone. GO:0051082 &#34;unfolded protein binding&#34; is proposed for obsoletion and is too vague -- it is a binding term that does not distinguish holdase from foldase from sensor mechanisms. The best replacement would be the proposed &#34;holdase chaperone activity&#34; NTR (an activity term for ATP-independent prevention of protein aggregation in situ). GO:0140309 &#34;unfolded protein carrier activity&#34; does NOT fit because (1) its definition requires escort &#34;between two different cellular components,&#34; (2) it is a child of GO:0140597 &#34;protein carrier chaperone,&#34; and (3) HSP26 prevents aggregation in situ without transporting substrates between compartments. Until the holdase NTR is created, GO:0051082 should be retained as an interim annotation. GO:0044183 &#34;protein folding chaperone&#34; is also inappropriate because HSP26 does not actively fold proteins.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="#" target="_blank" class="term-link">
                                     holdase chaperone activity (NTR needed; GO:0140309 does not fit -- carrier-specific)
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10581247" target="_blank" class="term-link">
                                         PMID:10581247
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Several sHsps have been shown to exhibit chaperone activity and protect proteins from irreversible aggregation in vitro. Here we show that Hsp26, an sHsp from Saccharomyces cerevisiae, is a temperature-regulated molecular chaperone.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10581247" target="_blank" class="term-link">
                                         PMID:10581247
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Binding of non-native proteins to dissociated Hsp26 produces large globular assemblies with a structure that appears to be completely reorganized relative to the original Hsp26 oligomers. In this complex one monomer of substrate is bound per Hsp26 dimer.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/16843901" target="_blank" class="term-link">
                                         PMID:16843901
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Hinge points between the domains allow a variety of assembly contacts, providing the flexibility required for formation of supercomplexes with non-native proteins.</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/HSP26/HSP26-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Hsp26 is an ATP-independent holdase that binds nonnative proteins and suppresses aggregation during heat stress.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
             </tbody>
         </table>
     </div>
-    
 
-    
+
+
     <div class="section">
         <h2 class="section-title">Core Functions</h2>
-        
+
         <div class="core-function-card">
-            
+
             <div style="display: flex; justify-content: space-between; align-items: center;">
                 <h3>HSP26 is an ATP-independent holdase chaperone that binds unfolded/misfolded proteins to prevent their irreversible aggregation. At heat shock temperatures, the 24-mer storage complex dissociates into active species that bind non-native proteins with 1:2 substrate:Hsp26 stoichiometry. This is the core molecular function of HSP26. GO:0051082 is used as interim until a holdase NTR is created; GO:0140309 does not fit (carrier-specific). GO:0044183 does not fit (HSP26 does not actively refold).</h3>
                 <span class="vote-buttons" data-g="P15992" data-a="FUNCTION: HSP26 is an ATP-independent holdase chaperone that..." data-r="" data-act="CORE_FUNCTION">
@@ -2191,10 +2202,10 @@
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
             </div>
-            
+
 
             <div class="core-function-terms">
-                
+
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
@@ -2203,81 +2214,92 @@
                         </a>
                     </span>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Directly Involved In:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034605" target="_blank" class="term-link">
                                 cellular response to heat
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Cellular Locations:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                 cytoplasm
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
 
-                
+
+
+
             </div>
 
-            
+
             <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
                 <strong>Supporting Evidence:</strong>
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10581247" target="_blank" class="term-link">
                                 PMID:10581247
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">Hsp26, an sHsp from Saccharomyces cerevisiae, is a temperature-regulated molecular chaperone. ... Binding of non-native proteins to dissociated Hsp26 produces large globular assemblies</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16843901" target="_blank" class="term-link">
                                 PMID:16843901
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">Hinge points between the domains allow a variety of assembly contacts, providing the flexibility required for formation of supercomplexes with non-native proteins.</div>
-                        
+
                     </li>
-                    
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:yeast/HSP26/HSP26-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">Hsp26 is an ATP-independent holdase that binds nonnative proteins and suppresses aggregation during heat stress.</div>
+
+                    </li>
+
                 </ul>
             </div>
-            
+
         </div>
-        
+
         <div class="core-function-card">
-            
+
             <div style="display: flex; justify-content: space-between; align-items: center;">
                 <h3>HSP26 forms large homo-oligomeric 24-mer complexes with tetrahedral symmetry. Self-association is essential for its chaperone function: the 24-mer serves as a storage/inactive form, and temperature-dependent dissociation produces the active holdase species.</h3>
                 <span class="vote-buttons" data-g="P15992" data-a="FUNCTION: HSP26 forms large homo-oligomeric 24-mer complexes..." data-r="" data-act="CORE_FUNCTION">
@@ -2285,10 +2307,10 @@
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
             </div>
-            
+
 
             <div class="core-function-terms">
-                
+
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
@@ -2297,391 +2319,416 @@
                         </a>
                     </span>
                 </div>
-                
 
-                
 
-                
 
-                
 
-                
+
+
+
+
+
             </div>
 
-            
+
             <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
                 <strong>Supporting Evidence:</strong>
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16843901" target="_blank" class="term-link">
                                 PMID:16843901
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">Cryo-electron microscopy of yeast Hsp26 reveals two distinct forms, each comprising 24 subunits arranged in a porous shell with tetrahedral symmetry.</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10581247" target="_blank" class="term-link">
                                 PMID:10581247
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">the 24mer chaperone complex dissociates ... the dissociation of the Hsp26 complex at heat shock temperatures is a prerequisite for efficient chaperone activity</div>
-                        
+
                     </li>
-                    
+
                 </ul>
             </div>
-            
-        </div>
-        
-    </div>
-    
 
-    
+        </div>
+
+    </div>
+
+
+
     <div class="section">
         <h2 class="section-title collapsible">References</h2>
         <div class="collapse-content">
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
+                        file:yeast/HSP26/HSP26-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research report for HSP26</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Falcon supports HSP26 as an ATP-independent small heat-shock holdase chaperone that suppresses aggregation of nonnative proteins.</div>
+
+                        <div class="finding-text">"Hsp26 is an ATP-independent holdase that binds nonnative proteins and suppresses aggregation."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
                             GO_REF:0000117
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/10581247" target="_blank" class="term-link">
                             PMID:10581247
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Hsp26: a temperature-regulated chaperone.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">HSP26 is a temperature-regulated molecular chaperone. The 24-mer storage complex dissociates at heat shock temperatures, and this dissociation is a prerequisite for efficient chaperone activity. Binding of non-native proteins to dissociated Hsp26 produces large globular assemblies with 1:2 substrate:Hsp26 stoichiometry.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/11914276" target="_blank" class="term-link">
                             PMID:11914276
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Subcellular localization of the yeast proteome.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Large-scale immunolocalization study of 2744 yeast proteins. HSP26 detected in cytoplasm.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/16429126" target="_blank" class="term-link">
                             PMID:16429126
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Proteome survey reveals modularity of the yeast cell machinery.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Genome-wide TAP-tag affinity purification/MS screen for yeast protein complexes. HSP26 detected as co-purifying with SSA2 and VMA2.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/16554755" target="_blank" class="term-link">
                             PMID:16554755
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Global landscape of protein complexes in the yeast Saccharomyces cerevisiae.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Large-scale TAP-tag study of yeast protein complexes. Multiple HSP26 interaction partners detected including ADH3, EMW1, FUS3, NEW1, POL32, RNR1, RTT101, SGV1, SME1, TFB4, UPC2, VMA2.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/16843901" target="_blank" class="term-link">
                             PMID:16843901
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Multiple distinct assemblies reveal conformational flexibility in the small heat shock protein Hsp26.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Cryo-EM structure of Hsp26 reveals two distinct 24-subunit forms with tetrahedral symmetry. Subunits form asymmetric dimers that assemble via trimeric contacts. C-terminal tails form 3-fold contacts. Hinge points between domains provide flexibility for supercomplex formation with non-native proteins.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/18719252" target="_blank" class="term-link">
                             PMID:18719252
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">High-quality binary protein interaction map of the yeast interactome network.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">High-quality binary yeast interactome. HSP26-HSP26 self-interaction confirmed.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/19536198" target="_blank" class="term-link">
                             PMID:19536198
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">An atlas of chaperone-protein interactions in Saccharomyces cerevisiae: implications to protein folding pathways in the cell.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Comprehensive TAP-tag analysis of all 63 yeast chaperones. HSP26 classified as a &#34;specific&#34; chaperone with fewer than 200 non-chaperone interactors, consistent with selective holdase function rather than promiscuous chaperoning.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/20844764" target="_blank" class="term-link">
                             PMID:20844764
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Proteome-wide search reveals unexpected RNA-binding proteins in Saccharomyces cerevisiae.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">HSP26 identified as novel RNA-binding protein by protein microarray screen and validated by IP-microarray. Co-purified with 279 specific mRNAs. Lacks known RNA-binding domain. Described among &#34;unexpected&#34; RBPs with &#34;day jobs&#34; as enzymes or chaperones.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/24291094" target="_blank" class="term-link">
                             PMID:24291094
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Coordination of translational control and protein homeostasis during severe heat stress.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Yeast heat stress granules contain mRNA, translation machinery, and molecular chaperones. Heat-SGs coassemble with aggregates of misfolded proteins. Disassembly requires Hsp104 and Hsp70 activity.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/24769239" target="_blank" class="term-link">
                             PMID:24769239
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Quantitative variations of the mitochondrial proteome and phosphoproteome during fermentative and respiratory growth in Saccharomyces cerevisiae.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Quantitative mitochondrial proteomics detected HSP26 in isolated mitochondrial fractions.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/2645298" target="_blank" class="term-link">
                             PMID:2645298
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The intracellular location of yeast heat-shock protein 26 varies with metabolism.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">HSP26 found in complexes &gt;500 kD. Intracellular localization depends on metabolic state: in glucose-grown log-phase cells after heat shock, concentrates in nuclei; in stationary-phase cells or cells grown in galactose/acetate, distributed throughout cytoplasm.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/26777405" target="_blank" class="term-link">
                             PMID:26777405
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">ATPase-Modulated Stress Granules Contain a Diverse Proteome and Substructure.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Proteomic analysis of stress granule cores reveals molecular chaperones as conserved components. ATP is required for stress granule assembly and dynamics.</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
         </div>
     </div>
-    
 
 
-    
+
+
     <div class="section">
         <h2 class="section-title">Suggested Questions for Experts</h2>
-        
+
         <div class="question-card">
             <div style="display: flex; justify-content: space-between; align-items: start;">
                 <div style="flex: 1;">
                     <p><strong>Q:</strong> What are the specific substrate proteins that HSP26 binds during heat shock in vivo?</p>
-                    
+
                 </div>
                 <span class="vote-buttons" data-g="P15992" data-a="Q: What are the specific substrate proteins that HSP2..." data-r="" data-act="QUESTION">
                     <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
@@ -2689,12 +2736,12 @@
                 </span>
             </div>
         </div>
-        
+
         <div class="question-card">
             <div style="display: flex; justify-content: space-between; align-items: start;">
                 <div style="flex: 1;">
                     <p><strong>Q:</strong> Does HSP26 mRNA binding activity (PMID:20844764) have a physiological role, or is it an artifact of the broad substrate-binding properties of chaperones?</p>
-                    
+
                 </div>
                 <span class="vote-buttons" data-g="P15992" data-a="Q: Does HSP26 mRNA binding activity (PMID:20844764) h..." data-r="" data-act="QUESTION">
                     <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
@@ -2702,12 +2749,12 @@
                 </span>
             </div>
         </div>
-        
+
         <div class="question-card">
             <div style="display: flex; justify-content: space-between; align-items: start;">
                 <div style="flex: 1;">
                     <p><strong>Q:</strong> How does HSP26 holdase activity coordinate with HSP104 disaggregase and HSP70 foldase during stress recovery?</p>
-                    
+
                 </div>
                 <span class="vote-buttons" data-g="P15992" data-a="Q: How does HSP26 holdase activity coordinate with HS..." data-r="" data-act="QUESTION">
                     <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
@@ -2715,12 +2762,12 @@
                 </span>
             </div>
         </div>
-        
+
         <div class="question-card">
             <div style="display: flex; justify-content: space-between; align-items: start;">
                 <div style="flex: 1;">
                     <p><strong>Q:</strong> Is the temperature-dependent oligomer dissociation mechanism conserved across yeast sHSPs (e.g., Hsp42)?</p>
-                    
+
                 </div>
                 <span class="vote-buttons" data-g="P15992" data-a="Q: Is the temperature-dependent oligomer dissociation..." data-r="" data-act="QUESTION">
                     <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
@@ -2728,32 +2775,395 @@
                 </span>
             </div>
         </div>
-        
+
     </div>
-    
 
-    
 
-    
+
+
+
     <div class="section">
         <h2 class="section-title">Tags</h2>
         <div class="aliases">
-            
+
             <span class="badge">UPB</span>
-            
+
             <span class="badge">sHSP</span>
-            
+
             <span class="badge">holdase</span>
-            
+
         </div>
     </div>
-    
+
 
     <!-- Computational Predictions Section -->
-    
+
 
     <!-- Additional Documentation Sections -->
-    
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Deep Research Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(HSP26-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P15992" data-a="DOC: Deep Research Falcon" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <hr />
+<p>provider: falcon<br />
+model: Edison Scientific Literature<br />
+cached: false<br />
+start_time: '2026-05-11T07:06:47.747857'<br />
+end_time: '2026-05-11T07:22:48.915615'<br />
+duration_seconds: 961.17<br />
+template_file: templates/gene_research_go_focused.md<br />
+template_variables:<br />
+  organism: yeast<br />
+  gene_id: HSP26<br />
+  gene_symbol: HSP26<br />
+  uniprot_accession: P15992<br />
+  protein_description: 'RecName: Full=Heat shock protein 26; AltName: Full=26 kDa<br />
+    heat shock protein;'<br />
+  gene_info: Name=HSP26; OrderedLocusNames=YBR072W; ORFNames=YBR0714;<br />
+  organism_full: Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).<br />
+  protein_family: Belongs to the small heat shock protein (HSP20) family.<br />
+  protein_domains: A-crystallin/Hsp20_dom. (IPR002068); HSP20-like_chaperone. (IPR008978);<br />
+    Small_HSP. (IPR031107); HSP20 (PF00011)<br />
+provider_config:<br />
+  timeout: 600<br />
+  max_retries: 3<br />
+  parameters:<br />
+    allowed_domains: []<br />
+    temperature: 0.1<br />
+citation_count: 31</p>
+<hr />
+<h2 id="question">Question</h2>
+<h1 id="gene-research-for-functional-annotation">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> P15992</li>
+<li><strong>Protein Description:</strong> RecName: Full=Heat shock protein 26; AltName: Full=26 kDa heat shock protein;</li>
+<li><strong>Gene Information:</strong> Name=HSP26; OrderedLocusNames=YBR072W; ORFNames=YBR0714;</li>
+<li><strong>Organism (full):</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Protein Family:</strong> Belongs to the small heat shock protein (HSP20) family.</li>
+<li><strong>Key Domains:</strong> A-crystallin/Hsp20_dom. (IPR002068); HSP20-like_chaperone. (IPR008978); Small_HSP. (IPR031107); HSP20 (PF00011)</li>
+</ul>
+<h3 id="mandatory-verification-steps">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "HSP26" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'HSP26' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>HSP26</strong> (gene ID: HSP26, UniProt: P15992) in yeast.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="output">Output</h2>
+<p>Question: You are an expert researcher providing comprehensive, well-cited information.</p>
+<p>Provide detailed information focusing on:<br />
+1. Key concepts and definitions with current understanding<br />
+2. Recent developments and latest research (prioritize 2023-2024 sources)<br />
+3. Current applications and real-world implementations<br />
+4. Expert opinions and analysis from authoritative sources<br />
+5. Relevant statistics and data from recent studies</p>
+<p>Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.<br />
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.</p>
+<h1 id="gene-research-for-functional-annotation_1">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context_1">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot_1">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> P15992</li>
+<li><strong>Protein Description:</strong> RecName: Full=Heat shock protein 26; AltName: Full=26 kDa heat shock protein;</li>
+<li><strong>Gene Information:</strong> Name=HSP26; OrderedLocusNames=YBR072W; ORFNames=YBR0714;</li>
+<li><strong>Organism (full):</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Protein Family:</strong> Belongs to the small heat shock protein (HSP20) family.</li>
+<li><strong>Key Domains:</strong> A-crystallin/Hsp20_dom. (IPR002068); HSP20-like_chaperone. (IPR008978); Small_HSP. (IPR031107); HSP20 (PF00011)</li>
+</ul>
+<h3 id="mandatory-verification-steps_1">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "HSP26" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature_1">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'HSP26' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target_1">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>HSP26</strong> (gene ID: HSP26, UniProt: P15992) in yeast.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="research-report-saccharomyces-cerevisiae-hsp26-uniprot-p15992-gene-hsp26-orf-ybr072wfunctional-annotation">Research report: <em>Saccharomyces cerevisiae</em> HSP26 (UniProt P15992; gene <strong>HSP26</strong>, ORF <strong>YBR072W</strong>)—functional annotation</h2>
+<h3 id="0-identity-verification-and-scope-control">0) Identity verification and scope control</h3>
+<p>The literature summarized here concerns <strong>Hsp26 from <em>Saccharomyces cerevisiae</em></strong>, explicitly described as the yeast <strong>small heat shock protein (sHsp)</strong> and characterized as an <strong>ATP-independent molecular chaperone</strong> that forms large oligomers and is activated by heat and post-translational regulation (e.g., phosphorylation). This matches the UniProt-provided target (P15992; HSP26; sHSP/HSP20 family; α-crystallin domain-containing). The primary mechanistic studies referenced here do not always print UniProt accessions or the ORF name in the excerpted text, but they consistently specify <em>S. cerevisiae</em> Hsp26 and its hallmark sHsp features (α-crystallin domain; oligomeric holdase; heat activation). (haslbeck1999hsp26atemperature‐regulated pages 1-2, muhlhofer2021phosphorylationactivatesthe pages 1-2, franzmann2008activationofthe pages 1-2)</p>
+<h3 id="1-key-concepts-and-definitions-current-understanding">1) Key concepts and definitions (current understanding)</h3>
+<h4 id="11-small-heat-shock-proteins-shsps-and-holdase-chaperone-activity">1.1 Small heat shock proteins (sHsps) and “holdase” chaperone activity</h4>
+<p>Hsp26 belongs to the sHsp/α-crystallin family. In this family, proteins typically function as <strong>ATP-independent “holdase” chaperones</strong>, binding non-native proteins to suppress irreversible aggregation and maintaining clients in a refolding-competent state that can later be processed by ATP-dependent chaperones (e.g., Hsp70). (franzmann2008activationofthe pages 1-2, verghese2012biologyofthe pages 20-21, haslbeck1999hsp26atemperature‐regulated pages 1-2)</p>
+<p>Consistent with this definition, yeast Hsp26 was shown to suppress aggregation of model substrates during thermal stress and to form stable Hsp26–substrate assemblies without requiring ATP. (haslbeck1999hsp26atemperature‐regulated pages 1-2)</p>
+<h4 id="12-oligomerization-as-a-regulatory-principle-in-hsp26">1.2 Oligomerization as a regulatory principle in Hsp26</h4>
+<p>A core concept in Hsp26 biology is that <strong>oligomeric state and internal domain contacts regulate activity</strong>. Hsp26 forms large oligomeric assemblies at permissive temperatures and becomes chaperone-active upon heat-triggered structural rearrangements and/or remodeling of the oligomer ensemble. (franzmann2008activationofthe pages 1-2, haslbeck1999hsp26atemperature‐regulated pages 4-5)</p>
+<h3 id="2-molecular-function-and-mechanism">2) Molecular function and mechanism</h3>
+<h4 id="21-oligomer-sizearchitecture-and-activation-temperatures">2.1 Oligomer size/architecture and activation temperatures</h4>
+<p><strong>Foundational biochemical definition (1999):</strong> Haslbeck et al. purified yeast Hsp26 and found that at 25°C it behaves as a <strong>~550 kDa complex</strong>, with a monomer mass of <strong>23,748 Da</strong>, consistent with a <strong>~24-subunit oligomer</strong>. Upon heating, oligomer dissociation begins around <strong>~35°C</strong> and at <strong>40–43°C</strong> the 550 kDa complex largely disappears, with a smaller species consistent with an <strong>~45 kDa dimer</strong> predominating; this dissociation is reversible after returning to 25°C. (Publication date: Dec 1999; URL: https://doi.org/10.1093/emboj/18.23.6744) (haslbeck1999hsp26atemperature‐regulated pages 1-2, haslbeck1999hsp26atemperature‐regulated pages 4-5)</p>
+<p><strong>Modern structural view (2021, cryo-EM):</strong> Mühlhofer et al. describe Hsp26 as forming <strong>polydisperse oligomers</strong> in a <strong>24-mer to 42-mer range</strong> and report a <strong>cryo-EM structure of a 40-mer</strong>. They quantify a thermal “first transition” consistent with oligomer dissociation: <strong>WT dissociation at 42.1°C</strong>, with multiple phosphomimetic variants dissociating at lower temperatures (e.g., <strong>S47E/T48E 36.8°C; S144E 35.1 ± 0.1°C; T163E 34.6 ± 0.9°C</strong>). Importantly, the α-crystallin domain is much more thermally stable (reported melting transition <strong>~68–72°C</strong>), supporting a model in which activation is driven by weakening/remodeling of interdomain/inter-subunit contacts rather than global unfolding. (Publication date: Nov 2021; URL: https://doi.org/10.1038/s41467-021-27036-7) (muhlhofer2021phosphorylationactivatesthe pages 1-2, muhlhofer2021phosphorylationactivatesthe pages 4-5)</p>
+<p>A key figure in Mühlhofer et al. visualizes these dissociation temperatures and highlights that phosphomimetic changes shift the activation transition to lower temperatures. (muhlhofer2021phosphorylationactivatesthe media 1375ea3d)</p>
+<h4 id="22-thermosensormiddle-domain-regulation-intrinsic-regulation">2.2 Thermosensor/middle domain regulation (intrinsic regulation)</h4>
+<p>Franzmann et al. (2008) identify a <strong>middle domain (MD)</strong> within the unusually long N-terminus of Hsp26 that functions as a <strong>thermosensor</strong> and intrinsic regulator of activity; Hsp26 is inactive at low temperature (e.g., 25°C) and becomes active upon heat-induced rearrangement of this domain. (Publication date: Feb 2008; URL: https://doi.org/10.1016/j.molcel.2007.11.025) (franzmann2008activationofthe pages 1-2)</p>
+<h4 id="23-client-binding-and-stoichiometry">2.3 Client binding and stoichiometry</h4>
+<p>Haslbeck et al. (1999) provide a quantitative stoichiometric model for client binding: within Hsp26–substrate assemblies, <strong>approximately one substrate monomer is bound per Hsp26 dimer</strong>. In citrate synthase aggregation assays at <strong>43°C</strong>, a <strong>2:1 molar ratio</strong> of Hsp26 complex to citrate synthase dimer almost completely suppressed aggregation. (haslbeck1999hsp26atemperature‐regulated pages 1-2)</p>
+<h4 id="24-phosphorylation-as-a-non-thermal-activation-route">2.4 Phosphorylation as a non-thermal activation route</h4>
+<p>A major recent mechanistic development is that <strong>phosphorylation can activate Hsp26 independently of heat</strong>, by weakening inhibitory domain contacts.</p>
+<p>Mühlhofer et al. (2021) report that Hsp26 contains <strong>nine phosphorylation sites</strong> across different structural elements and that phosphomimetic mutations can activate Hsp26 at permissive temperatures, interpreted as relieving intrinsic inhibition and exposing N-terminal client-binding determinants. (muhlhofer2021phosphorylationactivatesthe pages 1-2)</p>
+<p>The 2023 small heat shock protein workshop report highlights this phosphorylation-based regulation as a key example of how sHsps can be regulated beyond simple heat-driven transitions, noting that negative charges introduced at selected sites can unlock a buried N-terminal region or release interlocking C-terminal regions, thereby enabling client binding. (Publication date: Nov 2023; URL: https://doi.org/10.1007/s12192-023-01360-x) (ecroyd2023thebeautyand pages 1-2)</p>
+<p>Cryo-EM reconstructions of the Hsp26 40-mer for WT and selected mutants are shown in the figure extracted from Mühlhofer et al. (muhlhofer2021phosphorylationactivatesthe media ac65f9e2)</p>
+<h3 id="3-biological-processes-and-pathways">3) Biological processes and pathways</h3>
+<h4 id="31-cytosolic-proteostasis-and-cooperation-with-atp-dependent-systems">3.1 Cytosolic proteostasis and cooperation with ATP-dependent systems</h4>
+<p>Hsp26 is described as one of the two <strong>cytosolic</strong> sHsps in budding yeast (along with Hsp42) and participates in cytosolic proteostasis by buffering stress-denatured proteins. (duennwald2012smallheatshock pages 1-2)</p>
+<p>A central pathway concept is <strong>division of labor</strong>: Hsp26 (ATP-independent) captures/holds clients during acute stress, while ATP-dependent chaperones/disaggregases execute refolding and disaggregation. Haslbeck et al. explicitly connect sHsp-captured substrates to <strong>Hsp70-dependent reactivation/refolding</strong>. (haslbeck1999hsp26atemperature‐regulated pages 1-2)</p>
+<p>Duennwald et al. demonstrate functional cooperation between sHsps and disaggregation machinery: incorporation of Hsp26 into denatured aggregates can promote dissolution/renaturation by <strong>Hsp104 together with Hsp70/Hsp40</strong>, whereas adding Hsp26 after aggregates are already formed does not confer the same benefit—an experimentally important constraint consistent with Hsp26 acting early during aggregate formation. (Publication date: Jun 2012; URL: https://doi.org/10.1371/journal.pbio.1001346) (duennwald2012smallheatshock pages 1-2)</p>
+<h4 id="32-overlap-with-hsp42-and-proteome-stability-in-vivo">3.2 Overlap with Hsp42 and proteome stability in vivo</h4>
+<p>A genetic/proteostasis statistic widely used for functional inference is that deletion of HSP26 alone shows little phenotype, but combined loss of both cytosolic sHsps (<strong>hsp26Δ hsp42Δ</strong>) causes a <strong>~200% increase in insoluble proteins at 30°C</strong>, supporting functional overlap in maintaining solubility and proteome stability even under non-heat-shock conditions. (Publication date: Jun 2012; URL: https://doi.org/10.1128/MMBR.05018-11) (verghese2012biologyofthe pages 20-21)</p>
+<h3 id="4-regulation-stress-conditions-and-localization">4) Regulation, stress conditions, and localization</h3>
+<h4 id="41-stress-transcription-regulation-2024-development-genome-organization-and-kinetics">4.1 Stress transcription regulation (2024 development: genome organization and kinetics)</h4>
+<p>A key 2024 advance is the integration of Hsp26 into modern models of heat-shock transcription as a <strong>dual-regulated Hsf1/Msn2 target</strong>.</p>
+<p>Rubio et al. (2024) classify <strong>HSP26</strong> among heat shock response genes and report that it is <strong>regulated by both Msn2 and Hsf1</strong>. They note that during thermal upshift, the heat-shock response program typically includes <strong>&gt;10-fold mRNA increases within 10 min</strong>, and they describe heat shock as producing a <strong>high level of induction</strong> of HSP26. (Publication date: Oct 2024; URL: https://doi.org/10.7554/eLife.92464.4) (rubio2024heatshockfactor pages 3-5)</p>
+<p>A particularly informative result is that <strong>8.5% ethanol</strong> triggers rapid Hsf1-associated <strong>3D genome reorganization</strong> among heat-shock loci (intergenic interactions detectable by <strong>2.5 min</strong>, peaking around <strong>10–20 min</strong>, attenuating by ~<strong>60 min</strong>) yet <strong>HSP26 is not detectably activated at 10 min of ethanol exposure</strong> in their assays, illustrating kinetic uncoupling between genome reorganization/condensate behavior and immediate transcriptional output in ethanol stress. (rubio2024heatshockfactor pages 13-15, rubio2024heatshockfactor pages 8-9)</p>
+<h4 id="42-subcellular-localization">4.2 Subcellular localization</h4>
+<p>Within the retrieved evidence, Hsp26 is described as a <strong>cytosolic</strong> sHsp (one of two cytosolic sHsps in budding yeast). This localization is consistent with its role in buffering widespread cytosolic misfolding during heat and other proteotoxic stresses, and with its cooperation with cytosolic Hsp70/Hsp104 systems. (lippi2025theroleof pages 27-30, duennwald2012smallheatshock pages 1-2)</p>
+<h3 id="5-recent-developments-and-latest-research-emphasis-20232024">5) Recent developments and “latest research” emphasis (2023–2024)</h3>
+<p>The most relevant 2023–2024 developments for yeast Hsp26 in the retrieved evidence are:</p>
+<ol>
+<li><strong>Hsf1 condensates and 3D genome restructuring precede (and can be uncoupled from) early transcription</strong>, with HSP26 serving as an HSR locus illustrating delayed activation under ethanol stress compared with rapid heat-shock induction (Rubio et al., 2024, eLife). (rubio2024heatshockfactor pages 3-5, rubio2024heatshockfactor pages 13-15, rubio2024heatshockfactor pages 8-9)</li>
+<li><strong>Community/expert synthesis emphasizing phosphorylation as an important regulatory axis</strong> for sHSPs, including Hsp26, and the use of cryo-EM to resolve oligomer architectures despite sHSP polydispersity (Ecroyd et al., 2023, Cell Stress &amp; Chaperones). (ecroyd2023thebeautyand pages 1-2)</li>
+</ol>
+<h3 id="6-current-applications-and-real-world-implementations">6) Current applications and real-world implementations</h3>
+<p>Although Hsp26 is a basic-research protein, it is used in widely adopted experimental workflows that function as “real-world implementations” in molecular and cellular biology:</p>
+<ol>
+<li><strong>Proteostasis/aggregation suppression assays:</strong> Purified Hsp26 is used to quantify holdase function by suppressing aggregation of model substrates. Ferreira et al. report suppression of citrate synthase aggregation (e.g., <strong>72% suppression at 1:1 Hsp26 24-mer:CS dimer</strong>) and lysozyme aggregation (<strong>86% suppression at 1:16</strong>) and show oligomeric particles (~12 nm diameter) by EM, demonstrating practical tractability for biochemical labs. (Publication date: Jun 2006; URL: https://doi.org/10.1016/j.pep.2006.02.006) (ferreira2006purificationandcharacterization pages 1-2)</li>
+<li><strong>Disaggregation and amyloid dissolution systems:</strong> Hsp26 is used as an experimentally controllable modulator of aggregate properties that can potentiate dissolution by disaggregases (Hsp104/Hsp70 systems) and can be extended to disease-relevant amyloid substrates (e.g., α-synuclein, polyQ), linking yeast proteostasis machinery to general principles relevant to human protein-misfolding disorders. (duennwald2012smallheatshock pages 1-2)</li>
+<li><strong>Structural biology of dynamic oligomers:</strong> Hsp26’s defined, stress-responsive oligomer transitions and phosphoregulation support its use as a model system for cryo-EM/biophysical approaches to polydisperse assemblies, including mapping the thermosensor and phospho-regulated contact networks. (muhlhofer2021phosphorylationactivatesthe pages 1-2, ecroyd2023thebeautyand pages 1-2)</li>
+<li><strong>Stress-response genomics and nuclear organization:</strong> HSP26 is used as a canonical heat-shock locus for tracking Hsf1 binding, RNA polymerase II recruitment, and stress-induced 3D genome coalescence/condensate behavior under distinct proteotoxic stresses (heat vs ethanol). (rubio2024heatshockfactor pages 3-5, rubio2024heatshockfactor pages 8-9)</li>
+</ol>
+<h3 id="7-expert-opinions-and-authoritative-synthesis">7) Expert opinions and authoritative synthesis</h3>
+<p>Two authoritative syntheses frame Hsp26 biology in broader terms:</p>
+<ul>
+<li>The yeast heat-shock/chaperone review (Verghese et al., 2012) emphasizes sHsps (including Hsp26) as energy-independent holdases that stabilize nonnative proteins and exhibit functional overlap (e.g., the strong insolubility phenotype in the double sHsp mutant), highlighting Hsp26’s role as part of a coordinated proteostasis network rather than a single essential factor. (verghese2012biologyofthe pages 20-21)</li>
+<li>The 2023 sHsp workshop report (Ecroyd et al., 2023) emphasizes the complexity of sHsp oligomerization and regulation (including phosphorylation), and points to cryo-EM and related methods as key tools for resolving how dynamic sHsp assemblies engage clients—placing Hsp26 among the well-studied exemplars that drive conceptual progress in the field. (ecroyd2023thebeautyand pages 1-2)</li>
+</ul>
+<h3 id="8-consolidated-evidence-table">8) Consolidated evidence table</h3>
+<p>The following table consolidates key findings, quantitative values, and sources.</p>
+<table>
+<thead>
+<tr>
+<th>Topic</th>
+<th>Key finding</th>
+<th>Evidence type</th>
+<th>Primary source</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Family/domain identity</td>
+<td>Hsp26 is the <strong>Saccharomyces cerevisiae</strong> small heat shock protein (sHsp), an ATP-independent chaperone with a conserved <strong>α-crystallin domain (ACD)</strong> plus N-terminal and short C-terminal regions; the middle domain functions as a thermosensor. This matches the UniProt annotation for HSP26/P15992 as an HSP20-family protein (muhlhofer2021phosphorylationactivatesthe pages 1-2, franzmann2008activationofthe pages 1-2).</td>
+<td>Biochemical, structural</td>
+<td>Mühlhofer et al. 2021, <em>Nature Communications</em>. https://doi.org/10.1038/s41467-021-27036-7 ; Franzmann et al. 2008, <em>Molecular Cell</em>. https://doi.org/10.1016/j.molcel.2007.11.025</td>
+</tr>
+<tr>
+<td>Oligomerization</td>
+<td>Purified Hsp26 forms large oligomers: apparent mass ~<strong>550 kDa</strong> with monomer mass <strong>23,748 Da</strong>, consistent with a <strong>~24-mer</strong>; later cryo-EM work resolved a <strong>40-mer</strong> ensemble and noted assemblies in the <strong>24-mer to 42-mer</strong> range (haslbeck1999hsp26atemperature‐regulated pages 1-2, muhlhofer2021phosphorylationactivatesthe pages 1-2, muhlhofer2021phosphorylationactivatesthe pages 4-5, muhlhofer2021phosphorylationactivatesthe media 1375ea3d).</td>
+<td>Biochemical, structural</td>
+<td>Haslbeck et al. 1999, <em>EMBO Journal</em>. https://doi.org/10.1093/emboj/18.23.6744 ; Mühlhofer et al. 2021, <em>Nature Communications</em>. https://doi.org/10.1038/s41467-021-27036-7</td>
+</tr>
+<tr>
+<td>Heat activation mechanism</td>
+<td>At <strong>25°C</strong>, Hsp26 is predominantly an inactive oligomer; dissociation begins around <strong>35°C</strong> and by <strong>40–43°C</strong> the 550-kDa complex largely disappears, yielding a ~<strong>45 kDa dimer</strong> species. WT oligomer dissociation temperature was measured at <strong>42.1°C</strong> (haslbeck1999hsp26atemperature‐regulated pages 4-5, muhlhofer2021phosphorylationactivatesthe pages 4-5, muhlhofer2021phosphorylationactivatesthe media 1375ea3d).</td>
+<td>Biochemical, structural</td>
+<td>Haslbeck et al. 1999, <em>EMBO Journal</em>. https://doi.org/10.1093/emboj/18.23.6744 ; Mühlhofer et al. 2021, <em>Nature Communications</em>. https://doi.org/10.1038/s41467-021-27036-7</td>
+</tr>
+<tr>
+<td>Activation mechanism nuance</td>
+<td>Hsp26 activation is controlled by rearrangement of its <strong>thermosensor/middle domain</strong>; one mechanistic study concluded that activation <strong>does not require complete oligomer dissociation</strong>, indicating that conformational remodeling within the oligomer ensemble is central (franzmann2008activationofthe pages 1-2).</td>
+<td>Biochemical, mechanistic</td>
+<td>Franzmann et al. 2008, <em>Molecular Cell</em>. https://doi.org/10.1016/j.molcel.2007.11.025 ; Franzmann et al. 2005, <em>Journal of Molecular Biology</em>. https://doi.org/10.1016/j.jmb.2005.05.034</td>
+</tr>
+<tr>
+<td>Phosphorylation regulation</td>
+<td>Hsp26 contains <strong>9 phosphorylation sites</strong>. Phosphomimetic substitutions weaken domain contacts and activate client binding at permissive temperatures. WT dissociation occurs at <strong>42.1°C</strong>, whereas selected mutants dissociate earlier: <strong>S47E/T48E 36.8°C</strong>, <strong>S144E 35.1 ± 0.1°C</strong>, <strong>T163E 34.6 ± 0.9°C</strong>; the ACD melting transition remains much higher (<strong>68–72°C</strong>) (muhlhofer2021phosphorylationactivatesthe pages 1-2, muhlhofer2021phosphorylationactivatesthe pages 4-5, ecroyd2023thebeautyand pages 1-2, muhlhofer2021phosphorylationactivatesthe media 1375ea3d).</td>
+<td>Structural, biochemical</td>
+<td>Mühlhofer et al. 2021, <em>Nature Communications</em>. https://doi.org/10.1038/s41467-021-27036-7 ; Ecroyd et al. 2023, <em>Cell Stress and Chaperones</em>. https://doi.org/10.1007/s12192-023-01360-x</td>
+</tr>
+<tr>
+<td>Client binding / holdase function</td>
+<td>Hsp26 is an ATP-independent <strong>holdase</strong> that binds nonnative proteins and suppresses aggregation. In citrate synthase assays at <strong>43°C</strong>, a <strong>2:1 molar ratio</strong> of Hsp26 complex:CS dimer almost completely suppressed aggregation; chaperone–substrate assemblies contain roughly <strong>one substrate monomer per Hsp26 dimer</strong> (haslbeck1999hsp26atemperature‐regulated pages 1-2).</td>
+<td>Biochemical</td>
+<td>Haslbeck et al. 1999, <em>EMBO Journal</em>. https://doi.org/10.1093/emboj/18.23.6744</td>
+</tr>
+<tr>
+<td>Proteostasis role in vivo</td>
+<td>Loss of HSP26 alone is nonessential, but combined <strong>hsp26Δ hsp42Δ</strong> causes about a <strong>200% increase in insoluble proteins at 30°C</strong>, supporting overlapping sHsp roles in proteome stabilization under nonstress conditions as well as stress (verghese2012biologyofthe pages 20-21).</td>
+<td>Genetic, proteostasis</td>
+<td>Verghese et al. 2012, <em>Microbiology and Molecular Biology Reviews</em>. https://doi.org/10.1128/MMBR.05018-11</td>
+</tr>
+<tr>
+<td>Cooperation with refolding/disaggregation systems</td>
+<td>Hsp26-bound clients are handed off to ATP-dependent chaperones. Hsp26 can promote dissolution/renaturation of denatured aggregates by <strong>Hsp104 + Hsp70/Hsp40</strong> when present during aggregate formation, consistent with its role as an upstream sequestration/holding factor in the cytosolic proteostasis network (duennwald2012smallheatshock pages 1-2, lippi2025theroleof pages 27-30).</td>
+<td>Biochemical, pathway</td>
+<td>Duennwald et al. 2012, <em>PLoS Biology</em>. https://doi.org/10.1371/journal.pbio.1001346 ; Lippi 2025, repository review. https://doi.org/10.53846/goediss-10952</td>
+</tr>
+<tr>
+<td>Subcellular localization</td>
+<td>Hsp26 is described as one of the two <strong>cytosolic</strong> sHsps in budding yeast, fitting its role in buffering misfolded cytosolic proteins generated by heat and other proteotoxic stressors (lippi2025theroleof pages 27-30, duennwald2012smallheatshock pages 1-2).</td>
+<td>Localization, review synthesis from primary studies</td>
+<td>Duennwald et al. 2012, <em>PLoS Biology</em>. https://doi.org/10.1371/journal.pbio.1001346 ; Lippi 2025, repository review. https://doi.org/10.53846/goediss-10952</td>
+</tr>
+<tr>
+<td>Heat-shock transcription regulation</td>
+<td>HSP26 is a <strong>classical heat-shock response gene</strong> co-regulated by <strong>Hsf1 and Msn2</strong>. Under heat shock, HSP26 shows rapid strong induction; the broader HSR mRNA program rises by <strong>&gt;10-fold within 10 min</strong> after thermal upshift, and HSP26 is included among strongly induced targets (rubio2024heatshockfactor pages 3-5, rubio2024heatshockfactor pages 5-8, rubio2024heatshockfactor pages 13-15).</td>
+<td>Genomics, transcriptional regulation</td>
+<td>Rubio et al. 2024, <em>eLife</em>. https://doi.org/10.7554/eLife.92464.4</td>
+</tr>
+<tr>
+<td>Ethanol vs heat kinetics</td>
+<td>Under <strong>8.5% ethanol</strong>, Hsp26/HSR loci undergo rapid Hsf1-dependent 3D genome reorganization and condensate-associated coalescence, with intergenic interactions detectable by <strong>2.5 min</strong>, peaking at <strong>10–20 min</strong>, yet <strong>HSP26 is not detectably activated at 10 min</strong> and shows delayed transcription relative to heat shock; by contrast, Pol II recruitment during heat shock peaks by ~<strong>2.5 min</strong> (rubio2024heatshockfactor pages 3-5, rubio2024heatshockfactor pages 5-8, rubio2024heatshockfactor pages 13-15, rubio2024heatshockfactor pages 8-9).</td>
+<td>Genomics, cell biology</td>
+<td>Rubio et al. 2024, <em>eLife</em>. https://doi.org/10.7554/eLife.92464.4</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table condenses experimentally supported functional annotation for Saccharomyces cerevisiae Hsp26, emphasizing mechanism, regulation, localization, and pathway context. It highlights quantitative values and the strongest primary sources useful for gene/protein annotation.</em></p>
+<h3 id="9-notes-on-remaining-uncertainties">9) Notes on remaining uncertainties</h3>
+<p><em>Client specificity in vivo:</em> The evidence strongly supports broad client binding (holdase action), but the exact endogenous client repertoire and the determinants of client selectivity are not fully resolved in the cited excerpts; this remains an active area where proteomics and structural studies continue to refine mechanistic detail. (lippi2025theroleof pages 27-30, ecroyd2023thebeautyand pages 1-2)</p>
+<h3 id="key-primary-sources-with-publication-dates-and-urls">Key primary sources (with publication dates and URLs)</h3>
+<ul>
+<li>Haslbeck et al. <strong>1999-12</strong>, <em>EMBO Journal</em>: “Hsp26: a temperature-regulated chaperone.” https://doi.org/10.1093/emboj/18.23.6744 (haslbeck1999hsp26atemperature‐regulated pages 1-2, haslbeck1999hsp26atemperature‐regulated pages 4-5)</li>
+<li>Franzmann et al. <strong>2008-02</strong>, <em>Molecular Cell</em>: “Activation of the chaperone Hsp26 is controlled by the rearrangement of its thermosensor domain.” https://doi.org/10.1016/j.molcel.2007.11.025 (franzmann2008activationofthe pages 1-2)</li>
+<li>Mühlhofer et al. <strong>2021-11</strong>, <em>Nature Communications</em>: “Phosphorylation activates the yeast small heat shock protein Hsp26…” https://doi.org/10.1038/s41467-021-27036-7 (muhlhofer2021phosphorylationactivatesthe pages 1-2, muhlhofer2021phosphorylationactivatesthe pages 4-5, muhlhofer2021phosphorylationactivatesthe media 1375ea3d, muhlhofer2021phosphorylationactivatesthe media ac65f9e2)</li>
+<li>Ecroyd et al. <strong>2023-11</strong>, <em>Cell Stress and Chaperones</em>: workshop report on sHsps (includes Hsp26 structural/regulatory highlights). https://doi.org/10.1007/s12192-023-01360-x (ecroyd2023thebeautyand pages 1-2)</li>
+<li>Rubio et al. <strong>2024-10</strong>, <em>eLife</em>: “Heat Shock Factor 1 forms nuclear condensates…” (includes HSP26 regulation, ethanol vs heat kinetics). https://doi.org/10.7554/eLife.92464.4 (rubio2024heatshockfactor pages 3-5, rubio2024heatshockfactor pages 13-15, rubio2024heatshockfactor pages 8-9)</li>
+<li>Duennwald et al. <strong>2012-06</strong>, <em>PLoS Biology</em>: sHsps potentiate amyloid dissolution by disaggregases. https://doi.org/10.1371/journal.pbio.1001346 (duennwald2012smallheatshock pages 1-2)</li>
+<li>Verghese et al. <strong>2012-06</strong>, <em>Microbiology and Molecular Biology Reviews</em>: yeast heat shock response and chaperone biology. https://doi.org/10.1128/MMBR.05018-11 (verghese2012biologyofthe pages 20-21)</li>
+<li>Ferreira et al. <strong>2006-06</strong>, <em>Protein Expression and Purification</em>: purification/EM/functional assays for yeast Hsp26. https://doi.org/10.1016/j.pep.2006.02.006 (ferreira2006purificationandcharacterization pages 1-2)</li>
+</ul>
+<p>References</p>
+<ol>
+<li>
+<p>(haslbeck1999hsp26atemperature‐regulated pages 1-2): M. Haslbeck, S. Walke, Thusnelda Stromer, M. Ehrnsperger, H. White, Shaoxia Chen, H. Saibil, and J. Buchner. Hsp26: a temperature‐regulated chaperone. The EMBO Journal, 18:6744-6751, Dec 1999. URL: https://doi.org/10.1093/emboj/18.23.6744, doi:10.1093/emboj/18.23.6744. This article has 614 citations.</p>
+</li>
+<li>
+<p>(muhlhofer2021phosphorylationactivatesthe pages 1-2): Moritz Mühlhofer, Carsten Peters, Thomas Kriehuber, Marina Kreuzeder, Pamina Kazman, Natalia Rodina, Bernd Reif, Martin Haslbeck, Sevil Weinkauf, and Johannes Buchner. Phosphorylation activates the yeast small heat shock protein hsp26 by weakening domain contacts in the oligomer ensemble. Nature Communications, Nov 2021. URL: https://doi.org/10.1038/s41467-021-27036-7, doi:10.1038/s41467-021-27036-7. This article has 39 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(franzmann2008activationofthe pages 1-2): Titus M. Franzmann, Petra Menhorn, Stefan Walter, and Johannes Buchner. Activation of the chaperone hsp26 is controlled by the rearrangement of its thermosensor domain. Molecular cell, 29 2:207-16, Feb 2008. URL: https://doi.org/10.1016/j.molcel.2007.11.025, doi:10.1016/j.molcel.2007.11.025. This article has 126 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(verghese2012biologyofthe pages 20-21): Jacob Verghese, Jennifer Abrams, Yanyu Wang, and Kevin A. Morano. Biology of the heat shock response and protein chaperones: budding yeast (saccharomyces cerevisiae) as a model system. Microbiology and Molecular Biology Reviews, 76:115-158, Jun 2012. URL: https://doi.org/10.1128/mmbr.05018-11, doi:10.1128/mmbr.05018-11. This article has 765 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(haslbeck1999hsp26atemperature‐regulated pages 4-5): M. Haslbeck, S. Walke, Thusnelda Stromer, M. Ehrnsperger, H. White, Shaoxia Chen, H. Saibil, and J. Buchner. Hsp26: a temperature‐regulated chaperone. The EMBO Journal, 18:6744-6751, Dec 1999. URL: https://doi.org/10.1093/emboj/18.23.6744, doi:10.1093/emboj/18.23.6744. This article has 614 citations.</p>
+</li>
+<li>
+<p>(muhlhofer2021phosphorylationactivatesthe pages 4-5): Moritz Mühlhofer, Carsten Peters, Thomas Kriehuber, Marina Kreuzeder, Pamina Kazman, Natalia Rodina, Bernd Reif, Martin Haslbeck, Sevil Weinkauf, and Johannes Buchner. Phosphorylation activates the yeast small heat shock protein hsp26 by weakening domain contacts in the oligomer ensemble. Nature Communications, Nov 2021. URL: https://doi.org/10.1038/s41467-021-27036-7, doi:10.1038/s41467-021-27036-7. This article has 39 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(muhlhofer2021phosphorylationactivatesthe media 1375ea3d): Moritz Mühlhofer, Carsten Peters, Thomas Kriehuber, Marina Kreuzeder, Pamina Kazman, Natalia Rodina, Bernd Reif, Martin Haslbeck, Sevil Weinkauf, and Johannes Buchner. Phosphorylation activates the yeast small heat shock protein hsp26 by weakening domain contacts in the oligomer ensemble. Nature Communications, Nov 2021. URL: https://doi.org/10.1038/s41467-021-27036-7, doi:10.1038/s41467-021-27036-7. This article has 39 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ecroyd2023thebeautyand pages 1-2): Heath Ecroyd, Britta Bartelt-Kirbach, Anat Ben-Zvi, Raffaella Bonavita, Yevheniia Bushman, Elena Casarotto, Ciro Cecconi, Wilson Chun Yu Lau, Jonathan D. Hibshman, Joep Joosten, Virginia Kimonis, Rachel Klevit, Krzysztof Liberek, Kathryn A. McMenimen, Tsukumi Miwa, Axel Mogk, Daniele Montepietra, Carsten Peters, Maria resa Te Rocchetti, Dominik Saman, Angela Sisto, Valentina Secco, Annika Strauch, Hideki Taguchi, Morgan Tanguay, Barbara Tedesco, Melinda E. Toth, Zihao Wang, Justin L.P. Benesch, and Serena Carra. The beauty and complexity of the small heat shock proteins: a report on the proceedings of the fourth workshop on small heat shock proteins. Cell Stress and Chaperones, 28:621-629, Nov 2023. URL: https://doi.org/10.1007/s12192-023-01360-x, doi:10.1007/s12192-023-01360-x. This article has 11 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(muhlhofer2021phosphorylationactivatesthe media ac65f9e2): Moritz Mühlhofer, Carsten Peters, Thomas Kriehuber, Marina Kreuzeder, Pamina Kazman, Natalia Rodina, Bernd Reif, Martin Haslbeck, Sevil Weinkauf, and Johannes Buchner. Phosphorylation activates the yeast small heat shock protein hsp26 by weakening domain contacts in the oligomer ensemble. Nature Communications, Nov 2021. URL: https://doi.org/10.1038/s41467-021-27036-7, doi:10.1038/s41467-021-27036-7. This article has 39 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(duennwald2012smallheatshock pages 1-2): Martin L. Duennwald, AnaLisa Echeverria, and James Shorter. Small heat shock proteins potentiate amyloid dissolution by protein disaggregases from yeast and humans. PLoS Biology, 10:e1001346, Jun 2012. URL: https://doi.org/10.1371/journal.pbio.1001346, doi:10.1371/journal.pbio.1001346. This article has 216 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(rubio2024heatshockfactor pages 3-5): Linda S Rubio, Suman Mohajan, and David S Gross. Heat shock factor 1 forms nuclear condensates and restructures the yeast genome before activating target genes. eLife, Oct 2024. URL: https://doi.org/10.7554/elife.92464.4, doi:10.7554/elife.92464.4. This article has 17 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(rubio2024heatshockfactor pages 13-15): Linda S Rubio, Suman Mohajan, and David S Gross. Heat shock factor 1 forms nuclear condensates and restructures the yeast genome before activating target genes. eLife, Oct 2024. URL: https://doi.org/10.7554/elife.92464.4, doi:10.7554/elife.92464.4. This article has 17 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(rubio2024heatshockfactor pages 8-9): Linda S Rubio, Suman Mohajan, and David S Gross. Heat shock factor 1 forms nuclear condensates and restructures the yeast genome before activating target genes. eLife, Oct 2024. URL: https://doi.org/10.7554/elife.92464.4, doi:10.7554/elife.92464.4. This article has 17 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lippi2025theroleof pages 27-30): Alice Lippi. The role of hsp42 in proteostasis-metabolism interplay and cellular longevity. ArXiv, 2025. URL: https://doi.org/10.53846/goediss-10952, doi:10.53846/goediss-10952. This article has 0 citations.</p>
+</li>
+<li>
+<p>(ferreira2006purificationandcharacterization pages 1-2): Renato Marins Ferreira, Leonardo Rodrigues de Andrade, Márcio Barros Dutra, Marcos Farina de Souza, Vânia Margaret Flosi Paschoalin, and Joab Trajano Silva. Purification and characterization of the chaperone-like hsp26 from saccharomyces cerevisiae. Protein expression and purification, 47 2:384-92, Jun 2006. URL: https://doi.org/10.1016/j.pep.2006.02.006, doi:10.1016/j.pep.2006.02.006. This article has 14 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(rubio2024heatshockfactor pages 5-8): Linda S Rubio, Suman Mohajan, and David S Gross. Heat shock factor 1 forms nuclear condensates and restructures the yeast genome before activating target genes. eLife, Oct 2024. URL: https://doi.org/10.7554/elife.92464.4, doi:10.7554/elife.92464.4. This article has 17 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>franzmann2008activationofthe pages 1-2</li>
+<li>muhlhofer2021phosphorylationactivatesthe pages 1-2</li>
+<li>ecroyd2023thebeautyand pages 1-2</li>
+<li>duennwald2012smallheatshock pages 1-2</li>
+<li>verghese2012biologyofthe pages 20-21</li>
+<li>rubio2024heatshockfactor pages 3-5</li>
+<li>ferreira2006purificationandcharacterization pages 1-2</li>
+<li>muhlhofer2021phosphorylationactivatesthe pages 4-5</li>
+<li>rubio2024heatshockfactor pages 13-15</li>
+<li>rubio2024heatshockfactor pages 8-9</li>
+<li>lippi2025theroleof pages 27-30</li>
+<li>rubio2024heatshockfactor pages 5-8</li>
+<li>https://doi.org/10.1093/emboj/18.23.6744</li>
+<li>https://doi.org/10.1038/s41467-021-27036-7</li>
+<li>https://doi.org/10.1016/j.molcel.2007.11.025</li>
+<li>https://doi.org/10.1007/s12192-023-01360-x</li>
+<li>https://doi.org/10.1371/journal.pbio.1001346</li>
+<li>https://doi.org/10.1128/MMBR.05018-11</li>
+<li>https://doi.org/10.7554/eLife.92464.4</li>
+<li>https://doi.org/10.1016/j.pep.2006.02.006</li>
+<li>https://doi.org/10.1016/j.jmb.2005.05.034</li>
+<li>https://doi.org/10.53846/goediss-10952</li>
+<li>https://doi.org/10.1093/emboj/18.23.6744,</li>
+<li>https://doi.org/10.1038/s41467-021-27036-7,</li>
+<li>https://doi.org/10.1016/j.molcel.2007.11.025,</li>
+<li>https://doi.org/10.1128/mmbr.05018-11,</li>
+<li>https://doi.org/10.1007/s12192-023-01360-x,</li>
+<li>https://doi.org/10.1371/journal.pbio.1001346,</li>
+<li>https://doi.org/10.7554/elife.92464.4,</li>
+<li>https://doi.org/10.53846/goediss-10952,</li>
+<li>https://doi.org/10.1016/j.pep.2006.02.006,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -3223,7 +3633,20 @@ existing_annotations:
       supporting_text: &gt;-
         Hinge points between the domains allow a variety of assembly contacts, providing the
         flexibility required for formation of supercomplexes with non-native proteins.
+    - reference_id: file:yeast/HSP26/HSP26-deep-research-falcon.md
+      supporting_text: &gt;-
+        Hsp26 is an ATP-independent holdase that binds nonnative proteins and
+        suppresses aggregation during heat stress.
 references:
+- id: file:yeast/HSP26/HSP26-deep-research-falcon.md
+  title: Falcon deep research report for HSP26
+  findings:
+  - statement: &gt;-
+      Falcon supports HSP26 as an ATP-independent small heat-shock holdase
+      chaperone that suppresses aggregation of nonnative proteins.
+    supporting_text: &gt;-
+      Hsp26 is an ATP-independent holdase that binds nonnative proteins and
+      suppresses aggregation.
 - id: GO_REF:0000117
   title: Electronic Gene Ontology annotations created by ARBA machine learning models
   findings: []
@@ -3335,6 +3758,10 @@ core_functions:
     supporting_text: &gt;-
       Hinge points between the domains allow a variety of assembly contacts, providing the
       flexibility required for formation of supercomplexes with non-native proteins.
+  - reference_id: file:yeast/HSP26/HSP26-deep-research-falcon.md
+    supporting_text: &gt;-
+      Hsp26 is an ATP-independent holdase that binds nonnative proteins and
+      suppresses aggregation during heat stress.
 - description: &gt;-
     HSP26 forms large homo-oligomeric 24-mer complexes with tetrahedral symmetry. Self-association
     is essential for its chaperone function: the 24-mer serves as a storage/inactive form, and
@@ -3380,7 +3807,7 @@ suggested_questions:
     </div>
 
     <!-- Pathway Visualization Link -->
-    
+
 
     <style>
         /* Markdown Section Styles */

--- a/genes/yeast/HSP26/HSP26-ai-review.yaml
+++ b/genes/yeast/HSP26/HSP26-ai-review.yaml
@@ -459,7 +459,20 @@ existing_annotations:
       supporting_text: >-
         Hinge points between the domains allow a variety of assembly contacts, providing the
         flexibility required for formation of supercomplexes with non-native proteins.
+    - reference_id: file:yeast/HSP26/HSP26-deep-research-falcon.md
+      supporting_text: >-
+        Hsp26 is an ATP-independent holdase that binds nonnative proteins and
+        suppresses aggregation during heat stress.
 references:
+- id: file:yeast/HSP26/HSP26-deep-research-falcon.md
+  title: Falcon deep research report for HSP26
+  findings:
+  - statement: >-
+      Falcon supports HSP26 as an ATP-independent small heat-shock holdase
+      chaperone that suppresses aggregation of nonnative proteins.
+    supporting_text: >-
+      Hsp26 is an ATP-independent holdase that binds nonnative proteins and
+      suppresses aggregation.
 - id: GO_REF:0000117
   title: Electronic Gene Ontology annotations created by ARBA machine learning models
   findings: []
@@ -571,6 +584,10 @@ core_functions:
     supporting_text: >-
       Hinge points between the domains allow a variety of assembly contacts, providing the
       flexibility required for formation of supercomplexes with non-native proteins.
+  - reference_id: file:yeast/HSP26/HSP26-deep-research-falcon.md
+    supporting_text: >-
+      Hsp26 is an ATP-independent holdase that binds nonnative proteins and
+      suppresses aggregation during heat stress.
 - description: >-
     HSP26 forms large homo-oligomeric 24-mer complexes with tetrahedral symmetry. Self-association
     is essential for its chaperone function: the 24-mer serves as a storage/inactive form, and

--- a/genes/yeast/HSP26/HSP26-deep-research-falcon.md
+++ b/genes/yeast/HSP26/HSP26-deep-research-falcon.md
@@ -1,0 +1,316 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-11T07:06:47.747857'
+end_time: '2026-05-11T07:22:48.915615'
+duration_seconds: 961.17
+template_file: templates/gene_research_go_focused.md
+template_variables:
+  organism: yeast
+  gene_id: HSP26
+  gene_symbol: HSP26
+  uniprot_accession: P15992
+  protein_description: 'RecName: Full=Heat shock protein 26; AltName: Full=26 kDa
+    heat shock protein;'
+  gene_info: Name=HSP26; OrderedLocusNames=YBR072W; ORFNames=YBR0714;
+  organism_full: Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+  protein_family: Belongs to the small heat shock protein (HSP20) family.
+  protein_domains: A-crystallin/Hsp20_dom. (IPR002068); HSP20-like_chaperone. (IPR008978);
+    Small_HSP. (IPR031107); HSP20 (PF00011)
+provider_config:
+  timeout: 600
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 31
+---
+
+## Question
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** P15992
+- **Protein Description:** RecName: Full=Heat shock protein 26; AltName: Full=26 kDa heat shock protein;
+- **Gene Information:** Name=HSP26; OrderedLocusNames=YBR072W; ORFNames=YBR0714;
+- **Organism (full):** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+- **Protein Family:** Belongs to the small heat shock protein (HSP20) family.
+- **Key Domains:** A-crystallin/Hsp20_dom. (IPR002068); HSP20-like_chaperone. (IPR008978); Small_HSP. (IPR031107); HSP20 (PF00011)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "HSP26" matches the protein description above**
+2. **Verify the organism is correct:** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'HSP26' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **HSP26** (gene ID: HSP26, UniProt: P15992) in yeast.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** P15992
+- **Protein Description:** RecName: Full=Heat shock protein 26; AltName: Full=26 kDa heat shock protein;
+- **Gene Information:** Name=HSP26; OrderedLocusNames=YBR072W; ORFNames=YBR0714;
+- **Organism (full):** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+- **Protein Family:** Belongs to the small heat shock protein (HSP20) family.
+- **Key Domains:** A-crystallin/Hsp20_dom. (IPR002068); HSP20-like_chaperone. (IPR008978); Small_HSP. (IPR031107); HSP20 (PF00011)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "HSP26" matches the protein description above**
+2. **Verify the organism is correct:** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'HSP26' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **HSP26** (gene ID: HSP26, UniProt: P15992) in yeast.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Research report: *Saccharomyces cerevisiae* HSP26 (UniProt P15992; gene **HSP26**, ORF **YBR072W**)—functional annotation
+
+### 0) Identity verification and scope control
+The literature summarized here concerns **Hsp26 from *Saccharomyces cerevisiae***, explicitly described as the yeast **small heat shock protein (sHsp)** and characterized as an **ATP-independent molecular chaperone** that forms large oligomers and is activated by heat and post-translational regulation (e.g., phosphorylation). This matches the UniProt-provided target (P15992; HSP26; sHSP/HSP20 family; α-crystallin domain-containing). The primary mechanistic studies referenced here do not always print UniProt accessions or the ORF name in the excerpted text, but they consistently specify *S. cerevisiae* Hsp26 and its hallmark sHsp features (α-crystallin domain; oligomeric holdase; heat activation). (haslbeck1999hsp26atemperature‐regulated pages 1-2, muhlhofer2021phosphorylationactivatesthe pages 1-2, franzmann2008activationofthe pages 1-2)
+
+### 1) Key concepts and definitions (current understanding)
+#### 1.1 Small heat shock proteins (sHsps) and “holdase” chaperone activity
+Hsp26 belongs to the sHsp/α-crystallin family. In this family, proteins typically function as **ATP-independent “holdase” chaperones**, binding non-native proteins to suppress irreversible aggregation and maintaining clients in a refolding-competent state that can later be processed by ATP-dependent chaperones (e.g., Hsp70). (franzmann2008activationofthe pages 1-2, verghese2012biologyofthe pages 20-21, haslbeck1999hsp26atemperature‐regulated pages 1-2)
+
+Consistent with this definition, yeast Hsp26 was shown to suppress aggregation of model substrates during thermal stress and to form stable Hsp26–substrate assemblies without requiring ATP. (haslbeck1999hsp26atemperature‐regulated pages 1-2)
+
+#### 1.2 Oligomerization as a regulatory principle in Hsp26
+A core concept in Hsp26 biology is that **oligomeric state and internal domain contacts regulate activity**. Hsp26 forms large oligomeric assemblies at permissive temperatures and becomes chaperone-active upon heat-triggered structural rearrangements and/or remodeling of the oligomer ensemble. (franzmann2008activationofthe pages 1-2, haslbeck1999hsp26atemperature‐regulated pages 4-5)
+
+### 2) Molecular function and mechanism
+#### 2.1 Oligomer size/architecture and activation temperatures
+**Foundational biochemical definition (1999):** Haslbeck et al. purified yeast Hsp26 and found that at 25°C it behaves as a **~550 kDa complex**, with a monomer mass of **23,748 Da**, consistent with a **~24-subunit oligomer**. Upon heating, oligomer dissociation begins around **~35°C** and at **40–43°C** the 550 kDa complex largely disappears, with a smaller species consistent with an **~45 kDa dimer** predominating; this dissociation is reversible after returning to 25°C. (Publication date: Dec 1999; URL: https://doi.org/10.1093/emboj/18.23.6744) (haslbeck1999hsp26atemperature‐regulated pages 1-2, haslbeck1999hsp26atemperature‐regulated pages 4-5)
+
+**Modern structural view (2021, cryo-EM):** Mühlhofer et al. describe Hsp26 as forming **polydisperse oligomers** in a **24-mer to 42-mer range** and report a **cryo-EM structure of a 40-mer**. They quantify a thermal “first transition” consistent with oligomer dissociation: **WT dissociation at 42.1°C**, with multiple phosphomimetic variants dissociating at lower temperatures (e.g., **S47E/T48E 36.8°C; S144E 35.1 ± 0.1°C; T163E 34.6 ± 0.9°C**). Importantly, the α-crystallin domain is much more thermally stable (reported melting transition **~68–72°C**), supporting a model in which activation is driven by weakening/remodeling of interdomain/inter-subunit contacts rather than global unfolding. (Publication date: Nov 2021; URL: https://doi.org/10.1038/s41467-021-27036-7) (muhlhofer2021phosphorylationactivatesthe pages 1-2, muhlhofer2021phosphorylationactivatesthe pages 4-5)
+
+A key figure in Mühlhofer et al. visualizes these dissociation temperatures and highlights that phosphomimetic changes shift the activation transition to lower temperatures. (muhlhofer2021phosphorylationactivatesthe media 1375ea3d)
+
+#### 2.2 Thermosensor/middle domain regulation (intrinsic regulation)
+Franzmann et al. (2008) identify a **middle domain (MD)** within the unusually long N-terminus of Hsp26 that functions as a **thermosensor** and intrinsic regulator of activity; Hsp26 is inactive at low temperature (e.g., 25°C) and becomes active upon heat-induced rearrangement of this domain. (Publication date: Feb 2008; URL: https://doi.org/10.1016/j.molcel.2007.11.025) (franzmann2008activationofthe pages 1-2)
+
+#### 2.3 Client binding and stoichiometry
+Haslbeck et al. (1999) provide a quantitative stoichiometric model for client binding: within Hsp26–substrate assemblies, **approximately one substrate monomer is bound per Hsp26 dimer**. In citrate synthase aggregation assays at **43°C**, a **2:1 molar ratio** of Hsp26 complex to citrate synthase dimer almost completely suppressed aggregation. (haslbeck1999hsp26atemperature‐regulated pages 1-2)
+
+#### 2.4 Phosphorylation as a non-thermal activation route
+A major recent mechanistic development is that **phosphorylation can activate Hsp26 independently of heat**, by weakening inhibitory domain contacts.
+
+Mühlhofer et al. (2021) report that Hsp26 contains **nine phosphorylation sites** across different structural elements and that phosphomimetic mutations can activate Hsp26 at permissive temperatures, interpreted as relieving intrinsic inhibition and exposing N-terminal client-binding determinants. (muhlhofer2021phosphorylationactivatesthe pages 1-2)
+
+The 2023 small heat shock protein workshop report highlights this phosphorylation-based regulation as a key example of how sHsps can be regulated beyond simple heat-driven transitions, noting that negative charges introduced at selected sites can unlock a buried N-terminal region or release interlocking C-terminal regions, thereby enabling client binding. (Publication date: Nov 2023; URL: https://doi.org/10.1007/s12192-023-01360-x) (ecroyd2023thebeautyand pages 1-2)
+
+Cryo-EM reconstructions of the Hsp26 40-mer for WT and selected mutants are shown in the figure extracted from Mühlhofer et al. (muhlhofer2021phosphorylationactivatesthe media ac65f9e2)
+
+### 3) Biological processes and pathways
+#### 3.1 Cytosolic proteostasis and cooperation with ATP-dependent systems
+Hsp26 is described as one of the two **cytosolic** sHsps in budding yeast (along with Hsp42) and participates in cytosolic proteostasis by buffering stress-denatured proteins. (duennwald2012smallheatshock pages 1-2)
+
+A central pathway concept is **division of labor**: Hsp26 (ATP-independent) captures/holds clients during acute stress, while ATP-dependent chaperones/disaggregases execute refolding and disaggregation. Haslbeck et al. explicitly connect sHsp-captured substrates to **Hsp70-dependent reactivation/refolding**. (haslbeck1999hsp26atemperature‐regulated pages 1-2)
+
+Duennwald et al. demonstrate functional cooperation between sHsps and disaggregation machinery: incorporation of Hsp26 into denatured aggregates can promote dissolution/renaturation by **Hsp104 together with Hsp70/Hsp40**, whereas adding Hsp26 after aggregates are already formed does not confer the same benefit—an experimentally important constraint consistent with Hsp26 acting early during aggregate formation. (Publication date: Jun 2012; URL: https://doi.org/10.1371/journal.pbio.1001346) (duennwald2012smallheatshock pages 1-2)
+
+#### 3.2 Overlap with Hsp42 and proteome stability in vivo
+A genetic/proteostasis statistic widely used for functional inference is that deletion of HSP26 alone shows little phenotype, but combined loss of both cytosolic sHsps (**hsp26Δ hsp42Δ**) causes a **~200% increase in insoluble proteins at 30°C**, supporting functional overlap in maintaining solubility and proteome stability even under non-heat-shock conditions. (Publication date: Jun 2012; URL: https://doi.org/10.1128/MMBR.05018-11) (verghese2012biologyofthe pages 20-21)
+
+### 4) Regulation, stress conditions, and localization
+#### 4.1 Stress transcription regulation (2024 development: genome organization and kinetics)
+A key 2024 advance is the integration of Hsp26 into modern models of heat-shock transcription as a **dual-regulated Hsf1/Msn2 target**.
+
+Rubio et al. (2024) classify **HSP26** among heat shock response genes and report that it is **regulated by both Msn2 and Hsf1**. They note that during thermal upshift, the heat-shock response program typically includes **>10-fold mRNA increases within 10 min**, and they describe heat shock as producing a **high level of induction** of HSP26. (Publication date: Oct 2024; URL: https://doi.org/10.7554/eLife.92464.4) (rubio2024heatshockfactor pages 3-5)
+
+A particularly informative result is that **8.5% ethanol** triggers rapid Hsf1-associated **3D genome reorganization** among heat-shock loci (intergenic interactions detectable by **2.5 min**, peaking around **10–20 min**, attenuating by ~**60 min**) yet **HSP26 is not detectably activated at 10 min of ethanol exposure** in their assays, illustrating kinetic uncoupling between genome reorganization/condensate behavior and immediate transcriptional output in ethanol stress. (rubio2024heatshockfactor pages 13-15, rubio2024heatshockfactor pages 8-9)
+
+#### 4.2 Subcellular localization
+Within the retrieved evidence, Hsp26 is described as a **cytosolic** sHsp (one of two cytosolic sHsps in budding yeast). This localization is consistent with its role in buffering widespread cytosolic misfolding during heat and other proteotoxic stresses, and with its cooperation with cytosolic Hsp70/Hsp104 systems. (lippi2025theroleof pages 27-30, duennwald2012smallheatshock pages 1-2)
+
+### 5) Recent developments and “latest research” emphasis (2023–2024)
+The most relevant 2023–2024 developments for yeast Hsp26 in the retrieved evidence are:
+
+1. **Hsf1 condensates and 3D genome restructuring precede (and can be uncoupled from) early transcription**, with HSP26 serving as an HSR locus illustrating delayed activation under ethanol stress compared with rapid heat-shock induction (Rubio et al., 2024, eLife). (rubio2024heatshockfactor pages 3-5, rubio2024heatshockfactor pages 13-15, rubio2024heatshockfactor pages 8-9)
+2. **Community/expert synthesis emphasizing phosphorylation as an important regulatory axis** for sHSPs, including Hsp26, and the use of cryo-EM to resolve oligomer architectures despite sHSP polydispersity (Ecroyd et al., 2023, Cell Stress & Chaperones). (ecroyd2023thebeautyand pages 1-2)
+
+### 6) Current applications and real-world implementations
+Although Hsp26 is a basic-research protein, it is used in widely adopted experimental workflows that function as “real-world implementations” in molecular and cellular biology:
+
+1. **Proteostasis/aggregation suppression assays:** Purified Hsp26 is used to quantify holdase function by suppressing aggregation of model substrates. Ferreira et al. report suppression of citrate synthase aggregation (e.g., **72% suppression at 1:1 Hsp26 24-mer:CS dimer**) and lysozyme aggregation (**86% suppression at 1:16**) and show oligomeric particles (~12 nm diameter) by EM, demonstrating practical tractability for biochemical labs. (Publication date: Jun 2006; URL: https://doi.org/10.1016/j.pep.2006.02.006) (ferreira2006purificationandcharacterization pages 1-2)
+2. **Disaggregation and amyloid dissolution systems:** Hsp26 is used as an experimentally controllable modulator of aggregate properties that can potentiate dissolution by disaggregases (Hsp104/Hsp70 systems) and can be extended to disease-relevant amyloid substrates (e.g., α-synuclein, polyQ), linking yeast proteostasis machinery to general principles relevant to human protein-misfolding disorders. (duennwald2012smallheatshock pages 1-2)
+3. **Structural biology of dynamic oligomers:** Hsp26’s defined, stress-responsive oligomer transitions and phosphoregulation support its use as a model system for cryo-EM/biophysical approaches to polydisperse assemblies, including mapping the thermosensor and phospho-regulated contact networks. (muhlhofer2021phosphorylationactivatesthe pages 1-2, ecroyd2023thebeautyand pages 1-2)
+4. **Stress-response genomics and nuclear organization:** HSP26 is used as a canonical heat-shock locus for tracking Hsf1 binding, RNA polymerase II recruitment, and stress-induced 3D genome coalescence/condensate behavior under distinct proteotoxic stresses (heat vs ethanol). (rubio2024heatshockfactor pages 3-5, rubio2024heatshockfactor pages 8-9)
+
+### 7) Expert opinions and authoritative synthesis
+Two authoritative syntheses frame Hsp26 biology in broader terms:
+
+* The yeast heat-shock/chaperone review (Verghese et al., 2012) emphasizes sHsps (including Hsp26) as energy-independent holdases that stabilize nonnative proteins and exhibit functional overlap (e.g., the strong insolubility phenotype in the double sHsp mutant), highlighting Hsp26’s role as part of a coordinated proteostasis network rather than a single essential factor. (verghese2012biologyofthe pages 20-21)
+* The 2023 sHsp workshop report (Ecroyd et al., 2023) emphasizes the complexity of sHsp oligomerization and regulation (including phosphorylation), and points to cryo-EM and related methods as key tools for resolving how dynamic sHsp assemblies engage clients—placing Hsp26 among the well-studied exemplars that drive conceptual progress in the field. (ecroyd2023thebeautyand pages 1-2)
+
+### 8) Consolidated evidence table
+The following table consolidates key findings, quantitative values, and sources.
+
+| Topic | Key finding | Evidence type | Primary source |
+|---|---|---|---|
+| Family/domain identity | Hsp26 is the **Saccharomyces cerevisiae** small heat shock protein (sHsp), an ATP-independent chaperone with a conserved **α-crystallin domain (ACD)** plus N-terminal and short C-terminal regions; the middle domain functions as a thermosensor. This matches the UniProt annotation for HSP26/P15992 as an HSP20-family protein (muhlhofer2021phosphorylationactivatesthe pages 1-2, franzmann2008activationofthe pages 1-2). | Biochemical, structural | Mühlhofer et al. 2021, *Nature Communications*. https://doi.org/10.1038/s41467-021-27036-7 ; Franzmann et al. 2008, *Molecular Cell*. https://doi.org/10.1016/j.molcel.2007.11.025 |
+| Oligomerization | Purified Hsp26 forms large oligomers: apparent mass ~**550 kDa** with monomer mass **23,748 Da**, consistent with a **~24-mer**; later cryo-EM work resolved a **40-mer** ensemble and noted assemblies in the **24-mer to 42-mer** range (haslbeck1999hsp26atemperature‐regulated pages 1-2, muhlhofer2021phosphorylationactivatesthe pages 1-2, muhlhofer2021phosphorylationactivatesthe pages 4-5, muhlhofer2021phosphorylationactivatesthe media 1375ea3d). | Biochemical, structural | Haslbeck et al. 1999, *EMBO Journal*. https://doi.org/10.1093/emboj/18.23.6744 ; Mühlhofer et al. 2021, *Nature Communications*. https://doi.org/10.1038/s41467-021-27036-7 |
+| Heat activation mechanism | At **25°C**, Hsp26 is predominantly an inactive oligomer; dissociation begins around **35°C** and by **40–43°C** the 550-kDa complex largely disappears, yielding a ~**45 kDa dimer** species. WT oligomer dissociation temperature was measured at **42.1°C** (haslbeck1999hsp26atemperature‐regulated pages 4-5, muhlhofer2021phosphorylationactivatesthe pages 4-5, muhlhofer2021phosphorylationactivatesthe media 1375ea3d). | Biochemical, structural | Haslbeck et al. 1999, *EMBO Journal*. https://doi.org/10.1093/emboj/18.23.6744 ; Mühlhofer et al. 2021, *Nature Communications*. https://doi.org/10.1038/s41467-021-27036-7 |
+| Activation mechanism nuance | Hsp26 activation is controlled by rearrangement of its **thermosensor/middle domain**; one mechanistic study concluded that activation **does not require complete oligomer dissociation**, indicating that conformational remodeling within the oligomer ensemble is central (franzmann2008activationofthe pages 1-2). | Biochemical, mechanistic | Franzmann et al. 2008, *Molecular Cell*. https://doi.org/10.1016/j.molcel.2007.11.025 ; Franzmann et al. 2005, *Journal of Molecular Biology*. https://doi.org/10.1016/j.jmb.2005.05.034 |
+| Phosphorylation regulation | Hsp26 contains **9 phosphorylation sites**. Phosphomimetic substitutions weaken domain contacts and activate client binding at permissive temperatures. WT dissociation occurs at **42.1°C**, whereas selected mutants dissociate earlier: **S47E/T48E 36.8°C**, **S144E 35.1 ± 0.1°C**, **T163E 34.6 ± 0.9°C**; the ACD melting transition remains much higher (**68–72°C**) (muhlhofer2021phosphorylationactivatesthe pages 1-2, muhlhofer2021phosphorylationactivatesthe pages 4-5, ecroyd2023thebeautyand pages 1-2, muhlhofer2021phosphorylationactivatesthe media 1375ea3d). | Structural, biochemical | Mühlhofer et al. 2021, *Nature Communications*. https://doi.org/10.1038/s41467-021-27036-7 ; Ecroyd et al. 2023, *Cell Stress and Chaperones*. https://doi.org/10.1007/s12192-023-01360-x |
+| Client binding / holdase function | Hsp26 is an ATP-independent **holdase** that binds nonnative proteins and suppresses aggregation. In citrate synthase assays at **43°C**, a **2:1 molar ratio** of Hsp26 complex:CS dimer almost completely suppressed aggregation; chaperone–substrate assemblies contain roughly **one substrate monomer per Hsp26 dimer** (haslbeck1999hsp26atemperature‐regulated pages 1-2). | Biochemical | Haslbeck et al. 1999, *EMBO Journal*. https://doi.org/10.1093/emboj/18.23.6744 |
+| Proteostasis role in vivo | Loss of HSP26 alone is nonessential, but combined **hsp26Δ hsp42Δ** causes about a **200% increase in insoluble proteins at 30°C**, supporting overlapping sHsp roles in proteome stabilization under nonstress conditions as well as stress (verghese2012biologyofthe pages 20-21). | Genetic, proteostasis | Verghese et al. 2012, *Microbiology and Molecular Biology Reviews*. https://doi.org/10.1128/MMBR.05018-11 |
+| Cooperation with refolding/disaggregation systems | Hsp26-bound clients are handed off to ATP-dependent chaperones. Hsp26 can promote dissolution/renaturation of denatured aggregates by **Hsp104 + Hsp70/Hsp40** when present during aggregate formation, consistent with its role as an upstream sequestration/holding factor in the cytosolic proteostasis network (duennwald2012smallheatshock pages 1-2, lippi2025theroleof pages 27-30). | Biochemical, pathway | Duennwald et al. 2012, *PLoS Biology*. https://doi.org/10.1371/journal.pbio.1001346 ; Lippi 2025, repository review. https://doi.org/10.53846/goediss-10952 |
+| Subcellular localization | Hsp26 is described as one of the two **cytosolic** sHsps in budding yeast, fitting its role in buffering misfolded cytosolic proteins generated by heat and other proteotoxic stressors (lippi2025theroleof pages 27-30, duennwald2012smallheatshock pages 1-2). | Localization, review synthesis from primary studies | Duennwald et al. 2012, *PLoS Biology*. https://doi.org/10.1371/journal.pbio.1001346 ; Lippi 2025, repository review. https://doi.org/10.53846/goediss-10952 |
+| Heat-shock transcription regulation | HSP26 is a **classical heat-shock response gene** co-regulated by **Hsf1 and Msn2**. Under heat shock, HSP26 shows rapid strong induction; the broader HSR mRNA program rises by **>10-fold within 10 min** after thermal upshift, and HSP26 is included among strongly induced targets (rubio2024heatshockfactor pages 3-5, rubio2024heatshockfactor pages 5-8, rubio2024heatshockfactor pages 13-15). | Genomics, transcriptional regulation | Rubio et al. 2024, *eLife*. https://doi.org/10.7554/eLife.92464.4 |
+| Ethanol vs heat kinetics | Under **8.5% ethanol**, Hsp26/HSR loci undergo rapid Hsf1-dependent 3D genome reorganization and condensate-associated coalescence, with intergenic interactions detectable by **2.5 min**, peaking at **10–20 min**, yet **HSP26 is not detectably activated at 10 min** and shows delayed transcription relative to heat shock; by contrast, Pol II recruitment during heat shock peaks by ~**2.5 min** (rubio2024heatshockfactor pages 3-5, rubio2024heatshockfactor pages 5-8, rubio2024heatshockfactor pages 13-15, rubio2024heatshockfactor pages 8-9). | Genomics, cell biology | Rubio et al. 2024, *eLife*. https://doi.org/10.7554/eLife.92464.4 |
+
+
+*Table: This table condenses experimentally supported functional annotation for Saccharomyces cerevisiae Hsp26, emphasizing mechanism, regulation, localization, and pathway context. It highlights quantitative values and the strongest primary sources useful for gene/protein annotation.*
+
+### 9) Notes on remaining uncertainties
+*Client specificity in vivo:* The evidence strongly supports broad client binding (holdase action), but the exact endogenous client repertoire and the determinants of client selectivity are not fully resolved in the cited excerpts; this remains an active area where proteomics and structural studies continue to refine mechanistic detail. (lippi2025theroleof pages 27-30, ecroyd2023thebeautyand pages 1-2)
+
+### Key primary sources (with publication dates and URLs)
+- Haslbeck et al. **1999-12**, *EMBO Journal*: “Hsp26: a temperature-regulated chaperone.” https://doi.org/10.1093/emboj/18.23.6744 (haslbeck1999hsp26atemperature‐regulated pages 1-2, haslbeck1999hsp26atemperature‐regulated pages 4-5)
+- Franzmann et al. **2008-02**, *Molecular Cell*: “Activation of the chaperone Hsp26 is controlled by the rearrangement of its thermosensor domain.” https://doi.org/10.1016/j.molcel.2007.11.025 (franzmann2008activationofthe pages 1-2)
+- Mühlhofer et al. **2021-11**, *Nature Communications*: “Phosphorylation activates the yeast small heat shock protein Hsp26…” https://doi.org/10.1038/s41467-021-27036-7 (muhlhofer2021phosphorylationactivatesthe pages 1-2, muhlhofer2021phosphorylationactivatesthe pages 4-5, muhlhofer2021phosphorylationactivatesthe media 1375ea3d, muhlhofer2021phosphorylationactivatesthe media ac65f9e2)
+- Ecroyd et al. **2023-11**, *Cell Stress and Chaperones*: workshop report on sHsps (includes Hsp26 structural/regulatory highlights). https://doi.org/10.1007/s12192-023-01360-x (ecroyd2023thebeautyand pages 1-2)
+- Rubio et al. **2024-10**, *eLife*: “Heat Shock Factor 1 forms nuclear condensates…” (includes HSP26 regulation, ethanol vs heat kinetics). https://doi.org/10.7554/eLife.92464.4 (rubio2024heatshockfactor pages 3-5, rubio2024heatshockfactor pages 13-15, rubio2024heatshockfactor pages 8-9)
+- Duennwald et al. **2012-06**, *PLoS Biology*: sHsps potentiate amyloid dissolution by disaggregases. https://doi.org/10.1371/journal.pbio.1001346 (duennwald2012smallheatshock pages 1-2)
+- Verghese et al. **2012-06**, *Microbiology and Molecular Biology Reviews*: yeast heat shock response and chaperone biology. https://doi.org/10.1128/MMBR.05018-11 (verghese2012biologyofthe pages 20-21)
+- Ferreira et al. **2006-06**, *Protein Expression and Purification*: purification/EM/functional assays for yeast Hsp26. https://doi.org/10.1016/j.pep.2006.02.006 (ferreira2006purificationandcharacterization pages 1-2)
+
+References
+
+1. (haslbeck1999hsp26atemperature‐regulated pages 1-2): M. Haslbeck, S. Walke, Thusnelda Stromer, M. Ehrnsperger, H. White, Shaoxia Chen, H. Saibil, and J. Buchner. Hsp26: a temperature‐regulated chaperone. The EMBO Journal, 18:6744-6751, Dec 1999. URL: https://doi.org/10.1093/emboj/18.23.6744, doi:10.1093/emboj/18.23.6744. This article has 614 citations.
+
+2. (muhlhofer2021phosphorylationactivatesthe pages 1-2): Moritz Mühlhofer, Carsten Peters, Thomas Kriehuber, Marina Kreuzeder, Pamina Kazman, Natalia Rodina, Bernd Reif, Martin Haslbeck, Sevil Weinkauf, and Johannes Buchner. Phosphorylation activates the yeast small heat shock protein hsp26 by weakening domain contacts in the oligomer ensemble. Nature Communications, Nov 2021. URL: https://doi.org/10.1038/s41467-021-27036-7, doi:10.1038/s41467-021-27036-7. This article has 39 citations and is from a highest quality peer-reviewed journal.
+
+3. (franzmann2008activationofthe pages 1-2): Titus M. Franzmann, Petra Menhorn, Stefan Walter, and Johannes Buchner. Activation of the chaperone hsp26 is controlled by the rearrangement of its thermosensor domain. Molecular cell, 29 2:207-16, Feb 2008. URL: https://doi.org/10.1016/j.molcel.2007.11.025, doi:10.1016/j.molcel.2007.11.025. This article has 126 citations and is from a highest quality peer-reviewed journal.
+
+4. (verghese2012biologyofthe pages 20-21): Jacob Verghese, Jennifer Abrams, Yanyu Wang, and Kevin A. Morano. Biology of the heat shock response and protein chaperones: budding yeast (saccharomyces cerevisiae) as a model system. Microbiology and Molecular Biology Reviews, 76:115-158, Jun 2012. URL: https://doi.org/10.1128/mmbr.05018-11, doi:10.1128/mmbr.05018-11. This article has 765 citations and is from a domain leading peer-reviewed journal.
+
+5. (haslbeck1999hsp26atemperature‐regulated pages 4-5): M. Haslbeck, S. Walke, Thusnelda Stromer, M. Ehrnsperger, H. White, Shaoxia Chen, H. Saibil, and J. Buchner. Hsp26: a temperature‐regulated chaperone. The EMBO Journal, 18:6744-6751, Dec 1999. URL: https://doi.org/10.1093/emboj/18.23.6744, doi:10.1093/emboj/18.23.6744. This article has 614 citations.
+
+6. (muhlhofer2021phosphorylationactivatesthe pages 4-5): Moritz Mühlhofer, Carsten Peters, Thomas Kriehuber, Marina Kreuzeder, Pamina Kazman, Natalia Rodina, Bernd Reif, Martin Haslbeck, Sevil Weinkauf, and Johannes Buchner. Phosphorylation activates the yeast small heat shock protein hsp26 by weakening domain contacts in the oligomer ensemble. Nature Communications, Nov 2021. URL: https://doi.org/10.1038/s41467-021-27036-7, doi:10.1038/s41467-021-27036-7. This article has 39 citations and is from a highest quality peer-reviewed journal.
+
+7. (muhlhofer2021phosphorylationactivatesthe media 1375ea3d): Moritz Mühlhofer, Carsten Peters, Thomas Kriehuber, Marina Kreuzeder, Pamina Kazman, Natalia Rodina, Bernd Reif, Martin Haslbeck, Sevil Weinkauf, and Johannes Buchner. Phosphorylation activates the yeast small heat shock protein hsp26 by weakening domain contacts in the oligomer ensemble. Nature Communications, Nov 2021. URL: https://doi.org/10.1038/s41467-021-27036-7, doi:10.1038/s41467-021-27036-7. This article has 39 citations and is from a highest quality peer-reviewed journal.
+
+8. (ecroyd2023thebeautyand pages 1-2): Heath Ecroyd, Britta Bartelt-Kirbach, Anat Ben-Zvi, Raffaella Bonavita, Yevheniia Bushman, Elena Casarotto, Ciro Cecconi, Wilson Chun Yu Lau, Jonathan D. Hibshman, Joep Joosten, Virginia Kimonis, Rachel Klevit, Krzysztof Liberek, Kathryn A. McMenimen, Tsukumi Miwa, Axel Mogk, Daniele Montepietra, Carsten Peters, Maria resa Te Rocchetti, Dominik Saman, Angela Sisto, Valentina Secco, Annika Strauch, Hideki Taguchi, Morgan Tanguay, Barbara Tedesco, Melinda E. Toth, Zihao Wang, Justin L.P. Benesch, and Serena Carra. The beauty and complexity of the small heat shock proteins: a report on the proceedings of the fourth workshop on small heat shock proteins. Cell Stress and Chaperones, 28:621-629, Nov 2023. URL: https://doi.org/10.1007/s12192-023-01360-x, doi:10.1007/s12192-023-01360-x. This article has 11 citations and is from a peer-reviewed journal.
+
+9. (muhlhofer2021phosphorylationactivatesthe media ac65f9e2): Moritz Mühlhofer, Carsten Peters, Thomas Kriehuber, Marina Kreuzeder, Pamina Kazman, Natalia Rodina, Bernd Reif, Martin Haslbeck, Sevil Weinkauf, and Johannes Buchner. Phosphorylation activates the yeast small heat shock protein hsp26 by weakening domain contacts in the oligomer ensemble. Nature Communications, Nov 2021. URL: https://doi.org/10.1038/s41467-021-27036-7, doi:10.1038/s41467-021-27036-7. This article has 39 citations and is from a highest quality peer-reviewed journal.
+
+10. (duennwald2012smallheatshock pages 1-2): Martin L. Duennwald, AnaLisa Echeverria, and James Shorter. Small heat shock proteins potentiate amyloid dissolution by protein disaggregases from yeast and humans. PLoS Biology, 10:e1001346, Jun 2012. URL: https://doi.org/10.1371/journal.pbio.1001346, doi:10.1371/journal.pbio.1001346. This article has 216 citations and is from a highest quality peer-reviewed journal.
+
+11. (rubio2024heatshockfactor pages 3-5): Linda S Rubio, Suman Mohajan, and David S Gross. Heat shock factor 1 forms nuclear condensates and restructures the yeast genome before activating target genes. eLife, Oct 2024. URL: https://doi.org/10.7554/elife.92464.4, doi:10.7554/elife.92464.4. This article has 17 citations and is from a domain leading peer-reviewed journal.
+
+12. (rubio2024heatshockfactor pages 13-15): Linda S Rubio, Suman Mohajan, and David S Gross. Heat shock factor 1 forms nuclear condensates and restructures the yeast genome before activating target genes. eLife, Oct 2024. URL: https://doi.org/10.7554/elife.92464.4, doi:10.7554/elife.92464.4. This article has 17 citations and is from a domain leading peer-reviewed journal.
+
+13. (rubio2024heatshockfactor pages 8-9): Linda S Rubio, Suman Mohajan, and David S Gross. Heat shock factor 1 forms nuclear condensates and restructures the yeast genome before activating target genes. eLife, Oct 2024. URL: https://doi.org/10.7554/elife.92464.4, doi:10.7554/elife.92464.4. This article has 17 citations and is from a domain leading peer-reviewed journal.
+
+14. (lippi2025theroleof pages 27-30): Alice Lippi. The role of hsp42 in proteostasis-metabolism interplay and cellular longevity. ArXiv, 2025. URL: https://doi.org/10.53846/goediss-10952, doi:10.53846/goediss-10952. This article has 0 citations.
+
+15. (ferreira2006purificationandcharacterization pages 1-2): Renato Marins Ferreira, Leonardo Rodrigues de Andrade, Márcio Barros Dutra, Marcos Farina de Souza, Vânia Margaret Flosi Paschoalin, and Joab Trajano Silva. Purification and characterization of the chaperone-like hsp26 from saccharomyces cerevisiae. Protein expression and purification, 47 2:384-92, Jun 2006. URL: https://doi.org/10.1016/j.pep.2006.02.006, doi:10.1016/j.pep.2006.02.006. This article has 14 citations and is from a peer-reviewed journal.
+
+16. (rubio2024heatshockfactor pages 5-8): Linda S Rubio, Suman Mohajan, and David S Gross. Heat shock factor 1 forms nuclear condensates and restructures the yeast genome before activating target genes. eLife, Oct 2024. URL: https://doi.org/10.7554/elife.92464.4, doi:10.7554/elife.92464.4. This article has 17 citations and is from a domain leading peer-reviewed journal.
+
+## Citations
+
+1. franzmann2008activationofthe pages 1-2
+2. muhlhofer2021phosphorylationactivatesthe pages 1-2
+3. ecroyd2023thebeautyand pages 1-2
+4. duennwald2012smallheatshock pages 1-2
+5. verghese2012biologyofthe pages 20-21
+6. rubio2024heatshockfactor pages 3-5
+7. ferreira2006purificationandcharacterization pages 1-2
+8. muhlhofer2021phosphorylationactivatesthe pages 4-5
+9. rubio2024heatshockfactor pages 13-15
+10. rubio2024heatshockfactor pages 8-9
+11. lippi2025theroleof pages 27-30
+12. rubio2024heatshockfactor pages 5-8
+13. https://doi.org/10.1093/emboj/18.23.6744
+14. https://doi.org/10.1038/s41467-021-27036-7
+15. https://doi.org/10.1016/j.molcel.2007.11.025
+16. https://doi.org/10.1007/s12192-023-01360-x
+17. https://doi.org/10.1371/journal.pbio.1001346
+18. https://doi.org/10.1128/MMBR.05018-11
+19. https://doi.org/10.7554/eLife.92464.4
+20. https://doi.org/10.1016/j.pep.2006.02.006
+21. https://doi.org/10.1016/j.jmb.2005.05.034
+22. https://doi.org/10.53846/goediss-10952
+23. https://doi.org/10.1093/emboj/18.23.6744,
+24. https://doi.org/10.1038/s41467-021-27036-7,
+25. https://doi.org/10.1016/j.molcel.2007.11.025,
+26. https://doi.org/10.1128/mmbr.05018-11,
+27. https://doi.org/10.1007/s12192-023-01360-x,
+28. https://doi.org/10.1371/journal.pbio.1001346,
+29. https://doi.org/10.7554/elife.92464.4,
+30. https://doi.org/10.53846/goediss-10952,
+31. https://doi.org/10.1016/j.pep.2006.02.006,

--- a/genes/yeast/LSM1/LSM1-ai-review.html
+++ b/genes/yeast/LSM1/LSM1-ai-review.html
@@ -671,46 +671,46 @@
     <div class="header">
         <h1>LSM1</h1>
         <div class="gene-info">
-            
+
             <div class="info-item">
-                
+
                 <span class="info-label">UniProt ID:</span>
                 <span>
                     <a href="https://www.uniprot.org/uniprotkb/P47017" target="_blank" class="term-link">
                         P47017
                     </a>
                 </span>
-                
+
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Organism:</span>
                 <span>Saccharomyces cerevisiae</span>
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
                 <span class="status-badge status-complete">
                     COMPLETE
                 </span>
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Aliases:</span>
                 <div class="aliases">
-                    
+
                     <span class="badge">SPB8</span>
-                    
+
                     <span class="badge">YJL124C</span>
-                    
+
                     <span class="badge">J0714</span>
-                    
+
                 </div>
             </div>
-            
+
         </div>
         <div style="margin-top: 1rem; text-align: center;">
             <a id="feedback-form-link"
@@ -741,7 +741,7 @@
         </div>
     </div>
 
-    
+
     <div class="description-card">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <h2>Gene Description</h2>
@@ -752,13 +752,13 @@
         </div>
         <p>LSM1 (Lsm1p) is the defining component of the cytoplasmic Lsm1-7-Pat1 heptameric complex, which is a critical activator of mRNA decapping and a key effector of deadenylation-dependent mRNA decay. Unlike other Lsm proteins (Lsm2-8) that function in U6 snRNA splicing, LSM1 is unique and forms a complex specifically involved in cytoplasmic mRNA turnover. The Lsm1-7 complex binds to poly(U) tracts at the 3&#39; end of deadenylated mRNAs and recruits the decapping machinery (Dcp1/Dcp2), converting capped mRNAs to susceptible substrates for 5&#39; to 3&#39; exonucleolytic degradation by Xrn1. The complex also functions in protective binding to mRNA 3&#39; ends. LSM1 is predominantly cytoplasmic but can also localize to P-bodies and has been detected in the nucleus.</p>
     </div>
-    
 
-    
 
-    
 
-    
+
+
+
+
     <div class="section">
         <h2 class="section-title">Existing Annotations Review</h2>
         <table class="annotations-table">
@@ -771,32 +771,32 @@
                 </tr>
             </thead>
             <tbody>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000290" target="_blank" class="term-link">
                                     GO:0000290
                                 </a>
                             </span>
                             <span class="term-label">deadenylation-dependent decapping of nuclear-transcribed mRNA</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -808,90 +808,101 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Phylogenetic annotation indicating that LSM1 is involved in deadenylation-dependent decapping of nuclear-transcribed mRNA based on ortholog inference. This annotation is well-supported by experimental evidence from multiple sources, including IMP annotations with PMIDs 10761922 and 15716506, which directly demonstrate the role of Lsm1p in mRNA decapping.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This is a core function of LSM1. The annotation is correct and represents the primary mechanistic role of the Lsm1-7-Pat1 complex. Bouveret et al. (2000) demonstrated that Lsm1p-Lsm7p complex activates the decapping step of mRNA degradation, with deletion mutants showing accumulation of capped mRNAs and blocks in mRNA decay. This is a conserved function across eukaryotes and LSM1 is the defining member of this pathway.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10747033" target="_blank" class="term-link">
                                         PMID:10747033
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Deletions of LSM1, 6, 7 and PAT1 genes increased the half-life of reporter mRNAs. Interestingly, accumulating mRNAs were capped, suggesting a block in mRNA decay at the decapping step.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10761922" target="_blank" class="term-link">
                                         PMID:10761922
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">mutations in seven yeast Lsm proteins (Lsm1-Lsm7) also lead to inhibition of mRNA decapping</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/15716506" target="_blank" class="term-link">
                                         PMID:15716506
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The decapping of eukaryotic mRNAs is a key step in their degradation. The heteroheptameric Lsm1p-7p complex is a general activator of decapping</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/LSM1/LSM1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The Lsm1-7 ring plus Pat1 is a key module that links 3&#39; end status to decapping: Pat1/Lsm1-7 binds oligoadenylated 3&#39; ends and helps recruit/activate the decapping enzyme.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003729" target="_blank" class="term-link">
                                     GO:0003729
                                 </a>
                             </span>
                             <span class="term-label">mRNA binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -903,77 +914,77 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Phylogenetic inference of mRNA binding capacity. This is mechanistically accurate as the Lsm1-7 complex binds to oligo-U tracts at the 3&#39; end of deadenylated mRNAs, which is essential for its decapping activation function. The annotation is supported by IDA evidence (PMID:23222640) that demonstrates LSM1 association with yeast mRNPs.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> LSM1 is a core component of the Lsm1-7 complex that binds to poly(U) tracts of mRNA 3&#39; ends as part of its mechanism for mRNA decay activation. The mRNA binding is functionally relevant to the decapping activation role. The complex specifically recognizes RNA motifs via the ring-structured Sm domain.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/15716506" target="_blank" class="term-link">
                                         PMID:15716506
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Mutations affecting the predicted RNA-binding and inter-subunit interaction residues of Lsm1p led to impairment of mRNA decay, suggesting that the integrity of the Lsm1p-7p complex and the ability of the Lsm1p-7p complex to interact with mRNA are important for mRNA decay function</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/24139796" target="_blank" class="term-link">
                                         PMID:24139796
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The 3.7 Å resolution structure of Lsm1-7 bound to the C-terminal domain of Pat1 reveals...A distinct structural feature of the cytoplasmic Lsm ring is the C-terminal extension of Lsm1, which plugs the exit site of the central channel and approaches the RNA binding pockets.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1990726" target="_blank" class="term-link">
                                     GO:1990726
                                 </a>
                             </span>
                             <span class="term-label">Lsm1-7-Pat1 complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -985,77 +996,77 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Phylogenetic annotation indicating LSM1 is a component of the Lsm1-7-Pat1 complex. This is well-supported by IDA evidence (PMID:24139796) that provides crystal structure of the complex, confirming LSM1 as a core subunit.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> LSM1 is the defining member of the Lsm1-7-Pat1 complex, forming the heptameric ring that recruits Pat1 for mRNA decay activation. Sharif &amp; Conti (2013) resolved the 2.3 Ångström crystal structure showing Lsm1-2-3-6-5-7-4 topology with LSM1 as the unique subunit. This is factual component annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10747033" target="_blank" class="term-link">
                                         PMID:10747033
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Lsm1p, together with Lsm2p-Lsm7p, forms a new seven-subunit complex...the Lsm1p-Lsm7p complex is associated with Pat1p and Xrn1p exoribonuclease</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/24139796" target="_blank" class="term-link">
                                         PMID:24139796
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The 2.3 Å resolution structure of S. cerevisiae Lsm1-7 shows the presence of a heptameric ring with Lsm1-2-3-6-5-7-4 topology</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000932" target="_blank" class="term-link">
                                     GO:0000932
                                 </a>
                             </span>
                             <span class="term-label">P-body</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1067,64 +1078,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Phylogenetic inference that LSM1 is active in or localized to P-bodies. This is accurate as Lsm1-7 is a core component of P-bodies where mRNA decapping and decay occur. Multiple IDA and IMP annotations (PMIDs 12730603, 18611963) directly support localization and function in P-bodies.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> LSM1 and the Lsm1-7-Pat1 complex are core P-body components. Sheth &amp; Parker (2003) demonstrated that proteins involved in mRNA decapping are concentrated in P-bodies, and that mRNA degradation intermediates localize to these structures. The complex is active_in P-bodies as the primary site of its mRNA decay function.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/12730603" target="_blank" class="term-link">
                                         PMID:12730603
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">proteins that activate or catalyze decapping are concentrated in P bodies...mRNA degradation intermediates are localized to P bodies</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000932" target="_blank" class="term-link">
                                     GO:0000932
                                 </a>
                             </span>
                             <span class="term-label">P-body</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1136,46 +1147,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> UniProt subcellular location mapping indicates P-body localization based on automated annotation. This is consistent with experimental evidence but is weaker than IBA inference or direct experimental evidence.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> P-body localization is correct and well-supported. While this IEA annotation is lower confidence than the IBA and IDA annotations, it is not incorrect and represents the same underlying biological reality. All annotations for P-body are consistent across different evidence types, confirming LSM1 localization to this critical mRNA decay compartment.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000956" target="_blank" class="term-link">
                                     GO:0000956
                                 </a>
                             </span>
                             <span class="term-label">nuclear-transcribed mRNA catabolic process</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -1187,46 +1198,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This parent mRNA catabolic process term is valid but broader than the specific decay subprocesses curated for LSM1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Changed from MODIFY to KEEP_AS_NON_CORE because the review rationale supports retaining the broad parent term as non-core rather than replacing it.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003723" target="_blank" class="term-link">
                                     GO:0003723
                                 </a>
                             </span>
                             <span class="term-label">RNA binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -1238,46 +1249,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation based on InterPro Sm domain and RNA-binding keywords. While LSM1 does bind RNA via its Sm domain, this is a generic parent term that is superseded by GO:0003729 (mRNA binding) which is more specific.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0003723 (RNA binding) is technically correct but overly general compared to GO:0003729 (mRNA binding), which specifies the actual substrate and mechanism. LSM1 specifically binds mRNA (particularly poly(U) tracts) rather than other RNA types like snRNAs. The more specific mRNA binding term is already present with IBA and IDA evidence. This general RNA binding term is redundant and less informative.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1289,64 +1300,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> UniProt subcellular location mapping to nucleus. LSM1 has been detected in the nucleus according to the UniProt record, and there is IDA evidence (PMID:23706738) supporting nuclear localization.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> LSM1 is present in both nucleus and cytoplasm. The UniProt entry states nuclear localization with ECO:0000269|PubMed:10761922 evidence. While the primary function of LSM1 is in the cytoplasm for mRNA decay, nuclear detection is documented and the annotation is correct.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10761922" target="_blank" class="term-link">
                                         PMID:10761922
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">the Lsm1-Lsm7 proteins co-immunoprecipitate with the mRNA decapping enzyme (Dcp1), a decapping activator (Pat1/Mrt1) and with mRNA</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1358,46 +1369,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation indicating cytoplasmic localization based on automated inference. This is correct and reflects the primary location of LSM1 where the mRNA decay machinery operates.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> LSM1 is predominantly localized to the cytoplasm where it functions in mRNA decay and P-body assembly. This is well-documented by multiple IDA annotations and is essential to its biological function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006397" target="_blank" class="term-link">
                                     GO:0006397
                                 </a>
                             </span>
                             <span class="term-label">mRNA processing</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -1409,46 +1420,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> UniProt keyword mapping indicates LSM1 involvement in mRNA processing. However, this is misleading because mRNA processing typically refers to 5&#39; capping, 3&#39; polyadenylation, and splicing of nascent transcripts.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This annotation is mechanistically incorrect for LSM1. GO:0006397 (mRNA processing) encompasses 5&#39; capping, 3&#39; polyadenylation, and splicing during transcription. LSM1 functions in mRNA decay/degradation, not mRNA processing. The Lsm1-7 complex removes the 5&#39; cap as part of decay, but this is degradation, not processing. The specific mRNA decay processes (GO:0000288, GO:0000290) are the correct annotations. This IEA annotation appears to result from incorrect keyword mapping and should not be retained.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032991" target="_blank" class="term-link">
                                     GO:0032991
                                 </a>
                             </span>
                             <span class="term-label">protein-containing complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1460,46 +1471,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> ARBA machine learning annotation indicating LSM1 is part of a protein-containing complex. This is correct as LSM1 is a core member of the Lsm1-7-Pat1 complex.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> LSM1 is an obligate component of the heptameric Lsm1-7-Pat1 complex. This is a generic parent term but accurate. More specific component annotations exist (GO:1990726 for the specific complex).
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1990904" target="_blank" class="term-link">
                                     GO:1990904
                                 </a>
                             </span>
                             <span class="term-label">ribonucleoprotein complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1511,57 +1522,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> UniProt keyword mapping indicates LSM1 is part of a ribonucleoprotein complex. The Lsm1-7 complex is indeed a ribonucleoprotein that binds and processes RNA.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The Lsm1-7-Pat1 complex is a ribonucleoprotein complex containing RNA-binding Sm domains and functionally interacting with mRNA. This annotation is accurate though the more specific complex identifier (GO:1990726) is more informative.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10688190" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:10688190
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A comprehensive analysis of protein-protein interactions in ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1573,86 +1584,86 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI evidence from comprehensive protein-protein interaction study. LSM1 interacts with LSM2, LSM3, LSM4, LSM5, LSM6, LSM7 as core members of the Lsm1-7 complex.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> While LSM1 does bind proteins as part of the Lsm1-7 complex, the generic GO:0005515 (protein binding) term is not informative for functional annotation. The specific protein-protein interactions and the biological role (complex assembly for mRNA decay) are better captured by GO:1990726 (Lsm1-7-Pat1 complex). Generic &#34;protein binding&#34; annotations lack functional specificity and should be replaced with mechanistically informative terms that describe what the binding accomplishes.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1990726" target="_blank" class="term-link">
                                     Lsm1-7-Pat1 complex
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10688190" target="_blank" class="term-link">
                                         PMID:10688190
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">A comprehensive analysis of protein-protein interactions in Saccharomyces cerevisiae.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10900456" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:10900456
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Genome-wide protein interaction screens reveal functional ne...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1664,86 +1675,86 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI evidence from genome-wide protein interaction screens showing LSM1 interactions with PAT1 and other Lsm proteins.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Generic protein binding annotation without functional context. LSM1 interacts with other Lsm proteins and PAT1, but this is comprehensively described by the complex component annotation GO:1990726. The generic term provides no insight into the biological significance of these interactions.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1990726" target="_blank" class="term-link">
                                     Lsm1-7-Pat1 complex
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10900456" target="_blank" class="term-link">
                                         PMID:10900456
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Genome-wide protein interaction screens reveal functional networks involving Sm-like proteins.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/11780629" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:11780629
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The DEAD box helicase, Dhh1p, functions in mRNA decapping an...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1755,75 +1766,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI evidence showing interaction of LSM1 with Dhh1 (DEAD box helicase) documented in interaction studies.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Generic protein binding term without mechanistic context. While LSM1 does interact with Dhh1, the biological significance and functional consequence are not captured by this vague annotation. The mRNA decay process annotations better describe what these interactions accomplish.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/11780629" target="_blank" class="term-link">
                                         PMID:11780629
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The DEAD box helicase, Dhh1p, functions in mRNA decapping and interacts with both the decapping and deadenylase complexes.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/11805837" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:11805837
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Systematic identification of protein complexes in Saccharomy...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1835,86 +1846,86 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI evidence from mass spectrometry studies of protein complexes identifying LSM1 in the Lsm1-7-Pat1 complex.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Generic protein binding annotation redundant with complex component annotation. The systematic protein complex identification is better represented by GO:1990726.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1990726" target="_blank" class="term-link">
                                     Lsm1-7-Pat1 complex
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/11805837" target="_blank" class="term-link">
                                         PMID:11805837
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Systematic identification of protein complexes in Saccharomyces cerevisiae by mass spectrometry.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/14759368" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:14759368
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     High-definition macromolecular composition of yeast RNA-proc...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1926,86 +1937,86 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI evidence from high-definition macromolecular composition of yeast RNA-processing complexes.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This annotation documents LSM1 protein interactions from complex characterization studies, but the generic &#34;protein binding&#34; term is uninformative. The complex assembly and function are better captured by specific GO terms.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1990726" target="_blank" class="term-link">
                                     Lsm1-7-Pat1 complex
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/14759368" target="_blank" class="term-link">
                                         PMID:14759368
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">High-definition macromolecular composition of yeast RNA-processing complexes.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16429126" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16429126
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Proteome survey reveals modularity of the yeast cell machine...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2017,86 +2028,86 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI evidence from proteome survey identifying LSM1 protein interactions.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Generic annotation without functional specificity. LSM1 protein interactions are functionally significant only in the context of mRNA decay machinery assembly.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1990726" target="_blank" class="term-link">
                                     Lsm1-7-Pat1 complex
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/16429126" target="_blank" class="term-link">
                                         PMID:16429126
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Proteome survey reveals modularity of the yeast cell machinery.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16554755" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16554755
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Global landscape of protein complexes in the yeast Saccharom...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2108,86 +2119,86 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI evidence from global landscape studies of yeast protein complexes.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Generic protein binding term redundant with more specific complex component annotation.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1990726" target="_blank" class="term-link">
                                     Lsm1-7-Pat1 complex
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/16554755" target="_blank" class="term-link">
                                         PMID:16554755
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Global landscape of protein complexes in the yeast Saccharomyces cerevisiae.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/18719252" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:18719252
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     High-quality binary protein interaction map of the yeast int...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2199,86 +2210,86 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI evidence from high-quality binary protein interaction mapping.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Binary protein interactions documented but better represented by complex component annotation.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1990726" target="_blank" class="term-link">
                                     Lsm1-7-Pat1 complex
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/18719252" target="_blank" class="term-link">
                                         PMID:18719252
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">High-quality binary protein interaction map of the yeast interactome network.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23267104" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23267104
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Proteome-wide protein interaction measurements of bacterial ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2290,86 +2301,86 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI evidence from proteome-wide protein interaction measurements.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Generic binding annotation without functional context.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1990726" target="_blank" class="term-link">
                                     Lsm1-7-Pat1 complex
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/23267104" target="_blank" class="term-link">
                                         PMID:23267104
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Proteome-wide protein interaction measurements of bacterial proteins of unknown function.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/37070168" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:37070168
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     RNA-dependent interactome allows network-based assignment of...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2381,86 +2392,86 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI evidence from RNA-dependent interactome analysis.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Generic protein binding term lacks functional specificity for RNA-binding protein annotation.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1990726" target="_blank" class="term-link">
                                     Lsm1-7-Pat1 complex
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/37070168" target="_blank" class="term-link">
                                         PMID:37070168
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">RNA-dependent interactome allows network-based assignment of RNA-binding protein function.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/37968396" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:37968396
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The social and structural architecture of the yeast protein ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2472,86 +2483,86 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI evidence from social and structural architecture study of yeast protein interactome.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Generic annotation not informative for molecular function annotation.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1990726" target="_blank" class="term-link">
                                     Lsm1-7-Pat1 complex
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/37968396" target="_blank" class="term-link">
                                         PMID:37968396
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The social and structural architecture of the yeast protein interactome.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000290" target="_blank" class="term-link">
                                     GO:0000290
                                 </a>
                             </span>
                             <span class="term-label">deadenylation-dependent decapping of nuclear-transcribed mRNA</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/15716506" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:15716506
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Mutations in the Saccharomyces cerevisiae LSM1 gene that aff...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2563,75 +2574,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IMP evidence from mutagenesis study directly testing LSM1 function in mRNA decapping. Tharun et al. (2005) used point mutations of LSM1 to show impaired mRNA decay and defective decapping.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This is strong experimental evidence that LSM1 is required for mRNA decapping activation. The mutagenesis study demonstrates that RNA-binding residues are critical for function, confirming the mechanistic role. Duplicate annotation with different evidence codes is appropriate.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/15716506" target="_blank" class="term-link">
                                         PMID:15716506
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Mutations affecting the predicted RNA-binding and inter-subunit interaction residues of Lsm1p led to impairment of mRNA decay, suggesting that the integrity of the Lsm1p-7p complex and the ability of the Lsm1p-7p complex to interact with mRNA are important for mRNA decay function</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000932" target="_blank" class="term-link">
                                     GO:0000932
                                 </a>
                             </span>
                             <span class="term-label">P-body</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/12730603" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:12730603
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Decapping and decay of messenger RNA occur in cytoplasmic pr...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2643,75 +2654,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA evidence from immunofluorescence and localization studies showing LSM1 in P-bodies. Sheth &amp; Parker (2003) demonstrated that decapping enzymes and LSM proteins localize to P-bodies.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Direct observation of LSM1 localization to P-bodies where mRNA decay occurs. This is consistent with IBA and IMP annotations and represents core cellular compartmentalization of LSM1 function.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/12730603" target="_blank" class="term-link">
                                         PMID:12730603
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">proteins that activate or catalyze decapping are concentrated in P bodies</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/22842922" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:22842922
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Dissecting DNA damage response pathways by analysing protein...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2723,75 +2734,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> HDA (high-throughput direct assay) evidence showing cytoplasmic localization from DNA damage response studies detecting LSM1 in cytoplasm.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytoplasmic localization is well-established and essential for LSM1 function. HDA evidence is high-confidence direct observation. Consistent with other localization evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/22842922" target="_blank" class="term-link">
                                         PMID:22842922
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Dissecting DNA damage response pathways by analysing protein localization and abundance changes during DNA replication stress</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1990726" target="_blank" class="term-link">
                                     GO:1990726
                                 </a>
                             </span>
                             <span class="term-label">Lsm1-7-Pat1 complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24139796" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:24139796
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Architecture of the Lsm1-7-Pat1 complex: a conserved assembl...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2803,75 +2814,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA evidence from crystal structure showing LSM1 as core subunit of the Lsm1-7-Pat1 complex. Sharif &amp; Conti (2013) provided 2.3 Å structure demonstrating complex architecture.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The crystal structure provides definitive evidence of LSM1 as a core component of the Lsm1-7-Pat1 complex. This is the highest quality structural evidence and confirms mechanistic details of complex assembly.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/24139796" target="_blank" class="term-link">
                                         PMID:24139796
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The 2.3 Å resolution structure of S. cerevisiae Lsm1-7 shows the presence of a heptameric ring</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003729" target="_blank" class="term-link">
                                     GO:0003729
                                 </a>
                             </span>
                             <span class="term-label">mRNA binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23222640" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23222640
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Global analysis of yeast mRNPs.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2883,75 +2894,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA evidence from global analysis of yeast mRNPs (messenger ribonucleoprotein particles) showing LSM1 associated with mRNA.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Direct evidence of LSM1 in mRNP complexes confirms functional mRNA binding. Consistent with IBA annotation and structural data showing RNA binding pocket.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/23222640" target="_blank" class="term-link">
                                         PMID:23222640
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Global analysis of yeast mRNPs</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003682" target="_blank" class="term-link">
                                     GO:0003682
                                 </a>
                             </span>
                             <span class="term-label">chromatin binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23706738" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23706738
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Gene expression is circular: factors for mRNA degradation al...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -2963,75 +2974,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA evidence from localization study reporting LSM1 chromatin binding. However, this annotation may reflect contamination or indirect association rather than true chromatin binding.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> LSM1 is an mRNA decay protein, not primarily a chromatin-binding protein. The Lsm1-7 complex functions in the cytoplasm and at P-bodies on mRNA transcripts, not at chromatin. The annotation from PMID:23706738 appears to report LSM1 in nuclei and potentially binding to chromatin during the &#34;Gene expression is circular&#34; studies, but this is not a core function. LSM1 does not have characteristic chromatin-binding domains. This annotation likely represents mislocalization or experimental artifact and should not be retained.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/23706738" target="_blank" class="term-link">
                                         PMID:23706738
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Gene expression is circular: factors for mRNA degradation also foster mRNA synthesis.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23706738" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23706738
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Gene expression is circular: factors for mRNA degradation al...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3043,75 +3054,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA evidence showing nuclear localization from the &#34;Gene expression is circular&#34; study. LSM1 is detected in both nucleus and cytoplasm.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Consistent with UniProt annotation showing nuclear localization. While cytoplasmic mRNA decay is the primary function, nuclear detection is documented. Acceptable to retain.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/23706738" target="_blank" class="term-link">
                                         PMID:23706738
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Gene expression is circular: factors for mRNA degradation also foster mRNA synthesis.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23706738" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23706738
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Gene expression is circular: factors for mRNA degradation al...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3123,75 +3134,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA evidence confirming cytoplasmic localization from direct observation studies.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cytoplasm is the primary site of LSM1 function. Direct observation confirms expected localization.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/23706738" target="_blank" class="term-link">
                                         PMID:23706738
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Gene expression is circular: factors for mRNA degradation also foster mRNA synthesis.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000288" target="_blank" class="term-link">
                                     GO:0000288
                                 </a>
                             </span>
                             <span class="term-label">nuclear-transcribed mRNA catabolic process, deadenylation-dependent decay</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10747033" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:10747033
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A Sm-like protein complex that participates in mRNA degradat...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3203,75 +3214,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IMP evidence from Bouveret et al. (2000) directly demonstrating LSM1 involvement in deadenylation-dependent mRNA decay through deletion analysis.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> LSM1 deletion mutants showed increased mRNA half-life and accumulation of capped mRNAs, demonstrating a block in the decapping step. This is the seminal paper identifying the Lsm1-7 complex role in mRNA decay. Core functional annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10747033" target="_blank" class="term-link">
                                         PMID:10747033
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Deletions of LSM1, 6, 7 and PAT1 genes increased the half-life of reporter mRNAs. Interestingly, accumulating mRNAs were capped, suggesting a block in mRNA decay at the decapping step.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000290" target="_blank" class="term-link">
                                     GO:0000290
                                 </a>
                             </span>
                             <span class="term-label">deadenylation-dependent decapping of nuclear-transcribed mRNA</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10761922" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:10761922
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Yeast Sm-like proteins function in mRNA decapping and decay.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3283,75 +3294,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IMP evidence from Tharun et al. (2000) showing LSM1-Lsm7 mutations inhibit mRNA decapping and demonstrating interaction with decapping machinery.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Tharun et al. demonstrated that lsm mutations specifically block mRNA decapping, and that Lsm proteins co-immunoprecipitate with Dcp1 and mRNA. This establishes the mechanistic link between LSM1 and decapping activation. Duplicate IMP annotation with different PMID is appropriate as it provides additional mechanistic detail.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10761922" target="_blank" class="term-link">
                                         PMID:10761922
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">mutations in seven yeast Lsm proteins (Lsm1-Lsm7) also lead to inhibition of mRNA decapping</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000932" target="_blank" class="term-link">
                                     GO:0000932
                                 </a>
                             </span>
                             <span class="term-label">P-body</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/12730603" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:12730603
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Decapping and decay of messenger RNA occur in cytoplasmic pr...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3363,75 +3374,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IMP evidence showing P-body function in mRNA decay where LSM1 acts as part of the decapping and decay machinery.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> While primarily a localization annotation (IDA also exists for same PMID), the IMP evidence demonstrates that P-body function in mRNA decay is dependent on the decapping machinery where LSM1 operates. Both evidence types are valid and appropriate.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/12730603" target="_blank" class="term-link">
                                         PMID:12730603
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">A major pathway of eukaryotic messenger RNA (mRNA) turnover begins with deadenylation, followed by decapping and 5&#39; to 3&#39; exonucleolytic decay</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000932" target="_blank" class="term-link">
                                     GO:0000932
                                 </a>
                             </span>
                             <span class="term-label">P-body</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/18611963" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:18611963
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A role for Q/N-rich aggregation-prone regions in P-body loca...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3443,75 +3454,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA evidence showing LSM1 localization to P-bodies in studies of Q/N-rich aggregation-prone regions required for P-body localization.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Direct observation of LSM1 in P-bodies. This annotation is consistent with other P-body localization evidence. Duplicate IDA annotations with different PMIDs are acceptable as they represent independent observations.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/18611963" target="_blank" class="term-link">
                                         PMID:18611963
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">A role for Q/N-rich aggregation-prone regions in P-body localization</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/18029398" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:18029398
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Requirements for nuclear localization of the Lsm2-8p complex...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3523,50 +3534,50 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA evidence from studies of Lsm2-8 nuclear complex showing that LSM1-7 cytoplasmic complex has different localization than its U6-binding counterpart.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Direct evidence of LSM1-7 cytoplasmic localization, demonstrating distinction from nuclear Lsm2-8 complex. Consistent with other cytoplasmic localization evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/18029398" target="_blank" class="term-link">
                                         PMID:18029398
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Requirements for nuclear localization of the Lsm2-8p complex and competition between nuclear and cytoplasmic Lsm complexes</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
             </tbody>
         </table>
     </div>
-    
 
-    
+
+
     <div class="section">
         <h2 class="section-title">Core Functions</h2>
-        
+
         <div class="core-function-card">
-            
+
             <div style="display: flex; justify-content: space-between; align-items: center;">
                 <h3>LSM1 binds mRNA through its Sm domain, specifically recognizing poly(U) tracts at the 3&#39; end of deadenylated mRNAs. This RNA binding is essential for the activation of decapping and represents a core catalytic property of LSM1. LSM1 functions as part of the Lsm1-7-Pat1 complex where it plays the defining role in mRNA decay activation through deadenylation-dependent decapping and 5&#39; to 3&#39; exonucleolytic degradation.</h3>
                 <span class="vote-buttons" data-g="P47017" data-a="FUNCTION: LSM1 binds mRNA through its Sm domain, specificall..." data-r="" data-act="CORE_FUNCTION">
@@ -3574,10 +3585,10 @@
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
             </div>
-            
+
 
             <div class="core-function-terms">
-                
+
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
@@ -3586,517 +3597,965 @@
                         </a>
                     </span>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Directly Involved In:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000290" target="_blank" class="term-link">
                                 deadenylation-dependent decapping of nuclear-transcribed mRNA
                             </a>
                         </span>
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000288" target="_blank" class="term-link">
                                 nuclear-transcribed mRNA catabolic process, deadenylation-dependent decay
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Cellular Locations:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                 cytoplasm
                             </a>
                         </span>
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000932" target="_blank" class="term-link">
                                 P-body
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
 
-                
+
+
+
             </div>
 
-            
-        </div>
-        
-    </div>
-    
 
-    
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:yeast/LSM1/LSM1-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">LSM1 encodes Lsm1p, the defining subunit of the cytoplasmic Lsm1-7 ring that partners with Pat1 to recognize deadenylated mRNAs and promote decapping and 5&#39; to 3&#39; mRNA decay.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class="section">
         <h2 class="section-title collapsible">References</h2>
         <div class="collapse-content">
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
+                        file:yeast/LSM1/LSM1-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research report for LSM1</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Falcon supports LSM1 as the defining cytoplasmic Lsm1-7-Pat1 complex subunit coupling deadenylated mRNA recognition to decapping and 5&#39; to 3&#39; decay.</div>
+
+                        <div class="finding-text">"The Lsm1-7 ring plus Pat1 is a key module that links 3&#39; end status to decapping: Pat1/Lsm1-7 binds oligoadenylated 3&#39; ends and helps recruit/activate the decapping enzyme."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
                             GO_REF:0000002
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
                             GO_REF:0000033
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Annotation inferences using phylogenetic trees</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000043.md" target="_blank" class="term-link">
                             GO_REF:0000043
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
                             GO_REF:0000044
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
                             GO_REF:0000117
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
                             GO_REF:0000120
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/10688190" target="_blank" class="term-link">
                             PMID:10688190
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A comprehensive analysis of protein-protein interactions in Saccharomyces cerevisiae.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/10747033" target="_blank" class="term-link">
                             PMID:10747033
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A Sm-like protein complex that participates in mRNA degradation.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/10761922" target="_blank" class="term-link">
                             PMID:10761922
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Yeast Sm-like proteins function in mRNA decapping and decay.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/10900456" target="_blank" class="term-link">
                             PMID:10900456
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Genome-wide protein interaction screens reveal functional networks involving Sm-like proteins.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/11780629" target="_blank" class="term-link">
                             PMID:11780629
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The DEAD box helicase, Dhh1p, functions in mRNA decapping and interacts with both the decapping and deadenylase complexes.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/11805837" target="_blank" class="term-link">
                             PMID:11805837
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Systematic identification of protein complexes in Saccharomyces cerevisiae by mass spectrometry.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/12730603" target="_blank" class="term-link">
                             PMID:12730603
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Decapping and decay of messenger RNA occur in cytoplasmic processing bodies.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/14759368" target="_blank" class="term-link">
                             PMID:14759368
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">High-definition macromolecular composition of yeast RNA-processing complexes.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/15716506" target="_blank" class="term-link">
                             PMID:15716506
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Mutations in the Saccharomyces cerevisiae LSM1 gene that affect mRNA decapping and 3&#39; end protection.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/16429126" target="_blank" class="term-link">
                             PMID:16429126
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Proteome survey reveals modularity of the yeast cell machinery.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/16554755" target="_blank" class="term-link">
                             PMID:16554755
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Global landscape of protein complexes in the yeast Saccharomyces cerevisiae.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/18029398" target="_blank" class="term-link">
                             PMID:18029398
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Requirements for nuclear localization of the Lsm2-8p complex and competition between nuclear and cytoplasmic Lsm complexes.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/18611963" target="_blank" class="term-link">
                             PMID:18611963
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A role for Q/N-rich aggregation-prone regions in P-body localization.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/18719252" target="_blank" class="term-link">
                             PMID:18719252
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">High-quality binary protein interaction map of the yeast interactome network.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/22842922" target="_blank" class="term-link">
                             PMID:22842922
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Dissecting DNA damage response pathways by analysing protein localization and abundance changes during DNA replication stress.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/23222640" target="_blank" class="term-link">
                             PMID:23222640
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Global analysis of yeast mRNPs.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/23267104" target="_blank" class="term-link">
                             PMID:23267104
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Proteome-wide protein interaction measurements of bacterial proteins of unknown function.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/23706738" target="_blank" class="term-link">
                             PMID:23706738
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene expression is circular: factors for mRNA degradation also foster mRNA synthesis.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/24139796" target="_blank" class="term-link">
                             PMID:24139796
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Architecture of the Lsm1-7-Pat1 complex: a conserved assembly in eukaryotic mRNA turnover.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/37070168" target="_blank" class="term-link">
                             PMID:37070168
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">RNA-dependent interactome allows network-based assignment of RNA-binding protein function.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/37968396" target="_blank" class="term-link">
                             PMID:37968396
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The social and structural architecture of the yeast protein interactome.</div>
-                
-                
+
+
             </div>
-            
+
         </div>
     </div>
-    
 
 
-    
 
-    
 
-    
+
+
+
+
 
     <!-- Computational Predictions Section -->
-    
+
 
     <!-- Additional Documentation Sections -->
-    
+
     <div class="section">
         <h2 class="section-title">📚 Additional Documentation</h2>
-        
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Deep Research Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(LSM1-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P47017" data-a="DOC: Deep Research Falcon" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <hr />
+<p>provider: falcon<br />
+model: Edison Scientific Literature<br />
+cached: false<br />
+start_time: '2026-05-11T07:24:44.940909'<br />
+end_time: '2026-05-11T07:49:02.661910'<br />
+duration_seconds: 1457.72<br />
+template_file: templates/gene_research_go_focused.md<br />
+template_variables:<br />
+  organism: yeast<br />
+  gene_id: LSM1<br />
+  gene_symbol: LSM1<br />
+  uniprot_accession: P47017<br />
+  protein_description: 'RecName: Full=LSM1-LSM7 complex subunit LSM1 {ECO:0000305};<br />
+    AltName: Full=SPB8 protein;'<br />
+  gene_info: Name=LSM1; Synonyms=SPB8; OrderedLocusNames=YJL124C; ORFNames=J0714;<br />
+  organism_full: Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).<br />
+  protein_family: Belongs to the snRNP Sm proteins family. .<br />
+  protein_domains: Lsm1. (IPR034104); LSM_dom_sf. (IPR010920); PTHR15588. (IPR044642);<br />
+    Sm. (IPR047575); Sm_dom_euk/arc. (IPR001163)<br />
+provider_config:<br />
+  timeout: 600<br />
+  max_retries: 3<br />
+  parameters:<br />
+    allowed_domains: []<br />
+    temperature: 0.1<br />
+citation_count: 39</p>
+<hr />
+<h2 id="question">Question</h2>
+<h1 id="gene-research-for-functional-annotation">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> P47017</li>
+<li><strong>Protein Description:</strong> RecName: Full=LSM1-LSM7 complex subunit LSM1 {ECO:0000305}; AltName: Full=SPB8 protein;</li>
+<li><strong>Gene Information:</strong> Name=LSM1; Synonyms=SPB8; OrderedLocusNames=YJL124C; ORFNames=J0714;</li>
+<li><strong>Organism (full):</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Protein Family:</strong> Belongs to the snRNP Sm proteins family. .</li>
+<li><strong>Key Domains:</strong> Lsm1. (IPR034104); LSM_dom_sf. (IPR010920); PTHR15588. (IPR044642); Sm. (IPR047575); Sm_dom_euk/arc. (IPR001163)</li>
+</ul>
+<h3 id="mandatory-verification-steps">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "LSM1" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'LSM1' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>LSM1</strong> (gene ID: LSM1, UniProt: P47017) in yeast.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="output">Output</h2>
+<p>Question: You are an expert researcher providing comprehensive, well-cited information.</p>
+<p>Provide detailed information focusing on:<br />
+1. Key concepts and definitions with current understanding<br />
+2. Recent developments and latest research (prioritize 2023-2024 sources)<br />
+3. Current applications and real-world implementations<br />
+4. Expert opinions and analysis from authoritative sources<br />
+5. Relevant statistics and data from recent studies</p>
+<p>Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.<br />
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.</p>
+<h1 id="gene-research-for-functional-annotation_1">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context_1">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot_1">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> P47017</li>
+<li><strong>Protein Description:</strong> RecName: Full=LSM1-LSM7 complex subunit LSM1 {ECO:0000305}; AltName: Full=SPB8 protein;</li>
+<li><strong>Gene Information:</strong> Name=LSM1; Synonyms=SPB8; OrderedLocusNames=YJL124C; ORFNames=J0714;</li>
+<li><strong>Organism (full):</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Protein Family:</strong> Belongs to the snRNP Sm proteins family. .</li>
+<li><strong>Key Domains:</strong> Lsm1. (IPR034104); LSM_dom_sf. (IPR010920); PTHR15588. (IPR044642); Sm. (IPR047575); Sm_dom_euk/arc. (IPR001163)</li>
+</ul>
+<h3 id="mandatory-verification-steps_1">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "LSM1" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature_1">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'LSM1' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target_1">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>LSM1</strong> (gene ID: LSM1, UniProt: P47017) in yeast.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="comprehensive-research-report-saccharomyces-cerevisiae-lsm1-uniprot-p47017-aka-spb8-locus-yjl124c">Comprehensive research report: <strong>Saccharomyces cerevisiae LSM1</strong> (UniProt <strong>P47017</strong>, aka <strong>SPB8</strong>, locus <strong>YJL124C</strong>)</h1>
+<h2 id="executive-summary">Executive summary</h2>
+<p><strong>LSM1</strong> encodes Lsm1p, the defining subunit of the <strong>cytoplasmic Lsm1–7 ring</strong> that partners with <strong>Pat1</strong> to recognize deadenylated (oligoadenylated) mRNAs and promote <strong>5′-cap removal (decapping)</strong> and subsequent <strong>5′→3′ mRNA decay</strong> by Xrn1. The Lsm1–7/Pat1 assembly is enriched in <strong>processing bodies (P-bodies)</strong> but contemporary evidence and expert synthesis emphasize that much decapping occurs <strong>co-translationally on polyribosomes</strong>, not necessarily inside P-bodies. Recent work (2023–2024) refines the classic “deadenylation triggers decapping” model by providing structural/biochemical detail for Lsm1–7–Pat1 recognition of 3′ ends, highlighting Dcp2 regulatory motifs targeted by Pat1/Scd6, quantifying large transcript sets controlled by Pat1/Dhh1/Lsm1, and expanding roles for Pat1/Lsm1–7 in <strong>nutrient signaling and autophagy</strong> via context-dependent <strong>3′-end protection</strong> of selected ATG transcripts. (tharun2005mutationsinthe pages 2-3, he2023eukaryoticmrnadecapping pages 3-4, zhao2023structureandfunction pages 8-10, he2023eukaryoticmrnadecapping pages 8-9, he2023eukaryoticmrnadecapping pages 17-19)</p>
+<h2 id="1-target-verification-and-geneprotein-identity-mandatory-disambiguation">1) Target verification and gene/protein identity (mandatory disambiguation)</h2>
+<h3 id="verified-identity">Verified identity</h3>
+<p>The literature examined here explicitly concerns <strong>Saccharomyces cerevisiae</strong> Lsm1p, a member of the <strong>Sm-like (Lsm) protein family</strong> that forms a <strong>cytoplasmic heptameric Lsm1–7 complex</strong> and acts in cytoplasmic mRNA turnover. This is distinct from the <strong>nuclear Lsm2–8</strong> ring (Lsm2–8) that functions in <strong>U6 snRNP</strong> biology and splicing. (tharun2005mutationsinthe pages 2-3, tharun2005mutationsinthe pages 1-2, daugeron2001theyeastpop2 pages 1-2)</p>
+<h3 id="key-distinction-preventing-ambiguity">Key distinction preventing ambiguity</h3>
+<ul>
+<li><strong>Cytoplasmic complex:</strong> Lsm1 is the <em>distinguishing</em> subunit of <strong>Lsm1–7</strong>; this ring functions in <strong>mRNA decapping/decay</strong>. (tharun2005mutationsinthe pages 2-3, tharun2005mutationsinthe pages 1-2)</li>
+<li><strong>Nuclear complex:</strong> <strong>Lsm2–8</strong> is a separate ring functioning in the nucleus (U6 snRNP), and is not the primary decapping activator complex. (tharun2005mutationsinthe pages 2-3)</li>
+</ul>
+<h2 id="2-key-concepts-and-definitions-current-understanding">2) Key concepts and definitions (current understanding)</h2>
+<h3 id="21-mrna-decapping-and-53-decay">2.1 mRNA decapping and 5′→3′ decay</h3>
+<p><strong>Decapping</strong> is the enzymatic removal of the 5′ cap structure from an mRNA, an event that commits the transcript to <strong>5′→3′ exonucleolytic degradation</strong> (primarily by Xrn1) and terminates its functional lifespan. In yeast, decapping is executed by a <strong>single Dcp1–Dcp2 enzyme</strong> whose targeting and activation depend on multiple “decapping activators,” including <strong>Pat1</strong> and the <strong>Lsm1–7 complex</strong>. (he2023eukaryoticmrnadecapping pages 1-3, he2023eukaryoticmrnadecapping pages 3-4)</p>
+<h3 id="22-deadenylation-coupled-decapping-and-the-lsm17pat1-module">2.2 Deadenylation-coupled decapping and the Lsm1–7–Pat1 module</h3>
+<p>A classical model is that decapping generally follows deadenylation, with poly(A) tails reduced to ~10 nt before efficient decapping. Within this framework, the <strong>Lsm1–7 ring plus Pat1</strong> is a key module that links 3′-end status to decapping: Pat1/Lsm1–7 binds oligoadenylated 3′ ends and helps recruit/activate the decapping enzyme. (he2023eukaryoticmrnadecapping pages 3-4, zhao2023structureandfunction pages 1-2)</p>
+<h3 id="23-p-bodies-as-cytoplasmic-mrnp-assemblies">2.3 P-bodies as cytoplasmic mRNP assemblies</h3>
+<p><strong>P-bodies</strong> are cytoplasmic foci enriched in decapping machinery (Dcp1/Dcp2), decapping activators (including Lsm1–7 and Pat1), Xrn1, and decay-targeted mRNAs. They are widely used as readouts of mRNP remodeling and mRNA repression/decay states. (sheth2006targetingofaberrant pages 1-3, tharun2005mutationsinthe pages 9-10)</p>
+<h2 id="3-primary-molecular-function-of-lsm1p-what-it-does">3) Primary molecular function of Lsm1p (what it does)</h2>
+<h3 id="31-primary-function-decapping-activation-and-coupling-to-53-decay">3.1 Primary function: decapping activation and coupling to 5′→3′ decay</h3>
+<p>Genetic and biochemical evidence establishes that the Lsm1–7 complex is a <strong>general activator of decapping</strong> in the major yeast 5′→3′ mRNA degradation pathway and that it associates (directly or via RNP bridging) with other decay factors including Pat1, Dhh1, Dcp1/Dcp2, and Xrn1. (tharun2005mutationsinthe pages 1-2, daugeron2001theyeastpop2 pages 1-2)</p>
+<h3 id="32-3-end-protection-of-deadenylated-mrnas">3.2 3′-end protection of deadenylated mRNAs</h3>
+<p>In addition to promoting decapping, Lsm1–7 contributes to <strong>protecting 3′ ends of deadenylated mRNAs from 3′ trimming</strong>, consistent with a model in which the ring binds the 3′ end of deadenylated substrates. Co-immunoprecipitation evidence shows Lsm proteins associate with deadenylated mRNA decay intermediates in vivo, supporting direct substrate engagement. (tharun2005mutationsinthe pages 1-2, tharun2005mutationsinthe pages 12-13)</p>
+<h2 id="4-cellular-localization-and-where-the-protein-carries-out-its-function">4) Cellular localization and where the protein carries out its function</h2>
+<h3 id="41-cytoplasmic-localization-and-p-body-association">4.1 Cytoplasmic localization and P-body association</h3>
+<p>Lsm1p (and Lsm1–7) is a <strong>cytoplasmic factor</strong> that localizes to <strong>P-bodies</strong>, which are enriched for decapping/5′→3′ decay factors. Loss of LSM1 disrupts P-body recruitment of other Lsm subunits, showing Lsm1’s importance for Lsm1–7 behavior in these cytoplasmic assemblies. (tharun2005mutationsinthe pages 9-10, sheth2006targetingofaberrant pages 1-3)</p>
+<h3 id="42-expert-synthesis-decapping-often-occurs-on-polyribosomes-not-necessarily-in-p-bodies">4.2 Expert synthesis: decapping often occurs on polyribosomes, not necessarily in P-bodies</h3>
+<p>A prominent recent synthesis highlights that many decapping activators (including Pat1/Lsm1–7) and decay enzymes are largely <strong>polyribosome-associated</strong>, and decapping can occur even when ribosomes are stalled on mRNAs (e.g., cycloheximide conditions). This supports a <strong>co-translational decapping</strong> paradigm and motivates caution in interpreting P-bodies as the main sites of decapping. (he2023eukaryoticmrnadecapping pages 17-19)</p>
+<h2 id="5-mechanism-how-lsm1-works-structurefunction-binding-specificity-interactions">5) Mechanism: how Lsm1 works (structure–function, binding specificity, interactions)</h2>
+<h3 id="51-architecture-lsm17-is-a-heptameric-sm-like-ring">5.1 Architecture: Lsm1–7 is a heptameric Sm-like ring</h3>
+<p>Reviews synthesizing structural data describe Lsm1–7 as a circular, heptameric <strong>Sm-ring</strong> that binds RNA. (he2023eukaryoticmrnadecapping pages 3-4)</p>
+<h3 id="52-rna-recognition-oligoadenylated-3-ends-and-u-rich-regions">5.2 RNA recognition: oligoadenylated 3′ ends and U-rich regions</h3>
+<p>Structural/biochemical evidence indicates that:<br />
+- <strong>Lsm1–7 binds near the mRNA 3′ end</strong> and <strong>specifically recognizes short oligo(A) tails</strong>.<br />
+- Adding <strong>Pat1</strong> increases affinity for oligo(A) RNA; the assembled Lsm1–7–Pat1 module also shows a preference for <strong>U-rich sequences</strong> near the 3′ end. (he2023eukaryoticmrnadecapping pages 3-4, zhao2023structureandfunction pages 8-10)</p>
+<h3 id="53-the-lsm1-c-terminal-extension-modulates-rna-binding">5.3 The Lsm1 C-terminal extension modulates RNA binding</h3>
+<p>A 2023 structural review notes that yeast Lsm1 has a distinctive <strong>C-terminal extension</strong> that forms an extended helix and can occlude the central opening of the ring; deleting this extension <strong>increases RNA-binding affinity</strong>, implying autoinhibitory or regulatory tuning of RNA engagement. (zhao2023structureandfunction pages 8-10)</p>
+<h3 id="54-genetic-evidence-lsm1-sm-domain-residues-and-c-terminus-are-required-for-decay-and-3-protection">5.4 Genetic evidence: Lsm1 Sm-domain residues and C-terminus are required for decay and 3′ protection</h3>
+<p>Targeted mutagenesis mapped essential functions to:<br />
+- Sm-like core residues predicted to contact RNA and to mediate inter-subunit contacts (ring integrity), which are required for decapping and 3′-end protection.<br />
+- The unique C-terminal region (∼61 aa) of Lsm1, where deletions or even a C-terminal tag disrupt decay/3′ protection, indicating functional specificity beyond the conserved Sm fold. (tharun2005mutationsinthe pages 6-8, tharun2005mutationsinthe pages 2-3)</p>
+<h3 id="55-recruitment-model-pat1-bridges-lsm17-to-the-decapping-enzyme-and-xrn1">5.5 Recruitment model: Pat1 bridges Lsm1–7 to the decapping enzyme and Xrn1</h3>
+<p>Mechanistic synthesis in 2023 proposes that:<br />
+- The Lsm1–7 ring makes direct contacts with <strong>Pat1</strong>.<br />
+- <strong>Pat1</strong> has multi-domain interactions: its C-terminal region binds <strong>Dcp2</strong> and <strong>Xrn1</strong>, while its M/C regions bind <strong>Lsm1–7</strong>.<br />
+- Pat1/Lsm1–7 has strong RNA-binding and a preference for oligoadenylated RNAs, supporting a model where <strong>Pat1/Lsm1–7 binds oligoadenylated 3′ ends and recruits decapping and downstream 5′→3′ decay factors</strong>. (he2023eukaryoticmrnadecapping pages 3-4, zhao2023structureandfunction pages 8-10)</p>
+<h3 id="56-visual-model-support-from-recent-review-figures">5.6 Visual model support from recent review figures</h3>
+<p>Figure panels extracted from He &amp; Jacobson (2023) schematically depict Pat1 interacting with the Lsm1–7 ring and placing the Pat1/Lsm1 module as a targeting component that directs assembly of an active decapping complex on specific substrates. (he2023eukaryoticmrnadecapping media 2ef221cc, he2023eukaryoticmrnadecapping media 0259c12e)</p>
+<h2 id="6-recent-developments-and-latest-research-prioritizing-20232024">6) Recent developments and latest research (prioritizing 2023–2024)</h2>
+<h3 id="61-transcriptome-scale-targeting-pat1dhh1-and-overlap-with-lsm1">6.1 Transcriptome-scale targeting: Pat1/Dhh1 (and overlap with Lsm1)</h3>
+<p>A 2023 mechanistic review summarizes that Pat1 and Lsm1 share a large fraction of endogenous targets (~84% overlap), and that Dhh1/Pat1/Lsm1 together regulate 1,587 transcripts, emphasizing that decapping activators impose transcript-selective regulation rather than only global turnover control. (he2023eukaryoticmrnadecapping pages 8-9)</p>
+<h3 id="62-multi-omics-evidence-linking-decapping-activators-to-nutrient-response-programs">6.2 Multi-omics evidence linking decapping activators to nutrient response programs</h3>
+<p>A 2023 yeast study used ribosome profiling, RNA-seq, CAGE (capped mRNAs), Pol II ChIP-seq, and quantitative proteomics to show that Pat1 and Dhh1 tune cellular responses to nutrient availability by controlling both <strong>mRNA turnover and translation</strong>. Quantitative results include:<br />
+- <strong>747 mRNAs upregulated</strong> in pat1Δ and <strong>982 upregulated</strong> in pat1Δ dhh1Δ (cutoff &gt;1.5-fold, FDR &lt; 0.05), indicating broad transcriptome effects.<br />
+- A <strong>~25% reduction</strong> in polysome/monosome ratio in pat1Δ and ~40% in the double mutant, consistent with broad translation changes.<br />
+- Pathway-specific sets including <strong>61 cell wall/agglutinin mRNAs</strong>, <strong>51 oxidative phosphorylation transcripts</strong>, and <strong>83 carbon catabolite repressed mRNAs</strong>, reflecting coordinated post-transcriptional control of metabolic programs. (vijjamarri2023mrnadecappingactivators pages 7-8, vijjamarri2023mrnadecappingactivators pages 16-17, vijjamarri2023mrnadecappingactivators pages 15-16)</p>
+<p>Although this study centers on Pat1/Dhh1, its conclusions are relevant to Lsm1 because Pat1’s decapping function is mechanistically coupled to Lsm1–7 recruitment to oligoadenylated mRNAs and their joint roles in decapping activation. (he2023eukaryoticmrnadecapping pages 3-4, vijjamarri2023mrnadecappingactivators pages 1-2)</p>
+<h3 id="63-context-dependent-protective-role-of-pat1lsm17-in-autophagy-2023-synthesis">6.3 Context-dependent “protective” role of Pat1/Lsm1–7 in autophagy (2023 synthesis)</h3>
+<p>A major conceptual refinement is that Pat1/Lsm1–7 can stabilize subsets of transcripts under specific physiological states. During nitrogen starvation–induced autophagy, Pat1 dephosphorylation promotes binding to select <strong>ATG mRNAs</strong>, and Pat1/Lsm1–7 protects these mRNAs from <strong>exosome-mediated 3′→5′ decay</strong> (with rescue by Ski3 loss), supporting their accumulation and translation for robust autophagy. (he2023eukaryoticmrnadecapping pages 17-19)</p>
+<h3 id="64-20232024-decappingautophagyageing-as-a-model-application-area">6.4 2023–2024: Decapping/autophagy/ageing as a model application area</h3>
+<p>A 2023 study of LSM mutants links lsm1Δ and LSM4 perturbations to defects in autophagy induction and ageing-associated phenotypes, framing the Pat1–Lsm module as important for stabilizing certain ATG mRNAs during starvation. (caraba2023yeastlsmproapoptotica pages 8-10)</p>
+<p>A 2024 review-like synthesis explicitly positions yeast decapping mutants (including lsm1Δ contexts) as model systems for ageing and autophagy, describing assays such as GFP-Atg8 flux readouts and rapamycin sensitivity as tractable implementations for connecting mRNA turnover to longevity pathways. (caraba2024yeastdecappingmutants pages 1-5, caraba2024yeastdecappingmutants pages 17-22)</p>
+<h2 id="7-current-applications-and-real-world-implementations">7) Current applications and real-world implementations</h2>
+<h3 id="71-yeast-as-a-platform-for-mechanistic-dissection-of-mrna-decay-and-quality-control">7.1 Yeast as a platform for mechanistic dissection of mRNA decay and quality control</h3>
+<p>Yeast remains a premier system for dissecting cytoplasmic mRNA decay and quality control pathways, including NMD, using genetically tractable decapping and P-body component mutants to “trap” decay intermediates and visualize compartmentalization. Classic implementations include GFP/RFP-tagging of decapping activators (including Lsm1) and reporter mRNAs engineered with RNA-binding sites to visualize their recruitment to P-bodies. (sheth2006targetingofaberrant pages 1-3)</p>
+<h3 id="72-high-throughput-and-quantitative-systems-biology-pipelines-2023">7.2 High-throughput and quantitative systems biology pipelines (2023)</h3>
+<p>Modern “real-world” implementation in basic research includes integrated multi-omics pipelines (Ribo-seq, RNA-seq, CAGE, Pol II ChIP-seq, quantitative proteomics) to quantify how decapping activators shape transcript levels and protein output under different nutrient conditions. (vijjamarri2023mrnadecappingactivators pages 1-2)</p>
+<h3 id="73-condensate-biology-and-phase-separation-as-an-application-context">7.3 Condensate biology and phase separation as an application context</h3>
+<p>Decapping/P-body factors intersect with biomolecular condensate biology. For example, an imaging-based screen and follow-up mechanistic work showed Lsm7 can form phase-separated condensates that seed stress granule formation, demonstrating how Lsm complexes (including the Lsm1–7/Pat1 module) are studied at the interface of RNA turnover and LLPS-driven stress responses—an area relevant to ageing and disease mechanisms. (lindstrom2022lsm7phaseseparatedcondensates pages 1-2)</p>
+<h3 id="74-autophagyageing-models-20232024">7.4 Autophagy/ageing models (2023–2024)</h3>
+<p>Yeast decapping mutants are applied as model systems for autophagy and lifespan research, with readouts such as rapamycin sensitivity, GFP-Atg8 processing, and stress resistance phenotyping used to evaluate how mRNA turnover machinery influences cellular maintenance pathways. (caraba2024yeastdecappingmutants pages 1-5, caraba2023yeastlsmproapoptotica pages 8-10)</p>
+<h2 id="8-expert-opinions-and-authoritative-analysis-selected-themes">8) Expert opinions and authoritative analysis (selected themes)</h2>
+<h3 id="81-reframing-p-bodies-as-not-necessarily-primary-decay-sites">8.1 Reframing P-bodies as not necessarily primary decay sites</h3>
+<p>An authoritative 2023 review emphasizes that P-bodies contain thousands of mRNAs and many decay factors, but argues that technical artifacts (e.g., MS2-based imaging approaches) and multiple lines of biochemical evidence support a view that P-bodies are <strong>not major sites of decapping</strong>; rather, decapping is often <strong>coupled to translation on polyribosomes</strong>. This informs how Lsm1 localization to P-bodies should be interpreted: enrichment does not necessarily imply that decapping occurs exclusively (or even mainly) within P-bodies. (he2023eukaryoticmrnadecapping pages 17-19)</p>
+<h3 id="82-lsm17pat1-as-a-context-dependent-regulator-decay-vs-protection">8.2 Lsm1–7/Pat1 as a context-dependent regulator (decay vs protection)</h3>
+<p>Recent synthesis highlights dual functionality: Pat1/Lsm1–7 is classically a decapping activator (loss stabilizes mRNAs) but can also protect specific mRNAs from 3′→5′ decay under starvation by binding and shielding their 3′ ends. This duality positions Lsm1 not as a simple “decay factor,” but as an mRNP remodeling module whose outcome depends on physiological context and competing decay routes. (he2023eukaryoticmrnadecapping pages 17-19)</p>
+<h2 id="9-statistics-and-data-highlights-recent-studies">9) Statistics and data highlights (recent studies)</h2>
+<ul>
+<li><strong>Targeting overlap:</strong> Pat1 and Lsm1 share ~<strong>84%</strong> overlap in endogenous targets; Dhh1/Pat1/Lsm1 together regulate <strong>1,587</strong> transcripts (review synthesis). (he2023eukaryoticmrnadecapping pages 8-9)</li>
+<li><strong>Transcriptome perturbation by decapping activators:</strong> In pat1Δ, <strong>747 mRNAs up</strong> and <strong>2024 down</strong>; in pat1Δ dhh1Δ, <strong>982 up</strong> and <strong>1052 down</strong> (RNA-seq thresholds &gt;1.5-fold, FDR &lt; 0.05). (vijjamarri2023mrnadecappingactivators pages 7-8)</li>
+<li><strong>Translation-state readout:</strong> Polysome/monosome ratio decreased by ~<strong>25%</strong> in pat1Δ and ~<strong>40%</strong> in pat1Δ dhh1Δ. (vijjamarri2023mrnadecappingactivators pages 7-8)</li>
+<li><strong>Pathway-specific sets:</strong> examples include <strong>61 cell wall/agglutinin mRNAs</strong>, <strong>51 oxidative phosphorylation transcripts</strong>, and <strong>83 carbon catabolite repressed mRNAs</strong> affected in Pat1/Dhh1 perturbations, indicating pathway-selective post-transcriptional control. (vijjamarri2023mrnadecappingactivators pages 16-17, vijjamarri2023mrnadecappingactivators pages 15-16)</li>
+</ul>
+<h2 id="10-evidence-map-table">10) Evidence map (table)</h2>
+<p>The following table consolidates evidence-backed functional annotation elements (identity, complex membership, mechanism, localization, pathways, and quantitative findings):</p>
+<table>
+<thead>
+<tr>
+<th>Aspect</th>
+<th>Key findings (1-2 sentences)</th>
+<th>Representative sources (include author-year, venue)</th>
+<th>URL/DOI</th>
+<th>Publication date</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Identity/complex</td>
+<td>The target matches <strong>Saccharomyces cerevisiae Lsm1/Spb8 (UniProt P47017)</strong>, the distinguishing subunit of the <strong>cytoplasmic heteroheptameric Lsm1–7 complex</strong>, which is functionally distinct from the <strong>nuclear Lsm2–8 complex</strong> involved in U6 snRNP/pre-mRNA splicing (tharun2005mutationsinthe pages 2-3, tharun2005mutationsinthe pages 1-2, daugeron2001theyeastpop2 pages 1-2).</td>
+<td>Tharun et al. 2005, <em>Genetics</em>; Daugeron et al. 2001, <em>Nucleic Acids Research</em></td>
+<td>https://doi.org/10.1534/genetics.104.034322; https://doi.org/10.1093/nar/29.12.2448</td>
+<td>May 2005; Jun 2001</td>
+</tr>
+<tr>
+<td>Molecular function</td>
+<td>Lsm1 functions in the <strong>major cytoplasmic 5′→3′ mRNA decay pathway</strong> as part of <strong>Pat1/Lsm1–7</strong>, acting as a <strong>general decapping activator</strong> and also contributing to <strong>3′-end protection</strong> of deadenylated mRNAs before Xrn1-mediated degradation (tharun2005mutationsinthe pages 1-2, he2023eukaryoticmrnadecapping pages 3-4, zhao2023structureandfunction pages 1-2).</td>
+<td>Tharun et al. 2005, <em>Genetics</em>; He &amp; Jacobson 2023, <em>The FEBS Journal</em>; Zhao et al. 2023, <em>Frontiers in Genetics</em></td>
+<td>https://doi.org/10.1534/genetics.104.034322; https://doi.org/10.1111/febs.16626; https://doi.org/10.3389/fgene.2023.1233842</td>
+<td>May 2005; Sep 2023; Oct 2023</td>
+</tr>
+<tr>
+<td>RNA-binding specificity</td>
+<td>Structural/biochemical work indicates the <strong>Lsm1–7 ring binds near mRNA 3′ ends</strong>, with preference for <strong>short oligoadenylated tails</strong>; addition of Pat1 increases affinity for oligo(A) RNA, and the assembled complex also shows preference for <strong>U-rich sequences near the 3′ end</strong> (he2023eukaryoticmrnadecapping pages 3-4, zhao2023structureandfunction pages 8-10).</td>
+<td>He &amp; Jacobson 2023, <em>The FEBS Journal</em>; Zhao et al. 2023, <em>Frontiers in Genetics</em></td>
+<td>https://doi.org/10.1111/febs.16626; https://doi.org/10.3389/fgene.2023.1233842</td>
+<td>Sep 2023; Oct 2023</td>
+</tr>
+<tr>
+<td>Interaction partners</td>
+<td>Lsm1–7 physically/functionally associates with <strong>Pat1, Dhh1, Dcp1/Dcp2, and Xrn1</strong>; Pat1 is the main bridge to decapping machinery, with Pat1 C-terminal regions binding <strong>Dcp2</strong> and <strong>Xrn1</strong> while Pat1 also contacts the Lsm1–7 ring (he2023eukaryoticmrnadecapping pages 3-4, zhao2023structureandfunction pages 8-10, daugeron2001theyeastpop2 pages 1-2).</td>
+<td>He &amp; Jacobson 2023, <em>The FEBS Journal</em>; Zhao et al. 2023, <em>Frontiers in Genetics</em>; Daugeron et al. 2001, <em>Nucleic Acids Research</em></td>
+<td>https://doi.org/10.1111/febs.16626; https://doi.org/10.3389/fgene.2023.1233842; https://doi.org/10.1093/nar/29.12.2448</td>
+<td>Sep 2023; Oct 2023; Jun 2001</td>
+</tr>
+<tr>
+<td>Localization</td>
+<td>Lsm1 is a <strong>P-body-associated cytoplasmic factor</strong>. P-bodies contain decapping enzymes, decapping activators including <strong>Lsm1–7</strong>, and Xrn1; Lsm1 is required for efficient recruitment/stability of other Lsm subunits at P-bodies, although some RNA-binding mutants still localize there (sheth2006targetingofaberrant pages 1-3, tharun2005mutationsinthe pages 9-10, lindstrom2022lsm7phaseseparatedcondensates pages 1-2).</td>
+<td>Sheth &amp; Parker 2006, <em>Cell</em>; Tharun et al. 2005, <em>Genetics</em>; Lindström et al. 2022, <em>Nature Communications</em></td>
+<td>https://doi.org/10.1016/j.cell.2006.04.037; https://doi.org/10.1534/genetics.104.034322; https://doi.org/10.1038/s41467-022-31282-8</td>
+<td>Jun 2006; May 2005; Jun 2022</td>
+</tr>
+<tr>
+<td>Pathways/phenotypes</td>
+<td>Beyond basal mRNA turnover, Pat1/Lsm1–7 has a <strong>context-dependent protective role</strong> in <strong>autophagy</strong>: during nitrogen starvation, Pat1/Lsm1–7 binds specific <strong>ATG mRNAs</strong> and protects them from <strong>exosome-mediated 3′→5′ decay</strong>, supporting autophagy induction; lsm1-related decapping defects are also linked to ageing/autophagy phenotypes in yeast models (he2023eukaryoticmrnadecapping pages 17-19, caraba2023yeastlsmproapoptotica pages 8-10).</td>
+<td>He &amp; Jacobson 2023, <em>The FEBS Journal</em>; Caraba et al. 2023, <em>International Journal of Molecular Sciences</em></td>
+<td>https://doi.org/10.1111/febs.16626; https://doi.org/10.3390/ijms241813708</td>
+<td>Sep 2023; Sep 2023</td>
+</tr>
+<tr>
+<td>Quantitative stats 2023-2024</td>
+<td>Recent yeast decapping studies cited in the evidence report that <strong>Pat1 and Lsm1 share ~84% overlap in endogenous targets</strong>, while <strong>Dhh1/Pat1/Lsm1 together regulate 1,587 transcripts</strong>; independent 2023 systems analyses of Pat1/Dhh1 mutants found <strong>747 mRNAs upregulated in pat1Δ</strong>, <strong>982 up in pat1Δ dhh1Δ</strong>, <strong>~25% lower polysome/monosome ratio in pat1Δ</strong>, and pathway-specific sets such as <strong>61 cell wall/agglutinin mRNAs</strong>, <strong>51 oxidative phosphorylation mRNAs</strong>, and <strong>83 carbon-catabolite-repressed mRNAs</strong> (he2023eukaryoticmrnadecapping pages 8-9, vijjamarri2023mrnadecappingactivators pages 16-17, vijjamarri2023mrnadecappingactivators pages 15-16, vijjamarri2023mrnadecappingactivators pages 7-8).</td>
+<td>He &amp; Jacobson 2023, <em>The FEBS Journal</em>; Vijjamarri et al. 2023, <em>Nucleic Acids Research</em></td>
+<td>https://doi.org/10.1111/febs.16626; https://doi.org/10.1093/nar/gkad584</td>
+<td>Sep 2023; Jul 2023</td>
+</tr>
+<tr>
+<td>Key experimental evidence</td>
+<td>Evidence includes <strong>targeted mutagenesis</strong> of predicted RNA-binding/inter-subunit residues in Lsm1, <strong>mRNA decay reporter assays</strong> (MFA2pG fragment accumulation and half-life measurements), <strong>co-immunoprecipitation</strong> with deadenylated mRNPs, <strong>fluorescence microscopy</strong> of P-bodies, and more recent <strong>structural/biochemical</strong> analyses showing a heptameric ring with an Lsm1 C-terminal extension that modulates RNA binding (zhao2023structureandfunction pages 8-10, tharun2005mutationsinthe pages 6-8, tharun2005mutationsinthe pages 2-3, tharun2005mutationsinthe pages 12-13).</td>
+<td>Zhao et al. 2023, <em>Frontiers in Genetics</em>; Tharun et al. 2005, <em>Genetics</em></td>
+<td>https://doi.org/10.3389/fgene.2023.1233842; https://doi.org/10.1534/genetics.104.034322</td>
+<td>Oct 2023; May 2005</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes evidence-supported functional annotation for Saccharomyces cerevisiae Lsm1/Spb8 (UniProt P47017), including its complex membership, mechanistic role in mRNA decay, localization, and recent quantitative findings. It is useful as a compact evidence map for the gene’s primary function and pathway context.</em></p>
+<h2 id="11-limitations-and-scope-notes">11) Limitations and scope notes</h2>
+<ul>
+<li>The provided evidence base includes strong yeast-specific foundational work and several 2023–2024 sources, but some 2023–2024 transcriptome-scale statistics are reported primarily for <strong>Pat1/Dhh1</strong> mutants, with Lsm1-specific modern multi-omics datasets not directly extracted here; nevertheless, Pat1 and Lsm1 are mechanistically coupled as the Pat1/Lsm1–7 module, and authoritative synthesis explicitly links their shared targeting and function. (he2023eukaryoticmrnadecapping pages 3-4, he2023eukaryoticmrnadecapping pages 8-9, vijjamarri2023mrnadecappingactivators pages 1-2)</li>
+<li>Some 2024 content used here appears as a review/preprint-like source with incomplete bibliographic metadata (“Unknown journal”), so its claims were used primarily where consistent with, and supported by, peer-reviewed primary/review literature. (caraba2024yeastdecappingmutants pages 1-5, caraba2024yeastdecappingmutants pages 17-22)</li>
+</ul>
+<h2 id="key-references-urls-publication-dates">Key references (URLs; publication dates)</h2>
+<ul>
+<li>He F, Jacobson A. <em>The FEBS Journal</em>. <strong>Sep 2023</strong>. “Eukaryotic mRNA decapping factors: molecular mechanisms and activity.” https://doi.org/10.1111/febs.16626 (he2023eukaryoticmrnadecapping pages 1-3, he2023eukaryoticmrnadecapping pages 3-4, he2023eukaryoticmrnadecapping pages 17-19)</li>
+<li>Zhao Q et al. <em>Frontiers in Genetics</em>. <strong>Oct 2023</strong>. “Structure and function of molecular machines involved in deadenylation-dependent 5′-3′ mRNA degradation.” https://doi.org/10.3389/fgene.2023.1233842 (zhao2023structureandfunction pages 8-10)</li>
+<li>Vijjamarri AK et al. <em>Nucleic Acids Research</em>. <strong>Jul 2023</strong>. “mRNA decapping activators Pat1 and Dhh1 regulate transcript abundance and translation to tune cellular responses to nutrient availability.” https://doi.org/10.1093/nar/gkad584 (vijjamarri2023mrnadecappingactivators pages 7-8, vijjamarri2023mrnadecappingactivators pages 16-17)</li>
+<li>Tharun S et al. <em>Genetics</em>. <strong>May 2005</strong>. “Mutations in the S. cerevisiae LSM1 Gene That Affect mRNA Decapping and 3′ End Protection.” https://doi.org/10.1534/genetics.104.034322 (tharun2005mutationsinthe pages 1-2, tharun2005mutationsinthe pages 6-8)</li>
+<li>Sheth U, Parker R. <em>Cell</em>. <strong>Jun 2006</strong>. “Targeting of Aberrant mRNAs to Cytoplasmic Processing Bodies.” https://doi.org/10.1016/j.cell.2006.04.037 (sheth2006targetingofaberrant pages 1-3)</li>
+<li>Caraba B et al. <em>International Journal of Molecular Sciences</em>. <strong>Sep 2023</strong>. “Yeast Lsm Pro-Apoptotic Mutants Show Defects in Autophagy.” https://doi.org/10.3390/ijms241813708 (caraba2023yeastlsmproapoptotica pages 8-10)</li>
+</ul>
+<p>References</p>
+<ol>
+<li>
+<p>(tharun2005mutationsinthe pages 2-3): Sundaresan Tharun, Denise Muhlrad, Ashis Chowdhury, and Roy Parker. Mutations in the saccharomyces cerevisiae lsm1 gene that affect mrna decapping and 3′ end protection. Genetics, 170:33-46, May 2005. URL: https://doi.org/10.1534/genetics.104.034322, doi:10.1534/genetics.104.034322. This article has 78 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(he2023eukaryoticmrnadecapping pages 3-4): Feng He and Allan Jacobson. Eukaryotic <scp>mrna</scp> decapping factors: molecular mechanisms and activity. The FEBS Journal, 290:5057-5085, Sep 2023. URL: https://doi.org/10.1111/febs.16626, doi:10.1111/febs.16626. This article has 39 citations.</p>
+</li>
+<li>
+<p>(zhao2023structureandfunction pages 8-10): Qi Zhao, Lorenzo Pavanello, Mark Bartlam, and Gerlof Sebastiaan Winkler. Structure and function of molecular machines involved in deadenylation-dependent 5′-3′ mrna degradation. Frontiers in Genetics, Oct 2023. URL: https://doi.org/10.3389/fgene.2023.1233842, doi:10.3389/fgene.2023.1233842. This article has 14 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(he2023eukaryoticmrnadecapping pages 8-9): Feng He and Allan Jacobson. Eukaryotic <scp>mrna</scp> decapping factors: molecular mechanisms and activity. The FEBS Journal, 290:5057-5085, Sep 2023. URL: https://doi.org/10.1111/febs.16626, doi:10.1111/febs.16626. This article has 39 citations.</p>
+</li>
+<li>
+<p>(he2023eukaryoticmrnadecapping pages 17-19): Feng He and Allan Jacobson. Eukaryotic <scp>mrna</scp> decapping factors: molecular mechanisms and activity. The FEBS Journal, 290:5057-5085, Sep 2023. URL: https://doi.org/10.1111/febs.16626, doi:10.1111/febs.16626. This article has 39 citations.</p>
+</li>
+<li>
+<p>(tharun2005mutationsinthe pages 1-2): Sundaresan Tharun, Denise Muhlrad, Ashis Chowdhury, and Roy Parker. Mutations in the saccharomyces cerevisiae lsm1 gene that affect mrna decapping and 3′ end protection. Genetics, 170:33-46, May 2005. URL: https://doi.org/10.1534/genetics.104.034322, doi:10.1534/genetics.104.034322. This article has 78 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(daugeron2001theyeastpop2 pages 1-2): M. Daugeron, F. Mauxion, and B. Séraphin. The yeast pop2 gene encodes a nuclease involved in mrna deadenylation. Nucleic acids research, 29 12:2448-55, Jun 2001. URL: https://doi.org/10.1093/nar/29.12.2448, doi:10.1093/nar/29.12.2448. This article has 264 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(he2023eukaryoticmrnadecapping pages 1-3): Feng He and Allan Jacobson. Eukaryotic <scp>mrna</scp> decapping factors: molecular mechanisms and activity. The FEBS Journal, 290:5057-5085, Sep 2023. URL: https://doi.org/10.1111/febs.16626, doi:10.1111/febs.16626. This article has 39 citations.</p>
+</li>
+<li>
+<p>(zhao2023structureandfunction pages 1-2): Qi Zhao, Lorenzo Pavanello, Mark Bartlam, and Gerlof Sebastiaan Winkler. Structure and function of molecular machines involved in deadenylation-dependent 5′-3′ mrna degradation. Frontiers in Genetics, Oct 2023. URL: https://doi.org/10.3389/fgene.2023.1233842, doi:10.3389/fgene.2023.1233842. This article has 14 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(sheth2006targetingofaberrant pages 1-3): Ujwal Sheth and Roy Parker. Targeting of aberrant mrnas to cytoplasmic processing bodies. Cell, 125:1095-1109, Jun 2006. URL: https://doi.org/10.1016/j.cell.2006.04.037, doi:10.1016/j.cell.2006.04.037. This article has 385 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(tharun2005mutationsinthe pages 9-10): Sundaresan Tharun, Denise Muhlrad, Ashis Chowdhury, and Roy Parker. Mutations in the saccharomyces cerevisiae lsm1 gene that affect mrna decapping and 3′ end protection. Genetics, 170:33-46, May 2005. URL: https://doi.org/10.1534/genetics.104.034322, doi:10.1534/genetics.104.034322. This article has 78 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(tharun2005mutationsinthe pages 12-13): Sundaresan Tharun, Denise Muhlrad, Ashis Chowdhury, and Roy Parker. Mutations in the saccharomyces cerevisiae lsm1 gene that affect mrna decapping and 3′ end protection. Genetics, 170:33-46, May 2005. URL: https://doi.org/10.1534/genetics.104.034322, doi:10.1534/genetics.104.034322. This article has 78 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(tharun2005mutationsinthe pages 6-8): Sundaresan Tharun, Denise Muhlrad, Ashis Chowdhury, and Roy Parker. Mutations in the saccharomyces cerevisiae lsm1 gene that affect mrna decapping and 3′ end protection. Genetics, 170:33-46, May 2005. URL: https://doi.org/10.1534/genetics.104.034322, doi:10.1534/genetics.104.034322. This article has 78 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(he2023eukaryoticmrnadecapping media 2ef221cc): Feng He and Allan Jacobson. Eukaryotic <scp>mrna</scp> decapping factors: molecular mechanisms and activity. The FEBS Journal, 290:5057-5085, Sep 2023. URL: https://doi.org/10.1111/febs.16626, doi:10.1111/febs.16626. This article has 39 citations.</p>
+</li>
+<li>
+<p>(he2023eukaryoticmrnadecapping media 0259c12e): Feng He and Allan Jacobson. Eukaryotic <scp>mrna</scp> decapping factors: molecular mechanisms and activity. The FEBS Journal, 290:5057-5085, Sep 2023. URL: https://doi.org/10.1111/febs.16626, doi:10.1111/febs.16626. This article has 39 citations.</p>
+</li>
+<li>
+<p>(vijjamarri2023mrnadecappingactivators pages 7-8): Anil Kumar Vijjamarri, Neha Gupta, Chisom Onu, Xiao Niu, Fan Zhang, Rakesh Kumar, Zhenguo Lin, Miriam L Greenberg, and Alan G Hinnebusch. Mrna decapping activators pat1 and dhh1 regulate transcript abundance and translation to tune cellular responses to nutrient availability. Nucleic acids research, 51:9314-9336, Jul 2023. URL: https://doi.org/10.1093/nar/gkad584, doi:10.1093/nar/gkad584. This article has 12 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(vijjamarri2023mrnadecappingactivators pages 16-17): Anil Kumar Vijjamarri, Neha Gupta, Chisom Onu, Xiao Niu, Fan Zhang, Rakesh Kumar, Zhenguo Lin, Miriam L Greenberg, and Alan G Hinnebusch. Mrna decapping activators pat1 and dhh1 regulate transcript abundance and translation to tune cellular responses to nutrient availability. Nucleic acids research, 51:9314-9336, Jul 2023. URL: https://doi.org/10.1093/nar/gkad584, doi:10.1093/nar/gkad584. This article has 12 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(vijjamarri2023mrnadecappingactivators pages 15-16): Anil Kumar Vijjamarri, Neha Gupta, Chisom Onu, Xiao Niu, Fan Zhang, Rakesh Kumar, Zhenguo Lin, Miriam L Greenberg, and Alan G Hinnebusch. Mrna decapping activators pat1 and dhh1 regulate transcript abundance and translation to tune cellular responses to nutrient availability. Nucleic acids research, 51:9314-9336, Jul 2023. URL: https://doi.org/10.1093/nar/gkad584, doi:10.1093/nar/gkad584. This article has 12 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(vijjamarri2023mrnadecappingactivators pages 1-2): Anil Kumar Vijjamarri, Neha Gupta, Chisom Onu, Xiao Niu, Fan Zhang, Rakesh Kumar, Zhenguo Lin, Miriam L Greenberg, and Alan G Hinnebusch. Mrna decapping activators pat1 and dhh1 regulate transcript abundance and translation to tune cellular responses to nutrient availability. Nucleic acids research, 51:9314-9336, Jul 2023. URL: https://doi.org/10.1093/nar/gkad584, doi:10.1093/nar/gkad584. This article has 12 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(caraba2023yeastlsmproapoptotica pages 8-10): Benedetta Caraba, Mariarita Stirpe, Vanessa Palermo, Ugo Vaccher, Michele Maria Bianchi, Claudio Falcone, and Cristina Mazzoni. Yeast lsm pro-apoptotic mutants show defects in autophagy. International Journal of Molecular Sciences, 24:13708, Sep 2023. URL: https://doi.org/10.3390/ijms241813708, doi:10.3390/ijms241813708. This article has 3 citations.</p>
+</li>
+<li>
+<p>(caraba2024yeastdecappingmutants pages 1-5): B Caraba. Yeast decapping mutants as model systems for ageing and autophagy. Unknown journal, 2024.</p>
+</li>
+<li>
+<p>(caraba2024yeastdecappingmutants pages 17-22): B Caraba. Yeast decapping mutants as model systems for ageing and autophagy. Unknown journal, 2024.</p>
+</li>
+<li>
+<p>(lindstrom2022lsm7phaseseparatedcondensates pages 1-2): Michelle Lindström, Lihua Chen, Shan Jiang, Dan Zhang, Yuan Gao, Ju Zheng, Xinxin Hao, Xiaoxue Yang, Arpitha Kabbinale, Johannes Thoma, Lisa C. Metzger, Deyuan Y. Zhang, Xuefeng Zhu, Huisheng Liu, Claes M. Gustafsson, Björn M. Burmann, Joris Winderickx, Per Sunnerhagen, and Beidong Liu. Lsm7 phase-separated condensates trigger stress granule formation. Nature Communications, Jun 2022. URL: https://doi.org/10.1038/s41467-022-31282-8, doi:10.1038/s41467-022-31282-8. This article has 22 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>tharun2005mutationsinthe pages 2-3</li>
+<li>he2023eukaryoticmrnadecapping pages 17-19</li>
+<li>he2023eukaryoticmrnadecapping pages 3-4</li>
+<li>zhao2023structureandfunction pages 8-10</li>
+<li>he2023eukaryoticmrnadecapping pages 8-9</li>
+<li>caraba2023yeastlsmproapoptotica pages 8-10</li>
+<li>sheth2006targetingofaberrant pages 1-3</li>
+<li>vijjamarri2023mrnadecappingactivators pages 1-2</li>
+<li>vijjamarri2023mrnadecappingactivators pages 7-8</li>
+<li>tharun2005mutationsinthe pages 1-2</li>
+<li>he2023eukaryoticmrnadecapping pages 1-3</li>
+<li>zhao2023structureandfunction pages 1-2</li>
+<li>tharun2005mutationsinthe pages 9-10</li>
+<li>tharun2005mutationsinthe pages 12-13</li>
+<li>tharun2005mutationsinthe pages 6-8</li>
+<li>vijjamarri2023mrnadecappingactivators pages 16-17</li>
+<li>vijjamarri2023mrnadecappingactivators pages 15-16</li>
+<li>caraba2024yeastdecappingmutants pages 1-5</li>
+<li>caraba2024yeastdecappingmutants pages 17-22</li>
+<li>https://doi.org/10.1534/genetics.104.034322;</li>
+<li>https://doi.org/10.1093/nar/29.12.2448</li>
+<li>https://doi.org/10.1111/febs.16626;</li>
+<li>https://doi.org/10.3389/fgene.2023.1233842</li>
+<li>https://doi.org/10.3389/fgene.2023.1233842;</li>
+<li>https://doi.org/10.1016/j.cell.2006.04.037;</li>
+<li>https://doi.org/10.1038/s41467-022-31282-8</li>
+<li>https://doi.org/10.3390/ijms241813708</li>
+<li>https://doi.org/10.1093/nar/gkad584</li>
+<li>https://doi.org/10.1534/genetics.104.034322</li>
+<li>https://doi.org/10.1111/febs.16626</li>
+<li>https://doi.org/10.1016/j.cell.2006.04.037</li>
+<li>https://doi.org/10.1534/genetics.104.034322,</li>
+<li>https://doi.org/10.1111/febs.16626,</li>
+<li>https://doi.org/10.3389/fgene.2023.1233842,</li>
+<li>https://doi.org/10.1093/nar/29.12.2448,</li>
+<li>https://doi.org/10.1016/j.cell.2006.04.037,</li>
+<li>https://doi.org/10.1093/nar/gkad584,</li>
+<li>https://doi.org/10.3390/ijms241813708,</li>
+<li>https://doi.org/10.1038/s41467-022-31282-8,</li>
+</ol>
+            </div>
+        </details>
+
         <details class="markdown-section">
             <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
                 <div style="flex: 1;">
@@ -4360,9 +4819,9 @@
 <p>Last updated: 2025-12-31</p>
             </div>
         </details>
-        
+
     </div>
-    
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -4412,6 +4871,12 @@ core_functions:
     label: cytoplasm
   - id: GO:0000932
     label: P-body
+  supported_by:
+  - reference_id: file:yeast/LSM1/LSM1-deep-research-falcon.md
+    supporting_text: &gt;-
+      LSM1 encodes Lsm1p, the defining subunit of the cytoplasmic Lsm1-7 ring
+      that partners with Pat1 to recognize deadenylated mRNAs and promote
+      decapping and 5&#39; to 3&#39; mRNA decay.
 existing_annotations:
 - term:
     id: GO:0000290
@@ -4442,6 +4907,11 @@ existing_annotations:
     - reference_id: PMID:15716506
       supporting_text: The decapping of eukaryotic mRNAs is a key step in their degradation.
         The heteroheptameric Lsm1p-7p complex is a general activator of decapping
+    - reference_id: file:yeast/LSM1/LSM1-deep-research-falcon.md
+      supporting_text: &gt;-
+        The Lsm1-7 ring plus Pat1 is a key module that links 3&#39; end status to
+        decapping: Pat1/Lsm1-7 binds oligoadenylated 3&#39; ends and helps
+        recruit/activate the decapping enzyme.
 - term:
     id: GO:0003729
     label: mRNA binding
@@ -5050,6 +5520,17 @@ existing_annotations:
       supporting_text: Requirements for nuclear localization of the Lsm2-8p complex
         and competition between nuclear and cytoplasmic Lsm complexes
 references:
+- id: file:yeast/LSM1/LSM1-deep-research-falcon.md
+  title: Falcon deep research report for LSM1
+  findings:
+  - statement: &gt;-
+      Falcon supports LSM1 as the defining cytoplasmic Lsm1-7-Pat1 complex
+      subunit coupling deadenylated mRNA recognition to decapping and 5&#39; to 3&#39;
+      decay.
+    supporting_text: &gt;-
+      The Lsm1-7 ring plus Pat1 is a key module that links 3&#39; end status to
+      decapping: Pat1/Lsm1-7 binds oligoadenylated 3&#39; ends and helps
+      recruit/activate the decapping enzyme.
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO
     terms
@@ -5151,7 +5632,7 @@ references:
     </div>
 
     <!-- Pathway Visualization Link -->
-    
+
 
     <style>
         /* Markdown Section Styles */

--- a/genes/yeast/LSM1/LSM1-ai-review.yaml
+++ b/genes/yeast/LSM1/LSM1-ai-review.yaml
@@ -39,6 +39,12 @@ core_functions:
     label: cytoplasm
   - id: GO:0000932
     label: P-body
+  supported_by:
+  - reference_id: file:yeast/LSM1/LSM1-deep-research-falcon.md
+    supporting_text: >-
+      LSM1 encodes Lsm1p, the defining subunit of the cytoplasmic Lsm1-7 ring
+      that partners with Pat1 to recognize deadenylated mRNAs and promote
+      decapping and 5' to 3' mRNA decay.
 existing_annotations:
 - term:
     id: GO:0000290
@@ -69,6 +75,11 @@ existing_annotations:
     - reference_id: PMID:15716506
       supporting_text: The decapping of eukaryotic mRNAs is a key step in their degradation.
         The heteroheptameric Lsm1p-7p complex is a general activator of decapping
+    - reference_id: file:yeast/LSM1/LSM1-deep-research-falcon.md
+      supporting_text: >-
+        The Lsm1-7 ring plus Pat1 is a key module that links 3' end status to
+        decapping: Pat1/Lsm1-7 binds oligoadenylated 3' ends and helps
+        recruit/activate the decapping enzyme.
 - term:
     id: GO:0003729
     label: mRNA binding
@@ -677,6 +688,17 @@ existing_annotations:
       supporting_text: Requirements for nuclear localization of the Lsm2-8p complex
         and competition between nuclear and cytoplasmic Lsm complexes
 references:
+- id: file:yeast/LSM1/LSM1-deep-research-falcon.md
+  title: Falcon deep research report for LSM1
+  findings:
+  - statement: >-
+      Falcon supports LSM1 as the defining cytoplasmic Lsm1-7-Pat1 complex
+      subunit coupling deadenylated mRNA recognition to decapping and 5' to 3'
+      decay.
+    supporting_text: >-
+      The Lsm1-7 ring plus Pat1 is a key module that links 3' end status to
+      decapping: Pat1/Lsm1-7 binds oligoadenylated 3' ends and helps
+      recruit/activate the decapping enzyme.
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO
     terms

--- a/genes/yeast/LSM1/LSM1-deep-research-falcon.md
+++ b/genes/yeast/LSM1/LSM1-deep-research-falcon.md
@@ -1,0 +1,365 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-11T07:24:44.940909'
+end_time: '2026-05-11T07:49:02.661910'
+duration_seconds: 1457.72
+template_file: templates/gene_research_go_focused.md
+template_variables:
+  organism: yeast
+  gene_id: LSM1
+  gene_symbol: LSM1
+  uniprot_accession: P47017
+  protein_description: 'RecName: Full=LSM1-LSM7 complex subunit LSM1 {ECO:0000305};
+    AltName: Full=SPB8 protein;'
+  gene_info: Name=LSM1; Synonyms=SPB8; OrderedLocusNames=YJL124C; ORFNames=J0714;
+  organism_full: Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+  protein_family: Belongs to the snRNP Sm proteins family. .
+  protein_domains: Lsm1. (IPR034104); LSM_dom_sf. (IPR010920); PTHR15588. (IPR044642);
+    Sm. (IPR047575); Sm_dom_euk/arc. (IPR001163)
+provider_config:
+  timeout: 600
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 39
+---
+
+## Question
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** P47017
+- **Protein Description:** RecName: Full=LSM1-LSM7 complex subunit LSM1 {ECO:0000305}; AltName: Full=SPB8 protein;
+- **Gene Information:** Name=LSM1; Synonyms=SPB8; OrderedLocusNames=YJL124C; ORFNames=J0714;
+- **Organism (full):** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+- **Protein Family:** Belongs to the snRNP Sm proteins family. .
+- **Key Domains:** Lsm1. (IPR034104); LSM_dom_sf. (IPR010920); PTHR15588. (IPR044642); Sm. (IPR047575); Sm_dom_euk/arc. (IPR001163)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "LSM1" matches the protein description above**
+2. **Verify the organism is correct:** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'LSM1' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **LSM1** (gene ID: LSM1, UniProt: P47017) in yeast.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** P47017
+- **Protein Description:** RecName: Full=LSM1-LSM7 complex subunit LSM1 {ECO:0000305}; AltName: Full=SPB8 protein;
+- **Gene Information:** Name=LSM1; Synonyms=SPB8; OrderedLocusNames=YJL124C; ORFNames=J0714;
+- **Organism (full):** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+- **Protein Family:** Belongs to the snRNP Sm proteins family. .
+- **Key Domains:** Lsm1. (IPR034104); LSM_dom_sf. (IPR010920); PTHR15588. (IPR044642); Sm. (IPR047575); Sm_dom_euk/arc. (IPR001163)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "LSM1" matches the protein description above**
+2. **Verify the organism is correct:** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'LSM1' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **LSM1** (gene ID: LSM1, UniProt: P47017) in yeast.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+# Comprehensive research report: **Saccharomyces cerevisiae LSM1** (UniProt **P47017**, aka **SPB8**, locus **YJL124C**)
+
+## Executive summary
+**LSM1** encodes Lsm1p, the defining subunit of the **cytoplasmic Lsm1–7 ring** that partners with **Pat1** to recognize deadenylated (oligoadenylated) mRNAs and promote **5′-cap removal (decapping)** and subsequent **5′→3′ mRNA decay** by Xrn1. The Lsm1–7/Pat1 assembly is enriched in **processing bodies (P-bodies)** but contemporary evidence and expert synthesis emphasize that much decapping occurs **co-translationally on polyribosomes**, not necessarily inside P-bodies. Recent work (2023–2024) refines the classic “deadenylation triggers decapping” model by providing structural/biochemical detail for Lsm1–7–Pat1 recognition of 3′ ends, highlighting Dcp2 regulatory motifs targeted by Pat1/Scd6, quantifying large transcript sets controlled by Pat1/Dhh1/Lsm1, and expanding roles for Pat1/Lsm1–7 in **nutrient signaling and autophagy** via context-dependent **3′-end protection** of selected ATG transcripts. (tharun2005mutationsinthe pages 2-3, he2023eukaryoticmrnadecapping pages 3-4, zhao2023structureandfunction pages 8-10, he2023eukaryoticmrnadecapping pages 8-9, he2023eukaryoticmrnadecapping pages 17-19)
+
+## 1) Target verification and gene/protein identity (mandatory disambiguation)
+### Verified identity
+The literature examined here explicitly concerns **Saccharomyces cerevisiae** Lsm1p, a member of the **Sm-like (Lsm) protein family** that forms a **cytoplasmic heptameric Lsm1–7 complex** and acts in cytoplasmic mRNA turnover. This is distinct from the **nuclear Lsm2–8** ring (Lsm2–8) that functions in **U6 snRNP** biology and splicing. (tharun2005mutationsinthe pages 2-3, tharun2005mutationsinthe pages 1-2, daugeron2001theyeastpop2 pages 1-2)
+
+### Key distinction preventing ambiguity
+- **Cytoplasmic complex:** Lsm1 is the *distinguishing* subunit of **Lsm1–7**; this ring functions in **mRNA decapping/decay**. (tharun2005mutationsinthe pages 2-3, tharun2005mutationsinthe pages 1-2)
+- **Nuclear complex:** **Lsm2–8** is a separate ring functioning in the nucleus (U6 snRNP), and is not the primary decapping activator complex. (tharun2005mutationsinthe pages 2-3)
+
+## 2) Key concepts and definitions (current understanding)
+### 2.1 mRNA decapping and 5′→3′ decay
+**Decapping** is the enzymatic removal of the 5′ cap structure from an mRNA, an event that commits the transcript to **5′→3′ exonucleolytic degradation** (primarily by Xrn1) and terminates its functional lifespan. In yeast, decapping is executed by a **single Dcp1–Dcp2 enzyme** whose targeting and activation depend on multiple “decapping activators,” including **Pat1** and the **Lsm1–7 complex**. (he2023eukaryoticmrnadecapping pages 1-3, he2023eukaryoticmrnadecapping pages 3-4)
+
+### 2.2 Deadenylation-coupled decapping and the Lsm1–7–Pat1 module
+A classical model is that decapping generally follows deadenylation, with poly(A) tails reduced to ~10 nt before efficient decapping. Within this framework, the **Lsm1–7 ring plus Pat1** is a key module that links 3′-end status to decapping: Pat1/Lsm1–7 binds oligoadenylated 3′ ends and helps recruit/activate the decapping enzyme. (he2023eukaryoticmrnadecapping pages 3-4, zhao2023structureandfunction pages 1-2)
+
+### 2.3 P-bodies as cytoplasmic mRNP assemblies
+**P-bodies** are cytoplasmic foci enriched in decapping machinery (Dcp1/Dcp2), decapping activators (including Lsm1–7 and Pat1), Xrn1, and decay-targeted mRNAs. They are widely used as readouts of mRNP remodeling and mRNA repression/decay states. (sheth2006targetingofaberrant pages 1-3, tharun2005mutationsinthe pages 9-10)
+
+## 3) Primary molecular function of Lsm1p (what it does)
+### 3.1 Primary function: decapping activation and coupling to 5′→3′ decay
+Genetic and biochemical evidence establishes that the Lsm1–7 complex is a **general activator of decapping** in the major yeast 5′→3′ mRNA degradation pathway and that it associates (directly or via RNP bridging) with other decay factors including Pat1, Dhh1, Dcp1/Dcp2, and Xrn1. (tharun2005mutationsinthe pages 1-2, daugeron2001theyeastpop2 pages 1-2)
+
+### 3.2 3′-end protection of deadenylated mRNAs
+In addition to promoting decapping, Lsm1–7 contributes to **protecting 3′ ends of deadenylated mRNAs from 3′ trimming**, consistent with a model in which the ring binds the 3′ end of deadenylated substrates. Co-immunoprecipitation evidence shows Lsm proteins associate with deadenylated mRNA decay intermediates in vivo, supporting direct substrate engagement. (tharun2005mutationsinthe pages 1-2, tharun2005mutationsinthe pages 12-13)
+
+## 4) Cellular localization and where the protein carries out its function
+### 4.1 Cytoplasmic localization and P-body association
+Lsm1p (and Lsm1–7) is a **cytoplasmic factor** that localizes to **P-bodies**, which are enriched for decapping/5′→3′ decay factors. Loss of LSM1 disrupts P-body recruitment of other Lsm subunits, showing Lsm1’s importance for Lsm1–7 behavior in these cytoplasmic assemblies. (tharun2005mutationsinthe pages 9-10, sheth2006targetingofaberrant pages 1-3)
+
+### 4.2 Expert synthesis: decapping often occurs on polyribosomes, not necessarily in P-bodies
+A prominent recent synthesis highlights that many decapping activators (including Pat1/Lsm1–7) and decay enzymes are largely **polyribosome-associated**, and decapping can occur even when ribosomes are stalled on mRNAs (e.g., cycloheximide conditions). This supports a **co-translational decapping** paradigm and motivates caution in interpreting P-bodies as the main sites of decapping. (he2023eukaryoticmrnadecapping pages 17-19)
+
+## 5) Mechanism: how Lsm1 works (structure–function, binding specificity, interactions)
+### 5.1 Architecture: Lsm1–7 is a heptameric Sm-like ring
+Reviews synthesizing structural data describe Lsm1–7 as a circular, heptameric **Sm-ring** that binds RNA. (he2023eukaryoticmrnadecapping pages 3-4)
+
+### 5.2 RNA recognition: oligoadenylated 3′ ends and U-rich regions
+Structural/biochemical evidence indicates that:
+- **Lsm1–7 binds near the mRNA 3′ end** and **specifically recognizes short oligo(A) tails**.
+- Adding **Pat1** increases affinity for oligo(A) RNA; the assembled Lsm1–7–Pat1 module also shows a preference for **U-rich sequences** near the 3′ end. (he2023eukaryoticmrnadecapping pages 3-4, zhao2023structureandfunction pages 8-10)
+
+### 5.3 The Lsm1 C-terminal extension modulates RNA binding
+A 2023 structural review notes that yeast Lsm1 has a distinctive **C-terminal extension** that forms an extended helix and can occlude the central opening of the ring; deleting this extension **increases RNA-binding affinity**, implying autoinhibitory or regulatory tuning of RNA engagement. (zhao2023structureandfunction pages 8-10)
+
+### 5.4 Genetic evidence: Lsm1 Sm-domain residues and C-terminus are required for decay and 3′ protection
+Targeted mutagenesis mapped essential functions to:
+- Sm-like core residues predicted to contact RNA and to mediate inter-subunit contacts (ring integrity), which are required for decapping and 3′-end protection.
+- The unique C-terminal region (∼61 aa) of Lsm1, where deletions or even a C-terminal tag disrupt decay/3′ protection, indicating functional specificity beyond the conserved Sm fold. (tharun2005mutationsinthe pages 6-8, tharun2005mutationsinthe pages 2-3)
+
+### 5.5 Recruitment model: Pat1 bridges Lsm1–7 to the decapping enzyme and Xrn1
+Mechanistic synthesis in 2023 proposes that:
+- The Lsm1–7 ring makes direct contacts with **Pat1**.
+- **Pat1** has multi-domain interactions: its C-terminal region binds **Dcp2** and **Xrn1**, while its M/C regions bind **Lsm1–7**.
+- Pat1/Lsm1–7 has strong RNA-binding and a preference for oligoadenylated RNAs, supporting a model where **Pat1/Lsm1–7 binds oligoadenylated 3′ ends and recruits decapping and downstream 5′→3′ decay factors**. (he2023eukaryoticmrnadecapping pages 3-4, zhao2023structureandfunction pages 8-10)
+
+### 5.6 Visual model support from recent review figures
+Figure panels extracted from He & Jacobson (2023) schematically depict Pat1 interacting with the Lsm1–7 ring and placing the Pat1/Lsm1 module as a targeting component that directs assembly of an active decapping complex on specific substrates. (he2023eukaryoticmrnadecapping media 2ef221cc, he2023eukaryoticmrnadecapping media 0259c12e)
+
+## 6) Recent developments and latest research (prioritizing 2023–2024)
+### 6.1 Transcriptome-scale targeting: Pat1/Dhh1 (and overlap with Lsm1)
+A 2023 mechanistic review summarizes that Pat1 and Lsm1 share a large fraction of endogenous targets (~84% overlap), and that Dhh1/Pat1/Lsm1 together regulate 1,587 transcripts, emphasizing that decapping activators impose transcript-selective regulation rather than only global turnover control. (he2023eukaryoticmrnadecapping pages 8-9)
+
+### 6.2 Multi-omics evidence linking decapping activators to nutrient response programs
+A 2023 yeast study used ribosome profiling, RNA-seq, CAGE (capped mRNAs), Pol II ChIP-seq, and quantitative proteomics to show that Pat1 and Dhh1 tune cellular responses to nutrient availability by controlling both **mRNA turnover and translation**. Quantitative results include:
+- **747 mRNAs upregulated** in pat1Δ and **982 upregulated** in pat1Δ dhh1Δ (cutoff >1.5-fold, FDR < 0.05), indicating broad transcriptome effects.
+- A **~25% reduction** in polysome/monosome ratio in pat1Δ and ~40% in the double mutant, consistent with broad translation changes.
+- Pathway-specific sets including **61 cell wall/agglutinin mRNAs**, **51 oxidative phosphorylation transcripts**, and **83 carbon catabolite repressed mRNAs**, reflecting coordinated post-transcriptional control of metabolic programs. (vijjamarri2023mrnadecappingactivators pages 7-8, vijjamarri2023mrnadecappingactivators pages 16-17, vijjamarri2023mrnadecappingactivators pages 15-16)
+
+Although this study centers on Pat1/Dhh1, its conclusions are relevant to Lsm1 because Pat1’s decapping function is mechanistically coupled to Lsm1–7 recruitment to oligoadenylated mRNAs and their joint roles in decapping activation. (he2023eukaryoticmrnadecapping pages 3-4, vijjamarri2023mrnadecappingactivators pages 1-2)
+
+### 6.3 Context-dependent “protective” role of Pat1/Lsm1–7 in autophagy (2023 synthesis)
+A major conceptual refinement is that Pat1/Lsm1–7 can stabilize subsets of transcripts under specific physiological states. During nitrogen starvation–induced autophagy, Pat1 dephosphorylation promotes binding to select **ATG mRNAs**, and Pat1/Lsm1–7 protects these mRNAs from **exosome-mediated 3′→5′ decay** (with rescue by Ski3 loss), supporting their accumulation and translation for robust autophagy. (he2023eukaryoticmrnadecapping pages 17-19)
+
+### 6.4 2023–2024: Decapping/autophagy/ageing as a model application area
+A 2023 study of LSM mutants links lsm1Δ and LSM4 perturbations to defects in autophagy induction and ageing-associated phenotypes, framing the Pat1–Lsm module as important for stabilizing certain ATG mRNAs during starvation. (caraba2023yeastlsmproapoptotica pages 8-10)
+
+A 2024 review-like synthesis explicitly positions yeast decapping mutants (including lsm1Δ contexts) as model systems for ageing and autophagy, describing assays such as GFP-Atg8 flux readouts and rapamycin sensitivity as tractable implementations for connecting mRNA turnover to longevity pathways. (caraba2024yeastdecappingmutants pages 1-5, caraba2024yeastdecappingmutants pages 17-22)
+
+## 7) Current applications and real-world implementations
+### 7.1 Yeast as a platform for mechanistic dissection of mRNA decay and quality control
+Yeast remains a premier system for dissecting cytoplasmic mRNA decay and quality control pathways, including NMD, using genetically tractable decapping and P-body component mutants to “trap” decay intermediates and visualize compartmentalization. Classic implementations include GFP/RFP-tagging of decapping activators (including Lsm1) and reporter mRNAs engineered with RNA-binding sites to visualize their recruitment to P-bodies. (sheth2006targetingofaberrant pages 1-3)
+
+### 7.2 High-throughput and quantitative systems biology pipelines (2023)
+Modern “real-world” implementation in basic research includes integrated multi-omics pipelines (Ribo-seq, RNA-seq, CAGE, Pol II ChIP-seq, quantitative proteomics) to quantify how decapping activators shape transcript levels and protein output under different nutrient conditions. (vijjamarri2023mrnadecappingactivators pages 1-2)
+
+### 7.3 Condensate biology and phase separation as an application context
+Decapping/P-body factors intersect with biomolecular condensate biology. For example, an imaging-based screen and follow-up mechanistic work showed Lsm7 can form phase-separated condensates that seed stress granule formation, demonstrating how Lsm complexes (including the Lsm1–7/Pat1 module) are studied at the interface of RNA turnover and LLPS-driven stress responses—an area relevant to ageing and disease mechanisms. (lindstrom2022lsm7phaseseparatedcondensates pages 1-2)
+
+### 7.4 Autophagy/ageing models (2023–2024)
+Yeast decapping mutants are applied as model systems for autophagy and lifespan research, with readouts such as rapamycin sensitivity, GFP-Atg8 processing, and stress resistance phenotyping used to evaluate how mRNA turnover machinery influences cellular maintenance pathways. (caraba2024yeastdecappingmutants pages 1-5, caraba2023yeastlsmproapoptotica pages 8-10)
+
+## 8) Expert opinions and authoritative analysis (selected themes)
+### 8.1 Reframing P-bodies as not necessarily primary decay sites
+An authoritative 2023 review emphasizes that P-bodies contain thousands of mRNAs and many decay factors, but argues that technical artifacts (e.g., MS2-based imaging approaches) and multiple lines of biochemical evidence support a view that P-bodies are **not major sites of decapping**; rather, decapping is often **coupled to translation on polyribosomes**. This informs how Lsm1 localization to P-bodies should be interpreted: enrichment does not necessarily imply that decapping occurs exclusively (or even mainly) within P-bodies. (he2023eukaryoticmrnadecapping pages 17-19)
+
+### 8.2 Lsm1–7/Pat1 as a context-dependent regulator (decay vs protection)
+Recent synthesis highlights dual functionality: Pat1/Lsm1–7 is classically a decapping activator (loss stabilizes mRNAs) but can also protect specific mRNAs from 3′→5′ decay under starvation by binding and shielding their 3′ ends. This duality positions Lsm1 not as a simple “decay factor,” but as an mRNP remodeling module whose outcome depends on physiological context and competing decay routes. (he2023eukaryoticmrnadecapping pages 17-19)
+
+## 9) Statistics and data highlights (recent studies)
+- **Targeting overlap:** Pat1 and Lsm1 share ~**84%** overlap in endogenous targets; Dhh1/Pat1/Lsm1 together regulate **1,587** transcripts (review synthesis). (he2023eukaryoticmrnadecapping pages 8-9)
+- **Transcriptome perturbation by decapping activators:** In pat1Δ, **747 mRNAs up** and **2024 down**; in pat1Δ dhh1Δ, **982 up** and **1052 down** (RNA-seq thresholds >1.5-fold, FDR < 0.05). (vijjamarri2023mrnadecappingactivators pages 7-8)
+- **Translation-state readout:** Polysome/monosome ratio decreased by ~**25%** in pat1Δ and ~**40%** in pat1Δ dhh1Δ. (vijjamarri2023mrnadecappingactivators pages 7-8)
+- **Pathway-specific sets:** examples include **61 cell wall/agglutinin mRNAs**, **51 oxidative phosphorylation transcripts**, and **83 carbon catabolite repressed mRNAs** affected in Pat1/Dhh1 perturbations, indicating pathway-selective post-transcriptional control. (vijjamarri2023mrnadecappingactivators pages 16-17, vijjamarri2023mrnadecappingactivators pages 15-16)
+
+## 10) Evidence map (table)
+The following table consolidates evidence-backed functional annotation elements (identity, complex membership, mechanism, localization, pathways, and quantitative findings):
+
+| Aspect | Key findings (1-2 sentences) | Representative sources (include author-year, venue) | URL/DOI | Publication date |
+|---|---|---|---|---|
+| Identity/complex | The target matches **Saccharomyces cerevisiae Lsm1/Spb8 (UniProt P47017)**, the distinguishing subunit of the **cytoplasmic heteroheptameric Lsm1–7 complex**, which is functionally distinct from the **nuclear Lsm2–8 complex** involved in U6 snRNP/pre-mRNA splicing (tharun2005mutationsinthe pages 2-3, tharun2005mutationsinthe pages 1-2, daugeron2001theyeastpop2 pages 1-2). | Tharun et al. 2005, *Genetics*; Daugeron et al. 2001, *Nucleic Acids Research* | https://doi.org/10.1534/genetics.104.034322; https://doi.org/10.1093/nar/29.12.2448 | May 2005; Jun 2001 |
+| Molecular function | Lsm1 functions in the **major cytoplasmic 5′→3′ mRNA decay pathway** as part of **Pat1/Lsm1–7**, acting as a **general decapping activator** and also contributing to **3′-end protection** of deadenylated mRNAs before Xrn1-mediated degradation (tharun2005mutationsinthe pages 1-2, he2023eukaryoticmrnadecapping pages 3-4, zhao2023structureandfunction pages 1-2). | Tharun et al. 2005, *Genetics*; He & Jacobson 2023, *The FEBS Journal*; Zhao et al. 2023, *Frontiers in Genetics* | https://doi.org/10.1534/genetics.104.034322; https://doi.org/10.1111/febs.16626; https://doi.org/10.3389/fgene.2023.1233842 | May 2005; Sep 2023; Oct 2023 |
+| RNA-binding specificity | Structural/biochemical work indicates the **Lsm1–7 ring binds near mRNA 3′ ends**, with preference for **short oligoadenylated tails**; addition of Pat1 increases affinity for oligo(A) RNA, and the assembled complex also shows preference for **U-rich sequences near the 3′ end** (he2023eukaryoticmrnadecapping pages 3-4, zhao2023structureandfunction pages 8-10). | He & Jacobson 2023, *The FEBS Journal*; Zhao et al. 2023, *Frontiers in Genetics* | https://doi.org/10.1111/febs.16626; https://doi.org/10.3389/fgene.2023.1233842 | Sep 2023; Oct 2023 |
+| Interaction partners | Lsm1–7 physically/functionally associates with **Pat1, Dhh1, Dcp1/Dcp2, and Xrn1**; Pat1 is the main bridge to decapping machinery, with Pat1 C-terminal regions binding **Dcp2** and **Xrn1** while Pat1 also contacts the Lsm1–7 ring (he2023eukaryoticmrnadecapping pages 3-4, zhao2023structureandfunction pages 8-10, daugeron2001theyeastpop2 pages 1-2). | He & Jacobson 2023, *The FEBS Journal*; Zhao et al. 2023, *Frontiers in Genetics*; Daugeron et al. 2001, *Nucleic Acids Research* | https://doi.org/10.1111/febs.16626; https://doi.org/10.3389/fgene.2023.1233842; https://doi.org/10.1093/nar/29.12.2448 | Sep 2023; Oct 2023; Jun 2001 |
+| Localization | Lsm1 is a **P-body-associated cytoplasmic factor**. P-bodies contain decapping enzymes, decapping activators including **Lsm1–7**, and Xrn1; Lsm1 is required for efficient recruitment/stability of other Lsm subunits at P-bodies, although some RNA-binding mutants still localize there (sheth2006targetingofaberrant pages 1-3, tharun2005mutationsinthe pages 9-10, lindstrom2022lsm7phaseseparatedcondensates pages 1-2). | Sheth & Parker 2006, *Cell*; Tharun et al. 2005, *Genetics*; Lindström et al. 2022, *Nature Communications* | https://doi.org/10.1016/j.cell.2006.04.037; https://doi.org/10.1534/genetics.104.034322; https://doi.org/10.1038/s41467-022-31282-8 | Jun 2006; May 2005; Jun 2022 |
+| Pathways/phenotypes | Beyond basal mRNA turnover, Pat1/Lsm1–7 has a **context-dependent protective role** in **autophagy**: during nitrogen starvation, Pat1/Lsm1–7 binds specific **ATG mRNAs** and protects them from **exosome-mediated 3′→5′ decay**, supporting autophagy induction; lsm1-related decapping defects are also linked to ageing/autophagy phenotypes in yeast models (he2023eukaryoticmrnadecapping pages 17-19, caraba2023yeastlsmproapoptotica pages 8-10). | He & Jacobson 2023, *The FEBS Journal*; Caraba et al. 2023, *International Journal of Molecular Sciences* | https://doi.org/10.1111/febs.16626; https://doi.org/10.3390/ijms241813708 | Sep 2023; Sep 2023 |
+| Quantitative stats 2023-2024 | Recent yeast decapping studies cited in the evidence report that **Pat1 and Lsm1 share ~84% overlap in endogenous targets**, while **Dhh1/Pat1/Lsm1 together regulate 1,587 transcripts**; independent 2023 systems analyses of Pat1/Dhh1 mutants found **747 mRNAs upregulated in pat1Δ**, **982 up in pat1Δ dhh1Δ**, **~25% lower polysome/monosome ratio in pat1Δ**, and pathway-specific sets such as **61 cell wall/agglutinin mRNAs**, **51 oxidative phosphorylation mRNAs**, and **83 carbon-catabolite-repressed mRNAs** (he2023eukaryoticmrnadecapping pages 8-9, vijjamarri2023mrnadecappingactivators pages 16-17, vijjamarri2023mrnadecappingactivators pages 15-16, vijjamarri2023mrnadecappingactivators pages 7-8). | He & Jacobson 2023, *The FEBS Journal*; Vijjamarri et al. 2023, *Nucleic Acids Research* | https://doi.org/10.1111/febs.16626; https://doi.org/10.1093/nar/gkad584 | Sep 2023; Jul 2023 |
+| Key experimental evidence | Evidence includes **targeted mutagenesis** of predicted RNA-binding/inter-subunit residues in Lsm1, **mRNA decay reporter assays** (MFA2pG fragment accumulation and half-life measurements), **co-immunoprecipitation** with deadenylated mRNPs, **fluorescence microscopy** of P-bodies, and more recent **structural/biochemical** analyses showing a heptameric ring with an Lsm1 C-terminal extension that modulates RNA binding (zhao2023structureandfunction pages 8-10, tharun2005mutationsinthe pages 6-8, tharun2005mutationsinthe pages 2-3, tharun2005mutationsinthe pages 12-13). | Zhao et al. 2023, *Frontiers in Genetics*; Tharun et al. 2005, *Genetics* | https://doi.org/10.3389/fgene.2023.1233842; https://doi.org/10.1534/genetics.104.034322 | Oct 2023; May 2005 |
+
+
+*Table: This table summarizes evidence-supported functional annotation for Saccharomyces cerevisiae Lsm1/Spb8 (UniProt P47017), including its complex membership, mechanistic role in mRNA decay, localization, and recent quantitative findings. It is useful as a compact evidence map for the gene’s primary function and pathway context.*
+
+## 11) Limitations and scope notes
+- The provided evidence base includes strong yeast-specific foundational work and several 2023–2024 sources, but some 2023–2024 transcriptome-scale statistics are reported primarily for **Pat1/Dhh1** mutants, with Lsm1-specific modern multi-omics datasets not directly extracted here; nevertheless, Pat1 and Lsm1 are mechanistically coupled as the Pat1/Lsm1–7 module, and authoritative synthesis explicitly links their shared targeting and function. (he2023eukaryoticmrnadecapping pages 3-4, he2023eukaryoticmrnadecapping pages 8-9, vijjamarri2023mrnadecappingactivators pages 1-2)
+- Some 2024 content used here appears as a review/preprint-like source with incomplete bibliographic metadata (“Unknown journal”), so its claims were used primarily where consistent with, and supported by, peer-reviewed primary/review literature. (caraba2024yeastdecappingmutants pages 1-5, caraba2024yeastdecappingmutants pages 17-22)
+
+## Key references (URLs; publication dates)
+- He F, Jacobson A. *The FEBS Journal*. **Sep 2023**. “Eukaryotic mRNA decapping factors: molecular mechanisms and activity.” https://doi.org/10.1111/febs.16626 (he2023eukaryoticmrnadecapping pages 1-3, he2023eukaryoticmrnadecapping pages 3-4, he2023eukaryoticmrnadecapping pages 17-19)
+- Zhao Q et al. *Frontiers in Genetics*. **Oct 2023**. “Structure and function of molecular machines involved in deadenylation-dependent 5′-3′ mRNA degradation.” https://doi.org/10.3389/fgene.2023.1233842 (zhao2023structureandfunction pages 8-10)
+- Vijjamarri AK et al. *Nucleic Acids Research*. **Jul 2023**. “mRNA decapping activators Pat1 and Dhh1 regulate transcript abundance and translation to tune cellular responses to nutrient availability.” https://doi.org/10.1093/nar/gkad584 (vijjamarri2023mrnadecappingactivators pages 7-8, vijjamarri2023mrnadecappingactivators pages 16-17)
+- Tharun S et al. *Genetics*. **May 2005**. “Mutations in the S. cerevisiae LSM1 Gene That Affect mRNA Decapping and 3′ End Protection.” https://doi.org/10.1534/genetics.104.034322 (tharun2005mutationsinthe pages 1-2, tharun2005mutationsinthe pages 6-8)
+- Sheth U, Parker R. *Cell*. **Jun 2006**. “Targeting of Aberrant mRNAs to Cytoplasmic Processing Bodies.” https://doi.org/10.1016/j.cell.2006.04.037 (sheth2006targetingofaberrant pages 1-3)
+- Caraba B et al. *International Journal of Molecular Sciences*. **Sep 2023**. “Yeast Lsm Pro-Apoptotic Mutants Show Defects in Autophagy.” https://doi.org/10.3390/ijms241813708 (caraba2023yeastlsmproapoptotica pages 8-10)
+
+
+References
+
+1. (tharun2005mutationsinthe pages 2-3): Sundaresan Tharun, Denise Muhlrad, Ashis Chowdhury, and Roy Parker. Mutations in the saccharomyces cerevisiae lsm1 gene that affect mrna decapping and 3′ end protection. Genetics, 170:33-46, May 2005. URL: https://doi.org/10.1534/genetics.104.034322, doi:10.1534/genetics.104.034322. This article has 78 citations and is from a domain leading peer-reviewed journal.
+
+2. (he2023eukaryoticmrnadecapping pages 3-4): Feng He and Allan Jacobson. Eukaryotic <scp>mrna</scp> decapping factors: molecular mechanisms and activity. The FEBS Journal, 290:5057-5085, Sep 2023. URL: https://doi.org/10.1111/febs.16626, doi:10.1111/febs.16626. This article has 39 citations.
+
+3. (zhao2023structureandfunction pages 8-10): Qi Zhao, Lorenzo Pavanello, Mark Bartlam, and Gerlof Sebastiaan Winkler. Structure and function of molecular machines involved in deadenylation-dependent 5′-3′ mrna degradation. Frontiers in Genetics, Oct 2023. URL: https://doi.org/10.3389/fgene.2023.1233842, doi:10.3389/fgene.2023.1233842. This article has 14 citations and is from a peer-reviewed journal.
+
+4. (he2023eukaryoticmrnadecapping pages 8-9): Feng He and Allan Jacobson. Eukaryotic <scp>mrna</scp> decapping factors: molecular mechanisms and activity. The FEBS Journal, 290:5057-5085, Sep 2023. URL: https://doi.org/10.1111/febs.16626, doi:10.1111/febs.16626. This article has 39 citations.
+
+5. (he2023eukaryoticmrnadecapping pages 17-19): Feng He and Allan Jacobson. Eukaryotic <scp>mrna</scp> decapping factors: molecular mechanisms and activity. The FEBS Journal, 290:5057-5085, Sep 2023. URL: https://doi.org/10.1111/febs.16626, doi:10.1111/febs.16626. This article has 39 citations.
+
+6. (tharun2005mutationsinthe pages 1-2): Sundaresan Tharun, Denise Muhlrad, Ashis Chowdhury, and Roy Parker. Mutations in the saccharomyces cerevisiae lsm1 gene that affect mrna decapping and 3′ end protection. Genetics, 170:33-46, May 2005. URL: https://doi.org/10.1534/genetics.104.034322, doi:10.1534/genetics.104.034322. This article has 78 citations and is from a domain leading peer-reviewed journal.
+
+7. (daugeron2001theyeastpop2 pages 1-2): M. Daugeron, F. Mauxion, and B. Séraphin. The yeast pop2 gene encodes a nuclease involved in mrna deadenylation. Nucleic acids research, 29 12:2448-55, Jun 2001. URL: https://doi.org/10.1093/nar/29.12.2448, doi:10.1093/nar/29.12.2448. This article has 264 citations and is from a highest quality peer-reviewed journal.
+
+8. (he2023eukaryoticmrnadecapping pages 1-3): Feng He and Allan Jacobson. Eukaryotic <scp>mrna</scp> decapping factors: molecular mechanisms and activity. The FEBS Journal, 290:5057-5085, Sep 2023. URL: https://doi.org/10.1111/febs.16626, doi:10.1111/febs.16626. This article has 39 citations.
+
+9. (zhao2023structureandfunction pages 1-2): Qi Zhao, Lorenzo Pavanello, Mark Bartlam, and Gerlof Sebastiaan Winkler. Structure and function of molecular machines involved in deadenylation-dependent 5′-3′ mrna degradation. Frontiers in Genetics, Oct 2023. URL: https://doi.org/10.3389/fgene.2023.1233842, doi:10.3389/fgene.2023.1233842. This article has 14 citations and is from a peer-reviewed journal.
+
+10. (sheth2006targetingofaberrant pages 1-3): Ujwal Sheth and Roy Parker. Targeting of aberrant mrnas to cytoplasmic processing bodies. Cell, 125:1095-1109, Jun 2006. URL: https://doi.org/10.1016/j.cell.2006.04.037, doi:10.1016/j.cell.2006.04.037. This article has 385 citations and is from a highest quality peer-reviewed journal.
+
+11. (tharun2005mutationsinthe pages 9-10): Sundaresan Tharun, Denise Muhlrad, Ashis Chowdhury, and Roy Parker. Mutations in the saccharomyces cerevisiae lsm1 gene that affect mrna decapping and 3′ end protection. Genetics, 170:33-46, May 2005. URL: https://doi.org/10.1534/genetics.104.034322, doi:10.1534/genetics.104.034322. This article has 78 citations and is from a domain leading peer-reviewed journal.
+
+12. (tharun2005mutationsinthe pages 12-13): Sundaresan Tharun, Denise Muhlrad, Ashis Chowdhury, and Roy Parker. Mutations in the saccharomyces cerevisiae lsm1 gene that affect mrna decapping and 3′ end protection. Genetics, 170:33-46, May 2005. URL: https://doi.org/10.1534/genetics.104.034322, doi:10.1534/genetics.104.034322. This article has 78 citations and is from a domain leading peer-reviewed journal.
+
+13. (tharun2005mutationsinthe pages 6-8): Sundaresan Tharun, Denise Muhlrad, Ashis Chowdhury, and Roy Parker. Mutations in the saccharomyces cerevisiae lsm1 gene that affect mrna decapping and 3′ end protection. Genetics, 170:33-46, May 2005. URL: https://doi.org/10.1534/genetics.104.034322, doi:10.1534/genetics.104.034322. This article has 78 citations and is from a domain leading peer-reviewed journal.
+
+14. (he2023eukaryoticmrnadecapping media 2ef221cc): Feng He and Allan Jacobson. Eukaryotic <scp>mrna</scp> decapping factors: molecular mechanisms and activity. The FEBS Journal, 290:5057-5085, Sep 2023. URL: https://doi.org/10.1111/febs.16626, doi:10.1111/febs.16626. This article has 39 citations.
+
+15. (he2023eukaryoticmrnadecapping media 0259c12e): Feng He and Allan Jacobson. Eukaryotic <scp>mrna</scp> decapping factors: molecular mechanisms and activity. The FEBS Journal, 290:5057-5085, Sep 2023. URL: https://doi.org/10.1111/febs.16626, doi:10.1111/febs.16626. This article has 39 citations.
+
+16. (vijjamarri2023mrnadecappingactivators pages 7-8): Anil Kumar Vijjamarri, Neha Gupta, Chisom Onu, Xiao Niu, Fan Zhang, Rakesh Kumar, Zhenguo Lin, Miriam L Greenberg, and Alan G Hinnebusch. Mrna decapping activators pat1 and dhh1 regulate transcript abundance and translation to tune cellular responses to nutrient availability. Nucleic acids research, 51:9314-9336, Jul 2023. URL: https://doi.org/10.1093/nar/gkad584, doi:10.1093/nar/gkad584. This article has 12 citations and is from a highest quality peer-reviewed journal.
+
+17. (vijjamarri2023mrnadecappingactivators pages 16-17): Anil Kumar Vijjamarri, Neha Gupta, Chisom Onu, Xiao Niu, Fan Zhang, Rakesh Kumar, Zhenguo Lin, Miriam L Greenberg, and Alan G Hinnebusch. Mrna decapping activators pat1 and dhh1 regulate transcript abundance and translation to tune cellular responses to nutrient availability. Nucleic acids research, 51:9314-9336, Jul 2023. URL: https://doi.org/10.1093/nar/gkad584, doi:10.1093/nar/gkad584. This article has 12 citations and is from a highest quality peer-reviewed journal.
+
+18. (vijjamarri2023mrnadecappingactivators pages 15-16): Anil Kumar Vijjamarri, Neha Gupta, Chisom Onu, Xiao Niu, Fan Zhang, Rakesh Kumar, Zhenguo Lin, Miriam L Greenberg, and Alan G Hinnebusch. Mrna decapping activators pat1 and dhh1 regulate transcript abundance and translation to tune cellular responses to nutrient availability. Nucleic acids research, 51:9314-9336, Jul 2023. URL: https://doi.org/10.1093/nar/gkad584, doi:10.1093/nar/gkad584. This article has 12 citations and is from a highest quality peer-reviewed journal.
+
+19. (vijjamarri2023mrnadecappingactivators pages 1-2): Anil Kumar Vijjamarri, Neha Gupta, Chisom Onu, Xiao Niu, Fan Zhang, Rakesh Kumar, Zhenguo Lin, Miriam L Greenberg, and Alan G Hinnebusch. Mrna decapping activators pat1 and dhh1 regulate transcript abundance and translation to tune cellular responses to nutrient availability. Nucleic acids research, 51:9314-9336, Jul 2023. URL: https://doi.org/10.1093/nar/gkad584, doi:10.1093/nar/gkad584. This article has 12 citations and is from a highest quality peer-reviewed journal.
+
+20. (caraba2023yeastlsmproapoptotica pages 8-10): Benedetta Caraba, Mariarita Stirpe, Vanessa Palermo, Ugo Vaccher, Michele Maria Bianchi, Claudio Falcone, and Cristina Mazzoni. Yeast lsm pro-apoptotic mutants show defects in autophagy. International Journal of Molecular Sciences, 24:13708, Sep 2023. URL: https://doi.org/10.3390/ijms241813708, doi:10.3390/ijms241813708. This article has 3 citations.
+
+21. (caraba2024yeastdecappingmutants pages 1-5): B Caraba. Yeast decapping mutants as model systems for ageing and autophagy. Unknown journal, 2024.
+
+22. (caraba2024yeastdecappingmutants pages 17-22): B Caraba. Yeast decapping mutants as model systems for ageing and autophagy. Unknown journal, 2024.
+
+23. (lindstrom2022lsm7phaseseparatedcondensates pages 1-2): Michelle Lindström, Lihua Chen, Shan Jiang, Dan Zhang, Yuan Gao, Ju Zheng, Xinxin Hao, Xiaoxue Yang, Arpitha Kabbinale, Johannes Thoma, Lisa C. Metzger, Deyuan Y. Zhang, Xuefeng Zhu, Huisheng Liu, Claes M. Gustafsson, Björn M. Burmann, Joris Winderickx, Per Sunnerhagen, and Beidong Liu. Lsm7 phase-separated condensates trigger stress granule formation. Nature Communications, Jun 2022. URL: https://doi.org/10.1038/s41467-022-31282-8, doi:10.1038/s41467-022-31282-8. This article has 22 citations and is from a highest quality peer-reviewed journal.
+
+## Citations
+
+1. tharun2005mutationsinthe pages 2-3
+2. he2023eukaryoticmrnadecapping pages 17-19
+3. he2023eukaryoticmrnadecapping pages 3-4
+4. zhao2023structureandfunction pages 8-10
+5. he2023eukaryoticmrnadecapping pages 8-9
+6. caraba2023yeastlsmproapoptotica pages 8-10
+7. sheth2006targetingofaberrant pages 1-3
+8. vijjamarri2023mrnadecappingactivators pages 1-2
+9. vijjamarri2023mrnadecappingactivators pages 7-8
+10. tharun2005mutationsinthe pages 1-2
+11. he2023eukaryoticmrnadecapping pages 1-3
+12. zhao2023structureandfunction pages 1-2
+13. tharun2005mutationsinthe pages 9-10
+14. tharun2005mutationsinthe pages 12-13
+15. tharun2005mutationsinthe pages 6-8
+16. vijjamarri2023mrnadecappingactivators pages 16-17
+17. vijjamarri2023mrnadecappingactivators pages 15-16
+18. caraba2024yeastdecappingmutants pages 1-5
+19. caraba2024yeastdecappingmutants pages 17-22
+20. https://doi.org/10.1534/genetics.104.034322;
+21. https://doi.org/10.1093/nar/29.12.2448
+22. https://doi.org/10.1111/febs.16626;
+23. https://doi.org/10.3389/fgene.2023.1233842
+24. https://doi.org/10.3389/fgene.2023.1233842;
+25. https://doi.org/10.1016/j.cell.2006.04.037;
+26. https://doi.org/10.1038/s41467-022-31282-8
+27. https://doi.org/10.3390/ijms241813708
+28. https://doi.org/10.1093/nar/gkad584
+29. https://doi.org/10.1534/genetics.104.034322
+30. https://doi.org/10.1111/febs.16626
+31. https://doi.org/10.1016/j.cell.2006.04.037
+32. https://doi.org/10.1534/genetics.104.034322,
+33. https://doi.org/10.1111/febs.16626,
+34. https://doi.org/10.3389/fgene.2023.1233842,
+35. https://doi.org/10.1093/nar/29.12.2448,
+36. https://doi.org/10.1016/j.cell.2006.04.037,
+37. https://doi.org/10.1093/nar/gkad584,
+38. https://doi.org/10.3390/ijms241813708,
+39. https://doi.org/10.1038/s41467-022-31282-8,


### PR DESCRIPTION
## Summary

Adds Falcon deep research reports and integrates them into review YAML/HTML for one pombe gene and four yeast genes:

- `SCHPO/scm3`
- `yeast/ATG7`
- `yeast/CYC1`
- `yeast/HSP26`
- `yeast/LSM1`

For each gene, the provider-generated `*-deep-research-falcon.md` report is added as a reference and used as supporting evidence for the main curated annotation/core function. `SCHPO/scm3` is moved from `DRAFT` to `COMPLETE` because the existing review had no pending actions and the Falcon report confirms the CENP-A/Cnp1 histone chaperone model.

## Validation

- `uv run python scripts/validate_deep_research.py genes/SCHPO/scm3/scm3-deep-research-falcon.md genes/yeast/ATG7/ATG7-deep-research-falcon.md genes/yeast/CYC1/CYC1-deep-research-falcon.md genes/yeast/HSP26/HSP26-deep-research-falcon.md genes/yeast/LSM1/LSM1-deep-research-falcon.md`
- `just validate SCHPO scm3`
- `just validate yeast ATG7`
- `just validate yeast CYC1`
- `just validate yeast HSP26`
- `just validate yeast LSM1`
- `just render SCHPO scm3`
- `just render yeast ATG7`
- `just render yeast CYC1`
- `just render yeast HSP26`
- `just render yeast LSM1`
- `git diff --check`

Note: `just validate yeast HSP26` passes with two pre-existing best-practice warnings about the existing holdase/NTR review state for `GO:0006457` and `GO:0051082`.