### PR TITLE
[codex] Add Falcon deep research batch 9

### DIFF
--- a/genes/yeast/APJ1/APJ1-ai-review.html
+++ b/genes/yeast/APJ1/APJ1-ai-review.html
@@ -671,33 +671,33 @@
     <div class="header">
         <h1>APJ1</h1>
         <div class="gene-info">
-            
+
             <div class="info-item">
-                
+
                 <span class="info-label">UniProt ID:</span>
                 <span>
                     <a href="https://www.uniprot.org/uniprotkb/P53940" target="_blank" class="term-link">
                         P53940
                     </a>
                 </span>
-                
+
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Organism:</span>
                 <span>Saccharomyces cerevisiae</span>
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
-                <span class="status-badge status-draft">
-                    DRAFT
+                <span class="status-badge status-complete">
+                    COMPLETE
                 </span>
             </div>
-            
-            
+
+
         </div>
         <div style="margin-top: 1rem; text-align: center;">
             <a id="feedback-form-link"
@@ -728,24 +728,24 @@
         </div>
     </div>
 
-    
+
     <div class="description-card">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <h2>Gene Description</h2>
-            <span class="vote-buttons" data-g="P53940" data-a="DESCRIPTION: TODO: Add description for APJ1..." data-r="" data-act="DESCRIPTION">
+            <span class="vote-buttons" data-g="P53940" data-a="DESCRIPTION: APJ1 encodes a low-abundance class A J-domain/Hsp4..." data-r="" data-act="DESCRIPTION">
                 <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
                 <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
             </span>
         </div>
-        <p>TODO: Add description for APJ1</p>
+        <p>APJ1 encodes a low-abundance class A J-domain/Hsp40 cochaperone that functions with Hsp70 in yeast protein quality control. The strongest evidence supports a nuclear and cytosolic proteostasis role, including Hsp70 ATPase activation, protein refolding and disaggregation contexts, prion-curing specialization, and genetic cooperation with SUMO-targeted degradation machinery.</p>
     </div>
-    
 
-    
 
-    
 
-    
+
+
+
+
     <div class="section">
         <h2 class="section-title">Existing Annotations Review</h2>
         <table class="annotations-table">
@@ -758,32 +758,32 @@
                 </tr>
             </thead>
             <tbody>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001671" target="_blank" class="term-link">
                                     GO:0001671
                                 </a>
                             </span>
                             <span class="term-label">ATPase activator activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -795,46 +795,62 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: ATPase activator activity is consistent with known biology of APJ1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/APJ1/APJ1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Apj1 is classified as a **class I (class A) J protein** in yeast</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034605" target="_blank" class="term-link">
                                     GO:0034605
                                 </a>
                             </span>
                             <span class="term-label">cellular response to heat</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -846,46 +862,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: cellular response to heat is consistent with known biology of APJ1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042026" target="_blank" class="term-link">
                                     GO:0042026
                                 </a>
                             </span>
                             <span class="term-label">protein refolding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -897,46 +913,62 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: protein refolding is consistent with known biology of APJ1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/APJ1/APJ1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Apj1 behaves as a **canonical Hsp70 co-chaperone**</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -948,57 +980,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: unfolded protein binding is better represented by a more specific replacement term for APJ1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Modified to align with current curation guidance and improve term specificity.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     protein folding chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -1010,46 +1042,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: nucleus may be context-dependent or peripheral for APJ1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -1061,46 +1093,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: nucleus may be context-dependent or peripheral for APJ1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -1112,46 +1144,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: cytoplasm may be context-dependent or peripheral for APJ1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                     GO:0006457
                                 </a>
                             </span>
                             <span class="term-label">protein folding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1163,46 +1195,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: protein folding is consistent with known biology of APJ1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008270" target="_blank" class="term-link">
                                     GO:0008270
                                 </a>
                             </span>
                             <span class="term-label">zinc ion binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1214,46 +1246,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: zinc ion binding is consistent with known biology of APJ1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030544" target="_blank" class="term-link">
                                     GO:0030544
                                 </a>
                             </span>
                             <span class="term-label">Hsp70 protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1265,46 +1297,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: Hsp70 protein binding is consistent with known biology of APJ1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031072" target="_blank" class="term-link">
                                     GO:0031072
                                 </a>
                             </span>
                             <span class="term-label">heat shock protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1316,46 +1348,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: heat shock protein binding is consistent with known biology of APJ1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046872" target="_blank" class="term-link">
                                     GO:0046872
                                 </a>
                             </span>
                             <span class="term-label">metal ion binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1367,46 +1399,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: metal ion binding is consistent with known biology of APJ1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -1418,68 +1450,68 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: unfolded protein binding is better represented by a more specific replacement term for APJ1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Modified to align with current curation guidance and improve term specificity.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     protein folding chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17892321" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:17892321
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Structure-templated predictions of novel protein interaction...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1491,57 +1523,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: protein binding is too generic or over-extended for APJ1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Marked over-annotated because more specific terms capture the biology more accurately.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008270" target="_blank" class="term-link">
                                     GO:0008270
                                 </a>
                             </span>
                             <span class="term-label">zinc ion binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">RCA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/30358795" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:30358795
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The cellular economy of the Saccharomyces cerevisiae zinc pr...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1553,57 +1585,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: zinc ion binding is consistent with known biology of APJ1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042405" target="_blank" class="term-link">
                                     GO:0042405
                                 </a>
                             </span>
                             <span class="term-label">nuclear inclusion body</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/32492414" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:32492414
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Chaperone-Mediated Protein Disaggregation Triggers Proteolyt...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -1615,57 +1647,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: nuclear inclusion body may be context-dependent or peripheral for APJ1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043335" target="_blank" class="term-link">
                                     GO:0043335
                                 </a>
                             </span>
                             <span class="term-label">protein unfolding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/32492414" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:32492414
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Chaperone-Mediated Protein Disaggregation Triggers Proteolyt...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1677,57 +1709,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: protein unfolding is consistent with known biology of APJ1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/11923285" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:11923285
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Increased expression of Hsp40 chaperones, transcriptional fa...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -1739,68 +1771,68 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: unfolded protein binding is better represented by a more specific replacement term for APJ1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Modified to align with current curation guidance and improve term specificity.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     protein folding chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/14562095" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:14562095
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Global analysis of protein localization in budding yeast.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -1812,57 +1844,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: nucleus may be context-dependent or peripheral for APJ1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/22842922" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:22842922
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Dissecting DNA damage response pathways by analysing protein...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -1874,57 +1906,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: nucleus may be context-dependent or peripheral for APJ1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/14562095" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:14562095
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Global analysis of protein localization in budding yeast.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -1936,57 +1968,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: cytoplasm may be context-dependent or peripheral for APJ1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
                                     GO:0005739
                                 </a>
                             </span>
                             <span class="term-label">mitochondrion</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/14576278" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:14576278
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The proteome of Saccharomyces cerevisiae mitochondria.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -1998,57 +2030,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: mitochondrion may be context-dependent or peripheral for APJ1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
                                     GO:0005739
                                 </a>
                             </span>
                             <span class="term-label">mitochondrion</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16823961" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16823961
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Toward the complete yeast mitochondrial proteome: multidimen...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -2060,57 +2092,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: mitochondrion may be context-dependent or peripheral for APJ1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034399" target="_blank" class="term-link">
                                     GO:0034399
                                 </a>
                             </span>
                             <span class="term-label">nuclear periphery</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/25817432" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:25817432
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Cmr1/WDR76 defines a nuclear genotoxic stress body linking g...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -2122,57 +2154,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: nuclear periphery may be context-dependent or peripheral for APJ1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001671" target="_blank" class="term-link">
                                     GO:0001671
                                 </a>
                             </span>
                             <span class="term-label">ATPase activator activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23329686" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23329686
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Sequential duplications of an ancient member of the DnaJ-fam...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2184,57 +2216,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: ATPase activator activity is consistent with known biology of APJ1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016925" target="_blank" class="term-link">
                                     GO:0016925
                                 </a>
                             </span>
                             <span class="term-label">protein sumoylation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IGI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23329686" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23329686
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Sequential duplications of an ancient member of the DnaJ-fam...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -2246,273 +2278,750 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: protein sumoylation may be context-dependent or peripheral for APJ1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
             </tbody>
         </table>
     </div>
-    
 
-    
 
-    
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>J-domain Hsp70 cochaperone activity in nuclear and cytosolic protein quality control. Apj1 stimulates Hsp70-dependent chaperone cycles and contributes to protein refolding/disaggregation contexts, prion curing, and stress-linked nuclear proteostasis.</h3>
+                <span class="vote-buttons" data-g="P53940" data-a="FUNCTION: J-domain Hsp70 cochaperone activity in nuclear and..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001671" target="_blank" class="term-link">
+                            ATPase activator activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
+                                protein folding
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042026" target="_blank" class="term-link">
+                                protein refolding
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:yeast/APJ1/APJ1-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">Apj1 is a **specialized, low-abundance, predominantly nuclear J-domain co-chaperone**</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class="section">
         <h2 class="section-title collapsible">References</h2>
         <div class="collapse-content">
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
                             GO_REF:0000002
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
                             GO_REF:0000033
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Annotation inferences using phylogenetic trees</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000043.md" target="_blank" class="term-link">
                             GO_REF:0000043
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
                             GO_REF:0000044
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/11923285" target="_blank" class="term-link">
                             PMID:11923285
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Increased expression of Hsp40 chaperones, transcriptional factors, and ribosomal protein Rpp0 can cure yeast prions.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/14562095" target="_blank" class="term-link">
                             PMID:14562095
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Global analysis of protein localization in budding yeast.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/14576278" target="_blank" class="term-link">
                             PMID:14576278
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The proteome of Saccharomyces cerevisiae mitochondria.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/16823961" target="_blank" class="term-link">
                             PMID:16823961
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Toward the complete yeast mitochondrial proteome: multidimensional separation techniques for mitochondrial proteomics.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/17892321" target="_blank" class="term-link">
                             PMID:17892321
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Structure-templated predictions of novel protein interactions from sequence information.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/22842922" target="_blank" class="term-link">
                             PMID:22842922
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Dissecting DNA damage response pathways by analysing protein localization and abundance changes during DNA replication stress.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/23329686" target="_blank" class="term-link">
                             PMID:23329686
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Sequential duplications of an ancient member of the DnaJ-family expanded the functional chaperone network in the eukaryotic cytosol.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/25817432" target="_blank" class="term-link">
                             PMID:25817432
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Cmr1/WDR76 defines a nuclear genotoxic stress body linking genome integrity and protein quality control.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/30358795" target="_blank" class="term-link">
                             PMID:30358795
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The cellular economy of the Saccharomyces cerevisiae zinc proteome.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/32492414" target="_blank" class="term-link">
                             PMID:32492414
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Chaperone-Mediated Protein Disaggregation Triggers Proteolytic Clearance of Intra-nuclear Protein Inclusions.</div>
-                
-                
+
+
             </div>
-            
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:yeast/APJ1/APJ1-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research report for APJ1</div>
+
+
+            </div>
+
         </div>
     </div>
-    
 
 
-    
 
-    
 
-    
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Should APJ1 receive a more specific GO biological process annotation for Hsp104-dependent prion curing or nuclear protein quality control once a suitable term is available?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P53940" data-a="Q: Should APJ1 receive a more specific GO biological ..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Are the reported nuclear inclusion and Hsf1 attenuation roles sufficiently peer-reviewed and generalizable for direct GO annotation?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P53940" data-a="Q: Are the reported nuclear inclusion and Hsf1 attenu..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Directly assay Apj1-dependent Hsp70 ATPase stimulation with wild-type and J-domain mutant Apj1 in defined client contexts.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="P53940" data-a="EXPERIMENT: Directly assay Apj1-dependent Hsp70 ATPase stimula..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Quantify Apj1 client recruitment to SUMOylated nuclear inclusions and test whether this requires the Zn-finger/client-binding regions.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="P53940" data-a="EXPERIMENT: Quantify Apj1 client recruitment to SUMOylated nuc..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
 
     <!-- Computational Predictions Section -->
-    
+
 
     <!-- Additional Documentation Sections -->
-    
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Deep Research Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(APJ1-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P53940" data-a="DOC: Deep Research Falcon" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <hr />
+<p>provider: falcon<br />
+model: Edison Scientific Literature<br />
+cached: false<br />
+start_time: '2026-05-11T08:43:34.866688'<br />
+end_time: '2026-05-11T08:53:24.503960'<br />
+duration_seconds: 589.64<br />
+template_file: templates/gene_research_go_focused.md<br />
+template_variables:<br />
+  organism: yeast<br />
+  gene_id: APJ1<br />
+  gene_symbol: APJ1<br />
+  uniprot_accession: P53940<br />
+  protein_description: 'RecName: Full=J domain-containing protein APJ1;'<br />
+  gene_info: Name=APJ1; OrderedLocusNames=YNL077W; ORFNames=N2342;<br />
+  organism_full: Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).<br />
+  protein_family: Not specified in UniProt<br />
+  protein_domains: DnaJ_C. (IPR002939); DnaJ_domain. (IPR001623); DnaJ_domain_CS.<br />
+    (IPR018253); DNJA1/2-like. (IPR044713); HSP40/DnaJ_pept-bd. (IPR008971)<br />
+provider_config:<br />
+  timeout: 600<br />
+  max_retries: 3<br />
+  parameters:<br />
+    allowed_domains: []<br />
+    temperature: 0.1<br />
+citation_count: 19</p>
+<hr />
+<h2 id="question">Question</h2>
+<h1 id="gene-research-for-functional-annotation">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> P53940</li>
+<li><strong>Protein Description:</strong> RecName: Full=J domain-containing protein APJ1;</li>
+<li><strong>Gene Information:</strong> Name=APJ1; OrderedLocusNames=YNL077W; ORFNames=N2342;</li>
+<li><strong>Organism (full):</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Protein Family:</strong> Not specified in UniProt</li>
+<li><strong>Key Domains:</strong> DnaJ_C. (IPR002939); DnaJ_domain. (IPR001623); DnaJ_domain_CS. (IPR018253); DNJA1/2-like. (IPR044713); HSP40/DnaJ_pept-bd. (IPR008971)</li>
+</ul>
+<h3 id="mandatory-verification-steps">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "APJ1" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'APJ1' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>APJ1</strong> (gene ID: APJ1, UniProt: P53940) in yeast.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="output">Output</h2>
+<p>Question: You are an expert researcher providing comprehensive, well-cited information.</p>
+<p>Provide detailed information focusing on:<br />
+1. Key concepts and definitions with current understanding<br />
+2. Recent developments and latest research (prioritize 2023-2024 sources)<br />
+3. Current applications and real-world implementations<br />
+4. Expert opinions and analysis from authoritative sources<br />
+5. Relevant statistics and data from recent studies</p>
+<p>Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.<br />
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.</p>
+<h1 id="gene-research-for-functional-annotation_1">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context_1">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot_1">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> P53940</li>
+<li><strong>Protein Description:</strong> RecName: Full=J domain-containing protein APJ1;</li>
+<li><strong>Gene Information:</strong> Name=APJ1; OrderedLocusNames=YNL077W; ORFNames=N2342;</li>
+<li><strong>Organism (full):</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Protein Family:</strong> Not specified in UniProt</li>
+<li><strong>Key Domains:</strong> DnaJ_C. (IPR002939); DnaJ_domain. (IPR001623); DnaJ_domain_CS. (IPR018253); DNJA1/2-like. (IPR044713); HSP40/DnaJ_pept-bd. (IPR008971)</li>
+</ul>
+<h3 id="mandatory-verification-steps_1">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "APJ1" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature_1">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'APJ1' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target_1">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>APJ1</strong> (gene ID: APJ1, UniProt: P53940) in yeast.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="research-report-functional-annotation-of-apj1-ynl077w-in-saccharomyces-cerevisiae-uniprot-p53940">Research Report: Functional Annotation of <strong>APJ1 (YNL077W)</strong> in <em>Saccharomyces cerevisiae</em> (UniProt <strong>P53940</strong>)</h1>
+<h2 id="0-target-verification-mandatory">0) Target verification (mandatory)</h2>
+<p>The literature retrieved and analyzed refers to <em>Saccharomyces cerevisiae</em> APJ1 as systematic ORF <strong>YNL077W</strong>, encoding a <strong>J-domain/Hsp40 family</strong> cochaperone (also called a J-domain protein, JDP). Multiple primary studies explicitly use the name <strong>Apj1</strong> together with <strong>YNL077W</strong>, analyze its <strong>J-domain (including the canonical HPD motif and the H34Q J-domain mutation)</strong>, and place it in yeast cytosolic/nuclear chaperone networks, matching the UniProt identity provided (P53940). (sahi2007networkofgeneral pages 1-3, sahi2013sequentialduplicationsof pages 1-2, sahi2013sequentialduplicationsof pages 6-7)</p>
+<h2 id="1-key-concepts-and-definitions-current-understanding">1) Key concepts and definitions (current understanding)</h2>
+<h3 id="11-j-domain-proteins-hsp40sjdps-and-apj1s-mechanistic-role">1.1 J-domain proteins (Hsp40s/JDPs) and Apj1’s mechanistic role</h3>
+<p>J-domain proteins are obligate cochaperones of Hsp70 chaperones: their J-domain stimulates Hsp70 ATPase activity and thereby promotes substrate binding and productive chaperone cycles. Apj1 is classified as a <strong>class I (class A) J protein</strong> in yeast, implying a canonical J-domain with the conserved <strong>HPD</strong> motif required for Hsp70 activation. (sahi2007networkofgeneral pages 1-3, sahi2013sequentialduplicationsof pages 1-2)</p>
+<p><strong>Operational definition for APJ1 function:</strong> in the studies below, “Apj1 function” is typically measured by its ability to support specific Hsp70-dependent processes (e.g., protein quality control, prion curing, or stress-response regulation) and by the requirement for a functional J-domain (e.g., loss of function with <strong>H34Q</strong>). (sahi2013sequentialduplicationsof pages 6-7, rugerherreros2025nuclearandcytosolic pages 9-11)</p>
+<h3 id="12-protein-quality-control-pqc-nuclear-inclusions-inq-and-stress-response-attenuation">1.2 Protein quality control (PQC), nuclear inclusions (INQ), and stress-response attenuation</h3>
+<p>Yeast PQC includes compartment-specific handling of misfolded proteins (refolding, sequestration, and degradation). The <strong>intranuclear quality control compartment (INQ)</strong> is a nuclear deposition site for misfolded/aggregated proteins under stress; Apj1 has been linked to targeting INQ-deposited proteins for proteasomal degradation and to shaping nuclear PQC outputs during heat shock. (rugerherreros2025nuclearandcytosolic pages 4-6)</p>
+<h3 id="13-sumo-targeted-ubiquitin-ligase-stubl-pathway-context">1.3 SUMO-targeted ubiquitin ligase (STUbL) pathway context</h3>
+<p>SUMOylation can mark proteins for downstream processing, including degradation via SUMO-targeted ubiquitin ligases (STUbLs). In yeast, <strong>Slx5</strong> is a key STUbL component. Genetic evidence connects <strong>APJ1</strong> to <strong>SUMO-mediated degradation</strong> in cooperation with Slx5. (sahi2013sequentialduplicationsof pages 6-7, sahi2013sequentialduplicationsof pages 7-8)</p>
+<h2 id="2-geneprotein-overview-domains-localization-and-abundance">2) Gene/protein overview: domains, localization, and abundance</h2>
+<h3 id="21-domain-architecture-inferredvalidated-by-experiments">2.1 Domain architecture inferred/validated by experiments</h3>
+<p>Apj1 is described as a cytosolic/nuclear DnaJ-family (Hsp40) J protein with an <strong>~70-residue N-terminal J-domain</strong> followed by additional regions typical of class I J proteins, and functional analysis highlights a <strong>Zn-binding (Zn-finger) region</strong> as important for specific Apj1 functions in degradation-linked contexts. (sahi2013sequentialduplicationsof pages 1-2, sahi2013sequentialduplicationsof pages 6-7)</p>
+<p>A 2024 functional dissection defined short N-terminal fragments sufficient for specific Apj1-dependent activities in prion curing and/or Sis1-related functions (see §3). (ganser2024uniquecharacteristicsof pages 1-2, ganser2024uniquecharacteristicsof pages 2-4)</p>
+<h3 id="22-subcellular-localization">2.2 Subcellular localization</h3>
+<p>Apj1 is reported to be <strong>predominantly nuclear</strong> while also present <strong>in the cytosol</strong>, consistent with dual roles in nuclear PQC and cytosolic chaperone networks. (sahi2007networkofgeneral pages 1-3)</p>
+<h3 id="23-quantitative-abundance">2.3 Quantitative abundance</h3>
+<p>Apj1 is low abundance relative to major J proteins such as Ydj1: one quantitative estimate cited in the chaperone-network study is <strong>~125 molecules per cell</strong> for Apj1 under the conditions examined. (sahi2007networkofgeneral pages 1-3)</p>
+<h2 id="3-experimentally-supported-functions-and-pathways">3) Experimentally supported functions and pathways</h2>
+<table>
+<thead>
+<tr>
+<th>Functional area</th>
+<th>Key findings</th>
+<th>Experimental evidence type</th>
+<th>Key molecules/partners</th>
+<th>Quantitative/construct details</th>
+<th>Primary citations (IDs)</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Hsp70 co-chaperone</td>
+<td>• Class I J protein with canonical J-domain/HPD motif that stimulates Hsp70 ATPase activity • J-domain is essential for function; H34Q disrupts Hsp70 cooperation • Functionally overlaps with other cytosolic/nuclear J proteins when overexpressed</td>
+<td>Domain/function analysis; J-domain mutagenesis; genetic complementation/overexpression rescue</td>
+<td>Hsp70, Ydj1, Sis1</td>
+<td>~125 molecules per cell in unstressed yeast; predominantly nuclear but also present in cytosol; overexpressed full-length Apj1 rescues ydj1 growth defect (sahi2007networkofgeneral pages 1-3, sahi2013sequentialduplicationsof pages 1-2, rugerherreros2025nuclearandcytosolic pages 9-11)</td>
+<td>(sahi2007networkofgeneral pages 1-3, sahi2013sequentialduplicationsof pages 1-2, rugerherreros2025nuclearandcytosolic pages 9-11)</td>
+</tr>
+<tr>
+<td>Prion biology</td>
+<td>• Anti-prion J protein required for efficient Hsp104-mediated curing of strong [PSI+] variants • Minimal N-terminus is sufficient for curing • Partial functional overlap with Sis1 in prion propagation/elimination</td>
+<td>Truncation complementation; Hsp104 overexpression assays; SDD-AGE; plasmid shuffle/growth assays</td>
+<td>Hsp104, Hsp70, Sis1, [PSI+] prion</td>
+<td>161-aa N-terminus sufficient for curing; 90-aa fragment (J-domain + adjacent Q/A region) sufficient for curing; 121-aa fragment supports viability without Sis1 and maintenance of several Sis1-dependent prions; heterologous J-domain can support Sis1-like functions but not Apj1-specific curing (ganser2024uniquecharacteristicsof pages 1-2, ganser2024uniquecharacteristicsof pages 2-4, ganser2024uniquecharacteristicsof media 6fb49813, ganser2024uniquecharacteristicsof media 5aa2f23d)</td>
+<td>(ganser2024uniquecharacteristicsof pages 1-2, ganser2024uniquecharacteristicsof pages 2-4, ganser2024uniquecharacteristicsof media 6fb49813, ganser2024uniquecharacteristicsof media 5aa2f23d)</td>
+</tr>
+<tr>
+<td>SUMO-mediated degradation / STUbL</td>
+<td>• Specialized role in degradation of sumoylated proteins • Strong synthetic interaction with STUbL factor SLX5 • Client binding and intact J-domain required for this degradation-linked function</td>
+<td>Synthetic genetic interaction; growth at elevated temperature; immunoblot of SUMO conjugates; domain-swap/deletion and hydrophobic-cleft mutagenesis</td>
+<td>Slx5, Hsp70, SUMOylated substrates</td>
+<td>apj1Δ alone has little defect, but apj1Δ slx5 grows much worse than slx5 and cannot form individual colonies at 37°C; SUMO-conjugates increase further in slx5 apj1 double mutant; H34Q fails to complement; Zn-finger region important; hydrophobic-cleft mutants I179S, L200S, L277S fail to substitute for WT Apj1 (sahi2013sequentialduplicationsof pages 6-7, sahi2013sequentialduplicationsof pages 7-8)</td>
+<td>(sahi2013sequentialduplicationsof pages 6-7, sahi2013sequentialduplicationsof pages 7-8)</td>
+</tr>
+<tr>
+<td>Heat shock response regulation</td>
+<td>• Nuclear Apj1 promotes attenuation of Hsf1 activity after heat shock • Acts as canonical Hsp70 co-chaperone targeting Hsf1 to Hsp70 for repression • Loss of Apj1 synergizes with Ydj1 defects to cause constitutive/persistent Hsf1 activation</td>
+<td>Microscopy; gene coalescence assays; ribosome profiling; J-domain mutagenesis; immunoblot of Hsf1 targets</td>
+<td>Hsf1, Hsp70, Ydj1, Btn2, Hsp42, HSP104/HSP12 loci</td>
+<td>In apj1Δ, Btn2 remains elevated up to 120 min after heat shock; Hsf1-target expression increased at 60 min (p=3.724e-05); apj1Δ ydj1 mutants show HSP104/HSP12 gene coalescence in 63% and 65.5% of cells at 25°C; Apj1 H34Q phenocopies deletion for Hsp70 cooperation (rugerherreros2025nuclearandcytosolic pages 1-4, rugerherreros2025nuclearandcytosolic pages 9-11, rugerherreros2025nuclearandcytosolic pages 4-6)</td>
+<td>(rugerherreros2025nuclearandcytosolic pages 1-4, rugerherreros2025nuclearandcytosolic pages 9-11, rugerherreros2025nuclearandcytosolic pages 4-6)</td>
+</tr>
+<tr>
+<td>Nuclear PQC / INQ</td>
+<td>• Apj1 is a nuclear class A J protein linked to nuclear protein quality control • Targets proteins deposited at INQ for proteasomal degradation • Absence of Apj1 increases formation/stability of nuclear inclusions and prolongs stress-induced nuclear remodeling</td>
+<td>Microscopy of Sis1/Hsf1 foci; heat-shock time courses; genetic analysis</td>
+<td>INQ, Sis1, Hsf1, proteasome, Ydj1</td>
+<td>apj1Δ cells show increased nuclear Sis1-GFP foci after heat shock: 53.7% vs 21% WT at 15 min and 59.2% vs 30.7% WT at 60 min; apj1Δ ydj1Δ cells have nuclear Sis1 foci before shock in 42.3% of cells; Hsf1-GFP foci persist through 60 min heat shock in apj1Δ (rugerherreros2025nuclearandcytosolic pages 9-11, rugerherreros2025nuclearandcytosolic pages 4-6)</td>
+<td>(rugerherreros2025nuclearandcytosolic pages 9-11, rugerherreros2025nuclearandcytosolic pages 4-6)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the main experimentally supported functions of Saccharomyces cerevisiae Apj1, including its roles as an Hsp70 co-chaperone, in prion control, SUMO-linked degradation, heat-shock regulation, and nuclear protein quality control. It also captures the key assays, molecular partners, and quantitative details most useful for a research report.</em></p>
+<h3 id="31-primary-molecular-function-hsp70-cochaperone-canonical-j-domain-dependence">3.1 Primary molecular function: Hsp70 cochaperone (canonical J-domain dependence)</h3>
+<p>Across multiple experimental contexts, Apj1 behaves as a <strong>canonical Hsp70 co-chaperone</strong>: mutation of the conserved J-domain histidine (H34Q) disrupts functional cooperation with Hsp70 and abrogates Apj1 activity in assays where Apj1 is required. (sahi2013sequentialduplicationsof pages 6-7, rugerherreros2025nuclearandcytosolic pages 9-11)</p>
+<p>Functional overlap within the cytosolic JDP network is supported by overexpression rescue: <strong>overexpression of full-length Apj1 can dramatically rescue the growth defect of ydj1 mutant cells</strong>, implying that Apj1 can substitute for some Ydj1-associated Hsp70 functions when sufficiently abundant. (sahi2007networkofgeneral pages 1-3)</p>
+<h3 id="32-prion-biology-apj1-in-hsp104-dependent-psi-curing-and-overlap-with-sis1">3.2 Prion biology: Apj1 in Hsp104-dependent [PSI+] curing and overlap with Sis1</h3>
+<p><strong>Recent development (2024):</strong> Ganser et al. (Frontiers in Molecular Biosciences; published <strong>April 2024</strong>; https://doi.org/10.3389/fmolb.2024.1392608) dissected the N-terminus of Apj1 and separated distinct functional elements relevant to prion curing versus Sis1-like roles. (ganser2024uniquecharacteristicsof pages 1-2, ganser2024uniquecharacteristicsof pages 2-4)</p>
+<p>Key findings:<br />
+- A <strong>90-residue</strong> fragment containing the <strong>J-domain plus an adjacent ~12-residue Q/A segment</strong> is <strong>sufficient for Hsp104-mediated [PSI+] prion curing</strong> in their experimental system. (ganser2024uniquecharacteristicsof pages 1-2, ganser2024uniquecharacteristicsof pages 2-4)<br />
+- A <strong>121-residue</strong> fragment (including the Grich/GF region) can <strong>sustain growth</strong> in cells lacking the essential class B JDP <strong>Sis1</strong> and can enable maintenance of several prions normally dependent on Sis1. (ganser2024uniquecharacteristicsof pages 1-2)<br />
+- A heterologous J-domain can substitute for Sis1-related functions but <strong>cannot</strong> substitute for Apj1’s <strong>prion-curing specificity</strong>, indicating specialization beyond generic J-domain activity. (ganser2024uniquecharacteristicsof pages 1-2)</p>
+<p>Visual evidence supporting the construct design and functional conclusions is shown in the retrieved figure regions from Ganser et al. (2024). (ganser2024uniquecharacteristicsof media 6fb49813, ganser2024uniquecharacteristicsof media 5aa2f23d)</p>
+<h3 id="33-sumo-mediated-protein-degradation-genetic-interaction-with-stubl-factor-slx5">3.3 SUMO-mediated protein degradation: genetic interaction with STUbL factor Slx5</h3>
+<p>A specialized role for Apj1 in <strong>SUMO-targeted proteolysis</strong> is supported by Sahi et al. (Molecular Biology and Evolution; published <strong>May 2013</strong>; https://doi.org/10.1093/molbev/mst008). (sahi2013sequentialduplicationsof pages 6-7)</p>
+<p>Key experimental evidence:<br />
+- <strong>Synthetic interaction with SLX5:</strong> an <strong>apj1 slx5</strong> double mutant shows substantially worse growth than <strong>slx5</strong> alone and fails to form individual colonies at <strong>37°C</strong>, whereas apj1 single mutants show little/no defect under many conditions, supporting a compensatory relationship in a degradation pathway. (sahi2013sequentialduplicationsof pages 7-8)<br />
+- <strong>SUMO conjugate accumulation:</strong> immunoblot evidence shows that the <strong>slx5 apj1</strong> double mutant accumulates <strong>higher levels of SUMOylated proteins</strong> than slx5 alone, which the authors interpret as Apj1 contributing to the proteolysis of sumoylated substrates. (sahi2013sequentialduplicationsof pages 6-7)<br />
+- <strong>Mechanistic requirements:</strong> the Apj1 <strong>J-domain</strong> is required (H34Q fails to complement), consistent with dependence on an Hsp70 machinery; the <strong>Zn-finger region</strong> is important, and mutations in a <strong>hydrophobic client-binding cleft</strong> (e.g., <strong>I179S, L200S, L277S</strong>) disrupt the ability to substitute for WT Apj1 in the slx5 background, supporting a client-binding requirement for this pathway role. (sahi2013sequentialduplicationsof pages 6-7, sahi2013sequentialduplicationsof pages 7-8)</p>
+<h3 id="34-heat-shock-response-hsr-regulation-and-nuclear-pqcinq-emerging-direction">3.4 Heat shock response (HSR) regulation and nuclear PQC/INQ (emerging direction)</h3>
+<p>A recent preprint (bioRxiv; posted <strong>July 2025</strong>; https://doi.org/10.1101/2025.04.14.648540) proposes an expanded role for Apj1 in <strong>heat shock response attenuation</strong> and <strong>nuclear PQC</strong>, integrating Hsp70/JDP function with transcriptional control of Hsf1. Because this is a preprint (not yet peer-reviewed as of the retrieved version), conclusions should be treated as provisional, but the quantitative data are informative. (rugerherreros2025nuclearandcytosolic pages 4-6, rugerherreros2025nuclearandcytosolic pages 9-11)</p>
+<p>Key findings reported:<br />
+- Apj1 is described as a <strong>nuclear class A JDP</strong> that helps repress/attenuate <strong>Hsf1</strong> activity by functioning as a canonical Hsp70 co-chaperone; the <strong>H34Q</strong> J-domain mutant abrogates Hsp70 cooperation and phenocopies apj1 deletion in relevant assays. (rugerherreros2025nuclearandcytosolic pages 9-11)<br />
+- In an <strong>apj1Δ ydj1Δ</strong> context, strong Hsf1 activation is observed even without acute stress, including <strong>coalescence of HSP104 and HSP12 loci</strong> in <strong>63% and 65.5%</strong> of mutant cells at <strong>25°C</strong>, and increased levels of Hsf1 targets (e.g., Btn2, Hsp42). (rugerherreros2025nuclearandcytosolic pages 9-11)<br />
+- For nuclear PQC readouts, the preprint reports increased nuclear inclusion phenotypes: <strong>apj1Δ</strong> cells show more nuclear <strong>Sis1-GFP foci</strong> after heat shock (e.g., <strong>53.7% vs 21%</strong> WT at 15 min; <strong>59.2% vs 30.7%</strong> WT at 60 min), and apj1Δ ydj1Δ cells show nuclear Sis1 foci before heat shock in <strong>42.3%</strong> of cells. (rugerherreros2025nuclearandcytosolic pages 9-11)<br />
+- The authors explicitly connect Apj1 to <strong>INQ</strong> (intranuclear quality control) function, stating that absence of Apj1 increases formation/stability of INQ and that Apj1 targets INQ-deposited proteins for proteasomal degradation. (rugerherreros2025nuclearandcytosolic pages 4-6)</p>
+<h2 id="4-current-applications-and-real-world-implementations">4) Current applications and real-world implementations</h2>
+<h3 id="41-yeast-as-a-model-for-proteostasis-and-amyloidprion-biology">4.1 Yeast as a model for proteostasis and amyloid/prion biology</h3>
+<p>Apj1 is used in yeast as a genetically tractable handle to probe how distinct Hsp70–JDP modules interface with <strong>Hsp104</strong> to eliminate prion/amyloid states (e.g., [PSI+]) and how specialized low-abundance JDPs can exert strong phenotype-specific effects via defined domains/regions. This is exemplified by the 2024 truncation experiments that separate “minimal prion-curing” activity from Sis1-complementation capacity. (ganser2024uniquecharacteristicsof pages 1-2, ganser2024uniquecharacteristicsof media 6fb49813)</p>
+<h3 id="42-industrialbiotechnology-relevance-yeast-trait-mapping">4.2 Industrial/biotechnology relevance (yeast trait mapping)</h3>
+<p>Although not a mechanistic characterization in <em>S. cerevisiae</em> S288c, APJ1 homologs have appeared in genetic mapping of industrially relevant traits. For example, bulk-segregant analysis in a natural <em>Saccharomyces sensu stricto</em> hybrid identified a locus containing an <strong>APJ1 homolog</strong> contributing to growth on xylose, illustrating that APJ1-family variation can emerge in applied contexts (biofuel-related strain improvement). (Note: this is association/trait-mapping evidence rather than direct biochemical function in S288c.) (schwartz2012apj1andgre3 pages 1-2 not processed into a citeable evidence snippet in this run; therefore it is not cited as primary evidence here.)</p>
+<h2 id="5-expert-synthesis-and-interpretation-authoritative-analysis">5) Expert synthesis and interpretation (authoritative analysis)</h2>
+<h3 id="51-a-unifying-functional-model">5.1 A unifying functional model</h3>
+<p>The strongest experimentally supported synthesis is that Apj1 is a <strong>specialized, low-abundance, predominantly nuclear J-domain co-chaperone</strong> that engages Hsp70 to direct distinct proteostasis outcomes depending on context: (i) <strong>prion curing</strong> in cooperation with Hsp104 and overlapping with Sis1 functions, and (ii) <strong>SUMO-linked degradation</strong> in functional interaction with Slx5, where Apj1’s client-binding capacity and Zn-finger region contribute to pathway performance. (sahi2007networkofgeneral pages 1-3, ganser2024uniquecharacteristicsof pages 1-2, sahi2013sequentialduplicationsof pages 6-7)</p>
+<h3 id="52-specificity-determinants-modular-n-terminus-vs-client-binding-regions">5.2 Specificity determinants: modular N-terminus vs client-binding regions</h3>
+<p>Ganser et al. (2024) show that a very short N-terminal fragment (90 aa) can be sufficient for prion-curing activity, whereas a longer fragment including additional low-complexity/GF-like regions is required for Sis1-like essential functions, supporting the idea that Apj1’s N-terminus contains determinants for prion-curing specialization. (ganser2024uniquecharacteristicsof pages 1-2, ganser2024uniquecharacteristicsof media 5aa2f23d)</p>
+<p>In contrast, Sahi et al. (2013) identify a requirement for client-binding features (hydrophobic cleft variants) and the Zn-finger region in SUMO-mediated degradation-related phenotypes, consistent with a model where different Apj1 regions govern different “client routing” behaviors (prion remodeling vs degradation). (sahi2013sequentialduplicationsof pages 7-8, sahi2013sequentialduplicationsof pages 6-7)</p>
+<h2 id="6-key-statistics-and-data-points-from-cited-studies">6) Key statistics and data points (from cited studies)</h2>
+<ul>
+<li><strong>Abundance:</strong> ~<strong>125 molecules/cell</strong> for Apj1 in one quantitative chaperone-network context. (sahi2007networkofgeneral pages 1-3)</li>
+<li><strong>Prion-curing constructs (Ganser et al., 2024; Apr 2024):</strong></li>
+<li><strong>90 aa</strong> (J-domain + Q/A) sufficient for Hsp104-mediated [PSI+] curing. (ganser2024uniquecharacteristicsof pages 1-2)</li>
+<li><strong>121 aa</strong> supports growth without Sis1 and supports maintenance of several Sis1-dependent prions. (ganser2024uniquecharacteristicsof pages 1-2)</li>
+<li>Visual evidence for truncation strategy and phenotypes is in retrieved figure regions. (ganser2024uniquecharacteristicsof media 6fb49813, ganser2024uniquecharacteristicsof media 5aa2f23d)</li>
+<li><strong>SUMO-pathway genetics (Sahi et al., 2013; May 2013):</strong> apj1 slx5 shows severe growth phenotype at <strong>37°C</strong>, and SUMO conjugates increase further in the double mutant vs slx5 alone. (sahi2013sequentialduplicationsof pages 7-8, sahi2013sequentialduplicationsof pages 6-7)</li>
+<li><strong>HSR/nuclear PQC phenotypes (bioRxiv preprint; Jul 2025):</strong></li>
+<li>Gene coalescence in apj1Δ ydj1Δ at 25°C: <strong>63% (HSP104)</strong> and <strong>65.5% (HSP12)</strong>. (rugerherreros2025nuclearandcytosolic pages 9-11)</li>
+<li>Nuclear Sis1-GFP foci after heat shock: <strong>53.7% vs 21%</strong> (apj1Δ vs WT, 15 min) and <strong>59.2% vs 30.7%</strong> (60 min). (rugerherreros2025nuclearandcytosolic pages 9-11)</li>
+</ul>
+<h2 id="7-limitations-of-this-synthesis">7) Limitations of this synthesis</h2>
+<ul>
+<li><strong>Direct substrates/clients</strong> of Apj1 in the SUMO-degradation pathway are not identified in the extracted evidence; the strongest support is genetic interaction and SUMO-conjugate accumulation, not direct client binding to named proteins. (sahi2013sequentialduplicationsof pages 6-7)</li>
+<li>The heat-shock/INQ regulatory role is presently supported here by a <strong>2025 preprint</strong>; confirmation in peer-reviewed literature should be sought as it becomes available. (rugerherreros2025nuclearandcytosolic pages 4-6)</li>
+</ul>
+<h2 id="8-annotated-bibliography-sources-prioritized-by-recencyauthority">8) Annotated bibliography (sources prioritized by recency/authority)</h2>
+<ul>
+<li>Ganser SJ et al. <strong>2024-04</strong>. <em>Frontiers in Molecular Biosciences.</em> “Unique characteristics…” https://doi.org/10.3389/fmolb.2024.1392608 (Primary mechanistic dissection of Apj1 N-terminus in prion biology; construct-level functional mapping). (ganser2024uniquecharacteristicsof pages 1-2, ganser2024uniquecharacteristicsof media 6fb49813)</li>
+<li>Carvalho FA et al. <strong>2023-03</strong>. <em>FEBS Letters.</em> “Hsp90 and metal-binding J-protein family…” https://doi.org/10.1002/1873-3468.14612 (Mentions APJ1 deletion phenotypes in broader JDP context; used here as contextual background, not a primary source of mechanistic claims). (Not extracted into citeable evidence snippets in this run.)</li>
+<li>Sahi C, Kominek J, et al. <strong>2013-05</strong>. <em>Molecular Biology and Evolution.</em> “Sequential duplications…” https://doi.org/10.1093/molbev/mst008 (Strong genetic/biochemical evidence connecting Apj1 to SUMO-mediated degradation via Slx5 interaction; domain-function requirements). (sahi2013sequentialduplicationsof pages 6-7, sahi2013sequentialduplicationsof pages 7-8)</li>
+<li>Sahi C, Craig EA. <strong>2007-04</strong>. <em>PNAS.</em> “Network of general and specialty J protein chaperones…” https://doi.org/10.1073/pnas.0702357104 (Chaperone network positioning; abundance and localization statements; functional redundancy via overexpression). (sahi2007networkofgeneral pages 1-3)</li>
+<li>Ruger-Herreros C et al. <strong>2025-07</strong> (preprint). <em>bioRxiv.</em> “Nuclear and cytosolic J-domain proteins…” https://doi.org/10.1101/2025.04.14.648540 (Emerging model for Apj1 roles in Hsf1 attenuation and INQ-linked nuclear PQC; quantitative microscopy/genomics). (rugerherreros2025nuclearandcytosolic pages 4-6, rugerherreros2025nuclearandcytosolic pages 9-11)</li>
+</ul>
+<p>References</p>
+<ol>
+<li>
+<p>(sahi2007networkofgeneral pages 1-3): Chandan Sahi and Elizabeth Anne Craig. Network of general and specialty j protein chaperones of the yeast cytosol. Proceedings of the National Academy of Sciences, 104:7163-7168, Apr 2007. URL: https://doi.org/10.1073/pnas.0702357104, doi:10.1073/pnas.0702357104. This article has 196 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(sahi2013sequentialduplicationsof pages 1-2): Chandan Sahi, Jacek Kominek, Thomas Ziegelhoffer, Hyun Young Yu, Maciej Baranowski, Jaroslaw Marszalek, and Elizabeth A. Craig. Sequential duplications of an ancient member of the dnaj-family expanded the functional chaperone network in the eukaryotic cytosol. Molecular biology and evolution, 30 5:985-98, May 2013. URL: https://doi.org/10.1093/molbev/mst008, doi:10.1093/molbev/mst008. This article has 54 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(sahi2013sequentialduplicationsof pages 6-7): Chandan Sahi, Jacek Kominek, Thomas Ziegelhoffer, Hyun Young Yu, Maciej Baranowski, Jaroslaw Marszalek, and Elizabeth A. Craig. Sequential duplications of an ancient member of the dnaj-family expanded the functional chaperone network in the eukaryotic cytosol. Molecular biology and evolution, 30 5:985-98, May 2013. URL: https://doi.org/10.1093/molbev/mst008, doi:10.1093/molbev/mst008. This article has 54 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(rugerherreros2025nuclearandcytosolic pages 9-11): Carmen Ruger-Herreros, Lucia Svoboda, Gurranna Male, Aseem Shrivastava, Markus Höpfler, Katharina Jetzinger, Jiri Koubek, Günter Kramer, Fabian den Brave, Axel Mogk, David S Gross, and Bernd Bukau. Nuclear and cytosolic j-domain proteins provide synergistic control of hsf1 at distinct phases of the heat shock response. bioRxiv, Jul 2025. URL: https://doi.org/10.1101/2025.04.14.648540, doi:10.1101/2025.04.14.648540. This article has 0 citations.</p>
+</li>
+<li>
+<p>(rugerherreros2025nuclearandcytosolic pages 4-6): Carmen Ruger-Herreros, Lucia Svoboda, Gurranna Male, Aseem Shrivastava, Markus Höpfler, Katharina Jetzinger, Jiri Koubek, Günter Kramer, Fabian den Brave, Axel Mogk, David S Gross, and Bernd Bukau. Nuclear and cytosolic j-domain proteins provide synergistic control of hsf1 at distinct phases of the heat shock response. bioRxiv, Jul 2025. URL: https://doi.org/10.1101/2025.04.14.648540, doi:10.1101/2025.04.14.648540. This article has 0 citations.</p>
+</li>
+<li>
+<p>(sahi2013sequentialduplicationsof pages 7-8): Chandan Sahi, Jacek Kominek, Thomas Ziegelhoffer, Hyun Young Yu, Maciej Baranowski, Jaroslaw Marszalek, and Elizabeth A. Craig. Sequential duplications of an ancient member of the dnaj-family expanded the functional chaperone network in the eukaryotic cytosol. Molecular biology and evolution, 30 5:985-98, May 2013. URL: https://doi.org/10.1093/molbev/mst008, doi:10.1093/molbev/mst008. This article has 54 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ganser2024uniquecharacteristicsof pages 1-2): Samantha J. Ganser, Bridget A. McNish, Gillian L. Schwanitz, John L. Delaney, Bridget A. Corpus, Brenda A. Schilke, Anup K. Biswal, Chandan Sahi, Elizabeth A. Craig, and Justin K. Hines. Unique characteristics of the j-domain proximal regions of hsp70 cochaperone apj1 in prion propagation/elimination and its overlap with sis1 function. Frontiers in Molecular Biosciences, Apr 2024. URL: https://doi.org/10.3389/fmolb.2024.1392608, doi:10.3389/fmolb.2024.1392608. This article has 2 citations.</p>
+</li>
+<li>
+<p>(ganser2024uniquecharacteristicsof pages 2-4): Samantha J. Ganser, Bridget A. McNish, Gillian L. Schwanitz, John L. Delaney, Bridget A. Corpus, Brenda A. Schilke, Anup K. Biswal, Chandan Sahi, Elizabeth A. Craig, and Justin K. Hines. Unique characteristics of the j-domain proximal regions of hsp70 cochaperone apj1 in prion propagation/elimination and its overlap with sis1 function. Frontiers in Molecular Biosciences, Apr 2024. URL: https://doi.org/10.3389/fmolb.2024.1392608, doi:10.3389/fmolb.2024.1392608. This article has 2 citations.</p>
+</li>
+<li>
+<p>(ganser2024uniquecharacteristicsof media 6fb49813): Samantha J. Ganser, Bridget A. McNish, Gillian L. Schwanitz, John L. Delaney, Bridget A. Corpus, Brenda A. Schilke, Anup K. Biswal, Chandan Sahi, Elizabeth A. Craig, and Justin K. Hines. Unique characteristics of the j-domain proximal regions of hsp70 cochaperone apj1 in prion propagation/elimination and its overlap with sis1 function. Frontiers in Molecular Biosciences, Apr 2024. URL: https://doi.org/10.3389/fmolb.2024.1392608, doi:10.3389/fmolb.2024.1392608. This article has 2 citations.</p>
+</li>
+<li>
+<p>(ganser2024uniquecharacteristicsof media 5aa2f23d): Samantha J. Ganser, Bridget A. McNish, Gillian L. Schwanitz, John L. Delaney, Bridget A. Corpus, Brenda A. Schilke, Anup K. Biswal, Chandan Sahi, Elizabeth A. Craig, and Justin K. Hines. Unique characteristics of the j-domain proximal regions of hsp70 cochaperone apj1 in prion propagation/elimination and its overlap with sis1 function. Frontiers in Molecular Biosciences, Apr 2024. URL: https://doi.org/10.3389/fmolb.2024.1392608, doi:10.3389/fmolb.2024.1392608. This article has 2 citations.</p>
+</li>
+<li>
+<p>(rugerherreros2025nuclearandcytosolic pages 1-4): Carmen Ruger-Herreros, Lucia Svoboda, Gurranna Male, Aseem Shrivastava, Markus Höpfler, Katharina Jetzinger, Jiri Koubek, Günter Kramer, Fabian den Brave, Axel Mogk, David S Gross, and Bernd Bukau. Nuclear and cytosolic j-domain proteins provide synergistic control of hsf1 at distinct phases of the heat shock response. bioRxiv, Jul 2025. URL: https://doi.org/10.1101/2025.04.14.648540, doi:10.1101/2025.04.14.648540. This article has 0 citations.</p>
+</li>
+</ol>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>rugerherreros2025nuclearandcytosolic pages 4-6</li>
+<li>sahi2007networkofgeneral pages 1-3</li>
+<li>ganser2024uniquecharacteristicsof pages 1-2</li>
+<li>sahi2013sequentialduplicationsof pages 6-7</li>
+<li>sahi2013sequentialduplicationsof pages 7-8</li>
+<li>rugerherreros2025nuclearandcytosolic pages 9-11</li>
+<li>sahi2013sequentialduplicationsof pages 1-2</li>
+<li>ganser2024uniquecharacteristicsof pages 2-4</li>
+<li>rugerherreros2025nuclearandcytosolic pages 1-4</li>
+<li>PSI+</li>
+<li>https://doi.org/10.3389/fmolb.2024.1392608</li>
+<li>https://doi.org/10.1093/molbev/mst008</li>
+<li>https://doi.org/10.1101/2025.04.14.648540</li>
+<li>https://doi.org/10.1002/1873-3468.14612</li>
+<li>https://doi.org/10.1073/pnas.0702357104</li>
+<li>https://doi.org/10.1073/pnas.0702357104,</li>
+<li>https://doi.org/10.1093/molbev/mst008,</li>
+<li>https://doi.org/10.1101/2025.04.14.648540,</li>
+<li>https://doi.org/10.3389/fmolb.2024.1392608,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -2524,11 +3033,16 @@
                 <pre><code>id: P53940
 gene_symbol: APJ1
 product_type: PROTEIN
-status: DRAFT
+status: COMPLETE
 taxon:
   id: NCBITaxon:559292
   label: Saccharomyces cerevisiae
-description: &#39;TODO: Add description for APJ1&#39;
+description: &gt;-
+  APJ1 encodes a low-abundance class A J-domain/Hsp40 cochaperone that functions
+  with Hsp70 in yeast protein quality control. The strongest evidence supports a
+  nuclear and cytosolic proteostasis role, including Hsp70 ATPase activation,
+  protein refolding and disaggregation contexts, prion-curing specialization, and
+  genetic cooperation with SUMO-targeted degradation machinery.
 existing_annotations:
 - term:
     id: GO:0001671
@@ -2539,6 +3053,9 @@ existing_annotations:
     summary: &#39;Manual review: ATPase activator activity is consistent with known biology of APJ1.&#39;
     action: ACCEPT
     reason: Retained as supported or plausible for this gene and evidence context.
+    supported_by:
+    - reference_id: file:yeast/APJ1/APJ1-deep-research-falcon.md
+      supporting_text: Apj1 is classified as a **class I (class A) J protein** in yeast
 - term:
     id: GO:0034605
     label: cellular response to heat
@@ -2557,6 +3074,9 @@ existing_annotations:
     summary: &#39;Manual review: protein refolding is consistent with known biology of APJ1.&#39;
     action: ACCEPT
     reason: Retained as supported or plausible for this gene and evidence context.
+    supported_by:
+    - reference_id: file:yeast/APJ1/APJ1-deep-research-falcon.md
+      supporting_text: Apj1 behaves as a **canonical Hsp70 co-chaperone**
 - term:
     id: GO:0051082
     label: unfolded protein binding
@@ -2816,13 +3336,40 @@ references:
 - id: PMID:32492414
   title: Chaperone-Mediated Protein Disaggregation Triggers Proteolytic Clearance of Intra-nuclear Protein Inclusions.
   findings: []
+- id: file:yeast/APJ1/APJ1-deep-research-falcon.md
+  title: Falcon deep research report for APJ1
+  findings: []
+core_functions:
+- description: &gt;-
+    J-domain Hsp70 cochaperone activity in nuclear and cytosolic protein quality
+    control. Apj1 stimulates Hsp70-dependent chaperone cycles and contributes to
+    protein refolding/disaggregation contexts, prion curing, and stress-linked
+    nuclear proteostasis.
+  molecular_function:
+    id: GO:0001671
+    label: ATPase activator activity
+  directly_involved_in:
+  - id: GO:0006457
+    label: protein folding
+  - id: GO:0042026
+    label: protein refolding
+  supported_by:
+  - reference_id: file:yeast/APJ1/APJ1-deep-research-falcon.md
+    supporting_text: Apj1 is a **specialized, low-abundance, predominantly nuclear J-domain co-chaperone**
+proposed_new_terms: []
+suggested_questions:
+- question: Should APJ1 receive a more specific GO biological process annotation for Hsp104-dependent prion curing or nuclear protein quality control once a suitable term is available?
+- question: Are the reported nuclear inclusion and Hsf1 attenuation roles sufficiently peer-reviewed and generalizable for direct GO annotation?
+suggested_experiments:
+- description: Directly assay Apj1-dependent Hsp70 ATPase stimulation with wild-type and J-domain mutant Apj1 in defined client contexts.
+- description: Quantify Apj1 client recruitment to SUMOylated nuclear inclusions and test whether this requires the Zn-finger/client-binding regions.
 </code></pre>
             </div>
         </details>
     </div>
 
     <!-- Pathway Visualization Link -->
-    
+
 
     <style>
         /* Markdown Section Styles */

--- a/genes/yeast/APJ1/APJ1-ai-review.html
+++ b/genes/yeast/APJ1/APJ1-ai-review.html
@@ -1033,10 +1033,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-keepasnoncore">
-                            KEEP AS NON CORE
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="P53940" data-a="GO:0005634" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                        <span class="vote-buttons" data-g="P53940" data-a="GO:0005634" data-r="GO_REF:0000033" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1044,15 +1044,31 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: nucleus may be context-dependent or peripheral for APJ1.
+                            <strong>Summary:</strong> Manual review: nucleus is supported as a major APJ1 localization.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+                            <strong>Reason:</strong> Falcon synthesis and chaperone-network literature support Apj1 as predominantly nuclear, consistent with its nuclear protein quality control role.
                         </div>
 
 
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/APJ1/APJ1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Apj1 is reported to be **predominantly nuclear**</div>
+
+                            </div>
+
+                        </div>
 
                     </td>
                 </tr>
@@ -1084,10 +1100,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-keepasnoncore">
-                            KEEP AS NON CORE
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="P53940" data-a="GO:0005634" data-r="GO_REF:0000044" data-act="KEEP_AS_NON_CORE">
+                        <span class="vote-buttons" data-g="P53940" data-a="GO:0005634" data-r="GO_REF:0000044" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1095,15 +1111,31 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: nucleus may be context-dependent or peripheral for APJ1.
+                            <strong>Summary:</strong> Manual review: nucleus is supported as a major APJ1 localization.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+                            <strong>Reason:</strong> Falcon synthesis and chaperone-network literature support Apj1 as predominantly nuclear, consistent with its nuclear protein quality control role.
                         </div>
 
 
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/APJ1/APJ1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Apj1 is reported to be **predominantly nuclear**</div>
+
+                            </div>
+
+                        </div>
 
                     </td>
                 </tr>
@@ -1135,10 +1167,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-keepasnoncore">
-                            KEEP AS NON CORE
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="P53940" data-a="GO:0005737" data-r="GO_REF:0000044" data-act="KEEP_AS_NON_CORE">
+                        <span class="vote-buttons" data-g="P53940" data-a="GO:0005737" data-r="GO_REF:0000044" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1146,15 +1178,31 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: cytoplasm may be context-dependent or peripheral for APJ1.
+                            <strong>Summary:</strong> Manual review: cytoplasm is supported as an APJ1 localization.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+                            <strong>Reason:</strong> Apj1 is also reported in the cytosol, consistent with its broader cytosolic/nuclear J-domain cochaperone role.
                         </div>
 
 
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/APJ1/APJ1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">while also present **in the cytosol**</div>
+
+                            </div>
+
+                        </div>
 
                     </td>
                 </tr>
@@ -1700,10 +1748,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P53940" data-a="GO:0043335" data-r="PMID:32492414" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P53940" data-a="GO:0043335" data-r="PMID:32492414" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1711,15 +1759,31 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: protein unfolding is consistent with known biology of APJ1.
+                            <strong>Summary:</strong> Manual review: protein unfolding is supported in the stress-specific nuclear inclusion clearance context for APJ1.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Retained as a context-specific nuclear protein quality control annotation; the evidence reflects chaperone-mediated disaggregation and proteolytic clearance of INQ substrates rather than the primary generic J-domain cochaperone activity.
                         </div>
 
 
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/APJ1/APJ1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Apj1 has been linked to targeting INQ-deposited proteins for proteasomal degradation</div>
+
+                            </div>
+
+                        </div>
 
                     </td>
                 </tr>
@@ -1835,10 +1899,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-keepasnoncore">
-                            KEEP AS NON CORE
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="P53940" data-a="GO:0005634" data-r="PMID:14562095" data-act="KEEP_AS_NON_CORE">
+                        <span class="vote-buttons" data-g="P53940" data-a="GO:0005634" data-r="PMID:14562095" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1846,15 +1910,31 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: nucleus may be context-dependent or peripheral for APJ1.
+                            <strong>Summary:</strong> Manual review: nucleus is supported as a major APJ1 localization.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+                            <strong>Reason:</strong> Falcon synthesis and chaperone-network literature support Apj1 as predominantly nuclear, consistent with its nuclear protein quality control role.
                         </div>
 
 
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/APJ1/APJ1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Apj1 is reported to be **predominantly nuclear**</div>
+
+                            </div>
+
+                        </div>
 
                     </td>
                 </tr>
@@ -1897,10 +1977,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-keepasnoncore">
-                            KEEP AS NON CORE
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="P53940" data-a="GO:0005634" data-r="PMID:22842922" data-act="KEEP_AS_NON_CORE">
+                        <span class="vote-buttons" data-g="P53940" data-a="GO:0005634" data-r="PMID:22842922" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1908,15 +1988,31 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: nucleus may be context-dependent or peripheral for APJ1.
+                            <strong>Summary:</strong> Manual review: nucleus is supported as a major APJ1 localization.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+                            <strong>Reason:</strong> Falcon synthesis and chaperone-network literature support Apj1 as predominantly nuclear, consistent with its nuclear protein quality control role.
                         </div>
 
 
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/APJ1/APJ1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Apj1 is reported to be **predominantly nuclear**</div>
+
+                            </div>
+
+                        </div>
 
                     </td>
                 </tr>
@@ -1959,10 +2055,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-keepasnoncore">
-                            KEEP AS NON CORE
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="P53940" data-a="GO:0005737" data-r="PMID:14562095" data-act="KEEP_AS_NON_CORE">
+                        <span class="vote-buttons" data-g="P53940" data-a="GO:0005737" data-r="PMID:14562095" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1970,15 +2066,31 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: cytoplasm may be context-dependent or peripheral for APJ1.
+                            <strong>Summary:</strong> Manual review: cytoplasm is supported as an APJ1 localization.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+                            <strong>Reason:</strong> Apj1 is also reported in the cytosol, consistent with its broader cytosolic/nuclear J-domain cochaperone role.
                         </div>
 
 
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/APJ1/APJ1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">while also present **in the cytosol**</div>
+
+                            </div>
+
+                        </div>
 
                     </td>
                 </tr>
@@ -2346,6 +2458,25 @@
                 </div>
 
 
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
+                                nucleus
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                cytoplasm
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
 
 
 
@@ -3095,27 +3226,36 @@ existing_annotations:
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: &#39;Manual review: nucleus may be context-dependent or peripheral for APJ1.&#39;
-    action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    summary: &#39;Manual review: nucleus is supported as a major APJ1 localization.&#39;
+    action: ACCEPT
+    reason: Falcon synthesis and chaperone-network literature support Apj1 as predominantly nuclear, consistent with its nuclear protein quality control role.
+    supported_by:
+    - reference_id: file:yeast/APJ1/APJ1-deep-research-falcon.md
+      supporting_text: Apj1 is reported to be **predominantly nuclear**
 - term:
     id: GO:0005634
     label: nucleus
   evidence_type: IEA
   original_reference_id: GO_REF:0000044
   review:
-    summary: &#39;Manual review: nucleus may be context-dependent or peripheral for APJ1.&#39;
-    action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    summary: &#39;Manual review: nucleus is supported as a major APJ1 localization.&#39;
+    action: ACCEPT
+    reason: Falcon synthesis and chaperone-network literature support Apj1 as predominantly nuclear, consistent with its nuclear protein quality control role.
+    supported_by:
+    - reference_id: file:yeast/APJ1/APJ1-deep-research-falcon.md
+      supporting_text: Apj1 is reported to be **predominantly nuclear**
 - term:
     id: GO:0005737
     label: cytoplasm
   evidence_type: IEA
   original_reference_id: GO_REF:0000044
   review:
-    summary: &#39;Manual review: cytoplasm may be context-dependent or peripheral for APJ1.&#39;
-    action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    summary: &#39;Manual review: cytoplasm is supported as an APJ1 localization.&#39;
+    action: ACCEPT
+    reason: Apj1 is also reported in the cytosol, consistent with its broader cytosolic/nuclear J-domain cochaperone role.
+    supported_by:
+    - reference_id: file:yeast/APJ1/APJ1-deep-research-falcon.md
+      supporting_text: while also present **in the cytosol**
 - term:
     id: GO:0006457
     label: protein folding
@@ -3206,9 +3346,12 @@ existing_annotations:
   evidence_type: IMP
   original_reference_id: PMID:32492414
   review:
-    summary: &#39;Manual review: protein unfolding is consistent with known biology of APJ1.&#39;
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    summary: &#39;Manual review: protein unfolding is supported in the stress-specific nuclear inclusion clearance context for APJ1.&#39;
+    action: KEEP_AS_NON_CORE
+    reason: Retained as a context-specific nuclear protein quality control annotation; the evidence reflects chaperone-mediated disaggregation and proteolytic clearance of INQ substrates rather than the primary generic J-domain cochaperone activity.
+    supported_by:
+    - reference_id: file:yeast/APJ1/APJ1-deep-research-falcon.md
+      supporting_text: Apj1 has been linked to targeting INQ-deposited proteins for proteasomal degradation
 - term:
     id: GO:0051082
     label: unfolded protein binding
@@ -3227,27 +3370,36 @@ existing_annotations:
   evidence_type: HDA
   original_reference_id: PMID:14562095
   review:
-    summary: &#39;Manual review: nucleus may be context-dependent or peripheral for APJ1.&#39;
-    action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    summary: &#39;Manual review: nucleus is supported as a major APJ1 localization.&#39;
+    action: ACCEPT
+    reason: Falcon synthesis and chaperone-network literature support Apj1 as predominantly nuclear, consistent with its nuclear protein quality control role.
+    supported_by:
+    - reference_id: file:yeast/APJ1/APJ1-deep-research-falcon.md
+      supporting_text: Apj1 is reported to be **predominantly nuclear**
 - term:
     id: GO:0005634
     label: nucleus
   evidence_type: HDA
   original_reference_id: PMID:22842922
   review:
-    summary: &#39;Manual review: nucleus may be context-dependent or peripheral for APJ1.&#39;
-    action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    summary: &#39;Manual review: nucleus is supported as a major APJ1 localization.&#39;
+    action: ACCEPT
+    reason: Falcon synthesis and chaperone-network literature support Apj1 as predominantly nuclear, consistent with its nuclear protein quality control role.
+    supported_by:
+    - reference_id: file:yeast/APJ1/APJ1-deep-research-falcon.md
+      supporting_text: Apj1 is reported to be **predominantly nuclear**
 - term:
     id: GO:0005737
     label: cytoplasm
   evidence_type: HDA
   original_reference_id: PMID:14562095
   review:
-    summary: &#39;Manual review: cytoplasm may be context-dependent or peripheral for APJ1.&#39;
-    action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    summary: &#39;Manual review: cytoplasm is supported as an APJ1 localization.&#39;
+    action: ACCEPT
+    reason: Apj1 is also reported in the cytosol, consistent with its broader cytosolic/nuclear J-domain cochaperone role.
+    supported_by:
+    - reference_id: file:yeast/APJ1/APJ1-deep-research-falcon.md
+      supporting_text: while also present **in the cytosol**
 - term:
     id: GO:0005739
     label: mitochondrion
@@ -3353,6 +3505,11 @@ core_functions:
     label: protein folding
   - id: GO:0042026
     label: protein refolding
+  locations:
+  - id: GO:0005634
+    label: nucleus
+  - id: GO:0005737
+    label: cytoplasm
   supported_by:
   - reference_id: file:yeast/APJ1/APJ1-deep-research-falcon.md
     supporting_text: Apj1 is a **specialized, low-abundance, predominantly nuclear J-domain co-chaperone**

--- a/genes/yeast/APJ1/APJ1-ai-review.yaml
+++ b/genes/yeast/APJ1/APJ1-ai-review.yaml
@@ -1,11 +1,16 @@
 id: P53940
 gene_symbol: APJ1
 product_type: PROTEIN
-status: DRAFT
+status: COMPLETE
 taxon:
   id: NCBITaxon:559292
   label: Saccharomyces cerevisiae
-description: 'TODO: Add description for APJ1'
+description: >-
+  APJ1 encodes a low-abundance class A J-domain/Hsp40 cochaperone that functions
+  with Hsp70 in yeast protein quality control. The strongest evidence supports a
+  nuclear and cytosolic proteostasis role, including Hsp70 ATPase activation,
+  protein refolding and disaggregation contexts, prion-curing specialization, and
+  genetic cooperation with SUMO-targeted degradation machinery.
 existing_annotations:
 - term:
     id: GO:0001671
@@ -16,6 +21,9 @@ existing_annotations:
     summary: 'Manual review: ATPase activator activity is consistent with known biology of APJ1.'
     action: ACCEPT
     reason: Retained as supported or plausible for this gene and evidence context.
+    supported_by:
+    - reference_id: file:yeast/APJ1/APJ1-deep-research-falcon.md
+      supporting_text: Apj1 is classified as a **class I (class A) J protein** in yeast
 - term:
     id: GO:0034605
     label: cellular response to heat
@@ -34,6 +42,9 @@ existing_annotations:
     summary: 'Manual review: protein refolding is consistent with known biology of APJ1.'
     action: ACCEPT
     reason: Retained as supported or plausible for this gene and evidence context.
+    supported_by:
+    - reference_id: file:yeast/APJ1/APJ1-deep-research-falcon.md
+      supporting_text: Apj1 behaves as a **canonical Hsp70 co-chaperone**
 - term:
     id: GO:0051082
     label: unfolded protein binding
@@ -293,3 +304,30 @@ references:
 - id: PMID:32492414
   title: Chaperone-Mediated Protein Disaggregation Triggers Proteolytic Clearance of Intra-nuclear Protein Inclusions.
   findings: []
+- id: file:yeast/APJ1/APJ1-deep-research-falcon.md
+  title: Falcon deep research report for APJ1
+  findings: []
+core_functions:
+- description: >-
+    J-domain Hsp70 cochaperone activity in nuclear and cytosolic protein quality
+    control. Apj1 stimulates Hsp70-dependent chaperone cycles and contributes to
+    protein refolding/disaggregation contexts, prion curing, and stress-linked
+    nuclear proteostasis.
+  molecular_function:
+    id: GO:0001671
+    label: ATPase activator activity
+  directly_involved_in:
+  - id: GO:0006457
+    label: protein folding
+  - id: GO:0042026
+    label: protein refolding
+  supported_by:
+  - reference_id: file:yeast/APJ1/APJ1-deep-research-falcon.md
+    supporting_text: Apj1 is a **specialized, low-abundance, predominantly nuclear J-domain co-chaperone**
+proposed_new_terms: []
+suggested_questions:
+- question: Should APJ1 receive a more specific GO biological process annotation for Hsp104-dependent prion curing or nuclear protein quality control once a suitable term is available?
+- question: Are the reported nuclear inclusion and Hsf1 attenuation roles sufficiently peer-reviewed and generalizable for direct GO annotation?
+suggested_experiments:
+- description: Directly assay Apj1-dependent Hsp70 ATPase stimulation with wild-type and J-domain mutant Apj1 in defined client contexts.
+- description: Quantify Apj1 client recruitment to SUMOylated nuclear inclusions and test whether this requires the Zn-finger/client-binding regions.

--- a/genes/yeast/APJ1/APJ1-ai-review.yaml
+++ b/genes/yeast/APJ1/APJ1-ai-review.yaml
@@ -63,27 +63,36 @@ existing_annotations:
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'Manual review: nucleus may be context-dependent or peripheral for APJ1.'
-    action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    summary: 'Manual review: nucleus is supported as a major APJ1 localization.'
+    action: ACCEPT
+    reason: Falcon synthesis and chaperone-network literature support Apj1 as predominantly nuclear, consistent with its nuclear protein quality control role.
+    supported_by:
+    - reference_id: file:yeast/APJ1/APJ1-deep-research-falcon.md
+      supporting_text: Apj1 is reported to be **predominantly nuclear**
 - term:
     id: GO:0005634
     label: nucleus
   evidence_type: IEA
   original_reference_id: GO_REF:0000044
   review:
-    summary: 'Manual review: nucleus may be context-dependent or peripheral for APJ1.'
-    action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    summary: 'Manual review: nucleus is supported as a major APJ1 localization.'
+    action: ACCEPT
+    reason: Falcon synthesis and chaperone-network literature support Apj1 as predominantly nuclear, consistent with its nuclear protein quality control role.
+    supported_by:
+    - reference_id: file:yeast/APJ1/APJ1-deep-research-falcon.md
+      supporting_text: Apj1 is reported to be **predominantly nuclear**
 - term:
     id: GO:0005737
     label: cytoplasm
   evidence_type: IEA
   original_reference_id: GO_REF:0000044
   review:
-    summary: 'Manual review: cytoplasm may be context-dependent or peripheral for APJ1.'
-    action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    summary: 'Manual review: cytoplasm is supported as an APJ1 localization.'
+    action: ACCEPT
+    reason: Apj1 is also reported in the cytosol, consistent with its broader cytosolic/nuclear J-domain cochaperone role.
+    supported_by:
+    - reference_id: file:yeast/APJ1/APJ1-deep-research-falcon.md
+      supporting_text: while also present **in the cytosol**
 - term:
     id: GO:0006457
     label: protein folding
@@ -174,9 +183,12 @@ existing_annotations:
   evidence_type: IMP
   original_reference_id: PMID:32492414
   review:
-    summary: 'Manual review: protein unfolding is consistent with known biology of APJ1.'
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    summary: 'Manual review: protein unfolding is supported in the stress-specific nuclear inclusion clearance context for APJ1.'
+    action: KEEP_AS_NON_CORE
+    reason: Retained as a context-specific nuclear protein quality control annotation; the evidence reflects chaperone-mediated disaggregation and proteolytic clearance of INQ substrates rather than the primary generic J-domain cochaperone activity.
+    supported_by:
+    - reference_id: file:yeast/APJ1/APJ1-deep-research-falcon.md
+      supporting_text: Apj1 has been linked to targeting INQ-deposited proteins for proteasomal degradation
 - term:
     id: GO:0051082
     label: unfolded protein binding
@@ -195,27 +207,36 @@ existing_annotations:
   evidence_type: HDA
   original_reference_id: PMID:14562095
   review:
-    summary: 'Manual review: nucleus may be context-dependent or peripheral for APJ1.'
-    action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    summary: 'Manual review: nucleus is supported as a major APJ1 localization.'
+    action: ACCEPT
+    reason: Falcon synthesis and chaperone-network literature support Apj1 as predominantly nuclear, consistent with its nuclear protein quality control role.
+    supported_by:
+    - reference_id: file:yeast/APJ1/APJ1-deep-research-falcon.md
+      supporting_text: Apj1 is reported to be **predominantly nuclear**
 - term:
     id: GO:0005634
     label: nucleus
   evidence_type: HDA
   original_reference_id: PMID:22842922
   review:
-    summary: 'Manual review: nucleus may be context-dependent or peripheral for APJ1.'
-    action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    summary: 'Manual review: nucleus is supported as a major APJ1 localization.'
+    action: ACCEPT
+    reason: Falcon synthesis and chaperone-network literature support Apj1 as predominantly nuclear, consistent with its nuclear protein quality control role.
+    supported_by:
+    - reference_id: file:yeast/APJ1/APJ1-deep-research-falcon.md
+      supporting_text: Apj1 is reported to be **predominantly nuclear**
 - term:
     id: GO:0005737
     label: cytoplasm
   evidence_type: HDA
   original_reference_id: PMID:14562095
   review:
-    summary: 'Manual review: cytoplasm may be context-dependent or peripheral for APJ1.'
-    action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    summary: 'Manual review: cytoplasm is supported as an APJ1 localization.'
+    action: ACCEPT
+    reason: Apj1 is also reported in the cytosol, consistent with its broader cytosolic/nuclear J-domain cochaperone role.
+    supported_by:
+    - reference_id: file:yeast/APJ1/APJ1-deep-research-falcon.md
+      supporting_text: while also present **in the cytosol**
 - term:
     id: GO:0005739
     label: mitochondrion
@@ -321,6 +342,11 @@ core_functions:
     label: protein folding
   - id: GO:0042026
     label: protein refolding
+  locations:
+  - id: GO:0005634
+    label: nucleus
+  - id: GO:0005737
+    label: cytoplasm
   supported_by:
   - reference_id: file:yeast/APJ1/APJ1-deep-research-falcon.md
     supporting_text: Apj1 is a **specialized, low-abundance, predominantly nuclear J-domain co-chaperone**

--- a/genes/yeast/APJ1/APJ1-deep-research-falcon.md
+++ b/genes/yeast/APJ1/APJ1-deep-research-falcon.md
@@ -1,0 +1,292 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-11T08:43:34.866688'
+end_time: '2026-05-11T08:53:24.503960'
+duration_seconds: 589.64
+template_file: templates/gene_research_go_focused.md
+template_variables:
+  organism: yeast
+  gene_id: APJ1
+  gene_symbol: APJ1
+  uniprot_accession: P53940
+  protein_description: 'RecName: Full=J domain-containing protein APJ1;'
+  gene_info: Name=APJ1; OrderedLocusNames=YNL077W; ORFNames=N2342;
+  organism_full: Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+  protein_family: Not specified in UniProt
+  protein_domains: DnaJ_C. (IPR002939); DnaJ_domain. (IPR001623); DnaJ_domain_CS.
+    (IPR018253); DNJA1/2-like. (IPR044713); HSP40/DnaJ_pept-bd. (IPR008971)
+provider_config:
+  timeout: 600
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 19
+---
+
+## Question
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** P53940
+- **Protein Description:** RecName: Full=J domain-containing protein APJ1;
+- **Gene Information:** Name=APJ1; OrderedLocusNames=YNL077W; ORFNames=N2342;
+- **Organism (full):** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+- **Protein Family:** Not specified in UniProt
+- **Key Domains:** DnaJ_C. (IPR002939); DnaJ_domain. (IPR001623); DnaJ_domain_CS. (IPR018253); DNJA1/2-like. (IPR044713); HSP40/DnaJ_pept-bd. (IPR008971)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "APJ1" matches the protein description above**
+2. **Verify the organism is correct:** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'APJ1' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **APJ1** (gene ID: APJ1, UniProt: P53940) in yeast.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** P53940
+- **Protein Description:** RecName: Full=J domain-containing protein APJ1;
+- **Gene Information:** Name=APJ1; OrderedLocusNames=YNL077W; ORFNames=N2342;
+- **Organism (full):** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+- **Protein Family:** Not specified in UniProt
+- **Key Domains:** DnaJ_C. (IPR002939); DnaJ_domain. (IPR001623); DnaJ_domain_CS. (IPR018253); DNJA1/2-like. (IPR044713); HSP40/DnaJ_pept-bd. (IPR008971)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "APJ1" matches the protein description above**
+2. **Verify the organism is correct:** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'APJ1' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **APJ1** (gene ID: APJ1, UniProt: P53940) in yeast.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+# Research Report: Functional Annotation of **APJ1 (YNL077W)** in *Saccharomyces cerevisiae* (UniProt **P53940**)
+
+## 0) Target verification (mandatory)
+The literature retrieved and analyzed refers to *Saccharomyces cerevisiae* APJ1 as systematic ORF **YNL077W**, encoding a **J-domain/Hsp40 family** cochaperone (also called a J-domain protein, JDP). Multiple primary studies explicitly use the name **Apj1** together with **YNL077W**, analyze its **J-domain (including the canonical HPD motif and the H34Q J-domain mutation)**, and place it in yeast cytosolic/nuclear chaperone networks, matching the UniProt identity provided (P53940). (sahi2007networkofgeneral pages 1-3, sahi2013sequentialduplicationsof pages 1-2, sahi2013sequentialduplicationsof pages 6-7)
+
+## 1) Key concepts and definitions (current understanding)
+### 1.1 J-domain proteins (Hsp40s/JDPs) and Apj1’s mechanistic role
+J-domain proteins are obligate cochaperones of Hsp70 chaperones: their J-domain stimulates Hsp70 ATPase activity and thereby promotes substrate binding and productive chaperone cycles. Apj1 is classified as a **class I (class A) J protein** in yeast, implying a canonical J-domain with the conserved **HPD** motif required for Hsp70 activation. (sahi2007networkofgeneral pages 1-3, sahi2013sequentialduplicationsof pages 1-2)
+
+**Operational definition for APJ1 function:** in the studies below, “Apj1 function” is typically measured by its ability to support specific Hsp70-dependent processes (e.g., protein quality control, prion curing, or stress-response regulation) and by the requirement for a functional J-domain (e.g., loss of function with **H34Q**). (sahi2013sequentialduplicationsof pages 6-7, rugerherreros2025nuclearandcytosolic pages 9-11)
+
+### 1.2 Protein quality control (PQC), nuclear inclusions (INQ), and stress-response attenuation
+Yeast PQC includes compartment-specific handling of misfolded proteins (refolding, sequestration, and degradation). The **intranuclear quality control compartment (INQ)** is a nuclear deposition site for misfolded/aggregated proteins under stress; Apj1 has been linked to targeting INQ-deposited proteins for proteasomal degradation and to shaping nuclear PQC outputs during heat shock. (rugerherreros2025nuclearandcytosolic pages 4-6)
+
+### 1.3 SUMO-targeted ubiquitin ligase (STUbL) pathway context
+SUMOylation can mark proteins for downstream processing, including degradation via SUMO-targeted ubiquitin ligases (STUbLs). In yeast, **Slx5** is a key STUbL component. Genetic evidence connects **APJ1** to **SUMO-mediated degradation** in cooperation with Slx5. (sahi2013sequentialduplicationsof pages 6-7, sahi2013sequentialduplicationsof pages 7-8)
+
+## 2) Gene/protein overview: domains, localization, and abundance
+### 2.1 Domain architecture inferred/validated by experiments
+Apj1 is described as a cytosolic/nuclear DnaJ-family (Hsp40) J protein with an **~70-residue N-terminal J-domain** followed by additional regions typical of class I J proteins, and functional analysis highlights a **Zn-binding (Zn-finger) region** as important for specific Apj1 functions in degradation-linked contexts. (sahi2013sequentialduplicationsof pages 1-2, sahi2013sequentialduplicationsof pages 6-7)
+
+A 2024 functional dissection defined short N-terminal fragments sufficient for specific Apj1-dependent activities in prion curing and/or Sis1-related functions (see §3). (ganser2024uniquecharacteristicsof pages 1-2, ganser2024uniquecharacteristicsof pages 2-4)
+
+### 2.2 Subcellular localization
+Apj1 is reported to be **predominantly nuclear** while also present **in the cytosol**, consistent with dual roles in nuclear PQC and cytosolic chaperone networks. (sahi2007networkofgeneral pages 1-3)
+
+### 2.3 Quantitative abundance
+Apj1 is low abundance relative to major J proteins such as Ydj1: one quantitative estimate cited in the chaperone-network study is **~125 molecules per cell** for Apj1 under the conditions examined. (sahi2007networkofgeneral pages 1-3)
+
+## 3) Experimentally supported functions and pathways
+| Functional area | Key findings | Experimental evidence type | Key molecules/partners | Quantitative/construct details | Primary citations (IDs) |
+|---|---|---|---|---|---|
+| Hsp70 co-chaperone | • Class I J protein with canonical J-domain/HPD motif that stimulates Hsp70 ATPase activity • J-domain is essential for function; H34Q disrupts Hsp70 cooperation • Functionally overlaps with other cytosolic/nuclear J proteins when overexpressed | Domain/function analysis; J-domain mutagenesis; genetic complementation/overexpression rescue | Hsp70, Ydj1, Sis1 | ~125 molecules per cell in unstressed yeast; predominantly nuclear but also present in cytosol; overexpressed full-length Apj1 rescues ydj1 growth defect (sahi2007networkofgeneral pages 1-3, sahi2013sequentialduplicationsof pages 1-2, rugerherreros2025nuclearandcytosolic pages 9-11) | (sahi2007networkofgeneral pages 1-3, sahi2013sequentialduplicationsof pages 1-2, rugerherreros2025nuclearandcytosolic pages 9-11) |
+| Prion biology | • Anti-prion J protein required for efficient Hsp104-mediated curing of strong [PSI+] variants • Minimal N-terminus is sufficient for curing • Partial functional overlap with Sis1 in prion propagation/elimination | Truncation complementation; Hsp104 overexpression assays; SDD-AGE; plasmid shuffle/growth assays | Hsp104, Hsp70, Sis1, [PSI+] prion | 161-aa N-terminus sufficient for curing; 90-aa fragment (J-domain + adjacent Q/A region) sufficient for curing; 121-aa fragment supports viability without Sis1 and maintenance of several Sis1-dependent prions; heterologous J-domain can support Sis1-like functions but not Apj1-specific curing (ganser2024uniquecharacteristicsof pages 1-2, ganser2024uniquecharacteristicsof pages 2-4, ganser2024uniquecharacteristicsof media 6fb49813, ganser2024uniquecharacteristicsof media 5aa2f23d) | (ganser2024uniquecharacteristicsof pages 1-2, ganser2024uniquecharacteristicsof pages 2-4, ganser2024uniquecharacteristicsof media 6fb49813, ganser2024uniquecharacteristicsof media 5aa2f23d) |
+| SUMO-mediated degradation / STUbL | • Specialized role in degradation of sumoylated proteins • Strong synthetic interaction with STUbL factor SLX5 • Client binding and intact J-domain required for this degradation-linked function | Synthetic genetic interaction; growth at elevated temperature; immunoblot of SUMO conjugates; domain-swap/deletion and hydrophobic-cleft mutagenesis | Slx5, Hsp70, SUMOylated substrates | apj1Δ alone has little defect, but apj1Δ slx5 grows much worse than slx5 and cannot form individual colonies at 37°C; SUMO-conjugates increase further in slx5 apj1 double mutant; H34Q fails to complement; Zn-finger region important; hydrophobic-cleft mutants I179S, L200S, L277S fail to substitute for WT Apj1 (sahi2013sequentialduplicationsof pages 6-7, sahi2013sequentialduplicationsof pages 7-8) | (sahi2013sequentialduplicationsof pages 6-7, sahi2013sequentialduplicationsof pages 7-8) |
+| Heat shock response regulation | • Nuclear Apj1 promotes attenuation of Hsf1 activity after heat shock • Acts as canonical Hsp70 co-chaperone targeting Hsf1 to Hsp70 for repression • Loss of Apj1 synergizes with Ydj1 defects to cause constitutive/persistent Hsf1 activation | Microscopy; gene coalescence assays; ribosome profiling; J-domain mutagenesis; immunoblot of Hsf1 targets | Hsf1, Hsp70, Ydj1, Btn2, Hsp42, HSP104/HSP12 loci | In apj1Δ, Btn2 remains elevated up to 120 min after heat shock; Hsf1-target expression increased at 60 min (p=3.724e-05); apj1Δ ydj1 mutants show HSP104/HSP12 gene coalescence in 63% and 65.5% of cells at 25°C; Apj1 H34Q phenocopies deletion for Hsp70 cooperation (rugerherreros2025nuclearandcytosolic pages 1-4, rugerherreros2025nuclearandcytosolic pages 9-11, rugerherreros2025nuclearandcytosolic pages 4-6) | (rugerherreros2025nuclearandcytosolic pages 1-4, rugerherreros2025nuclearandcytosolic pages 9-11, rugerherreros2025nuclearandcytosolic pages 4-6) |
+| Nuclear PQC / INQ | • Apj1 is a nuclear class A J protein linked to nuclear protein quality control • Targets proteins deposited at INQ for proteasomal degradation • Absence of Apj1 increases formation/stability of nuclear inclusions and prolongs stress-induced nuclear remodeling | Microscopy of Sis1/Hsf1 foci; heat-shock time courses; genetic analysis | INQ, Sis1, Hsf1, proteasome, Ydj1 | apj1Δ cells show increased nuclear Sis1-GFP foci after heat shock: 53.7% vs 21% WT at 15 min and 59.2% vs 30.7% WT at 60 min; apj1Δ ydj1Δ cells have nuclear Sis1 foci before shock in 42.3% of cells; Hsf1-GFP foci persist through 60 min heat shock in apj1Δ (rugerherreros2025nuclearandcytosolic pages 9-11, rugerherreros2025nuclearandcytosolic pages 4-6) | (rugerherreros2025nuclearandcytosolic pages 9-11, rugerherreros2025nuclearandcytosolic pages 4-6) |
+
+
+*Table: This table summarizes the main experimentally supported functions of Saccharomyces cerevisiae Apj1, including its roles as an Hsp70 co-chaperone, in prion control, SUMO-linked degradation, heat-shock regulation, and nuclear protein quality control. It also captures the key assays, molecular partners, and quantitative details most useful for a research report.*
+
+### 3.1 Primary molecular function: Hsp70 cochaperone (canonical J-domain dependence)
+Across multiple experimental contexts, Apj1 behaves as a **canonical Hsp70 co-chaperone**: mutation of the conserved J-domain histidine (H34Q) disrupts functional cooperation with Hsp70 and abrogates Apj1 activity in assays where Apj1 is required. (sahi2013sequentialduplicationsof pages 6-7, rugerherreros2025nuclearandcytosolic pages 9-11)
+
+Functional overlap within the cytosolic JDP network is supported by overexpression rescue: **overexpression of full-length Apj1 can dramatically rescue the growth defect of ydj1 mutant cells**, implying that Apj1 can substitute for some Ydj1-associated Hsp70 functions when sufficiently abundant. (sahi2007networkofgeneral pages 1-3)
+
+### 3.2 Prion biology: Apj1 in Hsp104-dependent [PSI+] curing and overlap with Sis1
+**Recent development (2024):** Ganser et al. (Frontiers in Molecular Biosciences; published **April 2024**; https://doi.org/10.3389/fmolb.2024.1392608) dissected the N-terminus of Apj1 and separated distinct functional elements relevant to prion curing versus Sis1-like roles. (ganser2024uniquecharacteristicsof pages 1-2, ganser2024uniquecharacteristicsof pages 2-4)
+
+Key findings:
+- A **90-residue** fragment containing the **J-domain plus an adjacent ~12-residue Q/A segment** is **sufficient for Hsp104-mediated [PSI+] prion curing** in their experimental system. (ganser2024uniquecharacteristicsof pages 1-2, ganser2024uniquecharacteristicsof pages 2-4)
+- A **121-residue** fragment (including the Grich/GF region) can **sustain growth** in cells lacking the essential class B JDP **Sis1** and can enable maintenance of several prions normally dependent on Sis1. (ganser2024uniquecharacteristicsof pages 1-2)
+- A heterologous J-domain can substitute for Sis1-related functions but **cannot** substitute for Apj1’s **prion-curing specificity**, indicating specialization beyond generic J-domain activity. (ganser2024uniquecharacteristicsof pages 1-2)
+
+Visual evidence supporting the construct design and functional conclusions is shown in the retrieved figure regions from Ganser et al. (2024). (ganser2024uniquecharacteristicsof media 6fb49813, ganser2024uniquecharacteristicsof media 5aa2f23d)
+
+### 3.3 SUMO-mediated protein degradation: genetic interaction with STUbL factor Slx5
+A specialized role for Apj1 in **SUMO-targeted proteolysis** is supported by Sahi et al. (Molecular Biology and Evolution; published **May 2013**; https://doi.org/10.1093/molbev/mst008). (sahi2013sequentialduplicationsof pages 6-7)
+
+Key experimental evidence:
+- **Synthetic interaction with SLX5:** an **apj1 slx5** double mutant shows substantially worse growth than **slx5** alone and fails to form individual colonies at **37°C**, whereas apj1 single mutants show little/no defect under many conditions, supporting a compensatory relationship in a degradation pathway. (sahi2013sequentialduplicationsof pages 7-8)
+- **SUMO conjugate accumulation:** immunoblot evidence shows that the **slx5 apj1** double mutant accumulates **higher levels of SUMOylated proteins** than slx5 alone, which the authors interpret as Apj1 contributing to the proteolysis of sumoylated substrates. (sahi2013sequentialduplicationsof pages 6-7)
+- **Mechanistic requirements:** the Apj1 **J-domain** is required (H34Q fails to complement), consistent with dependence on an Hsp70 machinery; the **Zn-finger region** is important, and mutations in a **hydrophobic client-binding cleft** (e.g., **I179S, L200S, L277S**) disrupt the ability to substitute for WT Apj1 in the slx5 background, supporting a client-binding requirement for this pathway role. (sahi2013sequentialduplicationsof pages 6-7, sahi2013sequentialduplicationsof pages 7-8)
+
+### 3.4 Heat shock response (HSR) regulation and nuclear PQC/INQ (emerging direction)
+A recent preprint (bioRxiv; posted **July 2025**; https://doi.org/10.1101/2025.04.14.648540) proposes an expanded role for Apj1 in **heat shock response attenuation** and **nuclear PQC**, integrating Hsp70/JDP function with transcriptional control of Hsf1. Because this is a preprint (not yet peer-reviewed as of the retrieved version), conclusions should be treated as provisional, but the quantitative data are informative. (rugerherreros2025nuclearandcytosolic pages 4-6, rugerherreros2025nuclearandcytosolic pages 9-11)
+
+Key findings reported:
+- Apj1 is described as a **nuclear class A JDP** that helps repress/attenuate **Hsf1** activity by functioning as a canonical Hsp70 co-chaperone; the **H34Q** J-domain mutant abrogates Hsp70 cooperation and phenocopies apj1 deletion in relevant assays. (rugerherreros2025nuclearandcytosolic pages 9-11)
+- In an **apj1Δ ydj1Δ** context, strong Hsf1 activation is observed even without acute stress, including **coalescence of HSP104 and HSP12 loci** in **63% and 65.5%** of mutant cells at **25°C**, and increased levels of Hsf1 targets (e.g., Btn2, Hsp42). (rugerherreros2025nuclearandcytosolic pages 9-11)
+- For nuclear PQC readouts, the preprint reports increased nuclear inclusion phenotypes: **apj1Δ** cells show more nuclear **Sis1-GFP foci** after heat shock (e.g., **53.7% vs 21%** WT at 15 min; **59.2% vs 30.7%** WT at 60 min), and apj1Δ ydj1Δ cells show nuclear Sis1 foci before heat shock in **42.3%** of cells. (rugerherreros2025nuclearandcytosolic pages 9-11)
+- The authors explicitly connect Apj1 to **INQ** (intranuclear quality control) function, stating that absence of Apj1 increases formation/stability of INQ and that Apj1 targets INQ-deposited proteins for proteasomal degradation. (rugerherreros2025nuclearandcytosolic pages 4-6)
+
+## 4) Current applications and real-world implementations
+### 4.1 Yeast as a model for proteostasis and amyloid/prion biology
+Apj1 is used in yeast as a genetically tractable handle to probe how distinct Hsp70–JDP modules interface with **Hsp104** to eliminate prion/amyloid states (e.g., [PSI+]) and how specialized low-abundance JDPs can exert strong phenotype-specific effects via defined domains/regions. This is exemplified by the 2024 truncation experiments that separate “minimal prion-curing” activity from Sis1-complementation capacity. (ganser2024uniquecharacteristicsof pages 1-2, ganser2024uniquecharacteristicsof media 6fb49813)
+
+### 4.2 Industrial/biotechnology relevance (yeast trait mapping)
+Although not a mechanistic characterization in *S. cerevisiae* S288c, APJ1 homologs have appeared in genetic mapping of industrially relevant traits. For example, bulk-segregant analysis in a natural *Saccharomyces sensu stricto* hybrid identified a locus containing an **APJ1 homolog** contributing to growth on xylose, illustrating that APJ1-family variation can emerge in applied contexts (biofuel-related strain improvement). (Note: this is association/trait-mapping evidence rather than direct biochemical function in S288c.) (schwartz2012apj1andgre3 pages 1-2 not processed into a citeable evidence snippet in this run; therefore it is not cited as primary evidence here.)
+
+## 5) Expert synthesis and interpretation (authoritative analysis)
+### 5.1 A unifying functional model
+The strongest experimentally supported synthesis is that Apj1 is a **specialized, low-abundance, predominantly nuclear J-domain co-chaperone** that engages Hsp70 to direct distinct proteostasis outcomes depending on context: (i) **prion curing** in cooperation with Hsp104 and overlapping with Sis1 functions, and (ii) **SUMO-linked degradation** in functional interaction with Slx5, where Apj1’s client-binding capacity and Zn-finger region contribute to pathway performance. (sahi2007networkofgeneral pages 1-3, ganser2024uniquecharacteristicsof pages 1-2, sahi2013sequentialduplicationsof pages 6-7)
+
+### 5.2 Specificity determinants: modular N-terminus vs client-binding regions
+Ganser et al. (2024) show that a very short N-terminal fragment (90 aa) can be sufficient for prion-curing activity, whereas a longer fragment including additional low-complexity/GF-like regions is required for Sis1-like essential functions, supporting the idea that Apj1’s N-terminus contains determinants for prion-curing specialization. (ganser2024uniquecharacteristicsof pages 1-2, ganser2024uniquecharacteristicsof media 5aa2f23d)
+
+In contrast, Sahi et al. (2013) identify a requirement for client-binding features (hydrophobic cleft variants) and the Zn-finger region in SUMO-mediated degradation-related phenotypes, consistent with a model where different Apj1 regions govern different “client routing” behaviors (prion remodeling vs degradation). (sahi2013sequentialduplicationsof pages 7-8, sahi2013sequentialduplicationsof pages 6-7)
+
+## 6) Key statistics and data points (from cited studies)
+- **Abundance:** ~**125 molecules/cell** for Apj1 in one quantitative chaperone-network context. (sahi2007networkofgeneral pages 1-3)
+- **Prion-curing constructs (Ganser et al., 2024; Apr 2024):**
+  - **90 aa** (J-domain + Q/A) sufficient for Hsp104-mediated [PSI+] curing. (ganser2024uniquecharacteristicsof pages 1-2)
+  - **121 aa** supports growth without Sis1 and supports maintenance of several Sis1-dependent prions. (ganser2024uniquecharacteristicsof pages 1-2)
+  - Visual evidence for truncation strategy and phenotypes is in retrieved figure regions. (ganser2024uniquecharacteristicsof media 6fb49813, ganser2024uniquecharacteristicsof media 5aa2f23d)
+- **SUMO-pathway genetics (Sahi et al., 2013; May 2013):** apj1 slx5 shows severe growth phenotype at **37°C**, and SUMO conjugates increase further in the double mutant vs slx5 alone. (sahi2013sequentialduplicationsof pages 7-8, sahi2013sequentialduplicationsof pages 6-7)
+- **HSR/nuclear PQC phenotypes (bioRxiv preprint; Jul 2025):**
+  - Gene coalescence in apj1Δ ydj1Δ at 25°C: **63% (HSP104)** and **65.5% (HSP12)**. (rugerherreros2025nuclearandcytosolic pages 9-11)
+  - Nuclear Sis1-GFP foci after heat shock: **53.7% vs 21%** (apj1Δ vs WT, 15 min) and **59.2% vs 30.7%** (60 min). (rugerherreros2025nuclearandcytosolic pages 9-11)
+
+## 7) Limitations of this synthesis
+- **Direct substrates/clients** of Apj1 in the SUMO-degradation pathway are not identified in the extracted evidence; the strongest support is genetic interaction and SUMO-conjugate accumulation, not direct client binding to named proteins. (sahi2013sequentialduplicationsof pages 6-7)
+- The heat-shock/INQ regulatory role is presently supported here by a **2025 preprint**; confirmation in peer-reviewed literature should be sought as it becomes available. (rugerherreros2025nuclearandcytosolic pages 4-6)
+
+## 8) Annotated bibliography (sources prioritized by recency/authority)
+- Ganser SJ et al. **2024-04**. *Frontiers in Molecular Biosciences.* “Unique characteristics…” https://doi.org/10.3389/fmolb.2024.1392608 (Primary mechanistic dissection of Apj1 N-terminus in prion biology; construct-level functional mapping). (ganser2024uniquecharacteristicsof pages 1-2, ganser2024uniquecharacteristicsof media 6fb49813)
+- Carvalho FA et al. **2023-03**. *FEBS Letters.* “Hsp90 and metal-binding J-protein family…” https://doi.org/10.1002/1873-3468.14612 (Mentions APJ1 deletion phenotypes in broader JDP context; used here as contextual background, not a primary source of mechanistic claims). (Not extracted into citeable evidence snippets in this run.)
+- Sahi C, Kominek J, et al. **2013-05**. *Molecular Biology and Evolution.* “Sequential duplications…” https://doi.org/10.1093/molbev/mst008 (Strong genetic/biochemical evidence connecting Apj1 to SUMO-mediated degradation via Slx5 interaction; domain-function requirements). (sahi2013sequentialduplicationsof pages 6-7, sahi2013sequentialduplicationsof pages 7-8)
+- Sahi C, Craig EA. **2007-04**. *PNAS.* “Network of general and specialty J protein chaperones…” https://doi.org/10.1073/pnas.0702357104 (Chaperone network positioning; abundance and localization statements; functional redundancy via overexpression). (sahi2007networkofgeneral pages 1-3)
+- Ruger-Herreros C et al. **2025-07** (preprint). *bioRxiv.* “Nuclear and cytosolic J-domain proteins…” https://doi.org/10.1101/2025.04.14.648540 (Emerging model for Apj1 roles in Hsf1 attenuation and INQ-linked nuclear PQC; quantitative microscopy/genomics). (rugerherreros2025nuclearandcytosolic pages 4-6, rugerherreros2025nuclearandcytosolic pages 9-11)
+
+References
+
+1. (sahi2007networkofgeneral pages 1-3): Chandan Sahi and Elizabeth Anne Craig. Network of general and specialty j protein chaperones of the yeast cytosol. Proceedings of the National Academy of Sciences, 104:7163-7168, Apr 2007. URL: https://doi.org/10.1073/pnas.0702357104, doi:10.1073/pnas.0702357104. This article has 196 citations and is from a highest quality peer-reviewed journal.
+
+2. (sahi2013sequentialduplicationsof pages 1-2): Chandan Sahi, Jacek Kominek, Thomas Ziegelhoffer, Hyun Young Yu, Maciej Baranowski, Jaroslaw Marszalek, and Elizabeth A. Craig. Sequential duplications of an ancient member of the dnaj-family expanded the functional chaperone network in the eukaryotic cytosol. Molecular biology and evolution, 30 5:985-98, May 2013. URL: https://doi.org/10.1093/molbev/mst008, doi:10.1093/molbev/mst008. This article has 54 citations and is from a highest quality peer-reviewed journal.
+
+3. (sahi2013sequentialduplicationsof pages 6-7): Chandan Sahi, Jacek Kominek, Thomas Ziegelhoffer, Hyun Young Yu, Maciej Baranowski, Jaroslaw Marszalek, and Elizabeth A. Craig. Sequential duplications of an ancient member of the dnaj-family expanded the functional chaperone network in the eukaryotic cytosol. Molecular biology and evolution, 30 5:985-98, May 2013. URL: https://doi.org/10.1093/molbev/mst008, doi:10.1093/molbev/mst008. This article has 54 citations and is from a highest quality peer-reviewed journal.
+
+4. (rugerherreros2025nuclearandcytosolic pages 9-11): Carmen Ruger-Herreros, Lucia Svoboda, Gurranna Male, Aseem Shrivastava, Markus Höpfler, Katharina Jetzinger, Jiri Koubek, Günter Kramer, Fabian den Brave, Axel Mogk, David S Gross, and Bernd Bukau. Nuclear and cytosolic j-domain proteins provide synergistic control of hsf1 at distinct phases of the heat shock response. bioRxiv, Jul 2025. URL: https://doi.org/10.1101/2025.04.14.648540, doi:10.1101/2025.04.14.648540. This article has 0 citations.
+
+5. (rugerherreros2025nuclearandcytosolic pages 4-6): Carmen Ruger-Herreros, Lucia Svoboda, Gurranna Male, Aseem Shrivastava, Markus Höpfler, Katharina Jetzinger, Jiri Koubek, Günter Kramer, Fabian den Brave, Axel Mogk, David S Gross, and Bernd Bukau. Nuclear and cytosolic j-domain proteins provide synergistic control of hsf1 at distinct phases of the heat shock response. bioRxiv, Jul 2025. URL: https://doi.org/10.1101/2025.04.14.648540, doi:10.1101/2025.04.14.648540. This article has 0 citations.
+
+6. (sahi2013sequentialduplicationsof pages 7-8): Chandan Sahi, Jacek Kominek, Thomas Ziegelhoffer, Hyun Young Yu, Maciej Baranowski, Jaroslaw Marszalek, and Elizabeth A. Craig. Sequential duplications of an ancient member of the dnaj-family expanded the functional chaperone network in the eukaryotic cytosol. Molecular biology and evolution, 30 5:985-98, May 2013. URL: https://doi.org/10.1093/molbev/mst008, doi:10.1093/molbev/mst008. This article has 54 citations and is from a highest quality peer-reviewed journal.
+
+7. (ganser2024uniquecharacteristicsof pages 1-2): Samantha J. Ganser, Bridget A. McNish, Gillian L. Schwanitz, John L. Delaney, Bridget A. Corpus, Brenda A. Schilke, Anup K. Biswal, Chandan Sahi, Elizabeth A. Craig, and Justin K. Hines. Unique characteristics of the j-domain proximal regions of hsp70 cochaperone apj1 in prion propagation/elimination and its overlap with sis1 function. Frontiers in Molecular Biosciences, Apr 2024. URL: https://doi.org/10.3389/fmolb.2024.1392608, doi:10.3389/fmolb.2024.1392608. This article has 2 citations.
+
+8. (ganser2024uniquecharacteristicsof pages 2-4): Samantha J. Ganser, Bridget A. McNish, Gillian L. Schwanitz, John L. Delaney, Bridget A. Corpus, Brenda A. Schilke, Anup K. Biswal, Chandan Sahi, Elizabeth A. Craig, and Justin K. Hines. Unique characteristics of the j-domain proximal regions of hsp70 cochaperone apj1 in prion propagation/elimination and its overlap with sis1 function. Frontiers in Molecular Biosciences, Apr 2024. URL: https://doi.org/10.3389/fmolb.2024.1392608, doi:10.3389/fmolb.2024.1392608. This article has 2 citations.
+
+9. (ganser2024uniquecharacteristicsof media 6fb49813): Samantha J. Ganser, Bridget A. McNish, Gillian L. Schwanitz, John L. Delaney, Bridget A. Corpus, Brenda A. Schilke, Anup K. Biswal, Chandan Sahi, Elizabeth A. Craig, and Justin K. Hines. Unique characteristics of the j-domain proximal regions of hsp70 cochaperone apj1 in prion propagation/elimination and its overlap with sis1 function. Frontiers in Molecular Biosciences, Apr 2024. URL: https://doi.org/10.3389/fmolb.2024.1392608, doi:10.3389/fmolb.2024.1392608. This article has 2 citations.
+
+10. (ganser2024uniquecharacteristicsof media 5aa2f23d): Samantha J. Ganser, Bridget A. McNish, Gillian L. Schwanitz, John L. Delaney, Bridget A. Corpus, Brenda A. Schilke, Anup K. Biswal, Chandan Sahi, Elizabeth A. Craig, and Justin K. Hines. Unique characteristics of the j-domain proximal regions of hsp70 cochaperone apj1 in prion propagation/elimination and its overlap with sis1 function. Frontiers in Molecular Biosciences, Apr 2024. URL: https://doi.org/10.3389/fmolb.2024.1392608, doi:10.3389/fmolb.2024.1392608. This article has 2 citations.
+
+11. (rugerherreros2025nuclearandcytosolic pages 1-4): Carmen Ruger-Herreros, Lucia Svoboda, Gurranna Male, Aseem Shrivastava, Markus Höpfler, Katharina Jetzinger, Jiri Koubek, Günter Kramer, Fabian den Brave, Axel Mogk, David S Gross, and Bernd Bukau. Nuclear and cytosolic j-domain proteins provide synergistic control of hsf1 at distinct phases of the heat shock response. bioRxiv, Jul 2025. URL: https://doi.org/10.1101/2025.04.14.648540, doi:10.1101/2025.04.14.648540. This article has 0 citations.
+
+## Citations
+
+1. rugerherreros2025nuclearandcytosolic pages 4-6
+2. sahi2007networkofgeneral pages 1-3
+3. ganser2024uniquecharacteristicsof pages 1-2
+4. sahi2013sequentialduplicationsof pages 6-7
+5. sahi2013sequentialduplicationsof pages 7-8
+6. rugerherreros2025nuclearandcytosolic pages 9-11
+7. sahi2013sequentialduplicationsof pages 1-2
+8. ganser2024uniquecharacteristicsof pages 2-4
+9. rugerherreros2025nuclearandcytosolic pages 1-4
+10. PSI+
+11. https://doi.org/10.3389/fmolb.2024.1392608
+12. https://doi.org/10.1093/molbev/mst008
+13. https://doi.org/10.1101/2025.04.14.648540
+14. https://doi.org/10.1002/1873-3468.14612
+15. https://doi.org/10.1073/pnas.0702357104
+16. https://doi.org/10.1073/pnas.0702357104,
+17. https://doi.org/10.1093/molbev/mst008,
+18. https://doi.org/10.1101/2025.04.14.648540,
+19. https://doi.org/10.3389/fmolb.2024.1392608,

--- a/genes/yeast/CPR6/CPR6-ai-review.html
+++ b/genes/yeast/CPR6/CPR6-ai-review.html
@@ -671,33 +671,33 @@
     <div class="header">
         <h1>CPR6</h1>
         <div class="gene-info">
-            
+
             <div class="info-item">
-                
+
                 <span class="info-label">UniProt ID:</span>
                 <span>
                     <a href="https://www.uniprot.org/uniprotkb/P53691" target="_blank" class="term-link">
                         P53691
                     </a>
                 </span>
-                
+
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Organism:</span>
                 <span>Saccharomyces cerevisiae</span>
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
-                <span class="status-badge status-in-progress">
-                    IN PROGRESS
+                <span class="status-badge status-complete">
+                    COMPLETE
                 </span>
             </div>
-            
-            
+
+
         </div>
         <div style="margin-top: 1rem; text-align: center;">
             <a id="feedback-form-link"
@@ -728,7 +728,7 @@
         </div>
     </div>
 
-    
+
     <div class="description-card">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <h2>Gene Description</h2>
@@ -739,13 +739,13 @@
         </div>
         <p>CPR6 is one of two CyP-40-like cyclophilin immunophilins in S. cerevisiae (the other being CPR7). It is a peptidyl-prolyl cis-trans isomerase (PPIase, EC 5.2.1.8) that functions as an Hsp90 co-chaperone. CPR6 contains an N-terminal cyclophilin PPIase domain and a C-terminal TPR (tetratricopeptide repeat) domain that mediates binding to Hsp90 (HSP82/HSC82). It catalyzes the cis-trans isomerization of proline imidic peptide bonds in oligopeptides and contributes to protein refolding. CPR6 binds cyclosporin A. Unlike CPR7, CPR6 is not essential for normal growth. CPR6 interacts with Hsp90 and also associates with ribosomes.</p>
     </div>
-    
 
-    
 
-    
 
-    
+
+
+
+
     <div class="section">
         <h2 class="section-title">Existing Annotations Review</h2>
         <table class="annotations-table">
@@ -758,32 +758,32 @@
                 </tr>
             </thead>
             <tbody>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003755" target="_blank" class="term-link">
                                     GO:0003755
                                 </a>
                             </span>
                             <span class="term-label">peptidyl-prolyl cis-trans isomerase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -795,46 +795,62 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> CPR6 is a cyclophilin with well-established PPIase activity. IBA annotation is correct.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> PPIase activity is the core molecular function of CPR6. UniProt describes it as catalyzing cis-trans isomerization of proline imidic peptide bonds (EC 5.2.1.8). IDA evidence from PMID:10942767 and PMID:9191025 confirms this activity.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/CPR6/CPR6-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Cpr6 contains a **PPIase domain** plus a **TPR domain**</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -846,46 +862,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> CPR6 is a cytoplasmic protein. IBA annotation is correct.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Consistent with IDA evidence (PMID:9191025) and HDA evidence (PMID:11914276, PMID:14562095) for cytoplasmic localization.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                     GO:0006457
                                 </a>
                             </span>
                             <span class="term-label">protein folding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -897,46 +913,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> CPR6 contributes to protein folding through its PPIase activity and co-chaperone function with Hsp90.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> CPR6 participates in protein folding through two mechanisms: its PPIase catalytic activity (proline isomerization facilitates protein folding) and its role as an Hsp90 co-chaperone via its TPR domain. IDA and IPI evidence from PMID:9927435 supports this annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016018" target="_blank" class="term-link">
                                     GO:0016018
                                 </a>
                             </span>
                             <span class="term-label">cyclosporin A binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -948,46 +964,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> CPR6 is a cyclophilin that binds cyclosporin A. IBA annotation is correct.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Cyclosporin A binding is a defining characteristic of cyclophilins. The name CPR6 (Cyclosporin-sensitive Proline Rotamase 6) reflects this property. The IBA inference is well-supported phylogenetically.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003755" target="_blank" class="term-link">
                                     GO:0003755
                                 </a>
                             </span>
                             <span class="term-label">peptidyl-prolyl cis-trans isomerase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -999,46 +1015,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation for PPIase activity. Redundant with IBA and IDA but correct.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Consistent with IBA and IDA annotations for PPIase activity.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1050,46 +1066,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation for cytoplasm from UniProt subcellular location mapping. Correct.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Consistent with IDA and HDA evidence for cytoplasmic localization.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                     GO:0006457
                                 </a>
                             </span>
                             <span class="term-label">protein folding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1101,46 +1117,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation for protein folding from InterPro. Correct.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Consistent with IBA and experimental annotations for protein folding involvement.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016853" target="_blank" class="term-link">
                                     GO:0016853
                                 </a>
                             </span>
                             <span class="term-label">isomerase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1152,46 +1168,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IEA annotation from UniProt keyword mapping. Broader than PPIase activity but not incorrect.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Isomerase activity is a parent term of peptidyl-prolyl cis-trans isomerase activity. While more specific annotations exist, this broader IEA annotation is not incorrect.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042026" target="_blank" class="term-link">
                                     GO:0042026
                                 </a>
                             </span>
                             <span class="term-label">protein refolding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1203,46 +1219,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> ARBA prediction for protein refolding. Supported by IDA evidence.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Supported by IDA evidence from PMID:10942767 which showed CPR6 has protein refolding activity.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1254,57 +1270,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> ARBA prediction for unfolded protein binding. GO:0051082 is proposed for obsoletion. CPR6 is a PPIase co-chaperone, not an independent chaperone.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0051082 is proposed for obsoletion. CPR6 is primarily a PPIase that functions as an Hsp90 co-chaperone. While it can bind unfolded proteins in in vitro assays (PMID:10942767), its primary mechanism of action is proline isomerization, not independent unfolded protein binding. The IDA from PMID:10942767 showed chaperone-like activity in refolding assays, but this is secondary to its PPIase function. The core MF is GO:0003755 (PPIase activity).
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/11805837" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:11805837
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Systematic identification of protein complexes in Saccharomy...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1316,57 +1332,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI from mass spectrometry study. Uninformative &#34;protein binding&#34; annotation.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> &#34;Protein binding&#34; is uninformative. CPR6 interacts with Hsp90 via its TPR domain; the more informative annotation would be GO:0051087 (protein-folding chaperone binding).
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/15766533" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:15766533
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Navigating the chaperone network: an integrative map of phys...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1378,57 +1394,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI from chaperone network study.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Uninformative &#34;protein binding&#34; for an Hsp90 co-chaperone.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16554755" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16554755
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Global landscape of protein complexes in the yeast Saccharom...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1440,57 +1456,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI from large-scale protein complex study.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Uninformative &#34;protein binding&#34; for an Hsp90 co-chaperone.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19536198" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19536198
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     An atlas of chaperone-protein interactions in Saccharomyces ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1502,57 +1518,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI from atlas of chaperone-protein interactions.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Uninformative &#34;protein binding&#34; for an Hsp90 co-chaperone.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21170051" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21170051
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Mixed Hsp90-cochaperone complexes are important for the prog...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1564,57 +1580,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI from mixed Hsp90-cochaperone complex study.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Uninformative &#34;protein binding&#34; for an Hsp90 co-chaperone.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23396352" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23396352
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Integration of the accelerator Aha1 in the Hsp90 co-chaperon...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1626,57 +1642,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI from Aha1 integration into Hsp90 co-chaperone cycle study.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Uninformative &#34;protein binding&#34; for an Hsp90 co-chaperone.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/37968396" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:37968396
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The social and structural architecture of the yeast protein ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1688,57 +1704,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI from yeast protein interactome architecture study.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Uninformative &#34;protein binding&#34; for an Hsp90 co-chaperone.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/8873448" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:8873448
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Identification of two CyP-40-like cyclophilins in Saccharomy...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1750,57 +1766,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI from original identification of CPR6 as CyP-40-like cyclophilin.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Uninformative &#34;protein binding&#34; for an Hsp90 co-chaperone.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/11914276" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:11914276
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Subcellular localization of the yeast proteome.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1812,57 +1828,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> High-throughput data for cytoplasmic localization.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Consistent with IDA evidence. Core localization.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/14562095" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:14562095
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Global analysis of protein localization in budding yeast.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1874,57 +1890,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> High-throughput GFP localization data confirming cytoplasm.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Global protein localization study. Consistent with IDA evidence.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                     GO:0006457
                                 </a>
                             </span>
                             <span class="term-label">protein folding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9927435" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:9927435
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Regulation of Hsp90 ATPase activity by tetratricopeptide rep...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1936,57 +1952,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IPI evidence for protein folding involvement through interaction with Hsp90.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> CPR6 participates in protein folding as an Hsp90 co-chaperone. The IPI evidence documents the functional interaction in the context of protein folding.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043022" target="_blank" class="term-link">
                                     GO:0043022
                                 </a>
                             </span>
                             <span class="term-label">ribosome binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/25380751" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:25380751
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The Hsp90 cochaperones Cpr6, Cpr7, and Cns1 interact with th...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -1998,57 +2014,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA evidence for ribosome binding. CPR6 associates with ribosomes.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> CPR6 has been shown to bind ribosomes by direct assay. This may be related to co-translational protein folding but is not the core PPIase/co-chaperone function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003755" target="_blank" class="term-link">
                                     GO:0003755
                                 </a>
                             </span>
                             <span class="term-label">peptidyl-prolyl cis-trans isomerase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10942767" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:10942767
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Cpr6 and Cpr7, two closely related Hsp90-associated immunoph...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2060,57 +2076,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA evidence for PPIase activity from comparative study of CPR6 and CPR7.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Direct assay demonstrates PPIase activity. Study compared CPR6 and CPR7, showing both have PPIase activity but differ in other functional properties.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003755" target="_blank" class="term-link">
                                     GO:0003755
                                 </a>
                             </span>
                             <span class="term-label">peptidyl-prolyl cis-trans isomerase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9191025" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:9191025
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Functional analysis of the yeast 40 kDa cyclophilin Cyp40 an...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2122,57 +2138,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA evidence for PPIase activity from functional analysis of yeast 40 kDa cyclophilin.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Direct assay demonstrates PPIase activity. Core molecular function of CPR6.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9191025" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:9191025
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Functional analysis of the yeast 40 kDa cyclophilin Cyp40 an...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2184,57 +2200,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA evidence for cytoplasmic localization.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core localization of CPR6.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                     GO:0006457
                                 </a>
                             </span>
                             <span class="term-label">protein folding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9927435" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:9927435
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Regulation of Hsp90 ATPase activity by tetratricopeptide rep...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2246,57 +2262,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA evidence for protein folding involvement.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Direct assay demonstrates CPR6 role in protein folding, consistent with its PPIase and co-chaperone functions.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042026" target="_blank" class="term-link">
                                     GO:0042026
                                 </a>
                             </span>
                             <span class="term-label">protein refolding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10942767" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:10942767
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Cpr6 and Cpr7, two closely related Hsp90-associated immunoph...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2308,57 +2324,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA evidence for protein refolding activity from comparative study of CPR6 and CPR7.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> PMID:10942767 demonstrated that CPR6 has protein refolding activity in vitro. This is consistent with its PPIase and co-chaperone functions.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10942767" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:10942767
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Cpr6 and Cpr7, two closely related Hsp90-associated immunoph...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2370,32 +2386,32 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> IDA evidence for unfolded protein binding. GO:0051082 is proposed for obsoletion. CPR6 is primarily a PPIase, not an independent chaperone.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> GO:0051082 is proposed for obsoletion. While PMID:10942767 showed CPR6 can bind unfolded proteins in vitro, its primary mechanism is proline isomerization (GO:0003755) and its co-chaperone function with Hsp90. The unfolded protein binding observed in vitro is secondary to these core functions. Marking as over-annotated rather than MODIFY because CPR6 is not an ATP-dependent chaperone and GO:0044183 would not be appropriate.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
             </tbody>
         </table>
     </div>
-    
 
-    
+
+
     <div class="section">
         <h2 class="section-title">Core Functions</h2>
-        
+
         <div class="core-function-card">
-            
+
             <div style="display: flex; justify-content: space-between; align-items: center;">
                 <h3>Primary molecular function: peptidyl-prolyl cis-trans isomerase (PPIase) activity. CPR6 catalyzes the cis-trans isomerization of proline imidic peptide bonds (EC 5.2.1.8). Supported by IBA, IDA (PMID:10942767, PMID:9191025), and IEA evidence.</h3>
                 <span class="vote-buttons" data-g="P53691" data-a="FUNCTION: Primary molecular function: peptidyl-prolyl cis-tr..." data-r="" data-act="CORE_FUNCTION">
@@ -2403,10 +2419,10 @@
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
             </div>
-            
+
 
             <div class="core-function-terms">
-                
+
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
@@ -2415,422 +2431,843 @@
                         </a>
                     </span>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Directly Involved In:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                 protein folding
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Cellular Locations:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                 cytoplasm
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
 
-                
+
+
+
             </div>
 
-            
-        </div>
-        
-    </div>
-    
 
-    
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:yeast/CPR6/CPR6-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">CPR6 encodes a **nonessential cytosolic CyP40-like cyclophilin**</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class="section">
         <h2 class="section-title collapsible">References</h2>
         <div class="collapse-content">
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
                             GO_REF:0000002
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
                             GO_REF:0000033
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Annotation inferences using phylogenetic trees</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000043.md" target="_blank" class="term-link">
                             GO_REF:0000043
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
                             GO_REF:0000044
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
                             GO_REF:0000117
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
                             GO_REF:0000120
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/10942767" target="_blank" class="term-link">
                             PMID:10942767
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Cpr6 and Cpr7, two closely related Hsp90-associated immunophilins from Saccharomyces cerevisiae, differ in their functional properties.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">CPR6 has PPIase activity and protein refolding activity in vitro</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">CPR6 and CPR7 differ in their functional properties despite structural similarity</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/11805837" target="_blank" class="term-link">
                             PMID:11805837
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Systematic identification of protein complexes in Saccharomyces cerevisiae by mass spectrometry.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/11914276" target="_blank" class="term-link">
                             PMID:11914276
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Subcellular localization of the yeast proteome.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/14562095" target="_blank" class="term-link">
                             PMID:14562095
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Global analysis of protein localization in budding yeast.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/15766533" target="_blank" class="term-link">
                             PMID:15766533
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Navigating the chaperone network: an integrative map of physical and genetic interactions mediated by the hsp90 chaperone.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/16554755" target="_blank" class="term-link">
                             PMID:16554755
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Global landscape of protein complexes in the yeast Saccharomyces cerevisiae.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/19536198" target="_blank" class="term-link">
                             PMID:19536198
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">An atlas of chaperone-protein interactions in Saccharomyces cerevisiae: implications to protein folding pathways in the cell.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/21170051" target="_blank" class="term-link">
                             PMID:21170051
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Mixed Hsp90-cochaperone complexes are important for the progression of the reaction cycle.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/23396352" target="_blank" class="term-link">
                             PMID:23396352
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Integration of the accelerator Aha1 in the Hsp90 co-chaperone cycle.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/25380751" target="_blank" class="term-link">
                             PMID:25380751
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The Hsp90 cochaperones Cpr6, Cpr7, and Cns1 interact with the intact ribosome.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/37968396" target="_blank" class="term-link">
                             PMID:37968396
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The social and structural architecture of the yeast protein interactome.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/8873448" target="_blank" class="term-link">
                             PMID:8873448
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Identification of two CyP-40-like cyclophilins in Saccharomyces cerevisiae, one of which is required for normal growth.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/9191025" target="_blank" class="term-link">
                             PMID:9191025
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Functional analysis of the yeast 40 kDa cyclophilin Cyp40 and its role for viability and steroid receptor regulation.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">CPR6 has PPIase catalytic activity and localizes to the cytoplasm</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/9927435" target="_blank" class="term-link">
                             PMID:9927435
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Regulation of Hsp90 ATPase activity by tetratricopeptide repeat (TPR)-domain co-chaperones.</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">CPR6 participates in protein folding as an Hsp90 co-chaperone</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:yeast/CPR6/CPR6-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research report for CPR6</div>
+
+
+            </div>
+
         </div>
     </div>
-    
 
 
-    
 
-    
 
-    
+
+
+
+
 
     <!-- Computational Predictions Section -->
-    
+
 
     <!-- Additional Documentation Sections -->
-    
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Deep Research Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(CPR6-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P53691" data-a="DOC: Deep Research Falcon" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <hr />
+<p>provider: falcon<br />
+model: Edison Scientific Literature<br />
+cached: false<br />
+start_time: '2026-05-11T08:43:34.885488'<br />
+end_time: '2026-05-11T08:59:19.653720'<br />
+duration_seconds: 944.77<br />
+template_file: templates/gene_research_go_focused.md<br />
+template_variables:<br />
+  organism: yeast<br />
+  gene_id: CPR6<br />
+  gene_symbol: CPR6<br />
+  uniprot_accession: P53691<br />
+  protein_description: 'RecName: Full=Peptidyl-prolyl cis-trans isomerase CPR6; Short=PPIase<br />
+    CPR6; EC=5.2.1.8; AltName: Full=Rotamase CPR6;'<br />
+  gene_info: Name=CPR6; OrderedLocusNames=YLR216C; ORFNames=L8167.24;<br />
+  organism_full: Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).<br />
+  protein_family: Belongs to the cyclophilin-type PPIase family. PPIase D<br />
+  protein_domains: Cyclophilin-like_dom_sf. (IPR029000); Cyclophilin-type_PPIase_CS.<br />
+    (IPR020892); Cyclophilin-type_PPIase_dom. (IPR002130); TPR-like_helical_dom_sf.<br />
+    (IPR011990); TPR_rpt. (IPR019734)<br />
+provider_config:<br />
+  timeout: 600<br />
+  max_retries: 3<br />
+  parameters:<br />
+    allowed_domains: []<br />
+    temperature: 0.1<br />
+citation_count: 24</p>
+<hr />
+<h2 id="question">Question</h2>
+<h1 id="gene-research-for-functional-annotation">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> P53691</li>
+<li><strong>Protein Description:</strong> RecName: Full=Peptidyl-prolyl cis-trans isomerase CPR6; Short=PPIase CPR6; EC=5.2.1.8; AltName: Full=Rotamase CPR6;</li>
+<li><strong>Gene Information:</strong> Name=CPR6; OrderedLocusNames=YLR216C; ORFNames=L8167.24;</li>
+<li><strong>Organism (full):</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Protein Family:</strong> Belongs to the cyclophilin-type PPIase family. PPIase D</li>
+<li><strong>Key Domains:</strong> Cyclophilin-like_dom_sf. (IPR029000); Cyclophilin-type_PPIase_CS. (IPR020892); Cyclophilin-type_PPIase_dom. (IPR002130); TPR-like_helical_dom_sf. (IPR011990); TPR_rpt. (IPR019734)</li>
+</ul>
+<h3 id="mandatory-verification-steps">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "CPR6" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'CPR6' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>CPR6</strong> (gene ID: CPR6, UniProt: P53691) in yeast.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="output">Output</h2>
+<p>Question: You are an expert researcher providing comprehensive, well-cited information.</p>
+<p>Provide detailed information focusing on:<br />
+1. Key concepts and definitions with current understanding<br />
+2. Recent developments and latest research (prioritize 2023-2024 sources)<br />
+3. Current applications and real-world implementations<br />
+4. Expert opinions and analysis from authoritative sources<br />
+5. Relevant statistics and data from recent studies</p>
+<p>Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.<br />
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.</p>
+<h1 id="gene-research-for-functional-annotation_1">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context_1">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot_1">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> P53691</li>
+<li><strong>Protein Description:</strong> RecName: Full=Peptidyl-prolyl cis-trans isomerase CPR6; Short=PPIase CPR6; EC=5.2.1.8; AltName: Full=Rotamase CPR6;</li>
+<li><strong>Gene Information:</strong> Name=CPR6; OrderedLocusNames=YLR216C; ORFNames=L8167.24;</li>
+<li><strong>Organism (full):</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Protein Family:</strong> Belongs to the cyclophilin-type PPIase family. PPIase D</li>
+<li><strong>Key Domains:</strong> Cyclophilin-like_dom_sf. (IPR029000); Cyclophilin-type_PPIase_CS. (IPR020892); Cyclophilin-type_PPIase_dom. (IPR002130); TPR-like_helical_dom_sf. (IPR011990); TPR_rpt. (IPR019734)</li>
+</ul>
+<h3 id="mandatory-verification-steps_1">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "CPR6" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature_1">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'CPR6' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target_1">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>CPR6</strong> (gene ID: CPR6, UniProt: P53691) in yeast.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="research-report-cpr6-ylr216c-uniprot-p53691-in-saccharomyces-cerevisiae-s288c">Research report: <strong>CPR6 (YLR216C; UniProt P53691)</strong> in <em>Saccharomyces cerevisiae</em> (S288c)</h2>
+<h3 id="0-target-verification-critical-identity-check">0) Target verification (critical identity check)</h3>
+<p>The literature analyzed here explicitly refers to <em>Saccharomyces cerevisiae</em> <strong>CPR6/YLR216C</strong>, encoding a <strong>cyclophilin 40 (CyP40)-like peptidyl-prolyl cis–trans isomerase</strong> with an <strong>N-terminal cyclophilin/PPIase domain</strong> and a <strong>C-terminal TPR domain</strong>, matching UniProt accession <strong>P53691</strong> and the domain architecture you provided (PPIase + TPR repeats) (dolinski1998cns1encodesan pages 1-2, duina1996identificationoftwo pages 1-2, tenge2015thehsp90cochaperones pages 1-2).</p>
+<h3 id="1-key-concepts-and-definitions-current-understanding">1) Key concepts and definitions (current understanding)</h3>
+<h4 id="11-cyclophilins-and-ppiase-activity">1.1 Cyclophilins and PPIase activity</h4>
+<p>Cyclophilins are <strong>peptidyl-prolyl cis–trans isomerases (PPIases; EC 5.2.1.8)</strong> that catalyze the interconversion of cis/trans conformations at <strong>Xaa–Pro peptide bonds</strong>, which can be rate-limiting during protein folding (mayr2000cpr6andcpr7 pages 1-1). In the yeast Hsp90 system, cyclophilins of the <strong>CyP40 class</strong> (including Cpr6 and Cpr7) are “large immunophilins” that couple a cyclophilin domain to <strong>TPR repeats</strong>, enabling docking to Hsp90 (mayr2000cpr6andcpr7 pages 1-1, dolinski1998cns1encodesan pages 1-2).</p>
+<h4 id="12-tpr-domains-and-hsp90-cochaperones">1.2 TPR domains and Hsp90 cochaperones</h4>
+<p>Many Hsp90 cochaperones contain <strong>tetratricopeptide repeats (TPRs)</strong> that bind the conserved <strong>C-terminal MEEVD motif</strong> of Hsp90, mediating a regulated exchange of cochaperones during the ATP-dependent Hsp90 folding cycle (tenge2015thehsp90cochaperones pages 1-2, dolinski1998cns1encodesan pages 1-2). CPR6 is one of these TPR cochaperones and is considered part of the cytosolic Hsp90 chaperone machine (tenge2015thehsp90cochaperones pages 1-2, mayr2000cpr6andcpr7 pages 1-1).</p>
+<h3 id="2-cpr6-protein-architecture-localization-and-interaction-network">2) CPR6 protein architecture, localization, and interaction network</h3>
+<h4 id="21-domain-architecture-what-cpr6-encodes">2.1 Domain architecture (what CPR6 encodes)</h4>
+<p>Cpr6 contains a <strong>PPIase domain</strong> plus a <strong>TPR domain</strong> “flanked by charged regions,” consistent with a dual enzymatic + cochaperone/adaptor role (tenge2015thehsp90cochaperones pages 1-2). A figure mapping truncations/mutations and their effects on interactions shows that the C-terminal region is crucial for ribosome association and helps resolve which regions drive Hsp90 vs ribosome binding (tenge2015thehsp90cochaperones media e3c93753).</p>
+<h4 id="22-subcellular-context-where-cpr6-acts">2.2 Subcellular context / where CPR6 acts</h4>
+<p>The retrieved experimental evidence places Cpr6 primarily in the <strong>cytosolic proteostasis network</strong> through its association with cytosolic Hsp90 (explicitly described as a cytosolic chaperone) and through a direct physical association with <strong>intact ribosomes</strong> (mayr2000cpr6andcpr7 pages 1-1, tenge2015thehsp90cochaperones pages 1-2). Specifically, purification of Cpr6 copurified multiple ribosomal proteins from <strong>both small and large subunits</strong>, demonstrating ribosome association rather than a purely soluble Hsp90 complex membership (tenge2015thehsp90cochaperones pages 1-2, tenge2015thehsp90cochaperones pages 5-6).</p>
+<h4 id="23-proteinprotein-interactions-directly-supported">2.3 Protein–protein interactions (directly supported)</h4>
+<p>Key experimentally supported partners/associations include:<br />
+- <strong>Hsp90</strong>: Cpr6 binds Hsp90 in biochemical pull-down experiments (GST-Cpr6 can recover Hsp90 from yeast or bacterial lysates expressing Hsp90) (duina1996acyclophilinfunction pages 1-2). The broader cochaperone framework also predicts TPR-mediated Hsp90 tail binding (dolinski1998cns1encodesan pages 1-2).<br />
+- <strong>Hsp70</strong>: Cpr6 isolates can copurify Hsp70 as part of cochaperone/client-associated complexes (tenge2015thehsp90cochaperones pages 1-2).<br />
+- <strong>Ura2</strong> (Hsp90 client): Cpr6 purification copurifies <strong>Ura2</strong>, an Hsp90 client required for pyrimidine biosynthesis, linking Cpr6 to client-facing Hsp90 function (tenge2015thehsp90cochaperones pages 1-2).<br />
+- <strong>Ribosome</strong>: Cpr6 interacts with intact ribosomes; only Cpr6 (among tested cochaperones in that study) and Zuo1 showed robust ribosome interaction (tenge2015thehsp90cochaperones pages 5-6).<br />
+- <strong>Cns1/Cpr7 network differences</strong>: In classic complex isolation work, <strong>Cns1</strong> was detected in complexes with Hsp90 and Cpr7, but not with Cpr6, implying paralog-specific wiring of Hsp90 cochaperone subcomplexes (dolinski1998cns1encodesan pages 1-2).</p>
+<h3 id="3-primary-molecular-function-catalysis-and-substrate-specificity">3) Primary molecular function: catalysis and substrate specificity</h3>
+<h4 id="31-catalyzed-reaction">3.1 Catalyzed reaction</h4>
+<p>Cpr6’s primary enzymatic activity is <strong>peptidyl-prolyl cis–trans isomerization</strong> at Xaa–Pro bonds (PPIase activity) (mayr2000cpr6andcpr7 pages 1-1).</p>
+<h4 id="32-substrate-specificity-what-is-known">3.2 Substrate specificity (what is known)</h4>
+<p>The retrieved texts support the <strong>general cyclophilin substrate class</strong> (Xaa–Pro peptide bonds) but do not provide a CPR6-specific physiological substrate list; instead, they emphasize its integration into <strong>Hsp90-dependent client maturation</strong> and ribosome-associated proteostasis (mayr2000cpr6andcpr7 pages 1-1, tenge2015thehsp90cochaperones pages 1-2). The best-supported “substrate context” is therefore: (i) <strong>folding intermediates/clients handled by Hsp90</strong>, and (ii) proteins associated with translation machinery via ribosome binding (tenge2015thehsp90cochaperones pages 1-2, tenge2015thehsp90cochaperones pages 5-6).</p>
+<h4 id="33-quantitative-biochemical-properties-directly-stated">3.3 Quantitative biochemical properties (directly stated)</h4>
+<ul>
+<li><strong>Relative PPIase strength:</strong> Cpr6 displays <strong>up to ~100-fold higher PPIase activity than Cpr7</strong> (mayr2000cpr6andcpr7 pages 1-1).</li>
+<li><strong>Chaperone activity comparison:</strong> Cpr6 has <strong>much lower intrinsic chaperone activity</strong> than Cpr7, despite higher PPIase activity, implying functional specialization between paralogs (mayr2000cpr6andcpr7 pages 1-1).</li>
+</ul>
+<h3 id="4-cpr6-function-in-pathwaysbiological-processes">4) CPR6 function in pathways/biological processes</h3>
+<h4 id="41-role-as-an-hsp90-cochaperone-mechanistic-framing">4.1 Role as an Hsp90 cochaperone (mechanistic framing)</h4>
+<p>Cpr6 is best described as an <strong>Hsp90-associated immunophilin cochaperone</strong> that regulates the Hsp90 folding cycle through TPR-mediated association and (in at least some contexts) through conformational control of Hsp90 states (mayr2000cpr6andcpr7 pages 1-1, mercier2023hsp90mutantswith pages 1-2).</p>
+<p>A 2023 yeast genetics study using distinct Hsp90 conformational mutants supports a model in which <strong>Hch1 destabilizes Hsp90–nucleotide interaction and hinders formation of the closed conformation</strong>, while <strong>Cpr6 counteracts Hch1 by stabilizing the closed conformation</strong> (mercier2023hsp90mutantswith pages 1-2). This positions Cpr6 as a regulator of the <strong>timing</strong> of transitions in the Hsp90 cycle, rather than merely an accessory enzyme (mercier2023hsp90mutantswith pages 1-2).</p>
+<h4 id="42-link-to-translation-ribosome-association-and-proteostasis">4.2 Link to translation: ribosome association and proteostasis</h4>
+<p>Tenge et al. provide strong evidence that Cpr6 is a ribosome-interacting Hsp90 cochaperone, describing this as a “novel link between the Hsp90 molecular-chaperone machine and protein synthesis” (tenge2015thehsp90cochaperones pages 1-2). Functionally:<br />
+- The <strong>TPR + flanking region</strong> contains <strong>distinct binding sites for Hsp90, Ura2, and the ribosome</strong> (tenge2015thehsp90cochaperones pages 5-6).<br />
+- Truncation or alteration of <strong>basic residues near the C-terminus</strong> disrupts ribosome interaction (tenge2015thehsp90cochaperones pages 1-2).<br />
+- CPR6 overexpression phenotypes in sensitized backgrounds depend on intact Hsp90/ribosome interaction (tenge2015thehsp90cochaperones pages 5-6).</p>
+<h3 id="5-genetics-and-phenotypes-what-perturbing-cpr6-does">5) Genetics and phenotypes (what perturbing CPR6 does)</h3>
+<h4 id="51-viability-and-baseline-growth">5.1 Viability and baseline growth</h4>
+<p>Yeast lacking <strong>CPR6</strong> are viable and in multiple reports show <strong>no obvious/noticeable growth defect</strong> under standard conditions, in contrast to CPR7 and CNS1 perturbations (dolinski1998cns1encodesan pages 1-2, tenge2015thehsp90cochaperones pages 1-2).</p>
+<h4 id="52-context-dependent-phenotypes-interaction-with-the-cochaperone-network">5.2 Context-dependent phenotypes (interaction with the cochaperone network)</h4>
+<ul>
+<li>In a temperature-sensitive <strong>cns1-G90D</strong> background, <strong>overexpression of CPR6 exacerbates growth defects</strong>, and Cpr6 mutants defective in ribosome interaction fail to produce this negative effect (tenge2015thehsp90cochaperones pages 1-2, tenge2015thehsp90cochaperones pages 5-6).</li>
+<li>In translation-stress assays, loss of CPR7 or CNS1 mutations confer <strong>hygromycin sensitivity</strong>, whereas CPR6 deletion did <strong>not</strong> under the tested conditions, suggesting non-identical contributions of CyP40 paralogs to translation-linked stress phenotypes (tenge2015thehsp90cochaperones pages 5-6).</li>
+</ul>
+<h4 id="53-hsp90-dependent-signal-transduction-clients-client-specific-outputs">5.3 Hsp90-dependent signal transduction clients (client-specific outputs)</h4>
+<p>A seminal study on Hsp90-dependent signaling in yeast provides client-selective phenotypes:<br />
+- <strong>Glucocorticoid receptor (GR):</strong> deleting <strong>CPR6</strong> did <em>not</em> reduce hormone-dependent GR activity (in contrast to CPR7 deletion, which reduced GR activity markedly) (duina1996acyclophilinfunction pages 1-2).<br />
+- <strong>Oncogenic tyrosine kinase (v-Src/pp60v-src-like client):</strong> in <strong>cpr6Δ</strong> cells, kinase <strong>activity decreased by ~50%</strong> while accumulation was unaffected, consistent with a role in client maturation/activation rather than expression (duina1996acyclophilinfunction pages 1-2).<br />
+These results support the concept that Cpr6 participates in the Hsp90 system but is <strong>not uniformly required</strong> for all Hsp90 clients; instead, it can have <strong>client- and context-specific</strong> effects (duina1996acyclophilinfunction pages 1-2, mayr2000cpr6andcpr7 pages 1-1).</p>
+<h3 id="6-recent-developments-20232024-and-expert-analysis">6) Recent developments (2023–2024) and expert analysis</h3>
+<p>Recent work increasingly frames cochaperones (including Cpr6) as regulators of <strong>Hsp90 conformational transitions</strong> and client fate. Key 2023–2024 advances captured in the retrieved corpus are summarized below.</p>
+<table>
+<thead>
+<tr>
+<th>Paper (year)</th>
+<th>Type</th>
+<th>Key CPR6-related finding</th>
+<th>Quantitative/statistical data</th>
+<th>URL/DOI</th>
+<th>Publication date if stated</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Mercier et al. (2023)</td>
+<td>Primary research</td>
+<td>Using yeast Hsp90 mutants, the authors show that <strong>Cpr6 counteracts Hch1 and stabilizes the closed conformation of Hsp90</strong>, supporting a role for Cpr6 as a conformational regulator/pacemaker of the Hsp90 cycle; they also report that Hsp90 inhibitor sensitivity tracks with conformational-state defects rather than simply ATPase activity (mercier2023hsp90mutantswith pages 1-2)</td>
+<td>Yeast has <strong>at least 12 cochaperones</strong>; Hsp90 supports folding/activation of an estimated <strong>10–15% of the yeast and human proteome</strong>; mutants defective in the <strong>loading</strong> phase are most sensitive to <strong>NVP-AUY922</strong>, whereas <strong>reopening-phase</strong> mutants are most resistant (mercier2023hsp90mutantswith pages 1-2)</td>
+<td>https://doi.org/10.1371/journal.pgen.1010772</td>
+<td>Published <strong>May 25, 2023</strong> (mercier2023hsp90mutantswith pages 1-2)</td>
+</tr>
+<tr>
+<td>Backe et al. (2023)</td>
+<td>Review</td>
+<td>Reviews how <strong>S. cerevisiae</strong> has been used to decipher Hsp90 function and cochaperone biology; relevant to CPR6 because yeast cochaperone networks, including TPR cochaperones such as Cpr6, are presented as central tools for defining conserved Hsp90 mechanisms (rios2024insightsintohsp90 pages 1-2)</td>
+<td>Emphasizes conservation of yeast-to-metazoan Hsp90 machinery; no CPR6-specific numeric value in the excerpted context (rios2024insightsintohsp90 pages 1-2)</td>
+<td>https://doi.org/10.1042/EBC20220224</td>
+<td>Published <strong>September 2023</strong></td>
+</tr>
+<tr>
+<td>Rios et al. (2024)</td>
+<td>Review</td>
+<td>Synthesizes <strong>yeast-derived mechanistic insights into Hsp90</strong> and highlights that Hsp90–cochaperone interactions are highly conserved between yeast and mammals; useful for CPR6 because it places Cpr6 within the conserved cytosolic Hsp90 cochaperone system and notes that deletion of <strong>CPR6 negatively affects critical roles regulating the folding pathway in vivo</strong> (rios2024insightsintohsp90 pages 1-2)</td>
+<td>Yeast Hsp90 isoforms are <strong>97% identical</strong>; reducing Hsc82/Hsp82 abundance to <strong>1%–5% of wild-type</strong> supports growth at optimal temperature but not elevated temperature (Hsp90 system context relevant to CPR6 function) (rios2024insightsintohsp90 pages 1-2)</td>
+<td>https://doi.org/10.3389/fmolb.2024.1325590</td>
+<td>Published <strong>February 8, 2024</strong> (rios2024insightsintohsp90 pages 1-2)</td>
+</tr>
+<tr>
+<td>Fulton et al. (2024)</td>
+<td>Primary research</td>
+<td>Shows Hsp90 and cochaperones have <strong>two genetically distinct roles in regulating eEF2</strong>; the study frames cochaperone subnetworks and explicitly includes <strong>CPR6</strong> among tested yeast cochaperone backgrounds, extending CPR6 relevance into translation/proteostasis-focused Hsp90 biology (fulton2024hsp90andcochaperones pages 1-2)</td>
+<td>Hsp90 is required for maintaining <strong>~20% of the yeast proteome</strong> in an active/folded state; estimated abundance is <strong>~229,000 Hsc82/Hsp82 molecules per cell</strong> and <strong>145,000 Eft1/Eft2 molecules per cell</strong> (fulton2024hsp90andcochaperones pages 1-2)</td>
+<td>https://doi.org/10.1371/journal.pgen.1011508</td>
+<td>Published <strong>December 9, 2024</strong> (fulton2024hsp90andcochaperones pages 1-2)</td>
+</tr>
+<tr>
+<td>Edkins et al. (2023)</td>
+<td>Meeting report/review</td>
+<td>Summarizes the 10th International Symposium on the Hsp90 chaperone machine; includes discussion of new yeast Hsp90 mutant data indicating that <strong>Cpr6 release appears necessary for later steps of the Hsp90 cycle</strong>, providing expert community-level interpretation of emerging CPR6 biology (mercier2023hsp90mutantswith pages 1-2)</td>
+<td>No CPR6-specific numeric statistic in the excerpted context; value is as an expert synthesis of unpublished/recently emerging data (mercier2023hsp90mutantswith pages 1-2)</td>
+<td>https://doi.org/10.1007/s12192-023-01342-z</td>
+<td>Published <strong>May 2023</strong> (mercier2023hsp90mutantswith pages 1-2)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes 2023–2024 papers and reviews most relevant to yeast CPR6 within the Hsp90 cochaperone system. It highlights recent mechanistic advances, quantitative context, and publication details useful for functional annotation.</em></p>
+<p>Two particularly relevant “expert interpretation” points from 2023–2024 sources are:<br />
+1) <strong>Conformational regulation over ATPase-centric models:</strong> Mercier et al. argue that timing of transitions into/out of Hsp90 closed conformations is tightly regulated by cochaperones, including Cpr6, shifting emphasis from ATPase rate alone toward conformational control (mercier2023hsp90mutantswith pages 1-2).<br />
+2) <strong>Proteostasis scale and translation linkage:</strong> Fulton et al. emphasize that Hsp90 supports a substantial fraction of the proteome and that cochaperone networks interact with translation fidelity pathways; although their focal client is eEF2 and other cochaperones (e.g., Cpr7, Cns1, Hgh1), the paper explicitly situates CPR6 within the cochaperone landscape being interrogated (fulton2024hsp90andcochaperones pages 1-2).</p>
+<h3 id="7-quantitativestatistical-highlights-recent-studies-and-key-primary-results">7) Quantitative/statistical highlights (recent studies and key primary results)</h3>
+<ul>
+<li><strong>Proteome fraction:</strong> Hsp90 is reported to be required for maintaining <strong>~20% of the yeast proteome</strong> in an active, folded conformation (fulton2024hsp90andcochaperones pages 1-2). This statistic provides the “systems” context in which cochaperones like Cpr6 operate.</li>
+<li><strong>Protein abundance estimates (per cell):</strong> Hsp90 (Hsc82/Hsp82) is estimated at <strong>~229,000 molecules per cell</strong> and eEF2 at <strong>145,000 molecules per cell</strong> (fulton2024hsp90andcochaperones pages 1-2).</li>
+<li><strong>Client effect size (CPR6 deletion):</strong> ~<strong>50% decrease</strong> in activity of an oncogenic tyrosine kinase client in <strong>cpr6Δ</strong> cells (duina1996acyclophilinfunction pages 1-2).</li>
+<li><strong>PPIase magnitude (paralog comparison):</strong> Cpr6 has <strong>up to ~100-fold higher PPIase activity</strong> than Cpr7 (mayr2000cpr6andcpr7 pages 1-1).</li>
+<li><strong>Domain mapping / construct-based quantitation:</strong> A functionally critical Cpr6 region spanning <strong>aa 171–371</strong> was sufficient for strong overexpression-linked growth effects in a sensitized background, even without the PPIase domain, indicating that at least some in vivo phenotypes are mediated by non-catalytic regions (tenge2015thehsp90cochaperones pages 5-6).</li>
+</ul>
+<h3 id="8-current-applications-and-real-world-implementations">8) Current applications and real-world implementations</h3>
+<h4 id="81-yeast-cpr6-as-a-tractable-model-for-conserved-hsp90cochaperone-biology">8.1 Yeast CPR6 as a tractable model for conserved Hsp90–cochaperone biology</h4>
+<p>The most mature real-world “implementation” is methodological: yeast provides a genetically powerful system to dissect conserved chaperone mechanisms and to map cochaperone-specific regulation. CPR6 is repeatedly used as part of that cochaperone toolkit, enabling inference relevant to eukaryotic Hsp90 systems broadly (rios2024insightsintohsp90 pages 1-2, mercier2023hsp90mutantswith pages 1-2).</p>
+<h4 id="82-drug-mechanism-relevance-via-hsp90-inhibitor-studies">8.2 Drug-mechanism relevance via Hsp90 inhibitor studies</h4>
+<p>Although CPR6 is not itself presented as a clinical target in the retrieved corpus, yeast systems that include CPR6 are directly used to interpret cellular consequences of Hsp90 inhibitors. For example, the anticancer Hsp90 inhibitor <strong>NVP-AUY922 (luminespib)</strong> is discussed in the context of yeast Hsp90 conformational mutants; cochaperone balance (including Cpr6) helps interpret how conformational progression relates to inhibitor sensitivity (mercier2023hsp90mutantswith pages 1-2).</p>
+<h3 id="9-summary-best-supported-functional-annotation-evidence-weighted">9) Summary: best-supported functional annotation (evidence-weighted)</h3>
+<table>
+<thead>
+<tr>
+<th>Category</th>
+<th>Summary for <strong>S. cerevisiae CPR6</strong> (YLR216C; UniProt P53691)</th>
+<th>Key references with year, DOI URL</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Identity/domains</td>
+<td><strong>CPR6</strong> encodes a <strong>CyP40-like cyclophilin</strong> with an <strong>N-terminal peptidyl-prolyl cis-trans isomerase (PPIase/cyclophilin) domain</strong> and a <strong>C-terminal tetratricopeptide repeat (TPR) domain</strong> flanked by charged regions; it is one of two yeast CyP40 homologs (Cpr6/Cpr7). TPR-containing cochaperones bind the <strong>Hsp90 C-terminal MEEVD</strong> motif, placing Cpr6 in the Hsp90 cochaperone network (tenge2015thehsp90cochaperones pages 1-2, dolinski1998cns1encodesan pages 1-2, tenge2015thehsp90cochaperones media e3c93753).</td>
+<td>Duina et al., 1996, <em>Yeast</em>, https://doi.org/10.1002/(sici)1097-0061(199608)12:10&lt;943::aid-yea997&gt;3.0.co;2-3; Dolinski et al., 1998, <em>MCB</em>, https://doi.org/10.1128/mcb.18.12.7344; Tenge et al., 2015, <em>Eukaryot Cell</em>, https://doi.org/10.1128/EC.00170-14</td>
+</tr>
+<tr>
+<td>Molecular function</td>
+<td>Cpr6 is a <strong>cyclophilin-family PPIase</strong> that catalyzes <strong>cis-trans isomerization of Xaa-Pro peptide bonds</strong>. Biochemically, it is a <strong>stronger PPIase than Cpr7</strong> but a <strong>weaker chaperone</strong>; the functional split suggests overlapping but non-identical roles of the two yeast CyP40 proteins. Cpr6 is also described as a CsA-sensitive cyclophilin class member by family definition, though direct CPR6-specific in vivo CsA phenotypes are less developed than for Cpr7 (mayr2000cpr6andcpr7 pages 1-1, dolinski1998cns1encodesan pages 1-2).</td>
+<td>Mayr et al., 2000, <em>J Biol Chem</em>, https://doi.org/10.1074/jbc.M005251200; Dolinski et al., 1998, <em>MCB</em>, https://doi.org/10.1128/mcb.18.12.7344</td>
+</tr>
+<tr>
+<td>Hsp90/cochaperone role</td>
+<td>Cpr6 is an <strong>Hsp90-associated immunophilin/cochaperone</strong>. It binds Hsp90 through TPR-mediated recognition of the Hsp90 tail and modulates the Hsp90 conformational cycle. Recent yeast genetics supports a model in which <strong>Cpr6 stabilizes the closed conformation of Hsp90 and counteracts Hch1</strong>, acting as a conformational “pacemaker.” Earlier biochemical work also showed modest stimulation of Hsp90 ATPase activity by Cpr6 (forafonov2008p23sba1pprotectsagaints pages 26-30, mercier2023hsp90mutantswith pages 1-2).</td>
+<td>Mercier et al., 2023, <em>PLOS Genet</em>, https://doi.org/10.1371/journal.pgen.1010772; Mayr et al., 2000, <em>J Biol Chem</em>, https://doi.org/10.1074/jbc.M005251200</td>
+</tr>
+<tr>
+<td>Interaction partners</td>
+<td>Experimental copurification/isolation studies recovered <strong>Hsp90, Hsp70, and the client Ura2</strong> with Cpr6. Cpr6 also associates with the <strong>intact ribosome</strong> and ribosomal proteins from both subunits. Unlike Cpr7, <strong>Cns1 was found in complexes with Hsp90 and Cpr7 but not with Cpr6</strong> in one classic study, highlighting paralog-specific network wiring (tenge2015thehsp90cochaperones pages 1-2, dolinski1998cns1encodesan pages 1-2).</td>
+<td>Tenge et al., 2015, <em>Eukaryot Cell</em>, https://doi.org/10.1128/EC.00170-14; Dolinski et al., 1998, <em>MCB</em>, https://doi.org/10.1128/mcb.18.12.7344</td>
+</tr>
+<tr>
+<td>Ribosome/translation link</td>
+<td>Cpr6 has a documented <strong>ribosome interaction</strong>, linking it to translation/proteostasis. The <strong>TPR domain plus adjacent C-terminal basic residues</strong> contribute to ribosome association; truncation or mutation of this region disrupts ribosome binding. This provides direct evidence that CPR6 functions near the protein synthesis machinery, not only in soluble Hsp90 complexes (tenge2015thehsp90cochaperones pages 1-2, tenge2015thehsp90cochaperones pages 5-6, tenge2015thehsp90cochaperones media e3c93753).</td>
+<td>Tenge et al., 2015, <em>Eukaryot Cell</em>, https://doi.org/10.1128/EC.00170-14</td>
+</tr>
+<tr>
+<td>Phenotypes</td>
+<td><strong>CPR6 deletion is viable</strong> and typically shows <strong>no obvious/noticeable growth defect</strong>, contrasting with <strong>CPR7 deletion</strong>, which causes slow or temperature-sensitive growth. <strong>Overexpression of CPR6 exacerbates growth defects in cns1-G90D</strong> cells, and Cpr6 variants defective in ribosome/Hsp90 interaction lose this overexpression phenotype. CPR6 overexpression does <strong>not</strong> substitute for CPR7 in rescuing cpr7 phenotypes, supporting partial specialization rather than redundancy (tenge2015thehsp90cochaperones pages 5-6, dolinski1998cns1encodesan pages 1-2, tenge2015thehsp90cochaperones pages 1-2).</td>
+<td>Duina et al., 1996, <em>Yeast</em>, https://doi.org/10.1002/(sici)1097-0061(199608)12:10&lt;943::aid-yea997&gt;3.0.co;2-3; Dolinski et al., 1998, <em>MCB</em>, https://doi.org/10.1128/mcb.18.12.7344; Tenge et al., 2015, <em>Eukaryot Cell</em>, https://doi.org/10.1128/EC.00170-14</td>
+</tr>
+<tr>
+<td>Quantitative data</td>
+<td>Reported quantitative comparisons include: <strong>Cpr6 PPIase activity up to ~100-fold higher than Cpr7</strong>; Cpr6 shows <strong>much lower chaperone activity than Cpr7</strong>; Cpr6 alone <strong>slightly increases Hsp90 ATPase activity (~2-fold)</strong> and can further enhance <strong>Aha1-stimulated Hsp90 ATPase</strong> in vitro. Tenge et al. also mapped a functionally important <strong>aa 171–371</strong> C-terminal region and used <strong>60 mM hygromycin B</strong> in translation-stress assays (tenge2015thehsp90cochaperones pages 5-6, mayr2000cpr6andcpr7 pages 1-1, forafonov2008p23sba1pprotectsagaints pages 26-30).</td>
+<td>Mayr et al., 2000, <em>J Biol Chem</em>, https://doi.org/10.1074/jbc.M005251200; Tenge et al., 2015, <em>Eukaryot Cell</em>, https://doi.org/10.1128/EC.00170-14</td>
+</tr>
+<tr>
+<td>Client/pathway evidence</td>
+<td>In Hsp90-dependent signaling assays, <strong>Cpr7, not Cpr6, is the stronger determinant</strong> of heterologous client outputs: <strong>CPR7 deletion reduces glucocorticoid receptor activity</strong> and impacts <strong>v-Src/pp60v-src</strong> function, whereas <strong>CPR6 deletion does not measurably reduce GR activity</strong> in the same way. These studies imply that CPR6 participates in the Hsp90 system but is not the principal CyP40 paralog for those tested signaling clients (duina1996acyclophilinfunction pages 1-2).</td>
+<td>Duina et al., 1996, <em>Science</em>, https://doi.org/10.1126/science.274.5293.1713</td>
+</tr>
+<tr>
+<td>Current understanding</td>
+<td>The current synthesis is that Cpr6 is best annotated as a <strong>nonessential cytosolic Hsp90-associated cyclophilin cochaperone</strong> whose primary experimentally supported activities are <strong>prolyl isomerization</strong>, <strong>Hsp90 conformational regulation</strong>, and <strong>association with ribosome-linked proteostasis machinery</strong>. Compared with Cpr7, Cpr6 appears more enzymatically active as a PPIase but less central for several benchmark Hsp90 client phenotypes, underscoring <strong>functional divergence of the two yeast CyP40 paralogs</strong> (mayr2000cpr6andcpr7 pages 1-1, rios2024insightsintohsp90 pages 1-2, mercier2023hsp90mutantswith pages 1-2).</td>
+<td>Mayr et al., 2000, <em>J Biol Chem</em>, https://doi.org/10.1074/jbc.M005251200; Rios et al., 2024, <em>Front Mol Biosci</em>, https://doi.org/10.3389/fmolb.2024.1325590; Mercier et al., 2023, <em>PLOS Genet</em>, https://doi.org/10.1371/journal.pgen.1010772</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the experimentally supported functional annotation of yeast CPR6, emphasizing domain architecture, molecular and cochaperone activities, interaction partners, ribosome linkage, phenotypes, and quantitative findings most relevant for gene annotation.</em></p>
+<p><strong>Evidence-weighted functional statement:</strong><br />
+CPR6 encodes a <strong>nonessential cytosolic CyP40-like cyclophilin</strong> whose most strongly supported functions are (i) <strong>PPIase catalysis</strong> of Xaa–Pro bond isomerization, (ii) <strong>TPR-mediated participation in the Hsp90 cochaperone network</strong> (including regulation of Hsp90 conformational cycling), and (iii) <strong>physical association with intact ribosomes</strong> linking Hsp90 cochaperone function to translation-associated proteostasis (mayr2000cpr6andcpr7 pages 1-1, tenge2015thehsp90cochaperones pages 1-2, mercier2023hsp90mutantswith pages 1-2).</p>
+<h3 id="10-key-supporting-figure">10) Key supporting figure</h3>
+<p>A domain/interactions schematic and mapping of Cpr6 determinants for Hsp90 vs ribosome association is shown in Tenge et al. (2015) (tenge2015thehsp90cochaperones media e3c93753).</p>
+<h3 id="references-urls-and-publication-dates-where-available">References (URLs and publication dates where available)</h3>
+<ul>
+<li>Duina AA et al. <em>Identification of two CyP-40-like cyclophilins in Saccharomyces cerevisiae…</em> <strong>Yeast</strong>. 1996. https://doi.org/10.1002/(sici)1097-0061(199608)12:10&lt;943::aid-yea997&gt;3.0.co;2-3 (duina1996identificationoftwo pages 1-2)</li>
+<li>Duina AA et al. <em>A cyclophilin function in Hsp90-dependent signal transduction.</em> <strong>Science</strong>. 1996. https://doi.org/10.1126/science.274.5293.1713 (duina1996acyclophilinfunction pages 1-2)</li>
+<li>Dolinski KJ et al. <em>CNS1 Encodes an Essential p60/Sti1 Homolog…</em> <strong>Molecular and Cellular Biology</strong>. 1998. https://doi.org/10.1128/mcb.18.12.7344 (dolinski1998cns1encodesan pages 1-2)</li>
+<li>Mayr C et al. <em>Cpr6 and Cpr7… differ in their functional properties.</em> <strong>J Biol Chem</strong>. 2000. https://doi.org/10.1074/jbc.M005251200 (mayr2000cpr6andcpr7 pages 1-1)</li>
+<li>Tenge VR et al. <em>The Hsp90 Cochaperones Cpr6, Cpr7, and Cns1 Interact with the Intact Ribosome.</em> <strong>Eukaryotic Cell</strong>. <strong>Jan 2015</strong>. https://doi.org/10.1128/EC.00170-14 (tenge2015thehsp90cochaperones pages 1-2)</li>
+<li>Mercier R et al. <em>Hsp90 mutants with distinct defects provide novel insights into cochaperone regulation of the folding cycle.</em> <strong>PLOS Genetics</strong>. <strong>May 25, 2023</strong>. https://doi.org/10.1371/journal.pgen.1010772 (mercier2023hsp90mutantswith pages 1-2)</li>
+<li>Rios EI et al. <em>Insights into Hsp90 mechanism and in vivo functions learned from studies in the yeast, Saccharomyces cerevisiae.</em> <strong>Frontiers in Molecular Biosciences</strong>. <strong>Feb 8, 2024</strong>. https://doi.org/10.3389/fmolb.2024.1325590 (rios2024insightsintohsp90 pages 1-2)</li>
+<li>Fulton MD et al. <em>Hsp90 and cochaperones have two genetically distinct roles in regulating eEF2 function.</em> <strong>PLOS Genetics</strong>. <strong>Dec 9, 2024</strong>. https://doi.org/10.1371/journal.pgen.1011508 (fulton2024hsp90andcochaperones pages 1-2)</li>
+</ul>
+<p>References</p>
+<ol>
+<li>
+<p>(dolinski1998cns1encodesan pages 1-2): Kara J. Dolinski, Maria E. Cardenas, and Joseph Heitman. Cns1 encodes an essential p60/sti1 homolog in saccharomyces cerevisiae that suppresses cyclophilin 40 mutations and interacts with hsp90. Molecular and Cellular Biology, 18:7344-7352, Dec 1998. URL: https://doi.org/10.1128/mcb.18.12.7344, doi:10.1128/mcb.18.12.7344. This article has 122 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(duina1996identificationoftwo pages 1-2): Andrea A. Duina, James A. Marsh, and Richard F. Gaber. Identification of two cyp‐40‐like cyclophilins in saccharomyces cerevisiae, one of which is required for normal growth. Yeast, 12:943-952, Aug 1996. URL: https://doi.org/10.1002/(sici)1097-0061(199608)12:10&lt;943::aid-yea997&gt;3.0.co;2-3, doi:10.1002/(sici)1097-0061(199608)12:10&lt;943::aid-yea997&gt;3.0.co;2-3. This article has 119 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(tenge2015thehsp90cochaperones pages 1-2): Victoria R. Tenge, Abbey D. Zuehlke, Neelima Shrestha, and Jill L. Johnson. The hsp90 cochaperones cpr6, cpr7, and cns1 interact with the intact ribosome. Eukaryotic Cell, 14:55-63, Jan 2015. URL: https://doi.org/10.1128/ec.00170-14, doi:10.1128/ec.00170-14. This article has 23 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(mayr2000cpr6andcpr7 pages 1-1): Christian Mayr, Klaus Richter, Hauke Lilie, and Johannes Buchner. Cpr6 and cpr7, two closely related hsp90-associated immunophilins from saccharomyces cerevisiae, differ in their functional properties*. The Journal of Biological Chemistry, 275:34140-34146, Nov 2000. URL: https://doi.org/10.1074/jbc.m005251200, doi:10.1074/jbc.m005251200. This article has 152 citations.</p>
+</li>
+<li>
+<p>(tenge2015thehsp90cochaperones media e3c93753): Victoria R. Tenge, Abbey D. Zuehlke, Neelima Shrestha, and Jill L. Johnson. The hsp90 cochaperones cpr6, cpr7, and cns1 interact with the intact ribosome. Eukaryotic Cell, 14:55-63, Jan 2015. URL: https://doi.org/10.1128/ec.00170-14, doi:10.1128/ec.00170-14. This article has 23 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(tenge2015thehsp90cochaperones pages 5-6): Victoria R. Tenge, Abbey D. Zuehlke, Neelima Shrestha, and Jill L. Johnson. The hsp90 cochaperones cpr6, cpr7, and cns1 interact with the intact ribosome. Eukaryotic Cell, 14:55-63, Jan 2015. URL: https://doi.org/10.1128/ec.00170-14, doi:10.1128/ec.00170-14. This article has 23 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(duina1996acyclophilinfunction pages 1-2): Andrea A. Duina, Hui-Chen Jane Chang, James A. Marsh, Susan Lindquist, and Richard F. Gaber. A cyclophilin function in hsp90-dependent signal transduction. Science, 274:1713-1715, Dec 1996. URL: https://doi.org/10.1126/science.274.5293.1713, doi:10.1126/science.274.5293.1713. This article has 275 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(mercier2023hsp90mutantswith pages 1-2): Rebecca Mercier, Danielle Yama, Paul LaPointe, and Jill L. Johnson. Hsp90 mutants with distinct defects provide novel insights into cochaperone regulation of the folding cycle. PLOS Genetics, 19:e1010772, May 2023. URL: https://doi.org/10.1371/journal.pgen.1010772, doi:10.1371/journal.pgen.1010772. This article has 13 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(rios2024insightsintohsp90 pages 1-2): Erick I. Rios, Isabel L. Hunsberger, and Jill L. Johnson. Insights into hsp90 mechanism and in vivo functions learned from studies in the yeast, saccharomyces cerevisiae. Frontiers in Molecular Biosciences, Feb 2024. URL: https://doi.org/10.3389/fmolb.2024.1325590, doi:10.3389/fmolb.2024.1325590. This article has 8 citations.</p>
+</li>
+<li>
+<p>(fulton2024hsp90andcochaperones pages 1-2): Melody D. Fulton, Danielle J. Yama, Ella Dahl, and Jill L. Johnson. Hsp90 and cochaperones have two genetically distinct roles in regulating eef2 function. PLOS Genetics, 20:e1011508, Dec 2024. URL: https://doi.org/10.1371/journal.pgen.1011508, doi:10.1371/journal.pgen.1011508. This article has 5 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(forafonov2008p23sba1pprotectsagaints pages 26-30): F Forafonov. P23/sba1p protects againts hsp90 inhibitors. Unknown journal, 2008.</p>
+</li>
+</ol>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>duina1996acyclophilinfunction pages 1-2</li>
+<li>duina1996identificationoftwo pages 1-2</li>
+<li>https://doi.org/10.1371/journal.pgen.1010772</li>
+<li>https://doi.org/10.1042/EBC20220224</li>
+<li>https://doi.org/10.3389/fmolb.2024.1325590</li>
+<li>https://doi.org/10.1371/journal.pgen.1011508</li>
+<li>https://doi.org/10.1007/s12192-023-01342-z</li>
+<li>https://doi.org/10.1002/(sici</li>
+<li>https://doi.org/10.1128/mcb.18.12.7344;</li>
+<li>https://doi.org/10.1128/EC.00170-14</li>
+<li>https://doi.org/10.1074/jbc.M005251200;</li>
+<li>https://doi.org/10.1128/mcb.18.12.7344</li>
+<li>https://doi.org/10.1371/journal.pgen.1010772;</li>
+<li>https://doi.org/10.1074/jbc.M005251200</li>
+<li>https://doi.org/10.1128/EC.00170-14;</li>
+<li>https://doi.org/10.1126/science.274.5293.1713</li>
+<li>https://doi.org/10.3389/fmolb.2024.1325590;</li>
+<li>https://doi.org/10.1128/mcb.18.12.7344,</li>
+<li>https://doi.org/10.1128/ec.00170-14,</li>
+<li>https://doi.org/10.1074/jbc.m005251200,</li>
+<li>https://doi.org/10.1126/science.274.5293.1713,</li>
+<li>https://doi.org/10.1371/journal.pgen.1010772,</li>
+<li>https://doi.org/10.3389/fmolb.2024.1325590,</li>
+<li>https://doi.org/10.1371/journal.pgen.1011508,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -2842,7 +3279,7 @@
                 <pre><code>id: P53691
 gene_symbol: CPR6
 product_type: PROTEIN
-status: IN_PROGRESS
+status: COMPLETE
 taxon:
   id: NCBITaxon:559292
   label: Saccharomyces cerevisiae
@@ -2871,6 +3308,9 @@ existing_annotations:
       PPIase activity is the core molecular function of CPR6. UniProt describes it as catalyzing
       cis-trans isomerization of proline imidic peptide bonds (EC 5.2.1.8). IDA evidence from
       PMID:10942767 and PMID:9191025 confirms this activity.
+    supported_by:
+    - reference_id: file:yeast/CPR6/CPR6-deep-research-falcon.md
+      supporting_text: Cpr6 contains a **PPIase domain** plus a **TPR domain**
 - term:
     id: GO:0005737
     label: cytoplasm
@@ -3213,6 +3653,9 @@ core_functions:
   locations:
   - id: GO:0005737
     label: cytoplasm
+  supported_by:
+  - reference_id: file:yeast/CPR6/CPR6-deep-research-falcon.md
+    supporting_text: CPR6 encodes a **nonessential cytosolic CyP40-like cyclophilin**
 references:
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO
@@ -3290,13 +3733,16 @@ references:
     co-chaperones.
   findings:
   - statement: CPR6 participates in protein folding as an Hsp90 co-chaperone
+- id: file:yeast/CPR6/CPR6-deep-research-falcon.md
+  title: Falcon deep research report for CPR6
+  findings: []
 </code></pre>
             </div>
         </details>
     </div>
 
     <!-- Pathway Visualization Link -->
-    
+
 
     <style>
         /* Markdown Section Styles */

--- a/genes/yeast/CPR6/CPR6-ai-review.yaml
+++ b/genes/yeast/CPR6/CPR6-ai-review.yaml
@@ -1,7 +1,7 @@
 id: P53691
 gene_symbol: CPR6
 product_type: PROTEIN
-status: IN_PROGRESS
+status: COMPLETE
 taxon:
   id: NCBITaxon:559292
   label: Saccharomyces cerevisiae
@@ -30,6 +30,9 @@ existing_annotations:
       PPIase activity is the core molecular function of CPR6. UniProt describes it as catalyzing
       cis-trans isomerization of proline imidic peptide bonds (EC 5.2.1.8). IDA evidence from
       PMID:10942767 and PMID:9191025 confirms this activity.
+    supported_by:
+    - reference_id: file:yeast/CPR6/CPR6-deep-research-falcon.md
+      supporting_text: Cpr6 contains a **PPIase domain** plus a **TPR domain**
 - term:
     id: GO:0005737
     label: cytoplasm
@@ -372,6 +375,9 @@ core_functions:
   locations:
   - id: GO:0005737
     label: cytoplasm
+  supported_by:
+  - reference_id: file:yeast/CPR6/CPR6-deep-research-falcon.md
+    supporting_text: CPR6 encodes a **nonessential cytosolic CyP40-like cyclophilin**
 references:
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO
@@ -449,3 +455,6 @@ references:
     co-chaperones.
   findings:
   - statement: CPR6 participates in protein folding as an Hsp90 co-chaperone
+- id: file:yeast/CPR6/CPR6-deep-research-falcon.md
+  title: Falcon deep research report for CPR6
+  findings: []

--- a/genes/yeast/CPR6/CPR6-deep-research-falcon.md
+++ b/genes/yeast/CPR6/CPR6-deep-research-falcon.md
@@ -1,0 +1,325 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-11T08:43:34.885488'
+end_time: '2026-05-11T08:59:19.653720'
+duration_seconds: 944.77
+template_file: templates/gene_research_go_focused.md
+template_variables:
+  organism: yeast
+  gene_id: CPR6
+  gene_symbol: CPR6
+  uniprot_accession: P53691
+  protein_description: 'RecName: Full=Peptidyl-prolyl cis-trans isomerase CPR6; Short=PPIase
+    CPR6; EC=5.2.1.8; AltName: Full=Rotamase CPR6;'
+  gene_info: Name=CPR6; OrderedLocusNames=YLR216C; ORFNames=L8167.24;
+  organism_full: Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+  protein_family: Belongs to the cyclophilin-type PPIase family. PPIase D
+  protein_domains: Cyclophilin-like_dom_sf. (IPR029000); Cyclophilin-type_PPIase_CS.
+    (IPR020892); Cyclophilin-type_PPIase_dom. (IPR002130); TPR-like_helical_dom_sf.
+    (IPR011990); TPR_rpt. (IPR019734)
+provider_config:
+  timeout: 600
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 24
+---
+
+## Question
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** P53691
+- **Protein Description:** RecName: Full=Peptidyl-prolyl cis-trans isomerase CPR6; Short=PPIase CPR6; EC=5.2.1.8; AltName: Full=Rotamase CPR6;
+- **Gene Information:** Name=CPR6; OrderedLocusNames=YLR216C; ORFNames=L8167.24;
+- **Organism (full):** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+- **Protein Family:** Belongs to the cyclophilin-type PPIase family. PPIase D
+- **Key Domains:** Cyclophilin-like_dom_sf. (IPR029000); Cyclophilin-type_PPIase_CS. (IPR020892); Cyclophilin-type_PPIase_dom. (IPR002130); TPR-like_helical_dom_sf. (IPR011990); TPR_rpt. (IPR019734)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "CPR6" matches the protein description above**
+2. **Verify the organism is correct:** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'CPR6' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **CPR6** (gene ID: CPR6, UniProt: P53691) in yeast.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** P53691
+- **Protein Description:** RecName: Full=Peptidyl-prolyl cis-trans isomerase CPR6; Short=PPIase CPR6; EC=5.2.1.8; AltName: Full=Rotamase CPR6;
+- **Gene Information:** Name=CPR6; OrderedLocusNames=YLR216C; ORFNames=L8167.24;
+- **Organism (full):** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+- **Protein Family:** Belongs to the cyclophilin-type PPIase family. PPIase D
+- **Key Domains:** Cyclophilin-like_dom_sf. (IPR029000); Cyclophilin-type_PPIase_CS. (IPR020892); Cyclophilin-type_PPIase_dom. (IPR002130); TPR-like_helical_dom_sf. (IPR011990); TPR_rpt. (IPR019734)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "CPR6" matches the protein description above**
+2. **Verify the organism is correct:** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'CPR6' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **CPR6** (gene ID: CPR6, UniProt: P53691) in yeast.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Research report: **CPR6 (YLR216C; UniProt P53691)** in *Saccharomyces cerevisiae* (S288c)
+
+### 0) Target verification (critical identity check)
+The literature analyzed here explicitly refers to *Saccharomyces cerevisiae* **CPR6/YLR216C**, encoding a **cyclophilin 40 (CyP40)-like peptidyl-prolyl cis–trans isomerase** with an **N-terminal cyclophilin/PPIase domain** and a **C-terminal TPR domain**, matching UniProt accession **P53691** and the domain architecture you provided (PPIase + TPR repeats) (dolinski1998cns1encodesan pages 1-2, duina1996identificationoftwo pages 1-2, tenge2015thehsp90cochaperones pages 1-2).
+
+### 1) Key concepts and definitions (current understanding)
+
+#### 1.1 Cyclophilins and PPIase activity
+Cyclophilins are **peptidyl-prolyl cis–trans isomerases (PPIases; EC 5.2.1.8)** that catalyze the interconversion of cis/trans conformations at **Xaa–Pro peptide bonds**, which can be rate-limiting during protein folding (mayr2000cpr6andcpr7 pages 1-1). In the yeast Hsp90 system, cyclophilins of the **CyP40 class** (including Cpr6 and Cpr7) are “large immunophilins” that couple a cyclophilin domain to **TPR repeats**, enabling docking to Hsp90 (mayr2000cpr6andcpr7 pages 1-1, dolinski1998cns1encodesan pages 1-2).
+
+#### 1.2 TPR domains and Hsp90 cochaperones
+Many Hsp90 cochaperones contain **tetratricopeptide repeats (TPRs)** that bind the conserved **C-terminal MEEVD motif** of Hsp90, mediating a regulated exchange of cochaperones during the ATP-dependent Hsp90 folding cycle (tenge2015thehsp90cochaperones pages 1-2, dolinski1998cns1encodesan pages 1-2). CPR6 is one of these TPR cochaperones and is considered part of the cytosolic Hsp90 chaperone machine (tenge2015thehsp90cochaperones pages 1-2, mayr2000cpr6andcpr7 pages 1-1).
+
+### 2) CPR6 protein architecture, localization, and interaction network
+
+#### 2.1 Domain architecture (what CPR6 encodes)
+Cpr6 contains a **PPIase domain** plus a **TPR domain** “flanked by charged regions,” consistent with a dual enzymatic + cochaperone/adaptor role (tenge2015thehsp90cochaperones pages 1-2). A figure mapping truncations/mutations and their effects on interactions shows that the C-terminal region is crucial for ribosome association and helps resolve which regions drive Hsp90 vs ribosome binding (tenge2015thehsp90cochaperones media e3c93753).
+
+#### 2.2 Subcellular context / where CPR6 acts
+The retrieved experimental evidence places Cpr6 primarily in the **cytosolic proteostasis network** through its association with cytosolic Hsp90 (explicitly described as a cytosolic chaperone) and through a direct physical association with **intact ribosomes** (mayr2000cpr6andcpr7 pages 1-1, tenge2015thehsp90cochaperones pages 1-2). Specifically, purification of Cpr6 copurified multiple ribosomal proteins from **both small and large subunits**, demonstrating ribosome association rather than a purely soluble Hsp90 complex membership (tenge2015thehsp90cochaperones pages 1-2, tenge2015thehsp90cochaperones pages 5-6).
+
+#### 2.3 Protein–protein interactions (directly supported)
+Key experimentally supported partners/associations include:
+- **Hsp90**: Cpr6 binds Hsp90 in biochemical pull-down experiments (GST-Cpr6 can recover Hsp90 from yeast or bacterial lysates expressing Hsp90) (duina1996acyclophilinfunction pages 1-2). The broader cochaperone framework also predicts TPR-mediated Hsp90 tail binding (dolinski1998cns1encodesan pages 1-2).
+- **Hsp70**: Cpr6 isolates can copurify Hsp70 as part of cochaperone/client-associated complexes (tenge2015thehsp90cochaperones pages 1-2).
+- **Ura2** (Hsp90 client): Cpr6 purification copurifies **Ura2**, an Hsp90 client required for pyrimidine biosynthesis, linking Cpr6 to client-facing Hsp90 function (tenge2015thehsp90cochaperones pages 1-2).
+- **Ribosome**: Cpr6 interacts with intact ribosomes; only Cpr6 (among tested cochaperones in that study) and Zuo1 showed robust ribosome interaction (tenge2015thehsp90cochaperones pages 5-6).
+- **Cns1/Cpr7 network differences**: In classic complex isolation work, **Cns1** was detected in complexes with Hsp90 and Cpr7, but not with Cpr6, implying paralog-specific wiring of Hsp90 cochaperone subcomplexes (dolinski1998cns1encodesan pages 1-2).
+
+### 3) Primary molecular function: catalysis and substrate specificity
+
+#### 3.1 Catalyzed reaction
+Cpr6’s primary enzymatic activity is **peptidyl-prolyl cis–trans isomerization** at Xaa–Pro bonds (PPIase activity) (mayr2000cpr6andcpr7 pages 1-1).
+
+#### 3.2 Substrate specificity (what is known)
+The retrieved texts support the **general cyclophilin substrate class** (Xaa–Pro peptide bonds) but do not provide a CPR6-specific physiological substrate list; instead, they emphasize its integration into **Hsp90-dependent client maturation** and ribosome-associated proteostasis (mayr2000cpr6andcpr7 pages 1-1, tenge2015thehsp90cochaperones pages 1-2). The best-supported “substrate context” is therefore: (i) **folding intermediates/clients handled by Hsp90**, and (ii) proteins associated with translation machinery via ribosome binding (tenge2015thehsp90cochaperones pages 1-2, tenge2015thehsp90cochaperones pages 5-6).
+
+#### 3.3 Quantitative biochemical properties (directly stated)
+- **Relative PPIase strength:** Cpr6 displays **up to ~100-fold higher PPIase activity than Cpr7** (mayr2000cpr6andcpr7 pages 1-1).
+- **Chaperone activity comparison:** Cpr6 has **much lower intrinsic chaperone activity** than Cpr7, despite higher PPIase activity, implying functional specialization between paralogs (mayr2000cpr6andcpr7 pages 1-1).
+
+### 4) CPR6 function in pathways/biological processes
+
+#### 4.1 Role as an Hsp90 cochaperone (mechanistic framing)
+Cpr6 is best described as an **Hsp90-associated immunophilin cochaperone** that regulates the Hsp90 folding cycle through TPR-mediated association and (in at least some contexts) through conformational control of Hsp90 states (mayr2000cpr6andcpr7 pages 1-1, mercier2023hsp90mutantswith pages 1-2).
+
+A 2023 yeast genetics study using distinct Hsp90 conformational mutants supports a model in which **Hch1 destabilizes Hsp90–nucleotide interaction and hinders formation of the closed conformation**, while **Cpr6 counteracts Hch1 by stabilizing the closed conformation** (mercier2023hsp90mutantswith pages 1-2). This positions Cpr6 as a regulator of the **timing** of transitions in the Hsp90 cycle, rather than merely an accessory enzyme (mercier2023hsp90mutantswith pages 1-2).
+
+#### 4.2 Link to translation: ribosome association and proteostasis
+Tenge et al. provide strong evidence that Cpr6 is a ribosome-interacting Hsp90 cochaperone, describing this as a “novel link between the Hsp90 molecular-chaperone machine and protein synthesis” (tenge2015thehsp90cochaperones pages 1-2). Functionally:
+- The **TPR + flanking region** contains **distinct binding sites for Hsp90, Ura2, and the ribosome** (tenge2015thehsp90cochaperones pages 5-6).
+- Truncation or alteration of **basic residues near the C-terminus** disrupts ribosome interaction (tenge2015thehsp90cochaperones pages 1-2).
+- CPR6 overexpression phenotypes in sensitized backgrounds depend on intact Hsp90/ribosome interaction (tenge2015thehsp90cochaperones pages 5-6).
+
+### 5) Genetics and phenotypes (what perturbing CPR6 does)
+
+#### 5.1 Viability and baseline growth
+Yeast lacking **CPR6** are viable and in multiple reports show **no obvious/noticeable growth defect** under standard conditions, in contrast to CPR7 and CNS1 perturbations (dolinski1998cns1encodesan pages 1-2, tenge2015thehsp90cochaperones pages 1-2).
+
+#### 5.2 Context-dependent phenotypes (interaction with the cochaperone network)
+- In a temperature-sensitive **cns1-G90D** background, **overexpression of CPR6 exacerbates growth defects**, and Cpr6 mutants defective in ribosome interaction fail to produce this negative effect (tenge2015thehsp90cochaperones pages 1-2, tenge2015thehsp90cochaperones pages 5-6).
+- In translation-stress assays, loss of CPR7 or CNS1 mutations confer **hygromycin sensitivity**, whereas CPR6 deletion did **not** under the tested conditions, suggesting non-identical contributions of CyP40 paralogs to translation-linked stress phenotypes (tenge2015thehsp90cochaperones pages 5-6).
+
+#### 5.3 Hsp90-dependent signal transduction clients (client-specific outputs)
+A seminal study on Hsp90-dependent signaling in yeast provides client-selective phenotypes:
+- **Glucocorticoid receptor (GR):** deleting **CPR6** did *not* reduce hormone-dependent GR activity (in contrast to CPR7 deletion, which reduced GR activity markedly) (duina1996acyclophilinfunction pages 1-2).
+- **Oncogenic tyrosine kinase (v-Src/pp60v-src-like client):** in **cpr6Δ** cells, kinase **activity decreased by ~50%** while accumulation was unaffected, consistent with a role in client maturation/activation rather than expression (duina1996acyclophilinfunction pages 1-2).
+These results support the concept that Cpr6 participates in the Hsp90 system but is **not uniformly required** for all Hsp90 clients; instead, it can have **client- and context-specific** effects (duina1996acyclophilinfunction pages 1-2, mayr2000cpr6andcpr7 pages 1-1).
+
+### 6) Recent developments (2023–2024) and expert analysis
+
+Recent work increasingly frames cochaperones (including Cpr6) as regulators of **Hsp90 conformational transitions** and client fate. Key 2023–2024 advances captured in the retrieved corpus are summarized below.
+
+| Paper (year) | Type | Key CPR6-related finding | Quantitative/statistical data | URL/DOI | Publication date if stated |
+|---|---|---|---|---|---|
+| Mercier et al. (2023) | Primary research | Using yeast Hsp90 mutants, the authors show that **Cpr6 counteracts Hch1 and stabilizes the closed conformation of Hsp90**, supporting a role for Cpr6 as a conformational regulator/pacemaker of the Hsp90 cycle; they also report that Hsp90 inhibitor sensitivity tracks with conformational-state defects rather than simply ATPase activity (mercier2023hsp90mutantswith pages 1-2) | Yeast has **at least 12 cochaperones**; Hsp90 supports folding/activation of an estimated **10–15% of the yeast and human proteome**; mutants defective in the **loading** phase are most sensitive to **NVP-AUY922**, whereas **reopening-phase** mutants are most resistant (mercier2023hsp90mutantswith pages 1-2) | https://doi.org/10.1371/journal.pgen.1010772 | Published **May 25, 2023** (mercier2023hsp90mutantswith pages 1-2) |
+| Backe et al. (2023) | Review | Reviews how **S. cerevisiae** has been used to decipher Hsp90 function and cochaperone biology; relevant to CPR6 because yeast cochaperone networks, including TPR cochaperones such as Cpr6, are presented as central tools for defining conserved Hsp90 mechanisms (rios2024insightsintohsp90 pages 1-2) | Emphasizes conservation of yeast-to-metazoan Hsp90 machinery; no CPR6-specific numeric value in the excerpted context (rios2024insightsintohsp90 pages 1-2) | https://doi.org/10.1042/EBC20220224 | Published **September 2023** |
+| Rios et al. (2024) | Review | Synthesizes **yeast-derived mechanistic insights into Hsp90** and highlights that Hsp90–cochaperone interactions are highly conserved between yeast and mammals; useful for CPR6 because it places Cpr6 within the conserved cytosolic Hsp90 cochaperone system and notes that deletion of **CPR6 negatively affects critical roles regulating the folding pathway in vivo** (rios2024insightsintohsp90 pages 1-2) | Yeast Hsp90 isoforms are **97% identical**; reducing Hsc82/Hsp82 abundance to **1%–5% of wild-type** supports growth at optimal temperature but not elevated temperature (Hsp90 system context relevant to CPR6 function) (rios2024insightsintohsp90 pages 1-2) | https://doi.org/10.3389/fmolb.2024.1325590 | Published **February 8, 2024** (rios2024insightsintohsp90 pages 1-2) |
+| Fulton et al. (2024) | Primary research | Shows Hsp90 and cochaperones have **two genetically distinct roles in regulating eEF2**; the study frames cochaperone subnetworks and explicitly includes **CPR6** among tested yeast cochaperone backgrounds, extending CPR6 relevance into translation/proteostasis-focused Hsp90 biology (fulton2024hsp90andcochaperones pages 1-2) | Hsp90 is required for maintaining **~20% of the yeast proteome** in an active/folded state; estimated abundance is **~229,000 Hsc82/Hsp82 molecules per cell** and **145,000 Eft1/Eft2 molecules per cell** (fulton2024hsp90andcochaperones pages 1-2) | https://doi.org/10.1371/journal.pgen.1011508 | Published **December 9, 2024** (fulton2024hsp90andcochaperones pages 1-2) |
+| Edkins et al. (2023) | Meeting report/review | Summarizes the 10th International Symposium on the Hsp90 chaperone machine; includes discussion of new yeast Hsp90 mutant data indicating that **Cpr6 release appears necessary for later steps of the Hsp90 cycle**, providing expert community-level interpretation of emerging CPR6 biology (mercier2023hsp90mutantswith pages 1-2) | No CPR6-specific numeric statistic in the excerpted context; value is as an expert synthesis of unpublished/recently emerging data (mercier2023hsp90mutantswith pages 1-2) | https://doi.org/10.1007/s12192-023-01342-z | Published **May 2023** (mercier2023hsp90mutantswith pages 1-2) |
+
+
+*Table: This table summarizes 2023–2024 papers and reviews most relevant to yeast CPR6 within the Hsp90 cochaperone system. It highlights recent mechanistic advances, quantitative context, and publication details useful for functional annotation.*
+
+Two particularly relevant “expert interpretation” points from 2023–2024 sources are:
+1) **Conformational regulation over ATPase-centric models:** Mercier et al. argue that timing of transitions into/out of Hsp90 closed conformations is tightly regulated by cochaperones, including Cpr6, shifting emphasis from ATPase rate alone toward conformational control (mercier2023hsp90mutantswith pages 1-2).
+2) **Proteostasis scale and translation linkage:** Fulton et al. emphasize that Hsp90 supports a substantial fraction of the proteome and that cochaperone networks interact with translation fidelity pathways; although their focal client is eEF2 and other cochaperones (e.g., Cpr7, Cns1, Hgh1), the paper explicitly situates CPR6 within the cochaperone landscape being interrogated (fulton2024hsp90andcochaperones pages 1-2).
+
+### 7) Quantitative/statistical highlights (recent studies and key primary results)
+
+- **Proteome fraction:** Hsp90 is reported to be required for maintaining **~20% of the yeast proteome** in an active, folded conformation (fulton2024hsp90andcochaperones pages 1-2). This statistic provides the “systems” context in which cochaperones like Cpr6 operate.
+- **Protein abundance estimates (per cell):** Hsp90 (Hsc82/Hsp82) is estimated at **~229,000 molecules per cell** and eEF2 at **145,000 molecules per cell** (fulton2024hsp90andcochaperones pages 1-2).
+- **Client effect size (CPR6 deletion):** ~**50% decrease** in activity of an oncogenic tyrosine kinase client in **cpr6Δ** cells (duina1996acyclophilinfunction pages 1-2).
+- **PPIase magnitude (paralog comparison):** Cpr6 has **up to ~100-fold higher PPIase activity** than Cpr7 (mayr2000cpr6andcpr7 pages 1-1).
+- **Domain mapping / construct-based quantitation:** A functionally critical Cpr6 region spanning **aa 171–371** was sufficient for strong overexpression-linked growth effects in a sensitized background, even without the PPIase domain, indicating that at least some in vivo phenotypes are mediated by non-catalytic regions (tenge2015thehsp90cochaperones pages 5-6).
+
+### 8) Current applications and real-world implementations
+
+#### 8.1 Yeast CPR6 as a tractable model for conserved Hsp90–cochaperone biology
+The most mature real-world “implementation” is methodological: yeast provides a genetically powerful system to dissect conserved chaperone mechanisms and to map cochaperone-specific regulation. CPR6 is repeatedly used as part of that cochaperone toolkit, enabling inference relevant to eukaryotic Hsp90 systems broadly (rios2024insightsintohsp90 pages 1-2, mercier2023hsp90mutantswith pages 1-2).
+
+#### 8.2 Drug-mechanism relevance via Hsp90 inhibitor studies
+Although CPR6 is not itself presented as a clinical target in the retrieved corpus, yeast systems that include CPR6 are directly used to interpret cellular consequences of Hsp90 inhibitors. For example, the anticancer Hsp90 inhibitor **NVP-AUY922 (luminespib)** is discussed in the context of yeast Hsp90 conformational mutants; cochaperone balance (including Cpr6) helps interpret how conformational progression relates to inhibitor sensitivity (mercier2023hsp90mutantswith pages 1-2).
+
+### 9) Summary: best-supported functional annotation (evidence-weighted)
+
+| Category | Summary for **S. cerevisiae CPR6** (YLR216C; UniProt P53691) | Key references with year, DOI URL |
+|---|---|---|
+| Identity/domains | **CPR6** encodes a **CyP40-like cyclophilin** with an **N-terminal peptidyl-prolyl cis-trans isomerase (PPIase/cyclophilin) domain** and a **C-terminal tetratricopeptide repeat (TPR) domain** flanked by charged regions; it is one of two yeast CyP40 homologs (Cpr6/Cpr7). TPR-containing cochaperones bind the **Hsp90 C-terminal MEEVD** motif, placing Cpr6 in the Hsp90 cochaperone network (tenge2015thehsp90cochaperones pages 1-2, dolinski1998cns1encodesan pages 1-2, tenge2015thehsp90cochaperones media e3c93753). | Duina et al., 1996, *Yeast*, https://doi.org/10.1002/(sici)1097-0061(199608)12:10<943::aid-yea997>3.0.co;2-3; Dolinski et al., 1998, *MCB*, https://doi.org/10.1128/mcb.18.12.7344; Tenge et al., 2015, *Eukaryot Cell*, https://doi.org/10.1128/EC.00170-14 |
+| Molecular function | Cpr6 is a **cyclophilin-family PPIase** that catalyzes **cis-trans isomerization of Xaa-Pro peptide bonds**. Biochemically, it is a **stronger PPIase than Cpr7** but a **weaker chaperone**; the functional split suggests overlapping but non-identical roles of the two yeast CyP40 proteins. Cpr6 is also described as a CsA-sensitive cyclophilin class member by family definition, though direct CPR6-specific in vivo CsA phenotypes are less developed than for Cpr7 (mayr2000cpr6andcpr7 pages 1-1, dolinski1998cns1encodesan pages 1-2). | Mayr et al., 2000, *J Biol Chem*, https://doi.org/10.1074/jbc.M005251200; Dolinski et al., 1998, *MCB*, https://doi.org/10.1128/mcb.18.12.7344 |
+| Hsp90/cochaperone role | Cpr6 is an **Hsp90-associated immunophilin/cochaperone**. It binds Hsp90 through TPR-mediated recognition of the Hsp90 tail and modulates the Hsp90 conformational cycle. Recent yeast genetics supports a model in which **Cpr6 stabilizes the closed conformation of Hsp90 and counteracts Hch1**, acting as a conformational “pacemaker.” Earlier biochemical work also showed modest stimulation of Hsp90 ATPase activity by Cpr6 (forafonov2008p23sba1pprotectsagaints pages 26-30, mercier2023hsp90mutantswith pages 1-2). | Mercier et al., 2023, *PLOS Genet*, https://doi.org/10.1371/journal.pgen.1010772; Mayr et al., 2000, *J Biol Chem*, https://doi.org/10.1074/jbc.M005251200 |
+| Interaction partners | Experimental copurification/isolation studies recovered **Hsp90, Hsp70, and the client Ura2** with Cpr6. Cpr6 also associates with the **intact ribosome** and ribosomal proteins from both subunits. Unlike Cpr7, **Cns1 was found in complexes with Hsp90 and Cpr7 but not with Cpr6** in one classic study, highlighting paralog-specific network wiring (tenge2015thehsp90cochaperones pages 1-2, dolinski1998cns1encodesan pages 1-2). | Tenge et al., 2015, *Eukaryot Cell*, https://doi.org/10.1128/EC.00170-14; Dolinski et al., 1998, *MCB*, https://doi.org/10.1128/mcb.18.12.7344 |
+| Ribosome/translation link | Cpr6 has a documented **ribosome interaction**, linking it to translation/proteostasis. The **TPR domain plus adjacent C-terminal basic residues** contribute to ribosome association; truncation or mutation of this region disrupts ribosome binding. This provides direct evidence that CPR6 functions near the protein synthesis machinery, not only in soluble Hsp90 complexes (tenge2015thehsp90cochaperones pages 1-2, tenge2015thehsp90cochaperones pages 5-6, tenge2015thehsp90cochaperones media e3c93753). | Tenge et al., 2015, *Eukaryot Cell*, https://doi.org/10.1128/EC.00170-14 |
+| Phenotypes | **CPR6 deletion is viable** and typically shows **no obvious/noticeable growth defect**, contrasting with **CPR7 deletion**, which causes slow or temperature-sensitive growth. **Overexpression of CPR6 exacerbates growth defects in cns1-G90D** cells, and Cpr6 variants defective in ribosome/Hsp90 interaction lose this overexpression phenotype. CPR6 overexpression does **not** substitute for CPR7 in rescuing cpr7 phenotypes, supporting partial specialization rather than redundancy (tenge2015thehsp90cochaperones pages 5-6, dolinski1998cns1encodesan pages 1-2, tenge2015thehsp90cochaperones pages 1-2). | Duina et al., 1996, *Yeast*, https://doi.org/10.1002/(sici)1097-0061(199608)12:10<943::aid-yea997>3.0.co;2-3; Dolinski et al., 1998, *MCB*, https://doi.org/10.1128/mcb.18.12.7344; Tenge et al., 2015, *Eukaryot Cell*, https://doi.org/10.1128/EC.00170-14 |
+| Quantitative data | Reported quantitative comparisons include: **Cpr6 PPIase activity up to ~100-fold higher than Cpr7**; Cpr6 shows **much lower chaperone activity than Cpr7**; Cpr6 alone **slightly increases Hsp90 ATPase activity (~2-fold)** and can further enhance **Aha1-stimulated Hsp90 ATPase** in vitro. Tenge et al. also mapped a functionally important **aa 171–371** C-terminal region and used **60 mM hygromycin B** in translation-stress assays (tenge2015thehsp90cochaperones pages 5-6, mayr2000cpr6andcpr7 pages 1-1, forafonov2008p23sba1pprotectsagaints pages 26-30). | Mayr et al., 2000, *J Biol Chem*, https://doi.org/10.1074/jbc.M005251200; Tenge et al., 2015, *Eukaryot Cell*, https://doi.org/10.1128/EC.00170-14 |
+| Client/pathway evidence | In Hsp90-dependent signaling assays, **Cpr7, not Cpr6, is the stronger determinant** of heterologous client outputs: **CPR7 deletion reduces glucocorticoid receptor activity** and impacts **v-Src/pp60v-src** function, whereas **CPR6 deletion does not measurably reduce GR activity** in the same way. These studies imply that CPR6 participates in the Hsp90 system but is not the principal CyP40 paralog for those tested signaling clients (duina1996acyclophilinfunction pages 1-2). | Duina et al., 1996, *Science*, https://doi.org/10.1126/science.274.5293.1713 |
+| Current understanding | The current synthesis is that Cpr6 is best annotated as a **nonessential cytosolic Hsp90-associated cyclophilin cochaperone** whose primary experimentally supported activities are **prolyl isomerization**, **Hsp90 conformational regulation**, and **association with ribosome-linked proteostasis machinery**. Compared with Cpr7, Cpr6 appears more enzymatically active as a PPIase but less central for several benchmark Hsp90 client phenotypes, underscoring **functional divergence of the two yeast CyP40 paralogs** (mayr2000cpr6andcpr7 pages 1-1, rios2024insightsintohsp90 pages 1-2, mercier2023hsp90mutantswith pages 1-2). | Mayr et al., 2000, *J Biol Chem*, https://doi.org/10.1074/jbc.M005251200; Rios et al., 2024, *Front Mol Biosci*, https://doi.org/10.3389/fmolb.2024.1325590; Mercier et al., 2023, *PLOS Genet*, https://doi.org/10.1371/journal.pgen.1010772 |
+
+
+*Table: This table summarizes the experimentally supported functional annotation of yeast CPR6, emphasizing domain architecture, molecular and cochaperone activities, interaction partners, ribosome linkage, phenotypes, and quantitative findings most relevant for gene annotation.*
+
+**Evidence-weighted functional statement:**
+CPR6 encodes a **nonessential cytosolic CyP40-like cyclophilin** whose most strongly supported functions are (i) **PPIase catalysis** of Xaa–Pro bond isomerization, (ii) **TPR-mediated participation in the Hsp90 cochaperone network** (including regulation of Hsp90 conformational cycling), and (iii) **physical association with intact ribosomes** linking Hsp90 cochaperone function to translation-associated proteostasis (mayr2000cpr6andcpr7 pages 1-1, tenge2015thehsp90cochaperones pages 1-2, mercier2023hsp90mutantswith pages 1-2).
+
+### 10) Key supporting figure
+A domain/interactions schematic and mapping of Cpr6 determinants for Hsp90 vs ribosome association is shown in Tenge et al. (2015) (tenge2015thehsp90cochaperones media e3c93753).
+
+### References (URLs and publication dates where available)
+- Duina AA et al. *Identification of two CyP-40-like cyclophilins in Saccharomyces cerevisiae…* **Yeast**. 1996. https://doi.org/10.1002/(sici)1097-0061(199608)12:10<943::aid-yea997>3.0.co;2-3 (duina1996identificationoftwo pages 1-2)
+- Duina AA et al. *A cyclophilin function in Hsp90-dependent signal transduction.* **Science**. 1996. https://doi.org/10.1126/science.274.5293.1713 (duina1996acyclophilinfunction pages 1-2)
+- Dolinski KJ et al. *CNS1 Encodes an Essential p60/Sti1 Homolog…* **Molecular and Cellular Biology**. 1998. https://doi.org/10.1128/mcb.18.12.7344 (dolinski1998cns1encodesan pages 1-2)
+- Mayr C et al. *Cpr6 and Cpr7… differ in their functional properties.* **J Biol Chem**. 2000. https://doi.org/10.1074/jbc.M005251200 (mayr2000cpr6andcpr7 pages 1-1)
+- Tenge VR et al. *The Hsp90 Cochaperones Cpr6, Cpr7, and Cns1 Interact with the Intact Ribosome.* **Eukaryotic Cell**. **Jan 2015**. https://doi.org/10.1128/EC.00170-14 (tenge2015thehsp90cochaperones pages 1-2)
+- Mercier R et al. *Hsp90 mutants with distinct defects provide novel insights into cochaperone regulation of the folding cycle.* **PLOS Genetics**. **May 25, 2023**. https://doi.org/10.1371/journal.pgen.1010772 (mercier2023hsp90mutantswith pages 1-2)
+- Rios EI et al. *Insights into Hsp90 mechanism and in vivo functions learned from studies in the yeast, Saccharomyces cerevisiae.* **Frontiers in Molecular Biosciences**. **Feb 8, 2024**. https://doi.org/10.3389/fmolb.2024.1325590 (rios2024insightsintohsp90 pages 1-2)
+- Fulton MD et al. *Hsp90 and cochaperones have two genetically distinct roles in regulating eEF2 function.* **PLOS Genetics**. **Dec 9, 2024**. https://doi.org/10.1371/journal.pgen.1011508 (fulton2024hsp90andcochaperones pages 1-2)
+
+References
+
+1. (dolinski1998cns1encodesan pages 1-2): Kara J. Dolinski, Maria E. Cardenas, and Joseph Heitman. Cns1 encodes an essential p60/sti1 homolog in saccharomyces cerevisiae that suppresses cyclophilin 40 mutations and interacts with hsp90. Molecular and Cellular Biology, 18:7344-7352, Dec 1998. URL: https://doi.org/10.1128/mcb.18.12.7344, doi:10.1128/mcb.18.12.7344. This article has 122 citations and is from a domain leading peer-reviewed journal.
+
+2. (duina1996identificationoftwo pages 1-2): Andrea A. Duina, James A. Marsh, and Richard F. Gaber. Identification of two cyp‐40‐like cyclophilins in saccharomyces cerevisiae, one of which is required for normal growth. Yeast, 12:943-952, Aug 1996. URL: https://doi.org/10.1002/(sici)1097-0061(199608)12:10<943::aid-yea997>3.0.co;2-3, doi:10.1002/(sici)1097-0061(199608)12:10<943::aid-yea997>3.0.co;2-3. This article has 119 citations and is from a peer-reviewed journal.
+
+3. (tenge2015thehsp90cochaperones pages 1-2): Victoria R. Tenge, Abbey D. Zuehlke, Neelima Shrestha, and Jill L. Johnson. The hsp90 cochaperones cpr6, cpr7, and cns1 interact with the intact ribosome. Eukaryotic Cell, 14:55-63, Jan 2015. URL: https://doi.org/10.1128/ec.00170-14, doi:10.1128/ec.00170-14. This article has 23 citations and is from a peer-reviewed journal.
+
+4. (mayr2000cpr6andcpr7 pages 1-1): Christian Mayr, Klaus Richter, Hauke Lilie, and Johannes Buchner. Cpr6 and cpr7, two closely related hsp90-associated immunophilins from saccharomyces cerevisiae, differ in their functional properties*. The Journal of Biological Chemistry, 275:34140-34146, Nov 2000. URL: https://doi.org/10.1074/jbc.m005251200, doi:10.1074/jbc.m005251200. This article has 152 citations.
+
+5. (tenge2015thehsp90cochaperones media e3c93753): Victoria R. Tenge, Abbey D. Zuehlke, Neelima Shrestha, and Jill L. Johnson. The hsp90 cochaperones cpr6, cpr7, and cns1 interact with the intact ribosome. Eukaryotic Cell, 14:55-63, Jan 2015. URL: https://doi.org/10.1128/ec.00170-14, doi:10.1128/ec.00170-14. This article has 23 citations and is from a peer-reviewed journal.
+
+6. (tenge2015thehsp90cochaperones pages 5-6): Victoria R. Tenge, Abbey D. Zuehlke, Neelima Shrestha, and Jill L. Johnson. The hsp90 cochaperones cpr6, cpr7, and cns1 interact with the intact ribosome. Eukaryotic Cell, 14:55-63, Jan 2015. URL: https://doi.org/10.1128/ec.00170-14, doi:10.1128/ec.00170-14. This article has 23 citations and is from a peer-reviewed journal.
+
+7. (duina1996acyclophilinfunction pages 1-2): Andrea A. Duina, Hui-Chen Jane Chang, James A. Marsh, Susan Lindquist, and Richard F. Gaber. A cyclophilin function in hsp90-dependent signal transduction. Science, 274:1713-1715, Dec 1996. URL: https://doi.org/10.1126/science.274.5293.1713, doi:10.1126/science.274.5293.1713. This article has 275 citations and is from a highest quality peer-reviewed journal.
+
+8. (mercier2023hsp90mutantswith pages 1-2): Rebecca Mercier, Danielle Yama, Paul LaPointe, and Jill L. Johnson. Hsp90 mutants with distinct defects provide novel insights into cochaperone regulation of the folding cycle. PLOS Genetics, 19:e1010772, May 2023. URL: https://doi.org/10.1371/journal.pgen.1010772, doi:10.1371/journal.pgen.1010772. This article has 13 citations and is from a domain leading peer-reviewed journal.
+
+9. (rios2024insightsintohsp90 pages 1-2): Erick I. Rios, Isabel L. Hunsberger, and Jill L. Johnson. Insights into hsp90 mechanism and in vivo functions learned from studies in the yeast, saccharomyces cerevisiae. Frontiers in Molecular Biosciences, Feb 2024. URL: https://doi.org/10.3389/fmolb.2024.1325590, doi:10.3389/fmolb.2024.1325590. This article has 8 citations.
+
+10. (fulton2024hsp90andcochaperones pages 1-2): Melody D. Fulton, Danielle J. Yama, Ella Dahl, and Jill L. Johnson. Hsp90 and cochaperones have two genetically distinct roles in regulating eef2 function. PLOS Genetics, 20:e1011508, Dec 2024. URL: https://doi.org/10.1371/journal.pgen.1011508, doi:10.1371/journal.pgen.1011508. This article has 5 citations and is from a domain leading peer-reviewed journal.
+
+11. (forafonov2008p23sba1pprotectsagaints pages 26-30): F Forafonov. P23/sba1p protects againts hsp90 inhibitors. Unknown journal, 2008.
+
+## Citations
+
+1. duina1996acyclophilinfunction pages 1-2
+2. duina1996identificationoftwo pages 1-2
+3. https://doi.org/10.1371/journal.pgen.1010772
+4. https://doi.org/10.1042/EBC20220224
+5. https://doi.org/10.3389/fmolb.2024.1325590
+6. https://doi.org/10.1371/journal.pgen.1011508
+7. https://doi.org/10.1007/s12192-023-01342-z
+8. https://doi.org/10.1002/(sici
+9. https://doi.org/10.1128/mcb.18.12.7344;
+10. https://doi.org/10.1128/EC.00170-14
+11. https://doi.org/10.1074/jbc.M005251200;
+12. https://doi.org/10.1128/mcb.18.12.7344
+13. https://doi.org/10.1371/journal.pgen.1010772;
+14. https://doi.org/10.1074/jbc.M005251200
+15. https://doi.org/10.1128/EC.00170-14;
+16. https://doi.org/10.1126/science.274.5293.1713
+17. https://doi.org/10.3389/fmolb.2024.1325590;
+18. https://doi.org/10.1128/mcb.18.12.7344,
+19. https://doi.org/10.1128/ec.00170-14,
+20. https://doi.org/10.1074/jbc.m005251200,
+21. https://doi.org/10.1126/science.274.5293.1713,
+22. https://doi.org/10.1371/journal.pgen.1010772,
+23. https://doi.org/10.3389/fmolb.2024.1325590,
+24. https://doi.org/10.1371/journal.pgen.1011508,

--- a/genes/yeast/EUG1/EUG1-ai-review.html
+++ b/genes/yeast/EUG1/EUG1-ai-review.html
@@ -970,7 +970,7 @@
 
                                 </span>
 
-                                <div class="support-text">Eug1p is described as an **ER-resident glycoprotein**</div>
+                                <div class="support-text">wild-type Eug1p is a weak oxidoreductase/isomerase</div>
 
                             </div>
 
@@ -2993,7 +2993,7 @@ existing_annotations:
     reason: Retained as supported or plausible for this gene and evidence context.
     supported_by:
     - reference_id: file:yeast/EUG1/EUG1-deep-research-falcon.md
-      supporting_text: Eug1p is described as an **ER-resident glycoprotein**
+      supporting_text: wild-type Eug1p is a weak oxidoreductase/isomerase
 - term:
     id: GO:0003756
     label: protein disulfide isomerase activity

--- a/genes/yeast/EUG1/EUG1-ai-review.html
+++ b/genes/yeast/EUG1/EUG1-ai-review.html
@@ -671,33 +671,33 @@
     <div class="header">
         <h1>EUG1</h1>
         <div class="gene-info">
-            
+
             <div class="info-item">
-                
+
                 <span class="info-label">UniProt ID:</span>
                 <span>
                     <a href="https://www.uniprot.org/uniprotkb/P32474" target="_blank" class="term-link">
                         P32474
                     </a>
                 </span>
-                
+
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Organism:</span>
                 <span>Saccharomyces cerevisiae</span>
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
-                <span class="status-badge status-draft">
-                    DRAFT
+                <span class="status-badge status-complete">
+                    COMPLETE
                 </span>
             </div>
-            
-            
+
+
         </div>
         <div style="margin-top: 1rem; text-align: center;">
             <a id="feedback-form-link"
@@ -728,24 +728,24 @@
         </div>
     </div>
 
-    
+
     <div class="description-card">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <h2>Gene Description</h2>
-            <span class="vote-buttons" data-g="P32474" data-a="DESCRIPTION: TODO: Add description for EUG1..." data-r="" data-act="DESCRIPTION">
+            <span class="vote-buttons" data-g="P32474" data-a="DESCRIPTION: EUG1 encodes a nonessential endoplasmic-reticulum ..." data-r="" data-act="DESCRIPTION">
                 <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
                 <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
             </span>
         </div>
-        <p>TODO: Add description for EUG1</p>
+        <p>EUG1 encodes a nonessential endoplasmic-reticulum protein disulfide isomerase family member with thioredoxin-like domains and atypical CXXS active-site motifs. Evidence supports an auxiliary ER protein-folding and quality-control role: wild-type Eug1p has weak classical oxidoreductase/isomerase activity, measurable chaperone-like activity, ER retention, and functional overlap with other yeast PDI-family proteins.</p>
     </div>
-    
 
-    
 
-    
 
-    
+
+
+
+
     <div class="section">
         <h2 class="section-title">Existing Annotations Review</h2>
         <table class="annotations-table">
@@ -758,32 +758,32 @@
                 </tr>
             </thead>
             <tbody>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005783" target="_blank" class="term-link">
                                     GO:0005783
                                 </a>
                             </span>
                             <span class="term-label">endoplasmic reticulum</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -795,46 +795,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: endoplasmic reticulum is consistent with known biology of EUG1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                     GO:0006457
                                 </a>
                             </span>
                             <span class="term-label">protein folding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -846,46 +846,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: protein folding is consistent with known biology of EUG1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034976" target="_blank" class="term-link">
                                     GO:0034976
                                 </a>
                             </span>
                             <span class="term-label">response to endoplasmic reticulum stress</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -897,46 +897,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: response to endoplasmic reticulum stress is consistent with known biology of EUG1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003756" target="_blank" class="term-link">
                                     GO:0003756
                                 </a>
                             </span>
                             <span class="term-label">protein disulfide isomerase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -948,46 +948,62 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: protein disulfide isomerase activity is consistent with known biology of EUG1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/EUG1/EUG1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Eug1p is described as an **ER-resident glycoprotein**</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003756" target="_blank" class="term-link">
                                     GO:0003756
                                 </a>
                             </span>
                             <span class="term-label">protein disulfide isomerase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -999,46 +1015,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: protein disulfide isomerase activity is consistent with known biology of EUG1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005788" target="_blank" class="term-link">
                                     GO:0005788
                                 </a>
                             </span>
                             <span class="term-label">endoplasmic reticulum lumen</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1050,46 +1066,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: endoplasmic reticulum lumen is consistent with known biology of EUG1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                     GO:0006457
                                 </a>
                             </span>
                             <span class="term-label">protein folding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1101,46 +1117,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: protein folding is consistent with known biology of EUG1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015035" target="_blank" class="term-link">
                                     GO:0015035
                                 </a>
                             </span>
                             <span class="term-label">protein-disulfide reductase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1152,46 +1168,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: protein-disulfide reductase activity is consistent with known biology of EUG1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016853" target="_blank" class="term-link">
                                     GO:0016853
                                 </a>
                             </span>
                             <span class="term-label">isomerase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1203,46 +1219,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: isomerase activity is consistent with known biology of EUG1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1254,57 +1270,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: unfolded protein binding is too generic or over-extended for EUG1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Marked over-annotated because more specific terms capture the biology more accurately.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/27107014" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:27107014
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     An inter-species protein-protein interaction network across ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1316,57 +1332,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: protein binding is too generic or over-extended for EUG1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Marked over-annotated because more specific terms capture the biology more accurately.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005783" target="_blank" class="term-link">
                                     GO:0005783
                                 </a>
                             </span>
                             <span class="term-label">endoplasmic reticulum</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/26928762" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:26928762
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     One library to make them all: streamlining the creation of y...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1378,57 +1394,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: endoplasmic reticulum is consistent with known biology of EUG1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005783" target="_blank" class="term-link">
                                     GO:0005783
                                 </a>
                             </span>
                             <span class="term-label">endoplasmic reticulum</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/11914276" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:11914276
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Subcellular localization of the yeast proteome.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1440,57 +1456,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: endoplasmic reticulum is consistent with known biology of EUG1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003756" target="_blank" class="term-link">
                                     GO:0003756
                                 </a>
                             </span>
                             <span class="term-label">protein disulfide isomerase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">ISS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/11157982" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:11157982
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Functional differences in yeast protein disulfide isomerases...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1502,57 +1518,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: protein disulfide isomerase activity is consistent with known biology of EUG1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015035" target="_blank" class="term-link">
                                     GO:0015035
                                 </a>
                             </span>
                             <span class="term-label">protein-disulfide reductase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">ISS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/11157982" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:11157982
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Functional differences in yeast protein disulfide isomerases...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1564,57 +1580,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: protein-disulfide reductase activity is consistent with known biology of EUG1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16002399" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16002399
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Interactions among yeast protein-disulfide isomerase protein...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1626,57 +1642,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: protein binding is too generic or over-extended for EUG1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Marked over-annotated because more specific terms capture the biology more accurately.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019153" target="_blank" class="term-link">
                                     GO:0019153
                                 </a>
                             </span>
                             <span class="term-label">protein-disulfide reductase (glutathione) activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16002399" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16002399
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Interactions among yeast protein-disulfide isomerase protein...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1688,57 +1704,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: protein-disulfide reductase (glutathione) activity is consistent with known biology of EUG1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16002399" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16002399
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Interactions among yeast protein-disulfide isomerase protein...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1750,57 +1766,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: unfolded protein binding is too generic or over-extended for EUG1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Marked over-annotated because more specific terms capture the biology more accurately.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003756" target="_blank" class="term-link">
                                     GO:0003756
                                 </a>
                             </span>
                             <span class="term-label">protein disulfide isomerase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/11157982" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:11157982
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Functional differences in yeast protein disulfide isomerases...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1812,57 +1828,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: protein disulfide isomerase activity is consistent with known biology of EUG1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003756" target="_blank" class="term-link">
                                     GO:0003756
                                 </a>
                             </span>
                             <span class="term-label">protein disulfide isomerase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IGI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/11157982" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:11157982
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Functional differences in yeast protein disulfide isomerases...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1874,57 +1890,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: protein disulfide isomerase activity is consistent with known biology of EUG1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003756" target="_blank" class="term-link">
                                     GO:0003756
                                 </a>
                             </span>
                             <span class="term-label">protein disulfide isomerase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16002399" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16002399
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Interactions among yeast protein-disulfide isomerase protein...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1936,57 +1952,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: protein disulfide isomerase activity is consistent with known biology of EUG1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                     GO:0006457
                                 </a>
                             </span>
                             <span class="term-label">protein folding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IGI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/11157982" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:11157982
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Functional differences in yeast protein disulfide isomerases...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1998,57 +2014,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: protein folding is consistent with known biology of EUG1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015035" target="_blank" class="term-link">
                                     GO:0015035
                                 </a>
                             </span>
                             <span class="term-label">protein-disulfide reductase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IGI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/11157982" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:11157982
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Functional differences in yeast protein disulfide isomerases...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2060,57 +2076,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: protein-disulfide reductase activity is consistent with known biology of EUG1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015035" target="_blank" class="term-link">
                                     GO:0015035
                                 </a>
                             </span>
                             <span class="term-label">protein-disulfide reductase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16002399" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16002399
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Interactions among yeast protein-disulfide isomerase protein...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2122,209 +2138,800 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: protein-disulfide reductase activity is consistent with known biology of EUG1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
             </tbody>
         </table>
     </div>
-    
 
-    
 
-    
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Auxiliary ER protein-folding factor in the protein disulfide isomerase family. Eug1p has atypical CXXS active sites, weak classical oxidoreductase activity relative to Pdi1p, and contributes to ER folding/proteostasis through isomerase-like, reductase-like, and chaperone-like activity.</h3>
+                <span class="vote-buttons" data-g="P32474" data-a="FUNCTION: Auxiliary ER protein-folding factor in the protein..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003756" target="_blank" class="term-link">
+                            protein disulfide isomerase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
+                                protein folding
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034976" target="_blank" class="term-link">
+                                response to endoplasmic reticulum stress
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005788" target="_blank" class="term-link">
+                                endoplasmic reticulum lumen
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:yeast/EUG1/EUG1-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">wild-type Eug1p is a weak oxidoreductase/isomerase</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class="section">
         <h2 class="section-title collapsible">References</h2>
         <div class="collapse-content">
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
                             GO_REF:0000033
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Annotation inferences using phylogenetic trees</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000043.md" target="_blank" class="term-link">
                             GO_REF:0000043
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
                             GO_REF:0000044
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
                             GO_REF:0000117
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
                             GO_REF:0000120
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/11157982" target="_blank" class="term-link">
                             PMID:11157982
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Functional differences in yeast protein disulfide isomerases.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/11914276" target="_blank" class="term-link">
                             PMID:11914276
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Subcellular localization of the yeast proteome.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/16002399" target="_blank" class="term-link">
                             PMID:16002399
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Interactions among yeast protein-disulfide isomerase proteins and endoplasmic reticulum chaperone proteins influence their activities.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/26928762" target="_blank" class="term-link">
                             PMID:26928762
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">One library to make them all: streamlining the creation of yeast libraries via a SWAp-Tag strategy.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/27107014" target="_blank" class="term-link">
                             PMID:27107014
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">An inter-species protein-protein interaction network across vast evolutionary distance.</div>
-                
-                
+
+
             </div>
-            
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:yeast/EUG1/EUG1-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research report for EUG1</div>
+
+
+            </div>
+
         </div>
     </div>
-    
 
 
-    
 
-    
 
-    
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Should EUG1 annotations distinguish weak native oxidoreductase activity from engineered CXXC mutant activity when choosing molecular-function terms?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P32474" data-a="Q: Should EUG1 annotations distinguish weak native ox..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Are recently reported ER interaction-mapping partners suitable for direct GO protein-binding annotations, or should they remain supporting context?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P32474" data-a="Q: Are recently reported ER interaction-mapping partn..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Compare wild-type Eug1p and CXXC-engineered variants on native ER client substrates under physiological expression levels.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="P32474" data-a="EXPERIMENT: Compare wild-type Eug1p and CXXC-engineered varian..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Validate Eug1p ER interaction partners from in situ mapping with reciprocal biochemical assays and client-folding readouts.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="P32474" data-a="EXPERIMENT: Validate Eug1p ER interaction partners from in sit..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
 
     <!-- Computational Predictions Section -->
-    
+
 
     <!-- Additional Documentation Sections -->
-    
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Deep Research Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(EUG1-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P32474" data-a="DOC: Deep Research Falcon" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <hr />
+<p>provider: falcon<br />
+model: Edison Scientific Literature<br />
+cached: false<br />
+start_time: '2026-05-11T08:54:18.901783'<br />
+end_time: '2026-05-11T09:08:35.774608'<br />
+duration_seconds: 856.87<br />
+template_file: templates/gene_research_go_focused.md<br />
+template_variables:<br />
+  organism: yeast<br />
+  gene_id: EUG1<br />
+  gene_symbol: EUG1<br />
+  uniprot_accession: P32474<br />
+  protein_description: 'RecName: Full=Protein disulfide-isomerase EUG1; Short=PDI;<br />
+    EC=5.3.4.1; AltName: Full=Endoplasmic reticulum protein EUG1; Flags: Precursor;'<br />
+  gene_info: Name=EUG1; OrderedLocusNames=YDR518W; ORFNames=D9719.23;<br />
+  organism_full: Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).<br />
+  protein_family: Belongs to the protein disulfide isomerase family.<br />
+  protein_domains: Prot_disulphide_isomerase. (IPR005792); Thioredoxin-like_sf. (IPR036249);<br />
+    Thioredoxin_domain. (IPR013766); Thioredoxin (PF00085); Thioredoxin_6 (PF13848)<br />
+provider_config:<br />
+  timeout: 600<br />
+  max_retries: 3<br />
+  parameters:<br />
+    allowed_domains: []<br />
+    temperature: 0.1<br />
+citation_count: 32</p>
+<hr />
+<h2 id="question">Question</h2>
+<h1 id="gene-research-for-functional-annotation">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> P32474</li>
+<li><strong>Protein Description:</strong> RecName: Full=Protein disulfide-isomerase EUG1; Short=PDI; EC=5.3.4.1; AltName: Full=Endoplasmic reticulum protein EUG1; Flags: Precursor;</li>
+<li><strong>Gene Information:</strong> Name=EUG1; OrderedLocusNames=YDR518W; ORFNames=D9719.23;</li>
+<li><strong>Organism (full):</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Protein Family:</strong> Belongs to the protein disulfide isomerase family.</li>
+<li><strong>Key Domains:</strong> Prot_disulphide_isomerase. (IPR005792); Thioredoxin-like_sf. (IPR036249); Thioredoxin_domain. (IPR013766); Thioredoxin (PF00085); Thioredoxin_6 (PF13848)</li>
+</ul>
+<h3 id="mandatory-verification-steps">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "EUG1" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'EUG1' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>EUG1</strong> (gene ID: EUG1, UniProt: P32474) in yeast.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="output">Output</h2>
+<p>Question: You are an expert researcher providing comprehensive, well-cited information.</p>
+<p>Provide detailed information focusing on:<br />
+1. Key concepts and definitions with current understanding<br />
+2. Recent developments and latest research (prioritize 2023-2024 sources)<br />
+3. Current applications and real-world implementations<br />
+4. Expert opinions and analysis from authoritative sources<br />
+5. Relevant statistics and data from recent studies</p>
+<p>Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.<br />
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.</p>
+<h1 id="gene-research-for-functional-annotation_1">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context_1">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot_1">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> P32474</li>
+<li><strong>Protein Description:</strong> RecName: Full=Protein disulfide-isomerase EUG1; Short=PDI; EC=5.3.4.1; AltName: Full=Endoplasmic reticulum protein EUG1; Flags: Precursor;</li>
+<li><strong>Gene Information:</strong> Name=EUG1; OrderedLocusNames=YDR518W; ORFNames=D9719.23;</li>
+<li><strong>Organism (full):</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Protein Family:</strong> Belongs to the protein disulfide isomerase family.</li>
+<li><strong>Key Domains:</strong> Prot_disulphide_isomerase. (IPR005792); Thioredoxin-like_sf. (IPR036249); Thioredoxin_domain. (IPR013766); Thioredoxin (PF00085); Thioredoxin_6 (PF13848)</li>
+</ul>
+<h3 id="mandatory-verification-steps_1">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "EUG1" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature_1">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'EUG1' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target_1">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>EUG1</strong> (gene ID: EUG1, UniProt: P32474) in yeast.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="research-report-eug1-ydr518w-uniprot-p32474-protein-disulfide-isomerase-family-member-in-saccharomyces-cerevisiae-s288c">Research report: <strong>EUG1 (YDR518W; UniProt P32474)</strong> — Protein disulfide-isomerase family member in <em>Saccharomyces cerevisiae</em> (S288c)</h2>
+<h3 id="1-key-concepts-definitions-and-current-understanding">1) Key concepts, definitions, and current understanding</h3>
+<h4 id="11-protein-disulfide-isomerase-pdi-family-in-the-er">1.1 Protein disulfide isomerase (PDI) family in the ER</h4>
+<p>Protein disulfide isomerase (PDI) family proteins are thioredoxin-domain oxidoreductases in the endoplasmic reticulum (ER) lumen that catalyze thiol–disulfide exchange reactions during secretory-protein folding, including disulfide bond formation (oxidation), disulfide reduction, and disulfide isomerization (reshuffling of incorrect disulfides) (suzuki2015redoxdiversityin pages 1-2). In budding yeast, Pdi1p is the essential PDI, while several nonessential homologues provide overlapping/auxiliary functions in ER oxidative folding and quality control (xiao2004thecontributionsof pages 2-2, nørgaard2001functionaldifferencesin pages 2-2).</p>
+<h4 id="12-eug1-geneprotein-identity-verification-disambiguation">1.2 EUG1 gene/protein identity verification (disambiguation)</h4>
+<p>Multiple independent sources explicitly place <strong>EUG1 (YDR518W)</strong> among the <strong>PDI1 homologues localized to the yeast ER</strong> (MPD1, MPD2, EUG1, EPS1) and among the yeast PDI family members (xiao2004thecontributionsof pages 2-2, suzuki2015redoxdiversityin pages 1-2). In addition, mechanistic evidence refers to “a yeast PDI homologue, Eug1p” and highlights its unusual active-site chemistry (beynonjones2006mutationalanalysisof pages 1-2). These points confirm that the literature summarized here corresponds to <strong>the same target as UniProt P32474 (Eug1p in <em>S. cerevisiae</em>)</strong>, not an unrelated “EUG1” gene from another organism (xiao2004thecontributionsof pages 2-2, beynonjones2006mutationalanalysisof pages 1-2).</p>
+<h3 id="2-molecular-features-of-eug1p-domains-active-sites-and-enzymatic-mechanism">2) Molecular features of Eug1p (domains, active sites) and enzymatic mechanism</h3>
+<h4 id="21-domain-architecture-and-active-site-motifs">2.1 Domain architecture and active-site motifs</h4>
+<p>Eug1p is described as a Pdi1p homologue with <strong>two thioredoxin-like domains</strong> and <strong>two non-canonical redox motifs of the form CXXS (rather than CXXC)</strong> (nørgaard2001functionaldifferencesin pages 2-2, nørgaard2001functionaldifferencesin pages 1-2). Active-site positions for the two CxxS motifs were reported as <strong>residues 62 and 405</strong> (hacioglu2010therolesof pages 3-4). This “CXXS” configuration is repeatedly emphasized as a key reason for Eug1p’s atypically weak oxidoreductase function relative to canonical PDIs (beynonjones2006mutationalanalysisof pages 1-2, nørgaard2001functionaldifferencesin pages 2-2).</p>
+<h4 id="22-catalyzed-reaction-class-and-substrate-specificity-functional-inference-direct-substrate-assays">2.2 Catalyzed reaction class and substrate specificity (functional inference + direct substrate assays)</h4>
+<p><strong>Reaction class:</strong> Like other PDI-family oxidoreductases, Eug1p participates in <strong>thiol–disulfide exchange</strong>, which in principle can catalyze oxidation/reduction/isomerization of disulfide bonds in ER client proteins (suzuki2015redoxdiversityin pages 1-2). </p>
+<p><strong>Substrate-level evidence:</strong> Several experiments use the secretory pathway substrate <strong>procarboxypeptidase Y (proCPY/CPY)</strong> to probe PDI-family function in vivo and in vitro. In deletion/overexpression backgrounds, loss of PDI homologues slows CPY maturation (xiao2004thecontributionsof pages 5-7, xiao2004thecontributionsof media f566842d). In biochemical assays, engineered Eug1p variants (see below) catalyze oxidative refolding and disulfide reshuffling of proCPY (nørgaard2001mutationofyeast pages 6-6, nørgaard2001mutationofyeast pages 4-6). These experiments provide the most direct “substrate specificity” evidence available in the retrieved corpus: Eug1p-related activity is demonstrated on a complex secretory cargo (proCPY) rather than a single defined peptide substrate (nørgaard2001mutationofyeast pages 4-6).</p>
+<h4 id="23-wild-type-eug1p-has-weak-oxidoreductaseisomerase-activity-but-detectable-chaperone-like-activity">2.3 Wild-type Eug1p has weak oxidoreductase/isomerase activity, but detectable chaperone-like activity</h4>
+<p>Multiple sources converge on the conclusion that <strong>wild-type Eug1p is a weak oxidoreductase/isomerase</strong> in standard PDI assays:<br />
+* A study of yeast PDI family functional differences emphasizes that Eug1p contains <strong>CXXS</strong> motifs and that Eug1p “alone is unable to carry oxidizing equivalents,” consistent with limited oxidase capacity (nørgaard2001functionaldifferencesin pages 2-2).<br />
+* A biochemical study concludes that “wild-type Eug1p is a poor isomerase” and that wild-type Eug1p has only a small signal in an insulin reduction assay and does not improve oxidative refolding of proCPY under the tested conditions (nørgaard2001mutationofyeast pages 4-6).<br />
+* A comparative analysis reports that isomerase activities of yeast PDI-family proteins including Eug1p were “extremely low,” while also indicating that (except for Mpd1p) PDI-family proteins retain chaperone activity (kimura2004functionaldifferencesbetween pages 1-2).</p>
+<p>In contrast to weak oxidoreductase activity, an ER-quality-control role via <strong>binding/anti-aggregation (chaperone-like)</strong> function is supported by in vitro chaperone metrics: Eug1p exhibited measurable chaperone activity with a reported parameter <strong>KD = 4.21×10^-4 M</strong> in the referenced assay context (vala2008characterizationoferv2p pages 58-61).</p>
+<h4 id="24-active-site-engineering-demonstrates-causality-of-the-cxxs-motif">2.4 Active-site engineering demonstrates causality of the CXXS motif</h4>
+<p>A key mechanistic demonstration is that converting Eug1p active sites from <strong>CXXS → CXXC</strong> greatly increases PDI-like function:<br />
+* Mutation of Eug1p CXXS active sites to CXXC caused a “dramatic increase” in PDI activity; the engineered form gained oxidase/isomerase activity on proCPY-related substrates (including a GS-proCPY assay where wild-type Eug1p showed no activity) (nørgaard2001mutationofyeast pages 6-6).<br />
+* Quantitatively, the engineered <strong>Eug1pCXXC-CXXC</strong> reached approximately <strong>30–50%</strong> of native yeast Pdi1p activity in the study’s assays (nørgaard2001mutationofyeast pages 6-6).<br />
+* In proCPY refolding kinetics, the authors reported proCPY has <strong>11 free thiols</strong> when fully reduced, decreasing rapidly with a plateau around <strong>1.5–2 thiols</strong> per proCPY after ~20–30 minutes; wild-type Eug1p did not affect the refolding rate/yield under those test conditions, while CXXC mutants shortened the lag phase and enhanced folding (nørgaard2001mutationofyeast pages 4-6).</p>
+<p>Collectively, these results support the interpretation that <strong>Eug1p’s primary physiological contribution is likely not bulk oxidation</strong>, and that its atypical active sites may tune it toward noncanonical roles (e.g., assisting folding via binding or specialized redox tasks) rather than being a major disulfide oxidase (nørgaard2001mutationofyeast pages 4-6, nørgaard2001functionaldifferencesin pages 2-2).</p>
+<h3 id="3-cellular-localization-and-pathway-context">3) Cellular localization and pathway context</h3>
+<h4 id="31-er-localization-and-retention">3.1 ER localization and retention</h4>
+<p>Eug1p is described as an <strong>ER-resident glycoprotein</strong> with an <strong>N-terminal signal sequence</strong> and a <strong>C-terminal HDEL ER retention signal</strong>, consistent with ER luminal residency (vala2008characterizationoferv2p pages 58-61). This matches broader genetic/functional categorization of EUG1 as one of the yeast ER PDI-family homologues (xiao2004thecontributionsof pages 2-2).</p>
+<h4 id="32-role-within-er-oxidative-foldingupr-network">3.2 Role within ER oxidative folding/UPR network</h4>
+<p>Expression of <strong>PDI1 and ER PDI homologues</strong> is described as regulated by the <strong>unfolded protein response (UPR)</strong>, and PDI homologues can be upregulated when PDI activity is defective—placing EUG1 within ER stress adaptation/proteostasis circuits (xiao2004thecontributionsof pages 5-7). Functional overlap among ER PDI-family members is also supported by the ability of ER homologues (including EUG1) to rescue a pdi1 mutation when overexpressed (xiao2004thecontributionsof pages 2-2).</p>
+<h3 id="4-genetics-phenotypes-and-mechanistic-interpretation">4) Genetics, phenotypes, and mechanistic interpretation</h3>
+<h4 id="41-essentiality-and-redundancy">4.1 Essentiality and redundancy</h4>
+<p>In yeast, <strong>PDI1 is essential</strong>, while <strong>EUG1 is nonessential</strong> under standard growth conditions (nørgaard2001functionaldifferencesin pages 1-2, vala2008characterizationoferv2p pages 58-61). Nonetheless, EUG1 can participate in partial compensation:<br />
+* Overexpressed homologues (EUG1/MPD1/MPD2) can restore viability to a pdi1-deleted strain, but such suppression often requires low endogenous levels of other homologues and is not fully interchangeable (nørgaard2001functionaldifferencesin pages 1-2).<br />
+* Specifically, suppression of pdi1 deletion by EUG1 requires endogenous homologues with <strong>CXXC</strong> motifs, consistent with Eug1p’s inability to provide oxidation alone (nørgaard2001functionaldifferencesin pages 1-2).</p>
+<h4 id="42-folding-phenotypes-cpy-maturation">4.2 Folding phenotypes: CPY maturation</h4>
+<p>Across multiple studies, the folding/maturation of secretory cargo is a sensitive readout of PDI-family function:<br />
+* In vivo, CPY maturation can become “extremely slow” in backgrounds lacking supportive PDI-homologue activity under certain conditions (xiao2004thecontributionsof pages 5-7).<br />
+* A retrieved figure/table from Xiao et al. (2004) provides pulse–chase evidence and half-time quantification for CPY maturation across mutant backgrounds that alter PDI-family capacity (xiao2004thecontributionsof media f566842d, xiao2004thecontributionsof media a580a63e).<br />
+* In another report, cells lacking EUG1 were viable but showed a slight vacuolar sorting defect for soluble vacuolar proteins including CPY; overexpression of EUG1 in a pdi1Δ strain permitted growth but did not correct proCPY accumulation, implying incomplete functional overlap with Pdi1p (vala2008characterizationoferv2p pages 58-61).</p>
+<h4 id="43-erad-er-associated-degradation">4.3 ERAD (ER-associated degradation)</h4>
+<p>Despite strong effects on folding and glycan modification in multiple deletion combinations, one study reports <strong>no significant effects on ER-associated degradation (ERAD)</strong> across the PDI-deleted strains tested, suggesting that (in that experimental space) PDI-family contributions are more critical for productive folding than for bulk ERAD flux (nørgaard2001functionaldifferencesin pages 1-2).</p>
+<h4 id="44-other-phenotypes-and-quantitative-data">4.4 Other phenotypes and quantitative data</h4>
+<p>Beyond secretion/folding readouts:<br />
+* Deletion of <strong>EUG1</strong> was associated with a reported <strong>~13% decrease in replicative lifespan</strong> in one study that surveyed thiol oxidoreductases (hacioglu2010therolesof pages 3-4).</p>
+<h3 id="5-proteinprotein-interactions-ppis-and-functional-networks">5) Protein–protein interactions (PPIs) and functional networks</h3>
+<h4 id="51-biochemical-interaction-evidence">5.1 Biochemical interaction evidence</h4>
+<p>In vitro binding evidence supports interaction between Eug1p and other ER PDI-like proteins:<br />
+* Eug1p binds Eps1p with reported <strong>KD = 6.06×10^-6 M</strong> (vala2008characterizationoferv2p pages 58-61).<br />
+* Functional cooperation was suggested by an observation that mixtures of Eps1p + Eug1p enhanced reductive activity in the cited assay context (reported as 122% in the excerpt) (vala2008characterizationoferv2p pages 58-61).</p>
+<h4 id="52-recent-development-2024-in-situ-er-ppi-mapping-yst-ppi">5.2 Recent development (2024): in situ ER PPI mapping (YST-PPI)</h4>
+<p>A 2024 bioRxiv preprint introduces <strong>YST-PPI</strong>, an in situ ER-resident PPI mapping approach using split-fast TEV protease, ER retention signals, and a surface-display cleavage readout quantified by flow cytometry (fan2024characterizinginteractionsof pages 1-4, fan2024characterizinginteractionsof pages 13-17). The authors tested 15 ER resident proteins (including Eug1p) and report a network with <strong>&gt;74 interacting pairs</strong> above a <strong>&gt;10% normalized interaction score</strong> threshold, with overall score ranges roughly 1–93% (fan2024characterizinginteractionsof pages 1-4, fan2024characterizinginteractionsof pages 7-10).</p>
+<p>Within the subset of interactions validated against BioGRID/STRING, the study lists multiple <strong>Eug1p interaction partners</strong>, including <strong>Sil1p, Yos9p, Scj1p, Cpr5p, Mpd1p, Mpd2p, Kre5p</strong>, and interactions among PDI-family members (e.g., Pdi1p–Eug1p) (fan2024characterizinginteractionsof pages 10-13). A specifically mentioned Eug1p interaction score example is <strong>Eug1p–Scj1p = 5%</strong> (fan2024characterizinginteractionsof pages 10-13). This 2024 dataset contributes an updated view of Eug1p’s ER interaction neighborhood, though it is preprint (not yet peer reviewed) and provides limited mechanistic detail per edge in the extracted snippets (fan2024characterizinginteractionsof pages 10-13).</p>
+<h3 id="6-current-applications-and-real-world-implementations">6) Current applications and real-world implementations</h3>
+<p>Direct “EUG1-specific” engineering examples were limited in the retrieved evidence. However, authoritative yeast biomanufacturing literature strongly supports <strong>manipulating ER folding and disulfide-handling capacity (PDI/chaperones/oxidases)</strong> as a practical strategy to improve recombinant secretion in <em>S. cerevisiae</em>—a context in which EUG1 is part of the endogenous ER folding-factor repertoire.</p>
+<p>A highly cited review on metabolic engineering of secretion reports:<br />
+* Overexpression of ER chaperones and folding catalysts such as <strong>Kar2p</strong> and <strong>PDI</strong> often improves secretion of heterologous proteins, and <strong>Kar2p/PDI cooperativity</strong> can increase secretion for some clients (e.g., scFv and β-glucosidase examples described) (hou2012metabolicengineeringof pages 10-11).<br />
+* Maintaining/engineering disulfide bonds can substantially affect yields: removal of IGF1 cysteines reduced expression by about <strong>one-third</strong>, and loss of a core disulfide in CD47 reduced expression level and affinity by <strong>~30%</strong> (hou2012metabolicengineeringof pages 9-10).<br />
+* Broader strain and pathway engineering (including screens connected to ER oxidation/folding machinery) can yield large improvements, including reported <strong>~15-fold</strong> and up to <strong>~70-fold</strong> secretion improvements in selected/engineered contexts (hou2012metabolicengineeringof pages 11-12).</p>
+<p>These real-world findings imply that, while Pdi1p is the primary essential ER oxidoreductase, the broader PDI-family system (including homologues like Eug1p that may contribute binding/isomerase-like capacity or specialized functions) is a relevant target space when tuning ER proteostasis for production (hou2012metabolicengineeringof pages 10-11, xiao2004thecontributionsof pages 2-2).</p>
+<h3 id="7-expert-analysis-and-synthesis">7) Expert analysis and synthesis</h3>
+<h4 id="71-what-is-eug1ps-primary-function-given-the-evidence">7.1 What is Eug1p’s “primary function” given the evidence?</h4>
+<p>The strongest, most Eug1p-specific mechanistic conclusion supported by the retrieved literature is:<br />
+* <strong>Wild-type Eug1p is an ER luminal PDI-family protein whose unusual CXXS active sites severely limit classical PDI oxidase/isomerase activity</strong>, and therefore Eug1p is unlikely to be a major provider of oxidizing equivalents for bulk disulfide formation in yeast (nørgaard2001functionaldifferencesin pages 2-2, nørgaard2001mutationofyeast pages 4-6).<br />
+* Eug1p instead appears to contribute through <strong>auxiliary ER folding functions</strong>, potentially including <strong>substrate binding/chaperone activity</strong> and/or specialized redox roles that do not require a canonical CXXC active site, consistent with measurable chaperone activity and weak oxidoreductase activity (vala2008characterizationoferv2p pages 58-61, kimura2004functionaldifferencesbetween pages 1-2).<br />
+* The fact that CXXS→CXXC engineering converts Eug1p into a much more active PDI strongly argues that Eug1p’s native motif is a functional “design choice” rather than an annotation artifact, and that its physiological role may be tuned away from strong oxidase chemistry (nørgaard2001mutationofyeast pages 6-6, nørgaard2001mutationofyeast pages 4-6).</p>
+<h4 id="72-relationship-to-uprquality-control-and-interactions">7.2 Relationship to UPR/quality control and interactions</h4>
+<p>EUG1 is embedded in ER proteostasis through UPR co-regulation with other PDI homologues (xiao2004thecontributionsof pages 5-7), genetic redundancy/conditional suppression behavior with other PDI homologues (nørgaard2001functionaldifferencesin pages 1-2), and a growing interaction network that includes ER chaperones/cochaperones and quality-control proteins (e.g., Sil1p, Yos9p, Scj1p) observed in the 2024 YST-PPI mapping (fan2024characterizinginteractionsof pages 10-13, fan2024characterizinginteractionsof pages 1-4). This supports the view that Eug1p’s contribution may be best interpreted at the level of ER network function rather than a single high-turnover enzymatic role.</p>
+<h3 id="8-limitations-and-recency">8) Limitations and recency</h3>
+<p>The retrieval yielded <strong>one clear 2024 Eug1p-relevant source</strong> (Fan et al., 2024 bioRxiv) that contributes novel interaction mapping methodology and an ER PPI neighborhood including Eug1p (fan2024characterizinginteractionsof pages 10-13, fan2024characterizinginteractionsof pages 1-4). However, <strong>peer-reviewed 2023–2024 Eug1p-specific primary literature was not retrieved</strong> in this run, so “latest research” emphasis is necessarily weighted toward (i) foundational functional genetics/biochemistry (2001–2004), (ii) mechanistic review context (2015), and (iii) a 2024 preprint for interaction mapping (nørgaard2001functionaldifferencesin pages 1-2, nørgaard2001mutationofyeast pages 4-6, suzuki2015redoxdiversityin pages 1-2, fan2024characterizinginteractionsof pages 10-13).</p>
+<h3 id="evidence-summary-table">Evidence summary table</h3>
+<table>
+<thead>
+<tr>
+<th>Category</th>
+<th>Key finding for <strong>EUG1 / Eug1p</strong></th>
+<th>Quantitative details</th>
+<th>Key source(s)</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Identity</td>
+<td><strong>Saccharomyces cerevisiae</strong> <strong>EUG1</strong> (<strong>YDR518W</strong>; UniProt <strong>P32474</strong>) encodes an ER-resident <strong>protein disulfide-isomerase family</strong> member / thioredoxin-domain oxidoreductase homologous to Pdi1p. It is one of four nonessential <strong>PDI1</strong> homologues in the yeast ER: <strong>MPD1, MPD2, EUG1, EPS1</strong>. (xiao2004thecontributionsof pages 1-2, xiao2004thecontributionsof pages 2-2, nørgaard2001functionaldifferencesin pages 2-2)</td>
+<td>~40% sequence identity to Pdi1p reported. (nørgaard2001functionaldifferencesin pages 2-2)</td>
+<td>Nørgaard et al., 2001, <em>J Cell Biol</em> 152:553-562, https://doi.org/10.1083/jcb.152.3.553 (nørgaard2001functionaldifferencesin pages 2-2, nørgaard2001functionaldifferencesin pages 1-2); Xiao et al., 2004, <em>J Biol Chem</em> 279:49780-49786, https://doi.org/10.1074/jbc.m409210200 (xiao2004thecontributionsof pages 1-2, xiao2004thecontributionsof pages 2-2)</td>
+</tr>
+<tr>
+<td>Domain architecture / motifs</td>
+<td>Eug1p contains <strong>two thioredoxin-like domains</strong> and <strong>two non-canonical active sites</strong> of the <strong>CXXS</strong> type rather than canonical PDI <strong>CXXC/CGHC</strong> motifs. Residue positions reported for the two CxxS motifs are <strong>62</strong> and <strong>405</strong>. (beynonjones2006mutationalanalysisof pages 1-2, nørgaard2001functionaldifferencesin pages 2-2, hacioglu2010therolesof pages 3-4)</td>
+<td>Active-site positions: <strong>CxxS at aa 62 and 405</strong>. (hacioglu2010therolesof pages 3-4)</td>
+<td>Nørgaard et al., 2001, <em>J Cell Biol</em>, https://doi.org/10.1083/jcb.152.3.553 (nørgaard2001functionaldifferencesin pages 2-2, nørgaard2001functionaldifferencesin pages 1-2); Beynon-Jones et al., 2006, <em>FEBS Lett</em> 580:1897-1902, https://doi.org/10.1016/j.febslet.2006.02.055 (beynonjones2006mutationalanalysisof pages 1-2); Hacioglu et al., 2010, <em>Mech Ageing Dev</em> 131:692-699, https://doi.org/10.1016/j.mad.2010.09.006 (hacioglu2010therolesof pages 3-4)</td>
+</tr>
+<tr>
+<td>Localization / ER retention</td>
+<td>Eug1p is reported as an <strong>ER-resident glycoprotein</strong> with an <strong>N-terminal signal sequence</strong> and a <strong>C-terminal HDEL</strong> ER-retention signal; broader literature also consistently places EUG1 among yeast <strong>ER PDI-family proteins</strong>. (vala2008characterizationoferv2p pages 58-61, xiao2004thecontributionsof pages 1-2, suzuki2015redoxdiversityin pages 1-2)</td>
+<td>Length reported as <strong>517 aa</strong>. (vala2008characterizationoferv2p pages 58-61)</td>
+<td>Vala, 2008, thesis/dissertation excerpt (vala2008characterizationoferv2p pages 58-61); Xiao et al., 2004, <em>J Biol Chem</em>, https://doi.org/10.1074/jbc.m409210200 (xiao2004thecontributionsof pages 1-2); Suzuki &amp; Schmitt, 2015, <em>Biol Chem</em> 396:539-554, https://doi.org/10.1515/hsz-2014-0299 (suzuki2015redoxdiversityin pages 1-2)</td>
+</tr>
+<tr>
+<td>Primary biochemical role</td>
+<td>Current evidence supports Eug1p primarily as a <strong>folding assistant / isomerase-like and chaperone-like ER factor</strong>, not a strong oxidase. Because its active sites are <strong>CXXS</strong>, Eug1p alone is considered unable or poorly able to transfer oxidizing equivalents efficiently compared with canonical CXXC PDIs. (nørgaard2001functionaldifferencesin pages 2-2, nørgaard2001mutationofyeast pages 4-6, kimura2004functionaldifferencesbetween pages 1-2)</td>
+<td>Wild-type Eug1p described as having <strong>very low oxidative/refolding activity</strong> and <strong>extremely low isomerase activity</strong>; chaperone activity is detectable. (vala2008characterizationoferv2p pages 58-61, kimura2004functionaldifferencesbetween pages 1-2)</td>
+<td>Nørgaard &amp; Winther, 2001, <em>Biochem J</em> 358:269-274, https://doi.org/10.1042/bj3580269 (nørgaard2001mutationofyeast pages 4-6); Kimura et al., 2004, <em>BBRC</em> 320:359-365, https://doi.org/10.1016/j.bbrc.2004.05.178 (kimura2004functionaldifferencesbetween pages 1-2)</td>
+</tr>
+<tr>
+<td>Oxidase / oxidative folding activity</td>
+<td>Wild-type Eug1p has <strong>very low oxidative refolding activity</strong> relative to Pdi1p. Overexpression can support growth in some <strong>pdi1Δ</strong> backgrounds, but this does not restore full Pdi1p-like oxidative folding capacity. (vala2008characterizationoferv2p pages 58-61, nørgaard2001functionaldifferencesin pages 2-2, nørgaard2001functionaldifferencesin pages 1-2)</td>
+<td>Oxidative refolding activity reported as <strong>2.16% of Pdi1p</strong> in a lysozyme assay. (vala2008characterizationoferv2p pages 58-61)</td>
+<td>Vala, 2008 excerpt (vala2008characterizationoferv2p pages 58-61); Nørgaard et al., 2001, <em>J Cell Biol</em>, https://doi.org/10.1083/jcb.152.3.553 (nørgaard2001functionaldifferencesin pages 2-2, nørgaard2001functionaldifferencesin pages 1-2)</td>
+</tr>
+<tr>
+<td>Reductase / isomerase activity</td>
+<td>Wild-type Eug1p shows only a <strong>small but significant</strong> insulin-reduction signal and is described as a <strong>poor isomerase</strong>; on some substrates it shows essentially <strong>no detectable isomerase activity</strong>. (nørgaard2001mutationofyeast pages 4-6, kimura2004functionaldifferencesbetween pages 1-2)</td>
+<td>Wild-type Eug1p had <strong>no activity on GS-proCPY</strong> in the cited assay; isomerase activities of Mpd1p, Mpd2p, and Eug1p were described as <strong>extremely low</strong>. (nørgaard2001mutationofyeast pages 6-6, kimura2004functionaldifferencesbetween pages 1-2)</td>
+<td>Nørgaard &amp; Winther, 2001, <em>Biochem J</em>, https://doi.org/10.1042/bj3580269 (nørgaard2001mutationofyeast pages 6-6, nørgaard2001mutationofyeast pages 4-6); Kimura et al., 2004, <em>BBRC</em>, https://doi.org/10.1016/j.bbrc.2004.05.178 (kimura2004functionaldifferencesbetween pages 1-2)</td>
+</tr>
+<tr>
+<td>Chaperone activity</td>
+<td>Eug1p has experimentally supported <strong>chaperone activity</strong> despite weak oxidoreductase function, consistent with a role in assisting ER protein folding/quality control. (vala2008characterizationoferv2p pages 58-61, kimura2004functionaldifferencesbetween pages 1-2, hacioglu2010therolesof pages 3-4)</td>
+<td>Mastoparan/rhodanase-related binding/activity parameter reported as <strong>KD = 4.21×10^-4 M</strong>; broader comparison paper states Eug1p retained chaperone activity while Mpd1p did not. (vala2008characterizationoferv2p pages 58-61, kimura2004functionaldifferencesbetween pages 1-2)</td>
+<td>Vala, 2008 excerpt (vala2008characterizationoferv2p pages 58-61); Kimura et al., 2004, <em>BBRC</em>, https://doi.org/10.1016/j.bbrc.2004.05.178 (kimura2004functionaldifferencesbetween pages 1-2); Hacioglu et al., 2010, <em>Mech Ageing Dev</em>, https://doi.org/10.1016/j.mad.2010.09.006 (hacioglu2010therolesof pages 3-4)</td>
+</tr>
+<tr>
+<td>Active-site engineering evidence</td>
+<td>Converting Eug1p active sites from <strong>CXXS to CXXC</strong> dramatically increases PDI-like activity, showing that the native <strong>CXXS</strong> motif is a major determinant of Eug1p’s weak oxidase/isomerase behavior. (nørgaard2001mutationofyeast pages 6-6, nørgaard2001mutationofyeast pages 4-6, beynonjones2006mutationalanalysisof pages 1-2)</td>
+<td><strong>EUG1CXXC-CXXC</strong> reached roughly <strong>30–50% of native yeast PDI</strong> activity and could complement backgrounds lacking auxiliary PDI-like proteins better than wild-type EUG1. (nørgaard2001mutationofyeast pages 6-6)</td>
+<td>Nørgaard &amp; Winther, 2001, <em>Biochem J</em>, https://doi.org/10.1042/bj3580269 (nørgaard2001mutationofyeast pages 6-6, nørgaard2001mutationofyeast pages 4-6); Beynon-Jones et al., 2006, <em>FEBS Lett</em>, https://doi.org/10.1016/j.febslet.2006.02.055 (beynonjones2006mutationalanalysisof pages 1-2)</td>
+</tr>
+<tr>
+<td>Genetic redundancy with PDI family</td>
+<td><strong>EUG1</strong> is <strong>nonessential</strong> individually. Overexpressed <strong>EUG1</strong> can help restore viability to <strong>pdi1Δ</strong> strains, but this depends on the presence of endogenous homologues with <strong>CXXC</strong> motifs; thus PDI-family homologues are <strong>not functionally interchangeable</strong>. <strong>Mpd1p</strong> is the only homologue reported to carry out all essential Pdi1p functions. (xiao2004thecontributionsof pages 2-2, nørgaard2001functionaldifferencesin pages 2-2, nørgaard2001functionaldifferencesin pages 1-2)</td>
+<td>Overexpression of <strong>EUG1, MPD1, or MPD2</strong> did <strong>not fully complement</strong> <strong>pdi1Δ</strong>; EUG1 suppression required endogenous CXXC-containing homologues. (nørgaard2001functionaldifferencesin pages 2-2, nørgaard2001functionaldifferencesin pages 1-2)</td>
+<td>Nørgaard et al., 2001, <em>J Cell Biol</em>, https://doi.org/10.1083/jcb.152.3.553 (nørgaard2001functionaldifferencesin pages 2-2, nørgaard2001functionaldifferencesin pages 1-2); Xiao et al., 2004, <em>J Biol Chem</em>, https://doi.org/10.1074/jbc.m409210200 (xiao2004thecontributionsof pages 2-2)</td>
+</tr>
+<tr>
+<td>CPY folding / maturation phenotype</td>
+<td>Loss of PDI-family support leads to slower <strong>carboxypeptidase Y (CPY/proCPY)</strong> folding and maturation. EUG1 overexpression permits growth in some contexts but does not fully rescue <strong>proCPY accumulation</strong>, supporting partial rather than full functional overlap with Pdi1p. (vala2008characterizationoferv2p pages 58-61, xiao2004thecontributionsof pages 5-7, xiao2004thecontributionsof media f566842d)</td>
+<td>Xiao et al. Figure 5 quantified <strong>half-times for CPY maturation</strong> across mutant backgrounds; text states CPY maturation becomes <strong>extremely slow</strong> when homologues are absent and only a weak Pdi1p isomerase variant is present. Vala excerpt states EUG1 overexpression did <strong>not correct proCPY accumulation</strong>. (xiao2004thecontributionsof pages 5-7, xiao2004thecontributionsof media f566842d, vala2008characterizationoferv2p pages 58-61)</td>
+<td>Xiao et al., 2004, <em>J Biol Chem</em>, https://doi.org/10.1074/jbc.m409210200 (xiao2004thecontributionsof pages 5-7, xiao2004thecontributionsof media f566842d); Vala, 2008 excerpt (vala2008characterizationoferv2p pages 58-61)</td>
+</tr>
+<tr>
+<td>ERAD phenotype</td>
+<td>Across multiple PDI deletion combinations, there were <strong>no significant effects on ER-associated degradation (ERAD)</strong>, suggesting EUG1/PDI-family contributions are more critical for folding/isomerization than for ERAD in the tested contexts. (nørgaard2001functionaldifferencesin pages 1-2)</td>
+<td>Qualitative: <strong>no significant ERAD effect</strong> reported. (nørgaard2001functionaldifferencesin pages 1-2)</td>
+<td>Nørgaard et al., 2001, <em>J Cell Biol</em>, https://doi.org/10.1083/jcb.152.3.553 (nørgaard2001functionaldifferencesin pages 1-2)</td>
+</tr>
+<tr>
+<td>Other phenotypes</td>
+<td>Deleting <strong>EUG1</strong> causes no gross growth defect under standard conditions, but one study reported a <strong>slight vacuolar protein sorting defect</strong> and another linked loss of EUG1 to reduced replicative lifespan. (vala2008characterizationoferv2p pages 58-61, hacioglu2010therolesof pages 3-4)</td>
+<td>Replicative lifespan reduction of about <strong>13%</strong> in <strong>eug1Δ</strong> cells; slight CPY/proteinase A sorting defect noted. (hacioglu2010therolesof pages 3-4, vala2008characterizationoferv2p pages 58-61)</td>
+<td>Hacioglu et al., 2010, <em>Mech Ageing Dev</em>, https://doi.org/10.1016/j.mad.2010.09.006 (hacioglu2010therolesof pages 3-4); Vala, 2008 excerpt (vala2008characterizationoferv2p pages 58-61)</td>
+</tr>
+<tr>
+<td>Interaction partners: classical biochemical evidence</td>
+<td>Eug1p interacts in vitro with <strong>Eps1p</strong>; functional cooperation among PDI-family proteins has been proposed. (vala2008characterizationoferv2p pages 58-61)</td>
+<td><strong>Eug1p–Eps1p KD = 6.06×10^-6 M</strong>; Eps1p also binds Pdi1p (<strong>7.33×10^-6 M</strong>), Mpd1p (<strong>3.88×10^-6 M</strong>), Kar2p (<strong>1.03×10^-6 M</strong>), and Cne1p (<strong>1.38×10^-5 M</strong>). Mixtures of <strong>Eps1p + Eug1p</strong> showed enhanced reductive activity (<strong>122%</strong> vs. 0% or 100% for individual proteins, as reported in the excerpt). (vala2008characterizationoferv2p pages 58-61)</td>
+<td>Vala, 2008 excerpt (vala2008characterizationoferv2p pages 58-61)</td>
+</tr>
+<tr>
+<td>Interaction partners: recent 2024 ER-PPI mapping</td>
+<td>A 2024 <strong>YST-PPI</strong> preprint mapped ER-resident interactions in situ and included <strong>Eug1p</strong> among tested proteins. Reported/validated Eug1p partners included <strong>Pdi1p, Sil1p, Yos9p, Scj1p, Cpr5p, Mpd1p, Mpd2p, Kre5p</strong>. (fan2024characterizinginteractionsof pages 10-13, fan2024characterizinginteractionsof pages 7-10, fan2024characterizinginteractionsof pages 1-4)</td>
+<td>Pairwise scores in the study ranged roughly <strong>1–93%</strong> overall; specific values mentioned for Eug1p-related examples include <strong>Eug1p–Scj1p = 5%</strong>. A validated network of <strong>&gt;74 interacting pairs</strong> above a <strong>&gt;10%</strong> cutoff was reported. (fan2024characterizinginteractionsof pages 10-13, fan2024characterizinginteractionsof pages 7-10, fan2024characterizinginteractionsof pages 1-4)</td>
+<td>Fan et al., 2024, <em>bioRxiv</em> preprint, published May 2024, https://doi.org/10.1101/2024.05.21.594841 (fan2024characterizinginteractionsof pages 10-13, fan2024characterizinginteractionsof pages 7-10, fan2024characterizinginteractionsof pages 1-4)</td>
+</tr>
+<tr>
+<td>Interaction-mapping methodology (recent)</td>
+<td><strong>YST-PPI</strong> measures interactions <strong>in situ</strong> in the yeast ER using <strong>split-TEV / split-fast TEV</strong>, <strong>ER retention signals</strong>, a cleavable surface-display substrate, and <strong>flow cytometry</strong> readout. This is relevant because Eug1p is an ER lumenal protein whose interactions may be missed by nucleus-based assays. (fan2024characterizinginteractionsof pages 10-13, fan2024characterizinginteractionsof pages 13-17, fan2024characterizinginteractionsof pages 1-4)</td>
+<td>Study tested <strong>15 ER resident proteins</strong>; reported <strong>91 pairs</strong> above negative-control threshold and <strong>74 pairs &gt;10%</strong> normalized interaction score. Positive control reached <strong>96%</strong>; negative control ~<strong>4%</strong>. (fan2024characterizinginteractionsof pages 7-10, fan2024characterizinginteractionsof pages 1-4)</td>
+<td>Fan et al., 2024, <em>bioRxiv</em>, https://doi.org/10.1101/2024.05.21.594841 (fan2024characterizinginteractionsof pages 10-13, fan2024characterizinginteractionsof pages 7-10, fan2024characterizinginteractionsof pages 13-17, fan2024characterizinginteractionsof pages 1-4)</td>
+</tr>
+<tr>
+<td>UPR / expression regulation</td>
+<td>PDI1 and its ER homologues, including <strong>EUG1</strong>, are reported to be regulated by the <strong>unfolded protein response (UPR)</strong> and can be upregulated when PDI activity is defective, placing Eug1p within the ER proteostasis/stress-response network. (xiao2004thecontributionsof pages 5-7)</td>
+<td>Qualitative induction/upregulation under ER folding stress. (xiao2004thecontributionsof pages 5-7)</td>
+<td>Xiao et al., 2004, <em>J Biol Chem</em>, https://doi.org/10.1074/jbc.m409210200 (xiao2004thecontributionsof pages 5-7)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes identity, biochemical function, localization, genetics, phenotypes, and interaction evidence for Saccharomyces cerevisiae EUG1/Eug1p using only evidence retrieved in the conversation. It is useful as a compact evidence map linking each major claim to specific context IDs and source citations.</em></p>
+<h3 id="key-figuretable-evidence-visual">Key figure/table evidence (visual)</h3>
+<p>Xiao et al. (2004) Table I and Figure 5 provide visual evidence for growth phenotypes across PDI-family deletion backgrounds and CPY maturation pulse–chase/half-time quantification (xiao2004thecontributionsof media f566842d, xiao2004thecontributionsof media a580a63e).</p>
+<h3 id="selected-bibliography-with-urls-and-publication-dates">Selected bibliography (with URLs and publication dates)</h3>
+<ul>
+<li>Fan X. et al. <strong>Characterizing interactions of ER resident proteins in situ through the YST-PPI method.</strong> <em>bioRxiv</em> (posted <strong>May 21, 2024</strong>). https://doi.org/10.1101/2024.05.21.594841 (fan2024characterizinginteractionsof pages 1-4, fan2024characterizinginteractionsof pages 10-13)</li>
+<li>Xiao R. et al. <strong>The Contributions of Protein Disulfide Isomerase and Its Homologues to Oxidative Protein Folding in the Yeast Endoplasmic Reticulum.</strong> <em>J Biol Chem</em> (<strong>Nov 2004</strong>). https://doi.org/10.1074/jbc.m409210200 (xiao2004thecontributionsof pages 1-2, xiao2004thecontributionsof pages 5-7)</li>
+<li>Nørgaard P. et al. <strong>Functional Differences in Yeast Protein Disulfide Isomerases.</strong> <em>J Cell Biol</em> (<strong>Feb 2001</strong>). https://doi.org/10.1083/jcb.152.3.553 (nørgaard2001functionaldifferencesin pages 1-2, nørgaard2001functionaldifferencesin pages 2-2)</li>
+<li>Nørgaard P., Winther J.R. <strong>Mutation of yeast Eug1p CXXS active sites to CXXC results in a dramatic increase in protein disulphide isomerase activity.</strong> <em>Biochem J</em> (<strong>Aug 2001</strong>). https://doi.org/10.1042/bj3580269 (nørgaard2001mutationofyeast pages 6-6, nørgaard2001mutationofyeast pages 4-6)</li>
+<li>Kimura T. et al. <strong>Functional differences between human and yeast protein disulfide isomerase family proteins.</strong> <em>BBRC</em> (<strong>Jul 2004</strong>). https://doi.org/10.1016/j.bbrc.2004.05.178 (kimura2004functionaldifferencesbetween pages 1-2)</li>
+<li>Suzuki Y., Schmitt M.J. <strong>Redox diversity in ERAD-mediated protein retrotranslocation from the endoplasmic reticulum: a complex puzzle.</strong> <em>Biological Chemistry</em> (<strong>May 2015</strong>). https://doi.org/10.1515/hsz-2014-0299 (suzuki2015redoxdiversityin pages 1-2)</li>
+<li>Hou J. et al. <strong>Metabolic engineering of recombinant protein secretion by Saccharomyces cerevisiae.</strong> <em>FEMS Yeast Research</em> (<strong>Aug 2012</strong>). https://doi.org/10.1111/j.1567-1364.2012.00810.x (hou2012metabolicengineeringof pages 9-10, hou2012metabolicengineeringof pages 10-11, hou2012metabolicengineeringof pages 11-12)</li>
+</ul>
+<p>References</p>
+<ol>
+<li>
+<p>(suzuki2015redoxdiversityin pages 1-2): Yutaka Suzuki and Manfred J. Schmitt. Redox diversity in erad-mediated protein retrotranslocation from the endoplasmic reticulum: a complex puzzle. Biological Chemistry, 396:539-554, May 2015. URL: https://doi.org/10.1515/hsz-2014-0299, doi:10.1515/hsz-2014-0299. This article has 11 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(xiao2004thecontributionsof pages 2-2): Ruoyu Xiao, Bonney Wilkinson, Anton Solovyov, Jakob R. Winther, Arne Holmgren, Johanna Lundström-Ljung, and Hiram F. Gilbert. The contributions of protein disulfide isomerase and its homologues to oxidative protein folding in the yeast endoplasmic reticulum*. Journal of Biological Chemistry, 279:49780-49786, Nov 2004. URL: https://doi.org/10.1074/jbc.m409210200, doi:10.1074/jbc.m409210200. This article has 87 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(nørgaard2001functionaldifferencesin pages 2-2): Per Nørgaard, Vibeke Westphal, Christine Tachibana, Lene Alsøe, Bjørn Holst, and Jakob R. Winther. Functional differences in yeast protein disulfide isomerases. The Journal of Cell Biology, 152:553-562, Feb 2001. URL: https://doi.org/10.1083/jcb.152.3.553, doi:10.1083/jcb.152.3.553. This article has 171 citations.</p>
+</li>
+<li>
+<p>(beynonjones2006mutationalanalysisof pages 1-2): Siân M. Beynon-Jones, Antony N. Antoniou, and Simon J. Powis. Mutational analysis of the oxidoreductase erp57 reveals the importance of the two central residues in the redox motif. FEBS Letters, 580:1897-1902, Mar 2006. URL: https://doi.org/10.1016/j.febslet.2006.02.055, doi:10.1016/j.febslet.2006.02.055. This article has 14 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(nørgaard2001functionaldifferencesin pages 1-2): Per Nørgaard, Vibeke Westphal, Christine Tachibana, Lene Alsøe, Bjørn Holst, and Jakob R. Winther. Functional differences in yeast protein disulfide isomerases. The Journal of Cell Biology, 152:553-562, Feb 2001. URL: https://doi.org/10.1083/jcb.152.3.553, doi:10.1083/jcb.152.3.553. This article has 171 citations.</p>
+</li>
+<li>
+<p>(hacioglu2010therolesof pages 3-4): Elise Hacioglu, Isil Esmer, Dmitri E. Fomenko, Vadim N. Gladyshev, and Ahmet Koc. The roles of thiol oxidoreductases in yeast replicative aging. Mechanisms of Ageing and Development, 131:692-699, Nov 2010. URL: https://doi.org/10.1016/j.mad.2010.09.006, doi:10.1016/j.mad.2010.09.006. This article has 15 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(xiao2004thecontributionsof pages 5-7): Ruoyu Xiao, Bonney Wilkinson, Anton Solovyov, Jakob R. Winther, Arne Holmgren, Johanna Lundström-Ljung, and Hiram F. Gilbert. The contributions of protein disulfide isomerase and its homologues to oxidative protein folding in the yeast endoplasmic reticulum*. Journal of Biological Chemistry, 279:49780-49786, Nov 2004. URL: https://doi.org/10.1074/jbc.m409210200, doi:10.1074/jbc.m409210200. This article has 87 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(xiao2004thecontributionsof media f566842d): Ruoyu Xiao, Bonney Wilkinson, Anton Solovyov, Jakob R. Winther, Arne Holmgren, Johanna Lundström-Ljung, and Hiram F. Gilbert. The contributions of protein disulfide isomerase and its homologues to oxidative protein folding in the yeast endoplasmic reticulum*. Journal of Biological Chemistry, 279:49780-49786, Nov 2004. URL: https://doi.org/10.1074/jbc.m409210200, doi:10.1074/jbc.m409210200. This article has 87 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(nørgaard2001mutationofyeast pages 6-6): Per NØRGAARD and Jakob R. WINTHER. Mutation of yeast eug1p cxxs active sites to cxxc results in a dramatic increase in protein disulphide isomerase activity. The Biochemical journal, 358 Pt 1:269-74, Aug 2001. URL: https://doi.org/10.1042/bj3580269, doi:10.1042/bj3580269. This article has 47 citations.</p>
+</li>
+<li>
+<p>(nørgaard2001mutationofyeast pages 4-6): Per NØRGAARD and Jakob R. WINTHER. Mutation of yeast eug1p cxxs active sites to cxxc results in a dramatic increase in protein disulphide isomerase activity. The Biochemical journal, 358 Pt 1:269-74, Aug 2001. URL: https://doi.org/10.1042/bj3580269, doi:10.1042/bj3580269. This article has 47 citations.</p>
+</li>
+<li>
+<p>(kimura2004functionaldifferencesbetween pages 1-2): Taiji Kimura, Yasuhiro Hosoda, Yukiko Kitamura, Hideshi Nakamura, Tomohisa Horibe, and Masakazu Kikuchi. Functional differences between human and yeast protein disulfide isomerase family proteins. Biochemical and biophysical research communications, 320 2:359-65, Jul 2004. URL: https://doi.org/10.1016/j.bbrc.2004.05.178, doi:10.1016/j.bbrc.2004.05.178. This article has 30 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(vala2008characterizationoferv2p pages 58-61): ALL Vala. Characterization of erv2p and pdi1p, two thiol oxidoreductases involved in protein disulfide bond formation in the endoplasmic reticulum of saccharomyces cerevisiae. Unknown journal, 2008.</p>
+</li>
+<li>
+<p>(xiao2004thecontributionsof media a580a63e): Ruoyu Xiao, Bonney Wilkinson, Anton Solovyov, Jakob R. Winther, Arne Holmgren, Johanna Lundström-Ljung, and Hiram F. Gilbert. The contributions of protein disulfide isomerase and its homologues to oxidative protein folding in the yeast endoplasmic reticulum*. Journal of Biological Chemistry, 279:49780-49786, Nov 2004. URL: https://doi.org/10.1074/jbc.m409210200, doi:10.1074/jbc.m409210200. This article has 87 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(fan2024characterizinginteractionsof pages 1-4): Xian Fan, Huahua He, Ting Wang, Pan Xu, Faying Zhang, Shantong Hu, Yueli Yun, Meng Mei, Guimin Zhang, and Li Yi. Characterizing interactions of er resident proteins in situ through the yst-ppi method. bioRxiv, May 2024. URL: https://doi.org/10.1101/2024.05.21.594841, doi:10.1101/2024.05.21.594841. This article has 0 citations.</p>
+</li>
+<li>
+<p>(fan2024characterizinginteractionsof pages 13-17): Xian Fan, Huahua He, Ting Wang, Pan Xu, Faying Zhang, Shantong Hu, Yueli Yun, Meng Mei, Guimin Zhang, and Li Yi. Characterizing interactions of er resident proteins in situ through the yst-ppi method. bioRxiv, May 2024. URL: https://doi.org/10.1101/2024.05.21.594841, doi:10.1101/2024.05.21.594841. This article has 0 citations.</p>
+</li>
+<li>
+<p>(fan2024characterizinginteractionsof pages 7-10): Xian Fan, Huahua He, Ting Wang, Pan Xu, Faying Zhang, Shantong Hu, Yueli Yun, Meng Mei, Guimin Zhang, and Li Yi. Characterizing interactions of er resident proteins in situ through the yst-ppi method. bioRxiv, May 2024. URL: https://doi.org/10.1101/2024.05.21.594841, doi:10.1101/2024.05.21.594841. This article has 0 citations.</p>
+</li>
+<li>
+<p>(fan2024characterizinginteractionsof pages 10-13): Xian Fan, Huahua He, Ting Wang, Pan Xu, Faying Zhang, Shantong Hu, Yueli Yun, Meng Mei, Guimin Zhang, and Li Yi. Characterizing interactions of er resident proteins in situ through the yst-ppi method. bioRxiv, May 2024. URL: https://doi.org/10.1101/2024.05.21.594841, doi:10.1101/2024.05.21.594841. This article has 0 citations.</p>
+</li>
+<li>
+<p>(hou2012metabolicengineeringof pages 10-11): Jin Hou, Keith E.J. Tyo, Zihe Liu, Dina Petranovic, and Jens Nielsen. Metabolic engineering of recombinant protein secretion by saccharomyces cerevisiae. FEMS yeast research, 12 5:491-510, Aug 2012. URL: https://doi.org/10.1111/j.1567-1364.2012.00810.x, doi:10.1111/j.1567-1364.2012.00810.x. This article has 292 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(hou2012metabolicengineeringof pages 9-10): Jin Hou, Keith E.J. Tyo, Zihe Liu, Dina Petranovic, and Jens Nielsen. Metabolic engineering of recombinant protein secretion by saccharomyces cerevisiae. FEMS yeast research, 12 5:491-510, Aug 2012. URL: https://doi.org/10.1111/j.1567-1364.2012.00810.x, doi:10.1111/j.1567-1364.2012.00810.x. This article has 292 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(hou2012metabolicengineeringof pages 11-12): Jin Hou, Keith E.J. Tyo, Zihe Liu, Dina Petranovic, and Jens Nielsen. Metabolic engineering of recombinant protein secretion by saccharomyces cerevisiae. FEMS yeast research, 12 5:491-510, Aug 2012. URL: https://doi.org/10.1111/j.1567-1364.2012.00810.x, doi:10.1111/j.1567-1364.2012.00810.x. This article has 292 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(xiao2004thecontributionsof pages 1-2): Ruoyu Xiao, Bonney Wilkinson, Anton Solovyov, Jakob R. Winther, Arne Holmgren, Johanna Lundström-Ljung, and Hiram F. Gilbert. The contributions of protein disulfide isomerase and its homologues to oxidative protein folding in the yeast endoplasmic reticulum*. Journal of Biological Chemistry, 279:49780-49786, Nov 2004. URL: https://doi.org/10.1074/jbc.m409210200, doi:10.1074/jbc.m409210200. This article has 87 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>suzuki2015redoxdiversityin pages 1-2</li>
+<li>beynonjones2006mutationalanalysisof pages 1-2</li>
+<li>hacioglu2010therolesof pages 3-4</li>
+<li>kimura2004functionaldifferencesbetween pages 1-2</li>
+<li>xiao2004thecontributionsof pages 2-2</li>
+<li>xiao2004thecontributionsof pages 5-7</li>
+<li>fan2024characterizinginteractionsof pages 10-13</li>
+<li>hou2012metabolicengineeringof pages 10-11</li>
+<li>hou2012metabolicengineeringof pages 9-10</li>
+<li>hou2012metabolicengineeringof pages 11-12</li>
+<li>xiao2004thecontributionsof pages 1-2</li>
+<li>fan2024characterizinginteractionsof pages 1-4</li>
+<li>fan2024characterizinginteractionsof pages 13-17</li>
+<li>fan2024characterizinginteractionsof pages 7-10</li>
+<li>https://doi.org/10.1083/jcb.152.3.553</li>
+<li>https://doi.org/10.1074/jbc.m409210200</li>
+<li>https://doi.org/10.1016/j.febslet.2006.02.055</li>
+<li>https://doi.org/10.1016/j.mad.2010.09.006</li>
+<li>https://doi.org/10.1515/hsz-2014-0299</li>
+<li>https://doi.org/10.1042/bj3580269</li>
+<li>https://doi.org/10.1016/j.bbrc.2004.05.178</li>
+<li>https://doi.org/10.1101/2024.05.21.594841</li>
+<li>https://doi.org/10.1111/j.1567-1364.2012.00810.x</li>
+<li>https://doi.org/10.1515/hsz-2014-0299,</li>
+<li>https://doi.org/10.1074/jbc.m409210200,</li>
+<li>https://doi.org/10.1083/jcb.152.3.553,</li>
+<li>https://doi.org/10.1016/j.febslet.2006.02.055,</li>
+<li>https://doi.org/10.1016/j.mad.2010.09.006,</li>
+<li>https://doi.org/10.1042/bj3580269,</li>
+<li>https://doi.org/10.1016/j.bbrc.2004.05.178,</li>
+<li>https://doi.org/10.1101/2024.05.21.594841,</li>
+<li>https://doi.org/10.1111/j.1567-1364.2012.00810.x,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -2336,11 +2943,17 @@
                 <pre><code>id: P32474
 gene_symbol: EUG1
 product_type: PROTEIN
-status: DRAFT
+status: COMPLETE
 taxon:
   id: NCBITaxon:559292
   label: Saccharomyces cerevisiae
-description: &#39;TODO: Add description for EUG1&#39;
+description: &gt;-
+  EUG1 encodes a nonessential endoplasmic-reticulum protein disulfide isomerase
+  family member with thioredoxin-like domains and atypical CXXS active-site
+  motifs. Evidence supports an auxiliary ER protein-folding and quality-control
+  role: wild-type Eug1p has weak classical oxidoreductase/isomerase activity,
+  measurable chaperone-like activity, ER retention, and functional overlap with
+  other yeast PDI-family proteins.
 existing_annotations:
 - term:
     id: GO:0005783
@@ -2378,6 +2991,9 @@ existing_annotations:
     summary: &#39;Manual review: protein disulfide isomerase activity is consistent with known biology of EUG1.&#39;
     action: ACCEPT
     reason: Retained as supported or plausible for this gene and evidence context.
+    supported_by:
+    - reference_id: file:yeast/EUG1/EUG1-deep-research-falcon.md
+      supporting_text: Eug1p is described as an **ER-resident glycoprotein**
 - term:
     id: GO:0003756
     label: protein disulfide isomerase activity
@@ -2589,13 +3205,43 @@ references:
 - id: PMID:27107014
   title: An inter-species protein-protein interaction network across vast evolutionary distance.
   findings: []
+- id: file:yeast/EUG1/EUG1-deep-research-falcon.md
+  title: Falcon deep research report for EUG1
+  findings: []
+core_functions:
+- description: &gt;-
+    Auxiliary ER protein-folding factor in the protein disulfide isomerase
+    family. Eug1p has atypical CXXS active sites, weak classical oxidoreductase
+    activity relative to Pdi1p, and contributes to ER folding/proteostasis
+    through isomerase-like, reductase-like, and chaperone-like activity.
+  molecular_function:
+    id: GO:0003756
+    label: protein disulfide isomerase activity
+  directly_involved_in:
+  - id: GO:0006457
+    label: protein folding
+  - id: GO:0034976
+    label: response to endoplasmic reticulum stress
+  locations:
+  - id: GO:0005788
+    label: endoplasmic reticulum lumen
+  supported_by:
+  - reference_id: file:yeast/EUG1/EUG1-deep-research-falcon.md
+    supporting_text: wild-type Eug1p is a weak oxidoreductase/isomerase
+proposed_new_terms: []
+suggested_questions:
+- question: Should EUG1 annotations distinguish weak native oxidoreductase activity from engineered CXXC mutant activity when choosing molecular-function terms?
+- question: Are recently reported ER interaction-mapping partners suitable for direct GO protein-binding annotations, or should they remain supporting context?
+suggested_experiments:
+- description: Compare wild-type Eug1p and CXXC-engineered variants on native ER client substrates under physiological expression levels.
+- description: Validate Eug1p ER interaction partners from in situ mapping with reciprocal biochemical assays and client-folding readouts.
 </code></pre>
             </div>
         </details>
     </div>
 
     <!-- Pathway Visualization Link -->
-    
+
 
     <style>
         /* Markdown Section Styles */

--- a/genes/yeast/EUG1/EUG1-ai-review.yaml
+++ b/genes/yeast/EUG1/EUG1-ai-review.yaml
@@ -51,7 +51,7 @@ existing_annotations:
     reason: Retained as supported or plausible for this gene and evidence context.
     supported_by:
     - reference_id: file:yeast/EUG1/EUG1-deep-research-falcon.md
-      supporting_text: Eug1p is described as an **ER-resident glycoprotein**
+      supporting_text: wild-type Eug1p is a weak oxidoreductase/isomerase
 - term:
     id: GO:0003756
     label: protein disulfide isomerase activity

--- a/genes/yeast/EUG1/EUG1-ai-review.yaml
+++ b/genes/yeast/EUG1/EUG1-ai-review.yaml
@@ -1,11 +1,17 @@
 id: P32474
 gene_symbol: EUG1
 product_type: PROTEIN
-status: DRAFT
+status: COMPLETE
 taxon:
   id: NCBITaxon:559292
   label: Saccharomyces cerevisiae
-description: 'TODO: Add description for EUG1'
+description: >-
+  EUG1 encodes a nonessential endoplasmic-reticulum protein disulfide isomerase
+  family member with thioredoxin-like domains and atypical CXXS active-site
+  motifs. Evidence supports an auxiliary ER protein-folding and quality-control
+  role: wild-type Eug1p has weak classical oxidoreductase/isomerase activity,
+  measurable chaperone-like activity, ER retention, and functional overlap with
+  other yeast PDI-family proteins.
 existing_annotations:
 - term:
     id: GO:0005783
@@ -43,6 +49,9 @@ existing_annotations:
     summary: 'Manual review: protein disulfide isomerase activity is consistent with known biology of EUG1.'
     action: ACCEPT
     reason: Retained as supported or plausible for this gene and evidence context.
+    supported_by:
+    - reference_id: file:yeast/EUG1/EUG1-deep-research-falcon.md
+      supporting_text: Eug1p is described as an **ER-resident glycoprotein**
 - term:
     id: GO:0003756
     label: protein disulfide isomerase activity
@@ -254,3 +263,33 @@ references:
 - id: PMID:27107014
   title: An inter-species protein-protein interaction network across vast evolutionary distance.
   findings: []
+- id: file:yeast/EUG1/EUG1-deep-research-falcon.md
+  title: Falcon deep research report for EUG1
+  findings: []
+core_functions:
+- description: >-
+    Auxiliary ER protein-folding factor in the protein disulfide isomerase
+    family. Eug1p has atypical CXXS active sites, weak classical oxidoreductase
+    activity relative to Pdi1p, and contributes to ER folding/proteostasis
+    through isomerase-like, reductase-like, and chaperone-like activity.
+  molecular_function:
+    id: GO:0003756
+    label: protein disulfide isomerase activity
+  directly_involved_in:
+  - id: GO:0006457
+    label: protein folding
+  - id: GO:0034976
+    label: response to endoplasmic reticulum stress
+  locations:
+  - id: GO:0005788
+    label: endoplasmic reticulum lumen
+  supported_by:
+  - reference_id: file:yeast/EUG1/EUG1-deep-research-falcon.md
+    supporting_text: wild-type Eug1p is a weak oxidoreductase/isomerase
+proposed_new_terms: []
+suggested_questions:
+- question: Should EUG1 annotations distinguish weak native oxidoreductase activity from engineered CXXC mutant activity when choosing molecular-function terms?
+- question: Are recently reported ER interaction-mapping partners suitable for direct GO protein-binding annotations, or should they remain supporting context?
+suggested_experiments:
+- description: Compare wild-type Eug1p and CXXC-engineered variants on native ER client substrates under physiological expression levels.
+- description: Validate Eug1p ER interaction partners from in situ mapping with reciprocal biochemical assays and client-folding readouts.

--- a/genes/yeast/EUG1/EUG1-deep-research-falcon.md
+++ b/genes/yeast/EUG1/EUG1-deep-research-falcon.md
@@ -1,0 +1,355 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-11T08:54:18.901783'
+end_time: '2026-05-11T09:08:35.774608'
+duration_seconds: 856.87
+template_file: templates/gene_research_go_focused.md
+template_variables:
+  organism: yeast
+  gene_id: EUG1
+  gene_symbol: EUG1
+  uniprot_accession: P32474
+  protein_description: 'RecName: Full=Protein disulfide-isomerase EUG1; Short=PDI;
+    EC=5.3.4.1; AltName: Full=Endoplasmic reticulum protein EUG1; Flags: Precursor;'
+  gene_info: Name=EUG1; OrderedLocusNames=YDR518W; ORFNames=D9719.23;
+  organism_full: Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+  protein_family: Belongs to the protein disulfide isomerase family.
+  protein_domains: Prot_disulphide_isomerase. (IPR005792); Thioredoxin-like_sf. (IPR036249);
+    Thioredoxin_domain. (IPR013766); Thioredoxin (PF00085); Thioredoxin_6 (PF13848)
+provider_config:
+  timeout: 600
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 32
+---
+
+## Question
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** P32474
+- **Protein Description:** RecName: Full=Protein disulfide-isomerase EUG1; Short=PDI; EC=5.3.4.1; AltName: Full=Endoplasmic reticulum protein EUG1; Flags: Precursor;
+- **Gene Information:** Name=EUG1; OrderedLocusNames=YDR518W; ORFNames=D9719.23;
+- **Organism (full):** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+- **Protein Family:** Belongs to the protein disulfide isomerase family.
+- **Key Domains:** Prot_disulphide_isomerase. (IPR005792); Thioredoxin-like_sf. (IPR036249); Thioredoxin_domain. (IPR013766); Thioredoxin (PF00085); Thioredoxin_6 (PF13848)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "EUG1" matches the protein description above**
+2. **Verify the organism is correct:** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'EUG1' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **EUG1** (gene ID: EUG1, UniProt: P32474) in yeast.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** P32474
+- **Protein Description:** RecName: Full=Protein disulfide-isomerase EUG1; Short=PDI; EC=5.3.4.1; AltName: Full=Endoplasmic reticulum protein EUG1; Flags: Precursor;
+- **Gene Information:** Name=EUG1; OrderedLocusNames=YDR518W; ORFNames=D9719.23;
+- **Organism (full):** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+- **Protein Family:** Belongs to the protein disulfide isomerase family.
+- **Key Domains:** Prot_disulphide_isomerase. (IPR005792); Thioredoxin-like_sf. (IPR036249); Thioredoxin_domain. (IPR013766); Thioredoxin (PF00085); Thioredoxin_6 (PF13848)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "EUG1" matches the protein description above**
+2. **Verify the organism is correct:** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'EUG1' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **EUG1** (gene ID: EUG1, UniProt: P32474) in yeast.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Research report: **EUG1 (YDR518W; UniProt P32474)** — Protein disulfide-isomerase family member in *Saccharomyces cerevisiae* (S288c)
+
+### 1) Key concepts, definitions, and current understanding
+
+#### 1.1 Protein disulfide isomerase (PDI) family in the ER
+Protein disulfide isomerase (PDI) family proteins are thioredoxin-domain oxidoreductases in the endoplasmic reticulum (ER) lumen that catalyze thiol–disulfide exchange reactions during secretory-protein folding, including disulfide bond formation (oxidation), disulfide reduction, and disulfide isomerization (reshuffling of incorrect disulfides) (suzuki2015redoxdiversityin pages 1-2). In budding yeast, Pdi1p is the essential PDI, while several nonessential homologues provide overlapping/auxiliary functions in ER oxidative folding and quality control (xiao2004thecontributionsof pages 2-2, nørgaard2001functionaldifferencesin pages 2-2).
+
+#### 1.2 EUG1 gene/protein identity verification (disambiguation)
+Multiple independent sources explicitly place **EUG1 (YDR518W)** among the **PDI1 homologues localized to the yeast ER** (MPD1, MPD2, EUG1, EPS1) and among the yeast PDI family members (xiao2004thecontributionsof pages 2-2, suzuki2015redoxdiversityin pages 1-2). In addition, mechanistic evidence refers to “a yeast PDI homologue, Eug1p” and highlights its unusual active-site chemistry (beynonjones2006mutationalanalysisof pages 1-2). These points confirm that the literature summarized here corresponds to **the same target as UniProt P32474 (Eug1p in *S. cerevisiae*)**, not an unrelated “EUG1” gene from another organism (xiao2004thecontributionsof pages 2-2, beynonjones2006mutationalanalysisof pages 1-2).
+
+### 2) Molecular features of Eug1p (domains, active sites) and enzymatic mechanism
+
+#### 2.1 Domain architecture and active-site motifs
+Eug1p is described as a Pdi1p homologue with **two thioredoxin-like domains** and **two non-canonical redox motifs of the form CXXS (rather than CXXC)** (nørgaard2001functionaldifferencesin pages 2-2, nørgaard2001functionaldifferencesin pages 1-2). Active-site positions for the two CxxS motifs were reported as **residues 62 and 405** (hacioglu2010therolesof pages 3-4). This “CXXS” configuration is repeatedly emphasized as a key reason for Eug1p’s atypically weak oxidoreductase function relative to canonical PDIs (beynonjones2006mutationalanalysisof pages 1-2, nørgaard2001functionaldifferencesin pages 2-2).
+
+#### 2.2 Catalyzed reaction class and substrate specificity (functional inference + direct substrate assays)
+**Reaction class:** Like other PDI-family oxidoreductases, Eug1p participates in **thiol–disulfide exchange**, which in principle can catalyze oxidation/reduction/isomerization of disulfide bonds in ER client proteins (suzuki2015redoxdiversityin pages 1-2). 
+
+**Substrate-level evidence:** Several experiments use the secretory pathway substrate **procarboxypeptidase Y (proCPY/CPY)** to probe PDI-family function in vivo and in vitro. In deletion/overexpression backgrounds, loss of PDI homologues slows CPY maturation (xiao2004thecontributionsof pages 5-7, xiao2004thecontributionsof media f566842d). In biochemical assays, engineered Eug1p variants (see below) catalyze oxidative refolding and disulfide reshuffling of proCPY (nørgaard2001mutationofyeast pages 6-6, nørgaard2001mutationofyeast pages 4-6). These experiments provide the most direct “substrate specificity” evidence available in the retrieved corpus: Eug1p-related activity is demonstrated on a complex secretory cargo (proCPY) rather than a single defined peptide substrate (nørgaard2001mutationofyeast pages 4-6).
+
+#### 2.3 Wild-type Eug1p has weak oxidoreductase/isomerase activity, but detectable chaperone-like activity
+Multiple sources converge on the conclusion that **wild-type Eug1p is a weak oxidoreductase/isomerase** in standard PDI assays:
+* A study of yeast PDI family functional differences emphasizes that Eug1p contains **CXXS** motifs and that Eug1p “alone is unable to carry oxidizing equivalents,” consistent with limited oxidase capacity (nørgaard2001functionaldifferencesin pages 2-2).
+* A biochemical study concludes that “wild-type Eug1p is a poor isomerase” and that wild-type Eug1p has only a small signal in an insulin reduction assay and does not improve oxidative refolding of proCPY under the tested conditions (nørgaard2001mutationofyeast pages 4-6).
+* A comparative analysis reports that isomerase activities of yeast PDI-family proteins including Eug1p were “extremely low,” while also indicating that (except for Mpd1p) PDI-family proteins retain chaperone activity (kimura2004functionaldifferencesbetween pages 1-2).
+
+In contrast to weak oxidoreductase activity, an ER-quality-control role via **binding/anti-aggregation (chaperone-like)** function is supported by in vitro chaperone metrics: Eug1p exhibited measurable chaperone activity with a reported parameter **KD = 4.21×10^-4 M** in the referenced assay context (vala2008characterizationoferv2p pages 58-61).
+
+#### 2.4 Active-site engineering demonstrates causality of the CXXS motif
+A key mechanistic demonstration is that converting Eug1p active sites from **CXXS → CXXC** greatly increases PDI-like function:
+* Mutation of Eug1p CXXS active sites to CXXC caused a “dramatic increase” in PDI activity; the engineered form gained oxidase/isomerase activity on proCPY-related substrates (including a GS-proCPY assay where wild-type Eug1p showed no activity) (nørgaard2001mutationofyeast pages 6-6).
+* Quantitatively, the engineered **Eug1pCXXC-CXXC** reached approximately **30–50%** of native yeast Pdi1p activity in the study’s assays (nørgaard2001mutationofyeast pages 6-6).
+* In proCPY refolding kinetics, the authors reported proCPY has **11 free thiols** when fully reduced, decreasing rapidly with a plateau around **1.5–2 thiols** per proCPY after ~20–30 minutes; wild-type Eug1p did not affect the refolding rate/yield under those test conditions, while CXXC mutants shortened the lag phase and enhanced folding (nørgaard2001mutationofyeast pages 4-6).
+
+Collectively, these results support the interpretation that **Eug1p’s primary physiological contribution is likely not bulk oxidation**, and that its atypical active sites may tune it toward noncanonical roles (e.g., assisting folding via binding or specialized redox tasks) rather than being a major disulfide oxidase (nørgaard2001mutationofyeast pages 4-6, nørgaard2001functionaldifferencesin pages 2-2).
+
+### 3) Cellular localization and pathway context
+
+#### 3.1 ER localization and retention
+Eug1p is described as an **ER-resident glycoprotein** with an **N-terminal signal sequence** and a **C-terminal HDEL ER retention signal**, consistent with ER luminal residency (vala2008characterizationoferv2p pages 58-61). This matches broader genetic/functional categorization of EUG1 as one of the yeast ER PDI-family homologues (xiao2004thecontributionsof pages 2-2).
+
+#### 3.2 Role within ER oxidative folding/UPR network
+Expression of **PDI1 and ER PDI homologues** is described as regulated by the **unfolded protein response (UPR)**, and PDI homologues can be upregulated when PDI activity is defective—placing EUG1 within ER stress adaptation/proteostasis circuits (xiao2004thecontributionsof pages 5-7). Functional overlap among ER PDI-family members is also supported by the ability of ER homologues (including EUG1) to rescue a pdi1 mutation when overexpressed (xiao2004thecontributionsof pages 2-2).
+
+### 4) Genetics, phenotypes, and mechanistic interpretation
+
+#### 4.1 Essentiality and redundancy
+In yeast, **PDI1 is essential**, while **EUG1 is nonessential** under standard growth conditions (nørgaard2001functionaldifferencesin pages 1-2, vala2008characterizationoferv2p pages 58-61). Nonetheless, EUG1 can participate in partial compensation:
+* Overexpressed homologues (EUG1/MPD1/MPD2) can restore viability to a pdi1-deleted strain, but such suppression often requires low endogenous levels of other homologues and is not fully interchangeable (nørgaard2001functionaldifferencesin pages 1-2).
+* Specifically, suppression of pdi1 deletion by EUG1 requires endogenous homologues with **CXXC** motifs, consistent with Eug1p’s inability to provide oxidation alone (nørgaard2001functionaldifferencesin pages 1-2).
+
+#### 4.2 Folding phenotypes: CPY maturation
+Across multiple studies, the folding/maturation of secretory cargo is a sensitive readout of PDI-family function:
+* In vivo, CPY maturation can become “extremely slow” in backgrounds lacking supportive PDI-homologue activity under certain conditions (xiao2004thecontributionsof pages 5-7).
+* A retrieved figure/table from Xiao et al. (2004) provides pulse–chase evidence and half-time quantification for CPY maturation across mutant backgrounds that alter PDI-family capacity (xiao2004thecontributionsof media f566842d, xiao2004thecontributionsof media a580a63e).
+* In another report, cells lacking EUG1 were viable but showed a slight vacuolar sorting defect for soluble vacuolar proteins including CPY; overexpression of EUG1 in a pdi1Δ strain permitted growth but did not correct proCPY accumulation, implying incomplete functional overlap with Pdi1p (vala2008characterizationoferv2p pages 58-61).
+
+#### 4.3 ERAD (ER-associated degradation)
+Despite strong effects on folding and glycan modification in multiple deletion combinations, one study reports **no significant effects on ER-associated degradation (ERAD)** across the PDI-deleted strains tested, suggesting that (in that experimental space) PDI-family contributions are more critical for productive folding than for bulk ERAD flux (nørgaard2001functionaldifferencesin pages 1-2).
+
+#### 4.4 Other phenotypes and quantitative data
+Beyond secretion/folding readouts:
+* Deletion of **EUG1** was associated with a reported **~13% decrease in replicative lifespan** in one study that surveyed thiol oxidoreductases (hacioglu2010therolesof pages 3-4).
+
+### 5) Protein–protein interactions (PPIs) and functional networks
+
+#### 5.1 Biochemical interaction evidence
+In vitro binding evidence supports interaction between Eug1p and other ER PDI-like proteins:
+* Eug1p binds Eps1p with reported **KD = 6.06×10^-6 M** (vala2008characterizationoferv2p pages 58-61).
+* Functional cooperation was suggested by an observation that mixtures of Eps1p + Eug1p enhanced reductive activity in the cited assay context (reported as 122% in the excerpt) (vala2008characterizationoferv2p pages 58-61).
+
+#### 5.2 Recent development (2024): in situ ER PPI mapping (YST-PPI)
+A 2024 bioRxiv preprint introduces **YST-PPI**, an in situ ER-resident PPI mapping approach using split-fast TEV protease, ER retention signals, and a surface-display cleavage readout quantified by flow cytometry (fan2024characterizinginteractionsof pages 1-4, fan2024characterizinginteractionsof pages 13-17). The authors tested 15 ER resident proteins (including Eug1p) and report a network with **>74 interacting pairs** above a **>10% normalized interaction score** threshold, with overall score ranges roughly 1–93% (fan2024characterizinginteractionsof pages 1-4, fan2024characterizinginteractionsof pages 7-10).
+
+Within the subset of interactions validated against BioGRID/STRING, the study lists multiple **Eug1p interaction partners**, including **Sil1p, Yos9p, Scj1p, Cpr5p, Mpd1p, Mpd2p, Kre5p**, and interactions among PDI-family members (e.g., Pdi1p–Eug1p) (fan2024characterizinginteractionsof pages 10-13). A specifically mentioned Eug1p interaction score example is **Eug1p–Scj1p = 5%** (fan2024characterizinginteractionsof pages 10-13). This 2024 dataset contributes an updated view of Eug1p’s ER interaction neighborhood, though it is preprint (not yet peer reviewed) and provides limited mechanistic detail per edge in the extracted snippets (fan2024characterizinginteractionsof pages 10-13).
+
+### 6) Current applications and real-world implementations
+
+Direct “EUG1-specific” engineering examples were limited in the retrieved evidence. However, authoritative yeast biomanufacturing literature strongly supports **manipulating ER folding and disulfide-handling capacity (PDI/chaperones/oxidases)** as a practical strategy to improve recombinant secretion in *S. cerevisiae*—a context in which EUG1 is part of the endogenous ER folding-factor repertoire.
+
+A highly cited review on metabolic engineering of secretion reports:
+* Overexpression of ER chaperones and folding catalysts such as **Kar2p** and **PDI** often improves secretion of heterologous proteins, and **Kar2p/PDI cooperativity** can increase secretion for some clients (e.g., scFv and β-glucosidase examples described) (hou2012metabolicengineeringof pages 10-11).
+* Maintaining/engineering disulfide bonds can substantially affect yields: removal of IGF1 cysteines reduced expression by about **one-third**, and loss of a core disulfide in CD47 reduced expression level and affinity by **~30%** (hou2012metabolicengineeringof pages 9-10).
+* Broader strain and pathway engineering (including screens connected to ER oxidation/folding machinery) can yield large improvements, including reported **~15-fold** and up to **~70-fold** secretion improvements in selected/engineered contexts (hou2012metabolicengineeringof pages 11-12).
+
+These real-world findings imply that, while Pdi1p is the primary essential ER oxidoreductase, the broader PDI-family system (including homologues like Eug1p that may contribute binding/isomerase-like capacity or specialized functions) is a relevant target space when tuning ER proteostasis for production (hou2012metabolicengineeringof pages 10-11, xiao2004thecontributionsof pages 2-2).
+
+### 7) Expert analysis and synthesis
+
+#### 7.1 What is Eug1p’s “primary function” given the evidence?
+The strongest, most Eug1p-specific mechanistic conclusion supported by the retrieved literature is:
+* **Wild-type Eug1p is an ER luminal PDI-family protein whose unusual CXXS active sites severely limit classical PDI oxidase/isomerase activity**, and therefore Eug1p is unlikely to be a major provider of oxidizing equivalents for bulk disulfide formation in yeast (nørgaard2001functionaldifferencesin pages 2-2, nørgaard2001mutationofyeast pages 4-6).
+* Eug1p instead appears to contribute through **auxiliary ER folding functions**, potentially including **substrate binding/chaperone activity** and/or specialized redox roles that do not require a canonical CXXC active site, consistent with measurable chaperone activity and weak oxidoreductase activity (vala2008characterizationoferv2p pages 58-61, kimura2004functionaldifferencesbetween pages 1-2).
+* The fact that CXXS→CXXC engineering converts Eug1p into a much more active PDI strongly argues that Eug1p’s native motif is a functional “design choice” rather than an annotation artifact, and that its physiological role may be tuned away from strong oxidase chemistry (nørgaard2001mutationofyeast pages 6-6, nørgaard2001mutationofyeast pages 4-6).
+
+#### 7.2 Relationship to UPR/quality control and interactions
+EUG1 is embedded in ER proteostasis through UPR co-regulation with other PDI homologues (xiao2004thecontributionsof pages 5-7), genetic redundancy/conditional suppression behavior with other PDI homologues (nørgaard2001functionaldifferencesin pages 1-2), and a growing interaction network that includes ER chaperones/cochaperones and quality-control proteins (e.g., Sil1p, Yos9p, Scj1p) observed in the 2024 YST-PPI mapping (fan2024characterizinginteractionsof pages 10-13, fan2024characterizinginteractionsof pages 1-4). This supports the view that Eug1p’s contribution may be best interpreted at the level of ER network function rather than a single high-turnover enzymatic role.
+
+### 8) Limitations and recency
+The retrieval yielded **one clear 2024 Eug1p-relevant source** (Fan et al., 2024 bioRxiv) that contributes novel interaction mapping methodology and an ER PPI neighborhood including Eug1p (fan2024characterizinginteractionsof pages 10-13, fan2024characterizinginteractionsof pages 1-4). However, **peer-reviewed 2023–2024 Eug1p-specific primary literature was not retrieved** in this run, so “latest research” emphasis is necessarily weighted toward (i) foundational functional genetics/biochemistry (2001–2004), (ii) mechanistic review context (2015), and (iii) a 2024 preprint for interaction mapping (nørgaard2001functionaldifferencesin pages 1-2, nørgaard2001mutationofyeast pages 4-6, suzuki2015redoxdiversityin pages 1-2, fan2024characterizinginteractionsof pages 10-13).
+
+### Evidence summary table
+
+| Category | Key finding for **EUG1 / Eug1p** | Quantitative details | Key source(s) |
+|---|---|---|---|
+| Identity | **Saccharomyces cerevisiae** **EUG1** (**YDR518W**; UniProt **P32474**) encodes an ER-resident **protein disulfide-isomerase family** member / thioredoxin-domain oxidoreductase homologous to Pdi1p. It is one of four nonessential **PDI1** homologues in the yeast ER: **MPD1, MPD2, EUG1, EPS1**. (xiao2004thecontributionsof pages 1-2, xiao2004thecontributionsof pages 2-2, nørgaard2001functionaldifferencesin pages 2-2) | ~40% sequence identity to Pdi1p reported. (nørgaard2001functionaldifferencesin pages 2-2) | Nørgaard et al., 2001, *J Cell Biol* 152:553-562, https://doi.org/10.1083/jcb.152.3.553 (nørgaard2001functionaldifferencesin pages 2-2, nørgaard2001functionaldifferencesin pages 1-2); Xiao et al., 2004, *J Biol Chem* 279:49780-49786, https://doi.org/10.1074/jbc.m409210200 (xiao2004thecontributionsof pages 1-2, xiao2004thecontributionsof pages 2-2) |
+| Domain architecture / motifs | Eug1p contains **two thioredoxin-like domains** and **two non-canonical active sites** of the **CXXS** type rather than canonical PDI **CXXC/CGHC** motifs. Residue positions reported for the two CxxS motifs are **62** and **405**. (beynonjones2006mutationalanalysisof pages 1-2, nørgaard2001functionaldifferencesin pages 2-2, hacioglu2010therolesof pages 3-4) | Active-site positions: **CxxS at aa 62 and 405**. (hacioglu2010therolesof pages 3-4) | Nørgaard et al., 2001, *J Cell Biol*, https://doi.org/10.1083/jcb.152.3.553 (nørgaard2001functionaldifferencesin pages 2-2, nørgaard2001functionaldifferencesin pages 1-2); Beynon-Jones et al., 2006, *FEBS Lett* 580:1897-1902, https://doi.org/10.1016/j.febslet.2006.02.055 (beynonjones2006mutationalanalysisof pages 1-2); Hacioglu et al., 2010, *Mech Ageing Dev* 131:692-699, https://doi.org/10.1016/j.mad.2010.09.006 (hacioglu2010therolesof pages 3-4) |
+| Localization / ER retention | Eug1p is reported as an **ER-resident glycoprotein** with an **N-terminal signal sequence** and a **C-terminal HDEL** ER-retention signal; broader literature also consistently places EUG1 among yeast **ER PDI-family proteins**. (vala2008characterizationoferv2p pages 58-61, xiao2004thecontributionsof pages 1-2, suzuki2015redoxdiversityin pages 1-2) | Length reported as **517 aa**. (vala2008characterizationoferv2p pages 58-61) | Vala, 2008, thesis/dissertation excerpt (vala2008characterizationoferv2p pages 58-61); Xiao et al., 2004, *J Biol Chem*, https://doi.org/10.1074/jbc.m409210200 (xiao2004thecontributionsof pages 1-2); Suzuki & Schmitt, 2015, *Biol Chem* 396:539-554, https://doi.org/10.1515/hsz-2014-0299 (suzuki2015redoxdiversityin pages 1-2) |
+| Primary biochemical role | Current evidence supports Eug1p primarily as a **folding assistant / isomerase-like and chaperone-like ER factor**, not a strong oxidase. Because its active sites are **CXXS**, Eug1p alone is considered unable or poorly able to transfer oxidizing equivalents efficiently compared with canonical CXXC PDIs. (nørgaard2001functionaldifferencesin pages 2-2, nørgaard2001mutationofyeast pages 4-6, kimura2004functionaldifferencesbetween pages 1-2) | Wild-type Eug1p described as having **very low oxidative/refolding activity** and **extremely low isomerase activity**; chaperone activity is detectable. (vala2008characterizationoferv2p pages 58-61, kimura2004functionaldifferencesbetween pages 1-2) | Nørgaard & Winther, 2001, *Biochem J* 358:269-274, https://doi.org/10.1042/bj3580269 (nørgaard2001mutationofyeast pages 4-6); Kimura et al., 2004, *BBRC* 320:359-365, https://doi.org/10.1016/j.bbrc.2004.05.178 (kimura2004functionaldifferencesbetween pages 1-2) |
+| Oxidase / oxidative folding activity | Wild-type Eug1p has **very low oxidative refolding activity** relative to Pdi1p. Overexpression can support growth in some **pdi1Δ** backgrounds, but this does not restore full Pdi1p-like oxidative folding capacity. (vala2008characterizationoferv2p pages 58-61, nørgaard2001functionaldifferencesin pages 2-2, nørgaard2001functionaldifferencesin pages 1-2) | Oxidative refolding activity reported as **2.16% of Pdi1p** in a lysozyme assay. (vala2008characterizationoferv2p pages 58-61) | Vala, 2008 excerpt (vala2008characterizationoferv2p pages 58-61); Nørgaard et al., 2001, *J Cell Biol*, https://doi.org/10.1083/jcb.152.3.553 (nørgaard2001functionaldifferencesin pages 2-2, nørgaard2001functionaldifferencesin pages 1-2) |
+| Reductase / isomerase activity | Wild-type Eug1p shows only a **small but significant** insulin-reduction signal and is described as a **poor isomerase**; on some substrates it shows essentially **no detectable isomerase activity**. (nørgaard2001mutationofyeast pages 4-6, kimura2004functionaldifferencesbetween pages 1-2) | Wild-type Eug1p had **no activity on GS-proCPY** in the cited assay; isomerase activities of Mpd1p, Mpd2p, and Eug1p were described as **extremely low**. (nørgaard2001mutationofyeast pages 6-6, kimura2004functionaldifferencesbetween pages 1-2) | Nørgaard & Winther, 2001, *Biochem J*, https://doi.org/10.1042/bj3580269 (nørgaard2001mutationofyeast pages 6-6, nørgaard2001mutationofyeast pages 4-6); Kimura et al., 2004, *BBRC*, https://doi.org/10.1016/j.bbrc.2004.05.178 (kimura2004functionaldifferencesbetween pages 1-2) |
+| Chaperone activity | Eug1p has experimentally supported **chaperone activity** despite weak oxidoreductase function, consistent with a role in assisting ER protein folding/quality control. (vala2008characterizationoferv2p pages 58-61, kimura2004functionaldifferencesbetween pages 1-2, hacioglu2010therolesof pages 3-4) | Mastoparan/rhodanase-related binding/activity parameter reported as **KD = 4.21×10^-4 M**; broader comparison paper states Eug1p retained chaperone activity while Mpd1p did not. (vala2008characterizationoferv2p pages 58-61, kimura2004functionaldifferencesbetween pages 1-2) | Vala, 2008 excerpt (vala2008characterizationoferv2p pages 58-61); Kimura et al., 2004, *BBRC*, https://doi.org/10.1016/j.bbrc.2004.05.178 (kimura2004functionaldifferencesbetween pages 1-2); Hacioglu et al., 2010, *Mech Ageing Dev*, https://doi.org/10.1016/j.mad.2010.09.006 (hacioglu2010therolesof pages 3-4) |
+| Active-site engineering evidence | Converting Eug1p active sites from **CXXS to CXXC** dramatically increases PDI-like activity, showing that the native **CXXS** motif is a major determinant of Eug1p’s weak oxidase/isomerase behavior. (nørgaard2001mutationofyeast pages 6-6, nørgaard2001mutationofyeast pages 4-6, beynonjones2006mutationalanalysisof pages 1-2) | **EUG1CXXC-CXXC** reached roughly **30–50% of native yeast PDI** activity and could complement backgrounds lacking auxiliary PDI-like proteins better than wild-type EUG1. (nørgaard2001mutationofyeast pages 6-6) | Nørgaard & Winther, 2001, *Biochem J*, https://doi.org/10.1042/bj3580269 (nørgaard2001mutationofyeast pages 6-6, nørgaard2001mutationofyeast pages 4-6); Beynon-Jones et al., 2006, *FEBS Lett*, https://doi.org/10.1016/j.febslet.2006.02.055 (beynonjones2006mutationalanalysisof pages 1-2) |
+| Genetic redundancy with PDI family | **EUG1** is **nonessential** individually. Overexpressed **EUG1** can help restore viability to **pdi1Δ** strains, but this depends on the presence of endogenous homologues with **CXXC** motifs; thus PDI-family homologues are **not functionally interchangeable**. **Mpd1p** is the only homologue reported to carry out all essential Pdi1p functions. (xiao2004thecontributionsof pages 2-2, nørgaard2001functionaldifferencesin pages 2-2, nørgaard2001functionaldifferencesin pages 1-2) | Overexpression of **EUG1, MPD1, or MPD2** did **not fully complement** **pdi1Δ**; EUG1 suppression required endogenous CXXC-containing homologues. (nørgaard2001functionaldifferencesin pages 2-2, nørgaard2001functionaldifferencesin pages 1-2) | Nørgaard et al., 2001, *J Cell Biol*, https://doi.org/10.1083/jcb.152.3.553 (nørgaard2001functionaldifferencesin pages 2-2, nørgaard2001functionaldifferencesin pages 1-2); Xiao et al., 2004, *J Biol Chem*, https://doi.org/10.1074/jbc.m409210200 (xiao2004thecontributionsof pages 2-2) |
+| CPY folding / maturation phenotype | Loss of PDI-family support leads to slower **carboxypeptidase Y (CPY/proCPY)** folding and maturation. EUG1 overexpression permits growth in some contexts but does not fully rescue **proCPY accumulation**, supporting partial rather than full functional overlap with Pdi1p. (vala2008characterizationoferv2p pages 58-61, xiao2004thecontributionsof pages 5-7, xiao2004thecontributionsof media f566842d) | Xiao et al. Figure 5 quantified **half-times for CPY maturation** across mutant backgrounds; text states CPY maturation becomes **extremely slow** when homologues are absent and only a weak Pdi1p isomerase variant is present. Vala excerpt states EUG1 overexpression did **not correct proCPY accumulation**. (xiao2004thecontributionsof pages 5-7, xiao2004thecontributionsof media f566842d, vala2008characterizationoferv2p pages 58-61) | Xiao et al., 2004, *J Biol Chem*, https://doi.org/10.1074/jbc.m409210200 (xiao2004thecontributionsof pages 5-7, xiao2004thecontributionsof media f566842d); Vala, 2008 excerpt (vala2008characterizationoferv2p pages 58-61) |
+| ERAD phenotype | Across multiple PDI deletion combinations, there were **no significant effects on ER-associated degradation (ERAD)**, suggesting EUG1/PDI-family contributions are more critical for folding/isomerization than for ERAD in the tested contexts. (nørgaard2001functionaldifferencesin pages 1-2) | Qualitative: **no significant ERAD effect** reported. (nørgaard2001functionaldifferencesin pages 1-2) | Nørgaard et al., 2001, *J Cell Biol*, https://doi.org/10.1083/jcb.152.3.553 (nørgaard2001functionaldifferencesin pages 1-2) |
+| Other phenotypes | Deleting **EUG1** causes no gross growth defect under standard conditions, but one study reported a **slight vacuolar protein sorting defect** and another linked loss of EUG1 to reduced replicative lifespan. (vala2008characterizationoferv2p pages 58-61, hacioglu2010therolesof pages 3-4) | Replicative lifespan reduction of about **13%** in **eug1Δ** cells; slight CPY/proteinase A sorting defect noted. (hacioglu2010therolesof pages 3-4, vala2008characterizationoferv2p pages 58-61) | Hacioglu et al., 2010, *Mech Ageing Dev*, https://doi.org/10.1016/j.mad.2010.09.006 (hacioglu2010therolesof pages 3-4); Vala, 2008 excerpt (vala2008characterizationoferv2p pages 58-61) |
+| Interaction partners: classical biochemical evidence | Eug1p interacts in vitro with **Eps1p**; functional cooperation among PDI-family proteins has been proposed. (vala2008characterizationoferv2p pages 58-61) | **Eug1p–Eps1p KD = 6.06×10^-6 M**; Eps1p also binds Pdi1p (**7.33×10^-6 M**), Mpd1p (**3.88×10^-6 M**), Kar2p (**1.03×10^-6 M**), and Cne1p (**1.38×10^-5 M**). Mixtures of **Eps1p + Eug1p** showed enhanced reductive activity (**122%** vs. 0% or 100% for individual proteins, as reported in the excerpt). (vala2008characterizationoferv2p pages 58-61) | Vala, 2008 excerpt (vala2008characterizationoferv2p pages 58-61) |
+| Interaction partners: recent 2024 ER-PPI mapping | A 2024 **YST-PPI** preprint mapped ER-resident interactions in situ and included **Eug1p** among tested proteins. Reported/validated Eug1p partners included **Pdi1p, Sil1p, Yos9p, Scj1p, Cpr5p, Mpd1p, Mpd2p, Kre5p**. (fan2024characterizinginteractionsof pages 10-13, fan2024characterizinginteractionsof pages 7-10, fan2024characterizinginteractionsof pages 1-4) | Pairwise scores in the study ranged roughly **1–93%** overall; specific values mentioned for Eug1p-related examples include **Eug1p–Scj1p = 5%**. A validated network of **>74 interacting pairs** above a **>10%** cutoff was reported. (fan2024characterizinginteractionsof pages 10-13, fan2024characterizinginteractionsof pages 7-10, fan2024characterizinginteractionsof pages 1-4) | Fan et al., 2024, *bioRxiv* preprint, published May 2024, https://doi.org/10.1101/2024.05.21.594841 (fan2024characterizinginteractionsof pages 10-13, fan2024characterizinginteractionsof pages 7-10, fan2024characterizinginteractionsof pages 1-4) |
+| Interaction-mapping methodology (recent) | **YST-PPI** measures interactions **in situ** in the yeast ER using **split-TEV / split-fast TEV**, **ER retention signals**, a cleavable surface-display substrate, and **flow cytometry** readout. This is relevant because Eug1p is an ER lumenal protein whose interactions may be missed by nucleus-based assays. (fan2024characterizinginteractionsof pages 10-13, fan2024characterizinginteractionsof pages 13-17, fan2024characterizinginteractionsof pages 1-4) | Study tested **15 ER resident proteins**; reported **91 pairs** above negative-control threshold and **74 pairs >10%** normalized interaction score. Positive control reached **96%**; negative control ~**4%**. (fan2024characterizinginteractionsof pages 7-10, fan2024characterizinginteractionsof pages 1-4) | Fan et al., 2024, *bioRxiv*, https://doi.org/10.1101/2024.05.21.594841 (fan2024characterizinginteractionsof pages 10-13, fan2024characterizinginteractionsof pages 7-10, fan2024characterizinginteractionsof pages 13-17, fan2024characterizinginteractionsof pages 1-4) |
+| UPR / expression regulation | PDI1 and its ER homologues, including **EUG1**, are reported to be regulated by the **unfolded protein response (UPR)** and can be upregulated when PDI activity is defective, placing Eug1p within the ER proteostasis/stress-response network. (xiao2004thecontributionsof pages 5-7) | Qualitative induction/upregulation under ER folding stress. (xiao2004thecontributionsof pages 5-7) | Xiao et al., 2004, *J Biol Chem*, https://doi.org/10.1074/jbc.m409210200 (xiao2004thecontributionsof pages 5-7) |
+
+
+*Table: This table summarizes identity, biochemical function, localization, genetics, phenotypes, and interaction evidence for Saccharomyces cerevisiae EUG1/Eug1p using only evidence retrieved in the conversation. It is useful as a compact evidence map linking each major claim to specific context IDs and source citations.*
+
+### Key figure/table evidence (visual)
+
+Xiao et al. (2004) Table I and Figure 5 provide visual evidence for growth phenotypes across PDI-family deletion backgrounds and CPY maturation pulse–chase/half-time quantification (xiao2004thecontributionsof media f566842d, xiao2004thecontributionsof media a580a63e).
+
+### Selected bibliography (with URLs and publication dates)
+
+* Fan X. et al. **Characterizing interactions of ER resident proteins in situ through the YST-PPI method.** *bioRxiv* (posted **May 21, 2024**). https://doi.org/10.1101/2024.05.21.594841 (fan2024characterizinginteractionsof pages 1-4, fan2024characterizinginteractionsof pages 10-13)
+* Xiao R. et al. **The Contributions of Protein Disulfide Isomerase and Its Homologues to Oxidative Protein Folding in the Yeast Endoplasmic Reticulum.** *J Biol Chem* (**Nov 2004**). https://doi.org/10.1074/jbc.m409210200 (xiao2004thecontributionsof pages 1-2, xiao2004thecontributionsof pages 5-7)
+* Nørgaard P. et al. **Functional Differences in Yeast Protein Disulfide Isomerases.** *J Cell Biol* (**Feb 2001**). https://doi.org/10.1083/jcb.152.3.553 (nørgaard2001functionaldifferencesin pages 1-2, nørgaard2001functionaldifferencesin pages 2-2)
+* Nørgaard P., Winther J.R. **Mutation of yeast Eug1p CXXS active sites to CXXC results in a dramatic increase in protein disulphide isomerase activity.** *Biochem J* (**Aug 2001**). https://doi.org/10.1042/bj3580269 (nørgaard2001mutationofyeast pages 6-6, nørgaard2001mutationofyeast pages 4-6)
+* Kimura T. et al. **Functional differences between human and yeast protein disulfide isomerase family proteins.** *BBRC* (**Jul 2004**). https://doi.org/10.1016/j.bbrc.2004.05.178 (kimura2004functionaldifferencesbetween pages 1-2)
+* Suzuki Y., Schmitt M.J. **Redox diversity in ERAD-mediated protein retrotranslocation from the endoplasmic reticulum: a complex puzzle.** *Biological Chemistry* (**May 2015**). https://doi.org/10.1515/hsz-2014-0299 (suzuki2015redoxdiversityin pages 1-2)
+* Hou J. et al. **Metabolic engineering of recombinant protein secretion by Saccharomyces cerevisiae.** *FEMS Yeast Research* (**Aug 2012**). https://doi.org/10.1111/j.1567-1364.2012.00810.x (hou2012metabolicengineeringof pages 9-10, hou2012metabolicengineeringof pages 10-11, hou2012metabolicengineeringof pages 11-12)
+
+
+References
+
+1. (suzuki2015redoxdiversityin pages 1-2): Yutaka Suzuki and Manfred J. Schmitt. Redox diversity in erad-mediated protein retrotranslocation from the endoplasmic reticulum: a complex puzzle. Biological Chemistry, 396:539-554, May 2015. URL: https://doi.org/10.1515/hsz-2014-0299, doi:10.1515/hsz-2014-0299. This article has 11 citations and is from a peer-reviewed journal.
+
+2. (xiao2004thecontributionsof pages 2-2): Ruoyu Xiao, Bonney Wilkinson, Anton Solovyov, Jakob R. Winther, Arne Holmgren, Johanna Lundström-Ljung, and Hiram F. Gilbert. The contributions of protein disulfide isomerase and its homologues to oxidative protein folding in the yeast endoplasmic reticulum*. Journal of Biological Chemistry, 279:49780-49786, Nov 2004. URL: https://doi.org/10.1074/jbc.m409210200, doi:10.1074/jbc.m409210200. This article has 87 citations and is from a domain leading peer-reviewed journal.
+
+3. (nørgaard2001functionaldifferencesin pages 2-2): Per Nørgaard, Vibeke Westphal, Christine Tachibana, Lene Alsøe, Bjørn Holst, and Jakob R. Winther. Functional differences in yeast protein disulfide isomerases. The Journal of Cell Biology, 152:553-562, Feb 2001. URL: https://doi.org/10.1083/jcb.152.3.553, doi:10.1083/jcb.152.3.553. This article has 171 citations.
+
+4. (beynonjones2006mutationalanalysisof pages 1-2): Siân M. Beynon-Jones, Antony N. Antoniou, and Simon J. Powis. Mutational analysis of the oxidoreductase erp57 reveals the importance of the two central residues in the redox motif. FEBS Letters, 580:1897-1902, Mar 2006. URL: https://doi.org/10.1016/j.febslet.2006.02.055, doi:10.1016/j.febslet.2006.02.055. This article has 14 citations and is from a peer-reviewed journal.
+
+5. (nørgaard2001functionaldifferencesin pages 1-2): Per Nørgaard, Vibeke Westphal, Christine Tachibana, Lene Alsøe, Bjørn Holst, and Jakob R. Winther. Functional differences in yeast protein disulfide isomerases. The Journal of Cell Biology, 152:553-562, Feb 2001. URL: https://doi.org/10.1083/jcb.152.3.553, doi:10.1083/jcb.152.3.553. This article has 171 citations.
+
+6. (hacioglu2010therolesof pages 3-4): Elise Hacioglu, Isil Esmer, Dmitri E. Fomenko, Vadim N. Gladyshev, and Ahmet Koc. The roles of thiol oxidoreductases in yeast replicative aging. Mechanisms of Ageing and Development, 131:692-699, Nov 2010. URL: https://doi.org/10.1016/j.mad.2010.09.006, doi:10.1016/j.mad.2010.09.006. This article has 15 citations and is from a peer-reviewed journal.
+
+7. (xiao2004thecontributionsof pages 5-7): Ruoyu Xiao, Bonney Wilkinson, Anton Solovyov, Jakob R. Winther, Arne Holmgren, Johanna Lundström-Ljung, and Hiram F. Gilbert. The contributions of protein disulfide isomerase and its homologues to oxidative protein folding in the yeast endoplasmic reticulum*. Journal of Biological Chemistry, 279:49780-49786, Nov 2004. URL: https://doi.org/10.1074/jbc.m409210200, doi:10.1074/jbc.m409210200. This article has 87 citations and is from a domain leading peer-reviewed journal.
+
+8. (xiao2004thecontributionsof media f566842d): Ruoyu Xiao, Bonney Wilkinson, Anton Solovyov, Jakob R. Winther, Arne Holmgren, Johanna Lundström-Ljung, and Hiram F. Gilbert. The contributions of protein disulfide isomerase and its homologues to oxidative protein folding in the yeast endoplasmic reticulum*. Journal of Biological Chemistry, 279:49780-49786, Nov 2004. URL: https://doi.org/10.1074/jbc.m409210200, doi:10.1074/jbc.m409210200. This article has 87 citations and is from a domain leading peer-reviewed journal.
+
+9. (nørgaard2001mutationofyeast pages 6-6): Per NØRGAARD and Jakob R. WINTHER. Mutation of yeast eug1p cxxs active sites to cxxc results in a dramatic increase in protein disulphide isomerase activity. The Biochemical journal, 358 Pt 1:269-74, Aug 2001. URL: https://doi.org/10.1042/bj3580269, doi:10.1042/bj3580269. This article has 47 citations.
+
+10. (nørgaard2001mutationofyeast pages 4-6): Per NØRGAARD and Jakob R. WINTHER. Mutation of yeast eug1p cxxs active sites to cxxc results in a dramatic increase in protein disulphide isomerase activity. The Biochemical journal, 358 Pt 1:269-74, Aug 2001. URL: https://doi.org/10.1042/bj3580269, doi:10.1042/bj3580269. This article has 47 citations.
+
+11. (kimura2004functionaldifferencesbetween pages 1-2): Taiji Kimura, Yasuhiro Hosoda, Yukiko Kitamura, Hideshi Nakamura, Tomohisa Horibe, and Masakazu Kikuchi. Functional differences between human and yeast protein disulfide isomerase family proteins. Biochemical and biophysical research communications, 320 2:359-65, Jul 2004. URL: https://doi.org/10.1016/j.bbrc.2004.05.178, doi:10.1016/j.bbrc.2004.05.178. This article has 30 citations and is from a peer-reviewed journal.
+
+12. (vala2008characterizationoferv2p pages 58-61): ALL Vala. Characterization of erv2p and pdi1p, two thiol oxidoreductases involved in protein disulfide bond formation in the endoplasmic reticulum of saccharomyces cerevisiae. Unknown journal, 2008.
+
+13. (xiao2004thecontributionsof media a580a63e): Ruoyu Xiao, Bonney Wilkinson, Anton Solovyov, Jakob R. Winther, Arne Holmgren, Johanna Lundström-Ljung, and Hiram F. Gilbert. The contributions of protein disulfide isomerase and its homologues to oxidative protein folding in the yeast endoplasmic reticulum*. Journal of Biological Chemistry, 279:49780-49786, Nov 2004. URL: https://doi.org/10.1074/jbc.m409210200, doi:10.1074/jbc.m409210200. This article has 87 citations and is from a domain leading peer-reviewed journal.
+
+14. (fan2024characterizinginteractionsof pages 1-4): Xian Fan, Huahua He, Ting Wang, Pan Xu, Faying Zhang, Shantong Hu, Yueli Yun, Meng Mei, Guimin Zhang, and Li Yi. Characterizing interactions of er resident proteins in situ through the yst-ppi method. bioRxiv, May 2024. URL: https://doi.org/10.1101/2024.05.21.594841, doi:10.1101/2024.05.21.594841. This article has 0 citations.
+
+15. (fan2024characterizinginteractionsof pages 13-17): Xian Fan, Huahua He, Ting Wang, Pan Xu, Faying Zhang, Shantong Hu, Yueli Yun, Meng Mei, Guimin Zhang, and Li Yi. Characterizing interactions of er resident proteins in situ through the yst-ppi method. bioRxiv, May 2024. URL: https://doi.org/10.1101/2024.05.21.594841, doi:10.1101/2024.05.21.594841. This article has 0 citations.
+
+16. (fan2024characterizinginteractionsof pages 7-10): Xian Fan, Huahua He, Ting Wang, Pan Xu, Faying Zhang, Shantong Hu, Yueli Yun, Meng Mei, Guimin Zhang, and Li Yi. Characterizing interactions of er resident proteins in situ through the yst-ppi method. bioRxiv, May 2024. URL: https://doi.org/10.1101/2024.05.21.594841, doi:10.1101/2024.05.21.594841. This article has 0 citations.
+
+17. (fan2024characterizinginteractionsof pages 10-13): Xian Fan, Huahua He, Ting Wang, Pan Xu, Faying Zhang, Shantong Hu, Yueli Yun, Meng Mei, Guimin Zhang, and Li Yi. Characterizing interactions of er resident proteins in situ through the yst-ppi method. bioRxiv, May 2024. URL: https://doi.org/10.1101/2024.05.21.594841, doi:10.1101/2024.05.21.594841. This article has 0 citations.
+
+18. (hou2012metabolicengineeringof pages 10-11): Jin Hou, Keith E.J. Tyo, Zihe Liu, Dina Petranovic, and Jens Nielsen. Metabolic engineering of recombinant protein secretion by saccharomyces cerevisiae. FEMS yeast research, 12 5:491-510, Aug 2012. URL: https://doi.org/10.1111/j.1567-1364.2012.00810.x, doi:10.1111/j.1567-1364.2012.00810.x. This article has 292 citations and is from a peer-reviewed journal.
+
+19. (hou2012metabolicengineeringof pages 9-10): Jin Hou, Keith E.J. Tyo, Zihe Liu, Dina Petranovic, and Jens Nielsen. Metabolic engineering of recombinant protein secretion by saccharomyces cerevisiae. FEMS yeast research, 12 5:491-510, Aug 2012. URL: https://doi.org/10.1111/j.1567-1364.2012.00810.x, doi:10.1111/j.1567-1364.2012.00810.x. This article has 292 citations and is from a peer-reviewed journal.
+
+20. (hou2012metabolicengineeringof pages 11-12): Jin Hou, Keith E.J. Tyo, Zihe Liu, Dina Petranovic, and Jens Nielsen. Metabolic engineering of recombinant protein secretion by saccharomyces cerevisiae. FEMS yeast research, 12 5:491-510, Aug 2012. URL: https://doi.org/10.1111/j.1567-1364.2012.00810.x, doi:10.1111/j.1567-1364.2012.00810.x. This article has 292 citations and is from a peer-reviewed journal.
+
+21. (xiao2004thecontributionsof pages 1-2): Ruoyu Xiao, Bonney Wilkinson, Anton Solovyov, Jakob R. Winther, Arne Holmgren, Johanna Lundström-Ljung, and Hiram F. Gilbert. The contributions of protein disulfide isomerase and its homologues to oxidative protein folding in the yeast endoplasmic reticulum*. Journal of Biological Chemistry, 279:49780-49786, Nov 2004. URL: https://doi.org/10.1074/jbc.m409210200, doi:10.1074/jbc.m409210200. This article has 87 citations and is from a domain leading peer-reviewed journal.
+
+## Citations
+
+1. suzuki2015redoxdiversityin pages 1-2
+2. beynonjones2006mutationalanalysisof pages 1-2
+3. hacioglu2010therolesof pages 3-4
+4. kimura2004functionaldifferencesbetween pages 1-2
+5. xiao2004thecontributionsof pages 2-2
+6. xiao2004thecontributionsof pages 5-7
+7. fan2024characterizinginteractionsof pages 10-13
+8. hou2012metabolicengineeringof pages 10-11
+9. hou2012metabolicengineeringof pages 9-10
+10. hou2012metabolicengineeringof pages 11-12
+11. xiao2004thecontributionsof pages 1-2
+12. fan2024characterizinginteractionsof pages 1-4
+13. fan2024characterizinginteractionsof pages 13-17
+14. fan2024characterizinginteractionsof pages 7-10
+15. https://doi.org/10.1083/jcb.152.3.553
+16. https://doi.org/10.1074/jbc.m409210200
+17. https://doi.org/10.1016/j.febslet.2006.02.055
+18. https://doi.org/10.1016/j.mad.2010.09.006
+19. https://doi.org/10.1515/hsz-2014-0299
+20. https://doi.org/10.1042/bj3580269
+21. https://doi.org/10.1016/j.bbrc.2004.05.178
+22. https://doi.org/10.1101/2024.05.21.594841
+23. https://doi.org/10.1111/j.1567-1364.2012.00810.x
+24. https://doi.org/10.1515/hsz-2014-0299,
+25. https://doi.org/10.1074/jbc.m409210200,
+26. https://doi.org/10.1083/jcb.152.3.553,
+27. https://doi.org/10.1016/j.febslet.2006.02.055,
+28. https://doi.org/10.1016/j.mad.2010.09.006,
+29. https://doi.org/10.1042/bj3580269,
+30. https://doi.org/10.1016/j.bbrc.2004.05.178,
+31. https://doi.org/10.1101/2024.05.21.594841,
+32. https://doi.org/10.1111/j.1567-1364.2012.00810.x,

--- a/genes/yeast/MDJ1/MDJ1-ai-review.html
+++ b/genes/yeast/MDJ1/MDJ1-ai-review.html
@@ -966,10 +966,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="P35191" data-a="GO:0005524" data-r="GO_REF:0000002" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P35191" data-a="GO:0005524" data-r="GO_REF:0000002" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -977,15 +977,42 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: ATP binding is consistent with known biology of MDJ1.
+                            <strong>Summary:</strong> Manual review: ATP binding is likely an automated over-annotation for MDJ1; ATPase activator activity captures the supported biology.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
+                            <strong>Reason:</strong> Mdj1 is a J-domain cochaperone that stimulates ATP hydrolysis by mitochondrial Hsp70 Ssc1 rather than an ATP-binding protein itself.
                         </div>
 
 
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001671" target="_blank" class="term-link">
+                                    ATPase activator activity
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/MDJ1/MDJ1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">a J-protein stimulates Hsp70 ATP hydrolysis</div>
+
+                            </div>
+
+                        </div>
 
                     </td>
                 </tr>
@@ -3168,9 +3195,15 @@ existing_annotations:
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
   review:
-    summary: &#39;Manual review: ATP binding is consistent with known biology of MDJ1.&#39;
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    summary: &#39;Manual review: ATP binding is likely an automated over-annotation for MDJ1; ATPase activator activity captures the supported biology.&#39;
+    action: MODIFY
+    reason: Mdj1 is a J-domain cochaperone that stimulates ATP hydrolysis by mitochondrial Hsp70 Ssc1 rather than an ATP-binding protein itself.
+    supported_by:
+    - reference_id: file:yeast/MDJ1/MDJ1-deep-research-falcon.md
+      supporting_text: a J-protein stimulates Hsp70 ATP hydrolysis
+    proposed_replacement_terms:
+    - id: GO:0001671
+      label: ATPase activator activity
 - term:
     id: GO:0005739
     label: mitochondrion

--- a/genes/yeast/MDJ1/MDJ1-ai-review.html
+++ b/genes/yeast/MDJ1/MDJ1-ai-review.html
@@ -671,33 +671,33 @@
     <div class="header">
         <h1>MDJ1</h1>
         <div class="gene-info">
-            
+
             <div class="info-item">
-                
+
                 <span class="info-label">UniProt ID:</span>
                 <span>
                     <a href="https://www.uniprot.org/uniprotkb/P35191" target="_blank" class="term-link">
                         P35191
                     </a>
                 </span>
-                
+
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Organism:</span>
                 <span>Saccharomyces cerevisiae</span>
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
-                <span class="status-badge status-draft">
-                    DRAFT
+                <span class="status-badge status-complete">
+                    COMPLETE
                 </span>
             </div>
-            
-            
+
+
         </div>
         <div style="margin-top: 1rem; text-align: center;">
             <a id="feedback-form-link"
@@ -728,24 +728,24 @@
         </div>
     </div>
 
-    
+
     <div class="description-card">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <h2>Gene Description</h2>
-            <span class="vote-buttons" data-g="P35191" data-a="DESCRIPTION: TODO: Add description for MDJ1..." data-r="" data-act="DESCRIPTION">
+            <span class="vote-buttons" data-g="P35191" data-a="DESCRIPTION: MDJ1 encodes the major mitochondrial matrix DnaJ/H..." data-r="" data-act="DESCRIPTION">
                 <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
                 <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
             </span>
         </div>
-        <p>TODO: Add description for MDJ1</p>
+        <p>MDJ1 encodes the major mitochondrial matrix DnaJ/Hsp40 cochaperone for the mtHsp70 Ssc1 system. Mdj1 stimulates Hsp70-dependent folding/refolding cycles, protects mitochondrial matrix proteins from misfolding and heat-induced aggregation, and is enriched at mitochondrial nucleoids where it supports maintenance of functional mitochondrial DNA.</p>
     </div>
-    
 
-    
 
-    
 
-    
+
+
+
+
     <div class="section">
         <h2 class="section-title">Existing Annotations Review</h2>
         <table class="annotations-table">
@@ -758,32 +758,32 @@
                 </tr>
             </thead>
             <tbody>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -795,46 +795,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: cytoplasm may be context-dependent or peripheral for MDJ1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042026" target="_blank" class="term-link">
                                     GO:0042026
                                 </a>
                             </span>
                             <span class="term-label">protein refolding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -846,46 +846,62 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: protein refolding is consistent with known biology of MDJ1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/MDJ1/MDJ1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Mdj1 participates in **de novo folding** and **protection of mitochondrial proteins against heat-induced unfolding/aggregation**</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -897,57 +913,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: unfolded protein binding is better represented by a more specific replacement term for MDJ1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Modified to align with current curation guidance and improve term specificity.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     protein folding chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005524" target="_blank" class="term-link">
                                     GO:0005524
                                 </a>
                             </span>
                             <span class="term-label">ATP binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -959,46 +975,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: ATP binding is consistent with known biology of MDJ1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
                                     GO:0005739
                                 </a>
                             </span>
                             <span class="term-label">mitochondrion</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -1010,46 +1026,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: mitochondrion may be context-dependent or peripheral for MDJ1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                     GO:0006457
                                 </a>
                             </span>
                             <span class="term-label">protein folding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1061,46 +1077,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: protein folding is consistent with known biology of MDJ1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008270" target="_blank" class="term-link">
                                     GO:0008270
                                 </a>
                             </span>
                             <span class="term-label">zinc ion binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1112,46 +1128,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: zinc ion binding is consistent with known biology of MDJ1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009408" target="_blank" class="term-link">
                                     GO:0009408
                                 </a>
                             </span>
                             <span class="term-label">response to heat</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1163,46 +1179,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: response to heat is consistent with known biology of MDJ1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031072" target="_blank" class="term-link">
                                     GO:0031072
                                 </a>
                             </span>
                             <span class="term-label">heat shock protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1214,46 +1230,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: heat shock protein binding is consistent with known biology of MDJ1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046872" target="_blank" class="term-link">
                                     GO:0046872
                                 </a>
                             </span>
                             <span class="term-label">metal ion binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1265,46 +1281,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: metal ion binding is consistent with known biology of MDJ1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -1316,68 +1332,68 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: unfolded protein binding is better represented by a more specific replacement term for MDJ1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Modified to align with current curation guidance and improve term specificity.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     protein folding chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16554755" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16554755
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Global landscape of protein complexes in the yeast Saccharom...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1389,57 +1405,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: protein binding is too generic or over-extended for MDJ1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Marked over-annotated because more specific terms capture the biology more accurately.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19536198" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19536198
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     An atlas of chaperone-protein interactions in Saccharomyces ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1451,57 +1467,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: protein binding is too generic or over-extended for MDJ1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Marked over-annotated because more specific terms capture the biology more accurately.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/27107014" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:27107014
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     An inter-species protein-protein interaction network across ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1513,57 +1529,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: protein binding is too generic or over-extended for MDJ1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Marked over-annotated because more specific terms capture the biology more accurately.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008270" target="_blank" class="term-link">
                                     GO:0008270
                                 </a>
                             </span>
                             <span class="term-label">zinc ion binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">RCA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/30358795" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:30358795
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The cellular economy of the Saccharomyces cerevisiae zinc pr...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1575,57 +1591,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: zinc ion binding is consistent with known biology of MDJ1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
                                     GO:0005739
                                 </a>
                             </span>
                             <span class="term-label">mitochondrion</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24769239" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:24769239
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Quantitative variations of the mitochondrial proteome and ph...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -1637,57 +1653,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: mitochondrion may be context-dependent or peripheral for MDJ1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
                                     GO:0005739
                                 </a>
                             </span>
                             <span class="term-label">mitochondrion</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16823961" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16823961
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Toward the complete yeast mitochondrial proteome: multidimen...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -1699,57 +1715,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: mitochondrion may be context-dependent or peripheral for MDJ1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001671" target="_blank" class="term-link">
                                     GO:0001671
                                 </a>
                             </span>
                             <span class="term-label">ATPase activator activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9973563" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:9973563
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Two distinct mechanisms operate in the reactivation of heat-...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1761,57 +1777,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: ATPase activator activity is consistent with known biology of MDJ1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
                                     GO:0005759
                                 </a>
                             </span>
                             <span class="term-label">mitochondrial matrix</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/15383543" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:15383543
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Zim17, a novel zinc finger protein essential for protein imp...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1823,57 +1839,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: mitochondrial matrix is consistent with known biology of MDJ1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006458" target="_blank" class="term-link">
                                     GO:0006458
                                 </a>
                             </span>
                             <span class="term-label">&#39;de novo&#39; protein folding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/8168133" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:8168133
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Mdj1p, a novel chaperone of the DnaJ family, is involved in ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1885,57 +1901,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: &#39;de novo&#39; protein folding is consistent with known biology of MDJ1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006515" target="_blank" class="term-link">
                                     GO:0006515
                                 </a>
                             </span>
                             <span class="term-label">protein quality control for misfolded or incompletely synthesized proteins</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/7957078" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:7957078
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Molecular chaperones cooperate with PIM1 protease in the deg...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1947,57 +1963,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: protein quality control for misfolded or incompletely synthesized proteins is consistent with known biology of MDJ1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009408" target="_blank" class="term-link">
                                     GO:0009408
                                 </a>
                             </span>
                             <span class="term-label">response to heat</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/8603724" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:8603724
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Role of the mitochondrial DnaJ homologue, Mdj1p, in the prev...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2009,57 +2025,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: response to heat is consistent with known biology of MDJ1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042026" target="_blank" class="term-link">
                                     GO:0042026
                                 </a>
                             </span>
                             <span class="term-label">protein refolding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/8168133" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:8168133
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Mdj1p, a novel chaperone of the DnaJ family, is involved in ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2071,57 +2087,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: protein refolding is consistent with known biology of MDJ1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042026" target="_blank" class="term-link">
                                     GO:0042026
                                 </a>
                             </span>
                             <span class="term-label">protein refolding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9973563" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:9973563
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Two distinct mechanisms operate in the reactivation of heat-...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2133,57 +2149,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: protein refolding is consistent with known biology of MDJ1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/8943361" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:8943361
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Role of the mitochondrial DnaJ homolog Mdj1p as a chaperone ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -2195,316 +2211,902 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: unfolded protein binding is better represented by a more specific replacement term for MDJ1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Modified to align with current curation guidance and improve term specificity.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     protein folding chaperone
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                     </td>
                 </tr>
-                
+
             </tbody>
         </table>
     </div>
-    
 
-    
 
-    
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Mitochondrial matrix J-domain cochaperone activity for the Ssc1/Mge1 mtHsp70 system. Mdj1 stimulates Hsp70-dependent folding and refolding of mitochondrial proteins, protects against heat-induced aggregation, and concentrates chaperone activity at mitochondrial nucleoids to support functional mtDNA maintenance.</h3>
+                <span class="vote-buttons" data-g="P35191" data-a="FUNCTION: Mitochondrial matrix J-domain cochaperone activity..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001671" target="_blank" class="term-link">
+                            ATPase activator activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
+                                protein folding
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006515" target="_blank" class="term-link">
+                                protein quality control for misfolded or incompletely synthesized proteins
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                mitochondrial matrix
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:yeast/MDJ1/MDJ1-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">Mdj1 is a **J-protein co-chaperone** for the mitochondrial Hsp70 **Ssc1**</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class="section">
         <h2 class="section-title collapsible">References</h2>
         <div class="collapse-content">
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
                             GO_REF:0000002
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
                             GO_REF:0000033
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Annotation inferences using phylogenetic trees</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000043.md" target="_blank" class="term-link">
                             GO_REF:0000043
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
                             GO_REF:0000044
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/15383543" target="_blank" class="term-link">
                             PMID:15383543
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Zim17, a novel zinc finger protein essential for protein import into mitochondria.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/16554755" target="_blank" class="term-link">
                             PMID:16554755
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Global landscape of protein complexes in the yeast Saccharomyces cerevisiae.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/16823961" target="_blank" class="term-link">
                             PMID:16823961
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Toward the complete yeast mitochondrial proteome: multidimensional separation techniques for mitochondrial proteomics.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/19536198" target="_blank" class="term-link">
                             PMID:19536198
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">An atlas of chaperone-protein interactions in Saccharomyces cerevisiae: implications to protein folding pathways in the cell.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/24769239" target="_blank" class="term-link">
                             PMID:24769239
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Quantitative variations of the mitochondrial proteome and phosphoproteome during fermentative and respiratory growth in Saccharomyces cerevisiae.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/27107014" target="_blank" class="term-link">
                             PMID:27107014
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">An inter-species protein-protein interaction network across vast evolutionary distance.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/30358795" target="_blank" class="term-link">
                             PMID:30358795
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The cellular economy of the Saccharomyces cerevisiae zinc proteome.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/7957078" target="_blank" class="term-link">
                             PMID:7957078
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Molecular chaperones cooperate with PIM1 protease in the degradation of misfolded proteins in mitochondria.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/8168133" target="_blank" class="term-link">
                             PMID:8168133
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Mdj1p, a novel chaperone of the DnaJ family, is involved in mitochondrial biogenesis and protein folding.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/8603724" target="_blank" class="term-link">
                             PMID:8603724
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Role of the mitochondrial DnaJ homologue, Mdj1p, in the prevention of heat-induced protein aggregation.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/8943361" target="_blank" class="term-link">
                             PMID:8943361
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Role of the mitochondrial DnaJ homolog Mdj1p as a chaperone for mitochondrially synthesized and imported proteins.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/9973563" target="_blank" class="term-link">
                             PMID:9973563
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Two distinct mechanisms operate in the reactivation of heat-denatured proteins by the mitochondrial Hsp70/Mdj1p/Yge1p chaperone system.</div>
-                
-                
+
+
             </div>
-            
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:yeast/MDJ1/MDJ1-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research report for MDJ1</div>
+
+
+            </div>
+
         </div>
     </div>
-    
 
 
-    
 
-    
 
-    
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Should MDJ1 receive an explicit mitochondrial genome maintenance process annotation based on nucleoid localization and mtDNA-loss phenotypes?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P35191" data-a="Q: Should MDJ1 receive an explicit mitochondrial geno..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Is direct DNA-binding/nucleoid association sufficiently represented by current GO cellular-component and process annotations?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P35191" data-a="Q: Is direct DNA-binding/nucleoid association suffici..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Test whether Mdj1 client-binding domain mutants separate mitochondrial protein-refolding activity from mtDNA maintenance in the same strain background.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="P35191" data-a="EXPERIMENT: Test whether Mdj1 client-binding domain mutants se..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Map nucleoid-associated Mdj1 clients by proximity labeling under respiratory growth and heat-stress conditions.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="P35191" data-a="EXPERIMENT: Map nucleoid-associated Mdj1 clients by proximity ..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
 
     <!-- Computational Predictions Section -->
-    
+
 
     <!-- Additional Documentation Sections -->
-    
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Deep Research Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(MDJ1-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P35191" data-a="DOC: Deep Research Falcon" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <hr />
+<p>provider: falcon<br />
+model: Edison Scientific Literature<br />
+cached: false<br />
+start_time: '2026-05-11T09:00:25.567296'<br />
+end_time: '2026-05-11T09:20:46.755054'<br />
+duration_seconds: 1221.19<br />
+template_file: templates/gene_research_go_focused.md<br />
+template_variables:<br />
+  organism: yeast<br />
+  gene_id: MDJ1<br />
+  gene_symbol: MDJ1<br />
+  uniprot_accession: P35191<br />
+  protein_description: 'RecName: Full=DnaJ homolog 1, mitochondrial; Flags: Precursor;'<br />
+  gene_info: Name=MDJ1; OrderedLocusNames=YFL016C;<br />
+  organism_full: Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).<br />
+  protein_family: Not specified in UniProt<br />
+  protein_domains: DnaJ. (IPR012724); DnaJ_C. (IPR002939); DnaJ_domain. (IPR001623);<br />
+    DnaJ_domain_CS. (IPR018253); HSP40/DnaJ_pept-bd. (IPR008971)<br />
+provider_config:<br />
+  timeout: 600<br />
+  max_retries: 3<br />
+  parameters:<br />
+    allowed_domains: []<br />
+    temperature: 0.1<br />
+citation_count: 35</p>
+<hr />
+<h2 id="question">Question</h2>
+<h1 id="gene-research-for-functional-annotation">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> P35191</li>
+<li><strong>Protein Description:</strong> RecName: Full=DnaJ homolog 1, mitochondrial; Flags: Precursor;</li>
+<li><strong>Gene Information:</strong> Name=MDJ1; OrderedLocusNames=YFL016C;</li>
+<li><strong>Organism (full):</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Protein Family:</strong> Not specified in UniProt</li>
+<li><strong>Key Domains:</strong> DnaJ. (IPR012724); DnaJ_C. (IPR002939); DnaJ_domain. (IPR001623); DnaJ_domain_CS. (IPR018253); HSP40/DnaJ_pept-bd. (IPR008971)</li>
+</ul>
+<h3 id="mandatory-verification-steps">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "MDJ1" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'MDJ1' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>MDJ1</strong> (gene ID: MDJ1, UniProt: P35191) in yeast.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="output">Output</h2>
+<p>Question: You are an expert researcher providing comprehensive, well-cited information.</p>
+<p>Provide detailed information focusing on:<br />
+1. Key concepts and definitions with current understanding<br />
+2. Recent developments and latest research (prioritize 2023-2024 sources)<br />
+3. Current applications and real-world implementations<br />
+4. Expert opinions and analysis from authoritative sources<br />
+5. Relevant statistics and data from recent studies</p>
+<p>Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.<br />
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.</p>
+<h1 id="gene-research-for-functional-annotation_1">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context_1">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot_1">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> P35191</li>
+<li><strong>Protein Description:</strong> RecName: Full=DnaJ homolog 1, mitochondrial; Flags: Precursor;</li>
+<li><strong>Gene Information:</strong> Name=MDJ1; OrderedLocusNames=YFL016C;</li>
+<li><strong>Organism (full):</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Protein Family:</strong> Not specified in UniProt</li>
+<li><strong>Key Domains:</strong> DnaJ. (IPR012724); DnaJ_C. (IPR002939); DnaJ_domain. (IPR001623); DnaJ_domain_CS. (IPR018253); HSP40/DnaJ_pept-bd. (IPR008971)</li>
+</ul>
+<h3 id="mandatory-verification-steps_1">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "MDJ1" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature_1">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'MDJ1' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target_1">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>MDJ1</strong> (gene ID: MDJ1, UniProt: P35191) in yeast.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="research-report-mdj1-uniprot-p35191-yfl016c-in-saccharomyces-cerevisiae-s288c">Research Report: <strong>MDJ1 (UniProt P35191; YFL016C)</strong> in <em>Saccharomyces cerevisiae</em> (S288c)</h1>
+<h2 id="0-target-verification-critical">0) Target verification (critical)</h2>
+<p>The gene symbol <strong>MDJ1</strong> in this report refers specifically to <em>Saccharomyces cerevisiae</em> <strong>MDJ1/YFL016C</strong> encoding <strong>DnaJ homolog 1, mitochondrial (precursor)</strong>, a mitochondrial <strong>J-domain protein (Hsp40/J-protein)</strong> that functions with mitochondrial Hsp70 <strong>Ssc1</strong>. This identity and functional class are explicitly supported by yeast primary literature and authoritative reviews describing Mdj1 as a mitochondrial matrix J-protein cooperating with Ssc1 and enriched at mitochondrial nucleoids. (ciesielski2016nucleoidlocalizationof pages 1-2, craig2011hsp70chaperones pages 3-5, craig2014yeasthsp70and pages 9-12)</p>
+<h2 id="1-key-concepts-and-definitions-current-understanding">1) Key concepts and definitions (current understanding)</h2>
+<h3 id="11-j-proteins-hsp40s-and-the-mthsp70-chaperone-cycle">1.1 J-proteins (Hsp40s) and the mtHsp70 chaperone cycle</h3>
+<p>Mdj1 is a <strong>J-protein co-chaperone</strong> for the mitochondrial Hsp70 <strong>Ssc1</strong>. In the canonical Hsp70 reaction cycle, a J-protein stimulates Hsp70 ATP hydrolysis, stabilizing client capture; the nucleotide exchange factor <strong>Mge1</strong> promotes ADP release and ATP rebinding, triggering client release and enabling iterative folding cycles. (craig2011hsp70chaperones pages 3-5, craig2014yeasthsp70and pages 9-12, craig2011hsp70chaperones pages 2-3)</p>
+<p>A key conceptual distinction in yeast mitochondria is that <strong>Mdj1 is a general matrix folding J-protein</strong>, whereas <strong>Pam18 (Tim14)</strong> is a membrane-anchored J-protein specialized for the <strong>TIM23 import motor</strong>; thus Mdj1 is not the primary J-protein driving presequence translocation across the inner membrane. (craig2011hsp70chaperones pages 3-5, craig2014yeasthsp70and pages 9-12)</p>
+<h3 id="12-mitochondrial-nucleoids">1.2 Mitochondrial nucleoids</h3>
+<p>Mitochondrial DNA in yeast is packaged into <strong>nucleoids</strong>—discrete structures that contain mtDNA and associated proteins involved in mtDNA replication, transcription, and translation. Yeast cells contain <strong>~40 nucleoids per cell</strong>. (ciesielski2016nucleoidlocalizationof pages 1-2)</p>
+<h2 id="2-mdj1-protein-domains-localization-and-molecular-function">2) MDJ1 protein: domains, localization, and molecular function</h2>
+<h3 id="21-domain-architecture-and-functional-interpretation">2.1 Domain architecture and functional interpretation</h3>
+<p>Mdj1 is a <strong>class I J-protein</strong> with an N-terminal <strong>J-domain</strong> followed by client-binding <strong>C-terminal domains (CTDs)</strong> typical of DnaJ/Hsp40 proteins. The J-domain is required for functional interaction with Ssc1, while CTDs contribute to client interactions and, in Mdj1, are required for DNA binding/nucleoid enrichment and mtDNA maintenance. (ciesielski2016nucleoidlocalizationof pages 2-3, ciesielski2016nucleoidlocalizationof pages 8-9)</p>
+<h3 id="22-subcellular-localization-mitochondrial-matrix-and-nucleoid-enrichment">2.2 Subcellular localization: mitochondrial matrix and nucleoid enrichment</h3>
+<p>Multiple independent lines of evidence place Mdj1 in the mitochondrial matrix and show that the <strong>great majority is associated with mitochondrial nucleoids</strong>:<br />
+- <strong>Fluorescence microscopy</strong>: Mdj1-GFP appears as dot-like structures co-localizing with DAPI-stained mtDNA and resembles the nucleoid marker Abf2-GFP. (ciesielski2016nucleoidlocalizationof pages 3-4, ciesielski2016nucleoidlocalizationof media 498c76e6)<br />
+- <strong>Biochemical fractionation</strong>: in sucrose gradients, Mdj1 co-migrates with mtDNA/nucleoid fractions and shifts away upon DNase I treatment, supporting DNA-dependent association. (ciesielski2016nucleoidlocalizationof pages 4-5)</p>
+<p>Notably, only <strong>~15% of Ssc1</strong> co-migrates with nucleoid fractions, indicating Mdj1 is far more nucleoid-enriched than its Hsp70 partner and supporting a model where Mdj1 tethers or concentrates Hsp70 activity at nucleoids. (ciesielski2016nucleoidlocalizationof pages 4-5)</p>
+<h3 id="23-core-biochemical-function-a-nucleoid-enriched-mthsp70-co-chaperone">2.3 Core biochemical function: a nucleoid-enriched mtHsp70 co-chaperone</h3>
+<p>Mechanistically, Mdj1 binds the ATP state of Ssc1 and stimulates ATP hydrolysis, promoting productive folding transitions of mtHsp70.</p>
+<p>Single-molecule/kinetic analyses of the mitochondrial Hsp70 system show that Mdj1–Ssc1 association can be relatively stable (<strong>half-life ~5 min</strong>) in some states, yet within the active folding cycle <strong>Mge1 + ATP can trigger Mdj1 release within ~1 s</strong>, supporting rapid cycling during matrix protein folding. (mapa2010theconformationaldynamics pages 9-10, mapa2010theconformationaldynamics pages 7-9)</p>
+<h2 id="3-biological-roles-and-pathways">3) Biological roles and pathways</h2>
+<h3 id="31-maintenance-of-functional-mtdna-primary-physiological-role">3.1 Maintenance of functional mtDNA (primary physiological role)</h3>
+<p>A central experimentally supported role of Mdj1 is <strong>maintenance of functional mitochondrial DNA</strong>. Cells lacking Mdj1 (or expressing J-domain-defective variants) are unable to maintain functional mtDNA and progressively lose respiratory competence, consistent with Mdj1’s nucleoid-centered activity and Ssc1 partnership. (ciesielski2016nucleoidlocalizationof pages 9-10, craig2014yeasthsp70and pages 9-12)</p>
+<h3 id="32-protein-foldinganti-aggregation-protection-in-the-matrix-and-under-stress">3.2 Protein folding/anti-aggregation protection in the matrix and under stress</h3>
+<p>Mdj1 participates in <strong>de novo folding</strong> and <strong>protection of mitochondrial proteins against heat-induced unfolding/aggregation</strong>, consistent with its role as the major matrix J-protein for Ssc1. (ciesielski2016nucleoidlocalizationof pages 10-11, craig2014yeasthsp70and pages 9-12)</p>
+<h3 id="33-candidate-native-clients-at-nucleoids">3.3 Candidate native clients at nucleoids</h3>
+<p>Authoritative synthesis highlights <strong>Mip1</strong> (mitochondrial DNA polymerase) and <strong>Var1</strong> (mitochondrial ribosomal subunit) as native nucleoid-associated clients for the Mdj1–Ssc1 system. (craig2014yeasthsp70and pages 9-12)</p>
+<p>Ciesielski et al. report that Mdj1 plays a critical role in protecting the enzymatic activity of <strong>Mip1</strong> under extreme heat stress, and note co-immunoprecipitation evidence linking mitochondrial polymerase to the mammalian ortholog (DnajA3/Tid1), supporting polymerase as a plausible conserved client. (ciesielski2016nucleoidlocalizationof pages 10-11)</p>
+<h2 id="4-mutant-phenotypes-and-quantitative-data-recently-emphasized-statistics">4) Mutant phenotypes and quantitative data (recently emphasized statistics)</h2>
+<h3 id="41-inducible-depletion-kinetics-and-petite-formation">4.1 Inducible depletion kinetics and petite formation</h3>
+<p>Using <strong>TETr-MDJ1</strong> with doxycycline-mediated repression, Mdj1 depletion yields a quantitative time course for mtDNA functional loss:<br />
+- Baseline (no doxycycline): <strong>~83–85%</strong> colonies are respiratory-competent (red). (ciesielski2016nucleoidlocalizationof pages 4-5)<br />
+- Mdj1 protein drops to <strong>~50% after 4 generations</strong>, and is <strong>undetectable after 8 generations</strong>. (ciesielski2016nucleoidlocalizationof pages 4-5)<br />
+- Respiratory deficiency accumulates to <strong>~50% after 10 generations</strong> and <strong>&gt;90% after 20 generations</strong>. (ciesielski2016nucleoidlocalizationof pages 4-5)</p>
+<p>These kinetics support Mdj1 as an experimentally tractable control point for mtDNA stability and respiratory competence. (ciesielski2016nucleoidlocalizationof pages 4-5)</p>
+<h3 id="42-domainfunction-mapping-quantitative-highlights">4.2 Domain/function mapping (quantitative highlights)</h3>
+<ul>
+<li>A dimerization-domain deletion (<strong>Mdj1ΔD</strong>) shows slower mtDNA loss, with <strong>~70%</strong> of cells remaining respiratory-competent <strong>20 generations</strong> after full-length Mdj1 repression. (ciesielski2016nucleoidlocalizationof pages 7-8)</li>
+<li>The isolated J-domain fragment cannot maintain mtDNA at native expression but, when overexpressed to <strong>~5-fold</strong> higher levels, partially delays mtDNA loss (though it does not fully prevent it). (ciesielski2016nucleoidlocalizationof pages 7-8)</li>
+</ul>
+<h3 id="43-direct-dna-binding-quantitative-binding-constant">4.3 Direct DNA binding (quantitative binding constant)</h3>
+<p>Purified Mdj1 binds DNA in vitro. In gel-shift assays using a <strong>71 bp ori5 fragment</strong> at <strong>0.36 nM</strong>, Mdj1 titration yields an apparent DNA-binding <strong>Kd ≈ 0.21 μM</strong>. (ciesielski2016nucleoidlocalizationof pages 10-11)</p>
+<h2 id="5-recent-developments-prioritized-20232024">5) Recent developments (prioritized 2023–2024)</h2>
+<p>While dedicated MDJ1-only papers are relatively sparse in 2023–2024, two high-authority yeast mitochondrial biogenesis/proteostasis studies explicitly leverage Mdj1 as a readout and place it into new mechanistic context.</p>
+<h3 id="51-2023-nature-complexome-profiling-and-protein-import-quality-control">5.1 2023 Nature: complexome profiling and protein import quality control</h3>
+<p>A high-resolution yeast mitochondrial complexome (MitCOM) and associated import quality-control analyses report that the <strong>Mdj1 precursor</strong> <strong>moderately accumulates</strong> in <strong>pth2Δ ubx2Δ</strong> mitochondria, supporting redundancy between Pth2 and Ubx2 pathways in clearing accumulated precursor proteins at/near the mitochondrial entry gate. Here, Mdj1 precursor vs mature forms are used as an import-stress/precursor-handling readout. (schulte2023mitochondrialcomplexomereveals pages 28-32)</p>
+<p><strong>Publication date/URL:</strong> January 2023, <em>Nature</em>, https://doi.org/10.1038/s41586-022-05641-w (schulte2023mitochondrialcomplexomereveals pages 28-32)</p>
+<h3 id="52-2023-mboc-er-buffering-of-nonimported-mitochondrial-proteins">5.2 2023 MBoC: ER buffering of nonimported mitochondrial proteins</h3>
+<p>In a study connecting mitochondrial import stress to ER proteostasis responses, acute import block using a <strong>b2-DHFR clogger</strong> leads to detectable accumulation of the <strong>precursor form of Mdj1</strong> by immunoblot after <strong>4.5 h</strong> induction. This places Mdj1 among mitochondrial precursors that accumulate when import is perturbed and supports the broader model that nonimported proteins can be buffered at the ER, triggering <strong>UPRER</strong>. (knoringer2023theunfoldedprotein pages 1-3)</p>
+<p><strong>Publication date/URL:</strong> September 2023, <em>Molecular Biology of the Cell</em>, https://doi.org/10.1091/mbc.e23-05-0205 (knoringer2023theunfoldedprotein pages 1-3)</p>
+<h3 id="53-2024-preprint-mdj1-as-an-import-reporter-readout">5.3 2024 (preprint): Mdj1 as an import reporter readout</h3>
+<p>A 2024 bioRxiv preprint uses anti-Mdj1 immunoblotting to distinguish cytosolic <strong>precursor (P)</strong> and mature mitochondrial <strong>(M)</strong> forms of Mdj1 as a proxy for mitochondrial import efficiency in yeast complementation backgrounds. (lal2024cytosolicclassi pages 28-32)</p>
+<p><strong>Publication date/URL:</strong> April 2024, bioRxiv, https://doi.org/10.1101/2024.04.19.590371 (lal2024cytosolicclassi pages 28-32)</p>
+<h2 id="6-current-applications-and-real-world-implementations">6) Current applications and real-world implementations</h2>
+<h3 id="61-mdj1-as-a-perturbation-handle-for-mtdna-maintenance-studies">6.1 Mdj1 as a perturbation handle for mtDNA maintenance studies</h3>
+<p>The TETr-MDJ1 + doxycycline depletion system provides a controlled, time-resolved method to induce mtDNA instability and respiratory loss, enabling downstream assays on mtDNA integrity, rho−/rho0 progression, and proteostasis controls (e.g., aggregation assays to distinguish direct mtDNA maintenance effects from global misfolding). (ciesielski2016nucleoidlocalizationof pages 5-5, ciesielski2016nucleoidlocalizationof pages 4-5)</p>
+<h3 id="62-mdj1-as-a-nucleoid-localization-reporter">6.2 Mdj1 as a nucleoid localization reporter</h3>
+<p>Mdj1-GFP and mutant Mdj1-GFP fusions, combined with DAPI staining and DNase-sensitive fractionation, function as practical <strong>nucleoid association reporters</strong> and enable domain-function dissection of nucleoid tethering. (ciesielski2016nucleoidlocalizationof pages 7-8, ciesielski2016nucleoidlocalizationof pages 4-5)</p>
+<h3 id="63-mdj1-as-an-importprecursor-stress-reporter">6.3 Mdj1 as an import/precursor-stress reporter</h3>
+<p>Because mature vs precursor Mdj1 can be resolved by SDS–PAGE and immunodetection, Mdj1 serves as a convenient endogenous reporter in mitochondrial import stress and precursor quality-control experiments, including MitCOM quality-control pathway characterization and import-clogger assays. (knoringer2023theunfoldedprotein pages 1-3, schulte2023mitochondrialcomplexomereveals pages 28-32)</p>
+<h2 id="7-expert-opinions-and-analysis-authoritative-synthesis">7) Expert opinions and analysis (authoritative synthesis)</h2>
+<p>Authoritative reviews and syntheses (Craig &amp; Marszalek) position Mdj1 as the principal mitochondrial matrix J-protein working with Ssc1 (mtHsp70) and Mge1 (NEF), orthologous to the bacterial DnaK/DnaJ/GrpE system. They emphasize (i) Mdj1’s <strong>general folding/anti-aggregation role</strong> in the matrix, (ii) its <strong>nucleoid enrichment</strong> and correlation with mtDNA maintenance, and (iii) the mechanistic separation between Mdj1-driven folding and Pam18-driven import motor activity. (craig2011hsp70chaperones pages 3-5, craig2014yeasthsp70and pages 9-12, craig2014yeasthsp70and pages 6-9)</p>
+<p>A mechanistic interpretation consistent with primary data is that Mdj1’s <strong>DNA binding and nucleoid enrichment</strong> locally concentrate Hsp70 chaperoning activity at nucleoids, enabling robust folding/assembly or remodeling of nucleoid-associated protein complexes required for mtDNA propagation—an idea supported by Mdj1’s strong nucleoid association, weak Ssc1 nucleoid enrichment (~15%), and strict mtDNA maintenance requirement for a functional J-domain/Ssc1 interaction. (ciesielski2016nucleoidlocalizationof pages 4-5, ciesielski2016nucleoidlocalizationof pages 9-10, ciesielski2016nucleoidlocalizationof pages 8-9)</p>
+<h2 id="8-summary-table-of-evidence">8) Summary table of evidence</h2>
+<p>The following table consolidates localization, function, pathway context, quantitative values, recent 2023 findings, and the best supporting sources.</p>
+<table>
+<thead>
+<tr>
+<th>Aspect</th>
+<th>Key finding</th>
+<th>Evidence type</th>
+<th>Best source(s) with year and URL</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Localization</td>
+<td>MDJ1 encodes a mitochondrial matrix class I J-protein (Hsp40) whose <strong>great majority localizes to mitochondrial nucleoids</strong>; Mdj1-GFP forms dot-like structures that co-localize with DAPI-stained mtDNA and Abf2-GFP. Yeast cells contain <strong>~40 nucleoids per cell</strong>. (ciesielski2016nucleoidlocalizationof pages 2-3, ciesielski2016nucleoidlocalizationof pages 1-2, ciesielski2016nucleoidlocalizationof pages 3-4, ciesielski2016nucleoidlocalizationof media 498c76e6)</td>
+<td>Imaging, cell biology</td>
+<td>Ciesielski et al., 2016, <em>BBA Mol Cell Res</em>, https://doi.org/10.1016/j.bbamcr.2013.05.012</td>
+</tr>
+<tr>
+<td>Nucleoid association vs Ssc1</td>
+<td>On sucrose gradients, the <strong>vast majority of Mdj1</strong> co-migrates with mtDNA/nucleoid fractions, whereas only <strong>~15% of Ssc1</strong> co-migrates, indicating Mdj1 is much more nucleoid-enriched than its Hsp70 partner. (ciesielski2016nucleoidlocalizationof pages 4-5)</td>
+<td>Biochemistry, fractionation</td>
+<td>Ciesielski et al., 2016, <em>BBA Mol Cell Res</em>, https://doi.org/10.1016/j.bbamcr.2013.05.012</td>
+</tr>
+<tr>
+<td>Molecular function</td>
+<td>Mdj1 is the principal <strong>J-protein co-chaperone for mitochondrial Hsp70 Ssc1</strong>, stimulating Ssc1 ATPase activity and promoting client capture/folding in the mitochondrial matrix; Mge1 acts as the nucleotide exchange factor to complete the cycle. (craig2011hsp70chaperones pages 3-5, craig2014yeasthsp70and pages 9-12, craig2011hsp70chaperones pages 2-3, craig2014yeasthsp70and pages 6-9)</td>
+<td>Biochemistry, review synthesis</td>
+<td>Craig &amp; Marszalek, 2011, <em>ELS</em>, https://doi.org/10.1002/9780470015902.a0023188; Craig &amp; Marszalek, 2014, https://doi.org/10.1007/978-1-4939-1130-1_3</td>
+</tr>
+<tr>
+<td>Mechanistic chaperone cycle</td>
+<td>Mdj1 binds the <strong>ATP form of Ssc1</strong>, stimulates ATP hydrolysis, and accelerates conformational changes associated with substrate trapping. Mdj1 can form a relatively stable complex with Ssc1, but during the folding cycle <strong>Mge1 + ATP trigger rapid Mdj1 release (~1 s)</strong>; without ATP/Mge1, Mdj1 dissociates with <strong>half-life ~5 min</strong>. (mapa2010theconformationaldynamics pages 9-10, mapa2010theconformationaldynamics pages 4-5, mapa2010theconformationaldynamics pages 7-9, mapa2010theconformationaldynamics pages 5-7)</td>
+<td>Biochemistry, kinetics, structural biophysics</td>
+<td>Mapa et al., 2010, <em>Molecular Cell</em>, https://doi.org/10.1016/j.molcel.2010.03.010</td>
+</tr>
+<tr>
+<td>Distinction from import motor J-proteins</td>
+<td>Mdj1 functions as the <strong>general matrix folding/refolding J-protein</strong>, whereas <strong>Pam18</strong> is the membrane-anchored import-motor J-protein specialized for preprotein translocation and not general matrix client handling. (craig2011hsp70chaperones pages 3-5, craig2014yeasthsp70and pages 9-12)</td>
+<td>Mechanistic review, genetics/biochemistry synthesis</td>
+<td>Craig &amp; Marszalek, 2011, <em>ELS</em>, https://doi.org/10.1002/9780470015902.a0023188; Craig &amp; Marszalek, 2014, https://doi.org/10.1007/978-1-4939-1130-1_3</td>
+</tr>
+<tr>
+<td>DNA binding</td>
+<td>Mdj1 has intrinsic DNA-binding activity in vitro; gel-shift assays with a 71-bp ori5 fragment gave an apparent <strong>Kd ~0.21 µM</strong>. DNA binding appears separable from peptide binding and correlates with nucleoid localization. (ciesielski2016nucleoidlocalizationof pages 10-11, ciesielski2016nucleoidlocalizationof pages 8-9)</td>
+<td>Biochemistry</td>
+<td>Ciesielski et al., 2016, <em>BBA Mol Cell Res</em>, https://doi.org/10.1016/j.bbamcr.2013.05.012</td>
+</tr>
+<tr>
+<td>Pathway/process</td>
+<td>Mdj1 functions in the <strong>core mtHsp70 chaperone machine</strong> (Mdj1–Ssc1–Mge1), supporting <strong>de novo folding, anti-aggregation/protection of matrix proteins, and maintenance of functional mtDNA</strong>. It is especially linked to nucleoid-centered mitochondrial DNA maintenance rather than the TIM23 import motor itself. (craig2014yeasthsp70and pages 9-12, craig2011hsp70chaperones pages 3-5)</td>
+<td>Genetics, biochemistry, review synthesis</td>
+<td>Craig &amp; Marszalek, 2014, https://doi.org/10.1007/978-1-4939-1130-1_3; Craig &amp; Marszalek, 2011, <em>ELS</em>, https://doi.org/10.1002/9780470015902.a0023188</td>
+</tr>
+<tr>
+<td>Native/likely clients</td>
+<td>Two native nucleoid-associated clients highlighted are <strong>Mip1</strong> (mitochondrial DNA polymerase) and <strong>Var1</strong> (mitochondrial ribosomal subunit). Mdj1 also protects <strong>Mip1 enzymatic activity during extreme heat stress</strong>. (ciesielski2016nucleoidlocalizationof pages 10-11, craig2014yeasthsp70and pages 9-12)</td>
+<td>Genetics, biochemistry</td>
+<td>Ciesielski et al., 2016, <em>BBA Mol Cell Res</em>, https://doi.org/10.1016/j.bbamcr.2013.05.012; Craig &amp; Marszalek, 2014, https://doi.org/10.1007/978-1-4939-1130-1_3</td>
+</tr>
+<tr>
+<td>Domain-function relationships</td>
+<td>The <strong>J-domain and cooperation with Ssc1 are essential</strong> for mtDNA maintenance; <strong>CTD1/CTD2</strong> are critical for DNA binding, nucleoid localization, and function. In contrast, deletion of the zinc-finger-like region or mutation of a substrate-binding cleft motif can preserve mtDNA maintenance under standard conditions. (ciesielski2016nucleoidlocalizationof pages 9-10, ciesielski2016nucleoidlocalizationof pages 2-3, ciesielski2016nucleoidlocalizationof pages 8-9)</td>
+<td>Genetics, domain mutagenesis, biochemistry</td>
+<td>Ciesielski et al., 2016, <em>BBA Mol Cell Res</em>, https://doi.org/10.1016/j.bbamcr.2013.05.012</td>
+</tr>
+<tr>
+<td>Mutant phenotype: mtDNA loss</td>
+<td>Cells lacking Mdj1 fail to maintain functional mtDNA. In a doxycycline-repressible system, Mdj1 fell to <strong>~50% after 4 generations</strong> and became <strong>undetectable after 8 generations</strong>; respiratory-deficient/petite cells then accumulated to <strong>~50% after 10 generations</strong> and <strong>&gt;90% after 20 generations</strong>. (ciesielski2016nucleoidlocalizationof pages 4-5)</td>
+<td>Genetics, depletion time course</td>
+<td>Ciesielski et al., 2016, <em>BBA Mol Cell Res</em>, https://doi.org/10.1016/j.bbamcr.2013.05.012</td>
+</tr>
+<tr>
+<td>Mutant phenotype: qualitative growth</td>
+<td>mdj1 mutants show <strong>temperature-sensitive growth</strong> and inability to maintain mtDNA; J-domain defects that disrupt Ssc1 interaction phenocopy mdj1 loss for mtDNA maintenance. (craig2014yeasthsp70and pages 9-12, ciesielski2016nucleoidlocalizationof pages 9-10)</td>
+<td>Genetics</td>
+<td>Craig &amp; Marszalek, 2014, https://doi.org/10.1007/978-1-4939-1130-1_3; Ciesielski et al., 2016, https://doi.org/10.1016/j.bbamcr.2013.05.012</td>
+</tr>
+<tr>
+<td>Mutant phenotype: domain variants</td>
+<td><strong>Mdj1ΔD</strong> shows slower loss of respiratory competence, with <strong>~70% cells still respiratory-competent after 20 generations</strong>; the isolated J-domain cannot maintain mtDNA, but when overexpressed to <strong>~5-fold higher levels</strong>, it partially delays mtDNA loss. <strong>ΔZ</strong> and <strong>LFI/AAA</strong> variants keep mtDNA but show heat-sensitive growth, with <strong>LFI/AAA barely forming colonies at 37°C</strong>. (ciesielski2016nucleoidlocalizationof pages 7-8)</td>
+<td>Genetics, domain mutagenesis</td>
+<td>Ciesielski et al., 2016, <em>BBA Mol Cell Res</em>, https://doi.org/10.1016/j.bbamcr.2013.05.012</td>
+</tr>
+<tr>
+<td>Heat-stress role</td>
+<td>Beyond constitutive mtDNA maintenance, Mdj1 supports <strong>de novo folding and protection from heat-induced unfolding/aggregation</strong> of mitochondrial proteins and is important for preserving <strong>Mip1 activity under extreme heat stress</strong>. Under optimal growth, Mip1 biochemical activity is not detectably affected by MDJ1 deletion. (ciesielski2016nucleoidlocalizationof pages 10-11, ciesielski2016nucleoidlocalizationof pages 9-10, craig2014yeasthsp70and pages 9-12)</td>
+<td>Biochemistry, stress genetics</td>
+<td>Ciesielski et al., 2016, <em>BBA Mol Cell Res</em>, https://doi.org/10.1016/j.bbamcr.2013.05.012; Craig &amp; Marszalek, 2014, https://doi.org/10.1007/978-1-4939-1130-1_3</td>
+</tr>
+<tr>
+<td>Recent 2023 finding: import quality control</td>
+<td>In the <strong>MitCOM/quality-control</strong> framework, the <strong>Mdj1 precursor moderately accumulates</strong> in <strong>pth2Δ ubx2Δ</strong> mitochondria, supporting a model where Pth2 and Ubx2 redundantly clear accumulated precursor proteins at the mitochondrial entry gate. (schulte2023mitochondrialcomplexomereveals pages 28-32)</td>
+<td>Proteomics, mitochondrial quality control</td>
+<td>Schulte et al., 2023, <em>Nature</em>, https://doi.org/10.1038/s41586-022-05641-w</td>
+</tr>
+<tr>
+<td>Recent 2023 finding: precursor buffering during import stress</td>
+<td>Acute import blockade with a <strong>b2-DHFR clogger</strong> causes accumulation of the <strong>precursor form of Mdj1</strong> detectable by immunoblot after <strong>4.5 h</strong> induction, placing Mdj1 among mitochondrial proteins sensitive to import stress and linked to ER buffering/UPRER responses. (knoringer2023theunfoldedprotein pages 1-3)</td>
+<td>Cell biology, immunoblot, proteostasis</td>
+<td>Knöringer et al., 2023, <em>Molecular Biology of the Cell</em>, https://doi.org/10.1091/mbc.e23-05-0205</td>
+</tr>
+<tr>
+<td>Key methods</td>
+<td>Core evidence comes from <strong>GFP imaging with DAPI/MitoTracker</strong>, <strong>sucrose-gradient co-fractionation</strong>, <strong>DNase-shift assays</strong>, <strong>DNA gel-shift binding</strong>, <strong>doxycycline depletion with respiratory colony scoring</strong>, <strong>growth on glycerol</strong>, <strong>mutational/domain analysis</strong>, and <strong>single-molecule/FRET-based kinetic analysis</strong> of the Ssc1-Mdj1-Mge1 cycle. (ciesielski2016nucleoidlocalizationof pages 3-4, ciesielski2016nucleoidlocalizationof media 498c76e6, mapa2010theconformationaldynamics pages 9-10, mapa2010theconformationaldynamics pages 4-5, knoringer2023theunfoldedprotein pages 1-3, schulte2023mitochondrialcomplexomereveals pages 28-32)</td>
+<td>Imaging, genetics, biochemistry, proteomics, biophysics</td>
+<td>Ciesielski et al., 2016, https://doi.org/10.1016/j.bbamcr.2013.05.012; Mapa et al., 2010, https://doi.org/10.1016/j.molcel.2010.03.010; Schulte et al., 2023, https://doi.org/10.1038/s41586-022-05641-w; Knöringer et al., 2023, https://doi.org/10.1091/mbc.e23-05-0205</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes experimentally supported functions, localization, pathway context, mutant phenotypes, quantitative measurements, and recent 2023 findings for Saccharomyces cerevisiae MDJ1/P35191. It condenses the most relevant evidence from primary papers and authoritative reviews into a citation-linked annotation aid.</em></p>
+<h2 id="9-key-references-with-urls-and-publication-dates">9) Key references (with URLs and publication dates)</h2>
+<ul>
+<li>Mapa K. et al. <strong>The conformational dynamics of the mitochondrial Hsp70 chaperone.</strong> <em>Molecular Cell</em> (Apr 2010). https://doi.org/10.1016/j.molcel.2010.03.010 (mapa2010theconformationaldynamics pages 9-10)</li>
+<li>Craig E.A., Marszalek J. <strong>Hsp70 chaperones.</strong> <em>Encyclopedia of Life Sciences</em> (Mar 2011). https://doi.org/10.1002/9780470015902.a0023188 (craig2011hsp70chaperones pages 3-5)</li>
+<li>Craig E.A., Marszalek J. <strong>Yeast Hsp70 and J-protein Chaperones: Function and Interaction Network.</strong> (Jan 2014). https://doi.org/10.1007/978-1-4939-1130-1_3 (craig2014yeasthsp70and pages 9-12)</li>
+<li>Ciesielski G.L. et al. <strong>Nucleoid localization of Hsp40 Mdj1 is important for its function in maintenance of mitochondrial DNA.</strong> <em>BBA – Molecular Cell Research</em> (Oct 2016). https://doi.org/10.1016/j.bbamcr.2013.05.012 (ciesielski2016nucleoidlocalizationof pages 4-5)</li>
+<li>Schulte U. et al. <strong>Mitochondrial complexome reveals quality-control pathways of protein import.</strong> <em>Nature</em> (Jan 2023). https://doi.org/10.1038/s41586-022-05641-w (schulte2023mitochondrialcomplexomereveals pages 28-32)</li>
+<li>Knöringer K. et al. <strong>The unfolded protein response of the endoplasmic reticulum supports mitochondrial biogenesis by buffering nonimported proteins.</strong> <em>Molecular Biology of the Cell</em> (Sep 2023). https://doi.org/10.1091/mbc.e23-05-0205 (knoringer2023theunfoldedprotein pages 1-3)</li>
+<li>Lal S.S. et al. <strong>Cytosolic Class I J-domain proteins aid mitochondrial protein import and influence homeostasis in Arabidopsis thaliana.</strong> bioRxiv (Apr 2024). https://doi.org/10.1101/2024.04.19.590371 (lal2024cytosolicclassi pages 28-32)</li>
+</ul>
+<p>References</p>
+<ol>
+<li>
+<p>(ciesielski2016nucleoidlocalizationof pages 1-2): Grzegorz L. Ciesielski, Magdalena Plotka, Mateusz Manicki, Brenda A. Schilke, Rafal Dutkiewicz, Chandan Sahi, Jaroslaw Marszalek, and Elizabeth A. Craig. Nucleoid localization of hsp40 mdj1 is important for its function in maintenance of mitochondrial dna. Biochimica et Biophysica Acta (BBA) - Molecular Cell Research, 1833:2233-2243, Oct 2016. URL: https://doi.org/10.1016/j.bbamcr.2013.05.012, doi:10.1016/j.bbamcr.2013.05.012. This article has 14 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(craig2011hsp70chaperones pages 3-5): Elizabeth A Craig and Jaroslaw Marszalek. Hsp 70 chaperones. Encyclopedia of Life Sciences, Mar 2011. URL: https://doi.org/10.1002/9780470015902.a0023188, doi:10.1002/9780470015902.a0023188. This article has 11 citations.</p>
+</li>
+<li>
+<p>(craig2014yeasthsp70and pages 9-12): Elizabeth A. Craig and Jaroslaw Marszalek. Yeast hsp70 and j-protein chaperones: function and interaction network. ArXiv, pages 53-82, Jan 2014. URL: https://doi.org/10.1007/978-1-4939-1130-1_3, doi:10.1007/978-1-4939-1130-1_3. This article has 4 citations.</p>
+</li>
+<li>
+<p>(craig2011hsp70chaperones pages 2-3): Elizabeth A Craig and Jaroslaw Marszalek. Hsp 70 chaperones. Encyclopedia of Life Sciences, Mar 2011. URL: https://doi.org/10.1002/9780470015902.a0023188, doi:10.1002/9780470015902.a0023188. This article has 11 citations.</p>
+</li>
+<li>
+<p>(ciesielski2016nucleoidlocalizationof pages 2-3): Grzegorz L. Ciesielski, Magdalena Plotka, Mateusz Manicki, Brenda A. Schilke, Rafal Dutkiewicz, Chandan Sahi, Jaroslaw Marszalek, and Elizabeth A. Craig. Nucleoid localization of hsp40 mdj1 is important for its function in maintenance of mitochondrial dna. Biochimica et Biophysica Acta (BBA) - Molecular Cell Research, 1833:2233-2243, Oct 2016. URL: https://doi.org/10.1016/j.bbamcr.2013.05.012, doi:10.1016/j.bbamcr.2013.05.012. This article has 14 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ciesielski2016nucleoidlocalizationof pages 8-9): Grzegorz L. Ciesielski, Magdalena Plotka, Mateusz Manicki, Brenda A. Schilke, Rafal Dutkiewicz, Chandan Sahi, Jaroslaw Marszalek, and Elizabeth A. Craig. Nucleoid localization of hsp40 mdj1 is important for its function in maintenance of mitochondrial dna. Biochimica et Biophysica Acta (BBA) - Molecular Cell Research, 1833:2233-2243, Oct 2016. URL: https://doi.org/10.1016/j.bbamcr.2013.05.012, doi:10.1016/j.bbamcr.2013.05.012. This article has 14 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ciesielski2016nucleoidlocalizationof pages 3-4): Grzegorz L. Ciesielski, Magdalena Plotka, Mateusz Manicki, Brenda A. Schilke, Rafal Dutkiewicz, Chandan Sahi, Jaroslaw Marszalek, and Elizabeth A. Craig. Nucleoid localization of hsp40 mdj1 is important for its function in maintenance of mitochondrial dna. Biochimica et Biophysica Acta (BBA) - Molecular Cell Research, 1833:2233-2243, Oct 2016. URL: https://doi.org/10.1016/j.bbamcr.2013.05.012, doi:10.1016/j.bbamcr.2013.05.012. This article has 14 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ciesielski2016nucleoidlocalizationof media 498c76e6): Grzegorz L. Ciesielski, Magdalena Plotka, Mateusz Manicki, Brenda A. Schilke, Rafal Dutkiewicz, Chandan Sahi, Jaroslaw Marszalek, and Elizabeth A. Craig. Nucleoid localization of hsp40 mdj1 is important for its function in maintenance of mitochondrial dna. Biochimica et Biophysica Acta (BBA) - Molecular Cell Research, 1833:2233-2243, Oct 2016. URL: https://doi.org/10.1016/j.bbamcr.2013.05.012, doi:10.1016/j.bbamcr.2013.05.012. This article has 14 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ciesielski2016nucleoidlocalizationof pages 4-5): Grzegorz L. Ciesielski, Magdalena Plotka, Mateusz Manicki, Brenda A. Schilke, Rafal Dutkiewicz, Chandan Sahi, Jaroslaw Marszalek, and Elizabeth A. Craig. Nucleoid localization of hsp40 mdj1 is important for its function in maintenance of mitochondrial dna. Biochimica et Biophysica Acta (BBA) - Molecular Cell Research, 1833:2233-2243, Oct 2016. URL: https://doi.org/10.1016/j.bbamcr.2013.05.012, doi:10.1016/j.bbamcr.2013.05.012. This article has 14 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(mapa2010theconformationaldynamics pages 9-10): Koyeli Mapa, Martin Sikor, Volodymyr Kudryavtsev, Karin Waegemann, Stanislav Kalinin, Claus A.M. Seidel, Walter Neupert, Don C. Lamb, and Dejana Mokranjac. The conformational dynamics of the mitochondrial hsp70 chaperone. Molecular cell, 38 1:89-100, Apr 2010. URL: https://doi.org/10.1016/j.molcel.2010.03.010, doi:10.1016/j.molcel.2010.03.010. This article has 207 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(mapa2010theconformationaldynamics pages 7-9): Koyeli Mapa, Martin Sikor, Volodymyr Kudryavtsev, Karin Waegemann, Stanislav Kalinin, Claus A.M. Seidel, Walter Neupert, Don C. Lamb, and Dejana Mokranjac. The conformational dynamics of the mitochondrial hsp70 chaperone. Molecular cell, 38 1:89-100, Apr 2010. URL: https://doi.org/10.1016/j.molcel.2010.03.010, doi:10.1016/j.molcel.2010.03.010. This article has 207 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ciesielski2016nucleoidlocalizationof pages 9-10): Grzegorz L. Ciesielski, Magdalena Plotka, Mateusz Manicki, Brenda A. Schilke, Rafal Dutkiewicz, Chandan Sahi, Jaroslaw Marszalek, and Elizabeth A. Craig. Nucleoid localization of hsp40 mdj1 is important for its function in maintenance of mitochondrial dna. Biochimica et Biophysica Acta (BBA) - Molecular Cell Research, 1833:2233-2243, Oct 2016. URL: https://doi.org/10.1016/j.bbamcr.2013.05.012, doi:10.1016/j.bbamcr.2013.05.012. This article has 14 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ciesielski2016nucleoidlocalizationof pages 10-11): Grzegorz L. Ciesielski, Magdalena Plotka, Mateusz Manicki, Brenda A. Schilke, Rafal Dutkiewicz, Chandan Sahi, Jaroslaw Marszalek, and Elizabeth A. Craig. Nucleoid localization of hsp40 mdj1 is important for its function in maintenance of mitochondrial dna. Biochimica et Biophysica Acta (BBA) - Molecular Cell Research, 1833:2233-2243, Oct 2016. URL: https://doi.org/10.1016/j.bbamcr.2013.05.012, doi:10.1016/j.bbamcr.2013.05.012. This article has 14 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ciesielski2016nucleoidlocalizationof pages 7-8): Grzegorz L. Ciesielski, Magdalena Plotka, Mateusz Manicki, Brenda A. Schilke, Rafal Dutkiewicz, Chandan Sahi, Jaroslaw Marszalek, and Elizabeth A. Craig. Nucleoid localization of hsp40 mdj1 is important for its function in maintenance of mitochondrial dna. Biochimica et Biophysica Acta (BBA) - Molecular Cell Research, 1833:2233-2243, Oct 2016. URL: https://doi.org/10.1016/j.bbamcr.2013.05.012, doi:10.1016/j.bbamcr.2013.05.012. This article has 14 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(schulte2023mitochondrialcomplexomereveals pages 28-32): Uwe Schulte, Fabian den Brave, Alexander Haupt, Arushi Gupta, Jiyao Song, Catrin S. Müller, Jeannine Engelke, Swadha Mishra, Christoph Mårtensson, Lars Ellenrieder, Chantal Priesnitz, Sebastian P. Straub, Kim Nguyen Doan, Bogusz Kulawiak, Wolfgang Bildl, Heike Rampelt, Nils Wiedemann, Nikolaus Pfanner, Bernd Fakler, and Thomas Becker. Mitochondrial complexome reveals quality-control pathways of protein import. Nature, 614:153-159, Jan 2023. URL: https://doi.org/10.1038/s41586-022-05641-w, doi:10.1038/s41586-022-05641-w. This article has 141 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(knoringer2023theunfoldedprotein pages 1-3): Katharina Knöringer, Carina Groh, Lena Krämer, Kevin C. Stein, Katja G. Hansen, Jannik Zimmermann, Bruce Morgan, Johannes M. Herrmann, Judith Frydman, and Felix Boos. The unfolded protein response of the endoplasmic reticulum supports mitochondrial biogenesis by buffering nonimported proteins. Molecular Biology of the Cell, Sep 2023. URL: https://doi.org/10.1091/mbc.e23-05-0205, doi:10.1091/mbc.e23-05-0205. This article has 18 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lal2024cytosolicclassi pages 28-32): Silviya S. Lal, Neha, Yadvendradatta Rajendra Prasad Yadav, Sreehari P., Amit K. Verma, and Chandan Sahi. Cytosolic class i j-domain proteins aid mitochondrial protein import and influence homeostasis in arabidopsis thaliana. bioRxiv, Apr 2024. URL: https://doi.org/10.1101/2024.04.19.590371, doi:10.1101/2024.04.19.590371. This article has 0 citations.</p>
+</li>
+<li>
+<p>(ciesielski2016nucleoidlocalizationof pages 5-5): Grzegorz L. Ciesielski, Magdalena Plotka, Mateusz Manicki, Brenda A. Schilke, Rafal Dutkiewicz, Chandan Sahi, Jaroslaw Marszalek, and Elizabeth A. Craig. Nucleoid localization of hsp40 mdj1 is important for its function in maintenance of mitochondrial dna. Biochimica et Biophysica Acta (BBA) - Molecular Cell Research, 1833:2233-2243, Oct 2016. URL: https://doi.org/10.1016/j.bbamcr.2013.05.012, doi:10.1016/j.bbamcr.2013.05.012. This article has 14 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(craig2014yeasthsp70and pages 6-9): Elizabeth A. Craig and Jaroslaw Marszalek. Yeast hsp70 and j-protein chaperones: function and interaction network. ArXiv, pages 53-82, Jan 2014. URL: https://doi.org/10.1007/978-1-4939-1130-1_3, doi:10.1007/978-1-4939-1130-1_3. This article has 4 citations.</p>
+</li>
+<li>
+<p>(mapa2010theconformationaldynamics pages 4-5): Koyeli Mapa, Martin Sikor, Volodymyr Kudryavtsev, Karin Waegemann, Stanislav Kalinin, Claus A.M. Seidel, Walter Neupert, Don C. Lamb, and Dejana Mokranjac. The conformational dynamics of the mitochondrial hsp70 chaperone. Molecular cell, 38 1:89-100, Apr 2010. URL: https://doi.org/10.1016/j.molcel.2010.03.010, doi:10.1016/j.molcel.2010.03.010. This article has 207 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(mapa2010theconformationaldynamics pages 5-7): Koyeli Mapa, Martin Sikor, Volodymyr Kudryavtsev, Karin Waegemann, Stanislav Kalinin, Claus A.M. Seidel, Walter Neupert, Don C. Lamb, and Dejana Mokranjac. The conformational dynamics of the mitochondrial hsp70 chaperone. Molecular cell, 38 1:89-100, Apr 2010. URL: https://doi.org/10.1016/j.molcel.2010.03.010, doi:10.1016/j.molcel.2010.03.010. This article has 207 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>ciesielski2016nucleoidlocalizationof pages 1-2</li>
+<li>ciesielski2016nucleoidlocalizationof pages 4-5</li>
+<li>ciesielski2016nucleoidlocalizationof pages 10-11</li>
+<li>ciesielski2016nucleoidlocalizationof pages 7-8</li>
+<li>schulte2023mitochondrialcomplexomereveals pages 28-32</li>
+<li>knoringer2023theunfoldedprotein pages 1-3</li>
+<li>lal2024cytosolicclassi pages 28-32</li>
+<li>mapa2010theconformationaldynamics pages 9-10</li>
+<li>ciesielski2016nucleoidlocalizationof pages 2-3</li>
+<li>ciesielski2016nucleoidlocalizationof pages 8-9</li>
+<li>ciesielski2016nucleoidlocalizationof pages 3-4</li>
+<li>mapa2010theconformationaldynamics pages 7-9</li>
+<li>ciesielski2016nucleoidlocalizationof pages 9-10</li>
+<li>ciesielski2016nucleoidlocalizationof pages 5-5</li>
+<li>mapa2010theconformationaldynamics pages 4-5</li>
+<li>mapa2010theconformationaldynamics pages 5-7</li>
+<li>https://doi.org/10.1038/s41586-022-05641-w</li>
+<li>https://doi.org/10.1091/mbc.e23-05-0205</li>
+<li>https://doi.org/10.1101/2024.04.19.590371</li>
+<li>https://doi.org/10.1016/j.bbamcr.2013.05.012</li>
+<li>https://doi.org/10.1002/9780470015902.a0023188;</li>
+<li>https://doi.org/10.1007/978-1-4939-1130-1_3</li>
+<li>https://doi.org/10.1016/j.molcel.2010.03.010</li>
+<li>https://doi.org/10.1007/978-1-4939-1130-1_3;</li>
+<li>https://doi.org/10.1002/9780470015902.a0023188</li>
+<li>https://doi.org/10.1016/j.bbamcr.2013.05.012;</li>
+<li>https://doi.org/10.1016/j.molcel.2010.03.010;</li>
+<li>https://doi.org/10.1038/s41586-022-05641-w;</li>
+<li>https://doi.org/10.1016/j.bbamcr.2013.05.012,</li>
+<li>https://doi.org/10.1002/9780470015902.a0023188,</li>
+<li>https://doi.org/10.1007/978-1-4939-1130-1_3,</li>
+<li>https://doi.org/10.1016/j.molcel.2010.03.010,</li>
+<li>https://doi.org/10.1038/s41586-022-05641-w,</li>
+<li>https://doi.org/10.1091/mbc.e23-05-0205,</li>
+<li>https://doi.org/10.1101/2024.04.19.590371,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -2516,11 +3118,16 @@
                 <pre><code>id: P35191
 gene_symbol: MDJ1
 product_type: PROTEIN
-status: DRAFT
+status: COMPLETE
 taxon:
   id: NCBITaxon:559292
   label: Saccharomyces cerevisiae
-description: &#39;TODO: Add description for MDJ1&#39;
+description: &gt;-
+  MDJ1 encodes the major mitochondrial matrix DnaJ/Hsp40 cochaperone for the
+  mtHsp70 Ssc1 system. Mdj1 stimulates Hsp70-dependent folding/refolding cycles,
+  protects mitochondrial matrix proteins from misfolding and heat-induced
+  aggregation, and is enriched at mitochondrial nucleoids where it supports
+  maintenance of functional mitochondrial DNA.
 existing_annotations:
 - term:
     id: GO:0005737
@@ -2540,6 +3147,9 @@ existing_annotations:
     summary: &#39;Manual review: protein refolding is consistent with known biology of MDJ1.&#39;
     action: ACCEPT
     reason: Retained as supported or plausible for this gene and evidence context.
+    supported_by:
+    - reference_id: file:yeast/MDJ1/MDJ1-deep-research-falcon.md
+      supporting_text: Mdj1 participates in **de novo folding** and **protection of mitochondrial proteins against heat-induced unfolding/aggregation**
 - term:
     id: GO:0051082
     label: unfolded protein binding
@@ -2805,13 +3415,44 @@ references:
 - id: PMID:9973563
   title: Two distinct mechanisms operate in the reactivation of heat-denatured proteins by the mitochondrial Hsp70/Mdj1p/Yge1p chaperone system.
   findings: []
+- id: file:yeast/MDJ1/MDJ1-deep-research-falcon.md
+  title: Falcon deep research report for MDJ1
+  findings: []
+core_functions:
+- description: &gt;-
+    Mitochondrial matrix J-domain cochaperone activity for the Ssc1/Mge1
+    mtHsp70 system. Mdj1 stimulates Hsp70-dependent folding and refolding of
+    mitochondrial proteins, protects against heat-induced aggregation, and
+    concentrates chaperone activity at mitochondrial nucleoids to support
+    functional mtDNA maintenance.
+  molecular_function:
+    id: GO:0001671
+    label: ATPase activator activity
+  directly_involved_in:
+  - id: GO:0006457
+    label: protein folding
+  - id: GO:0006515
+    label: protein quality control for misfolded or incompletely synthesized proteins
+  locations:
+  - id: GO:0005759
+    label: mitochondrial matrix
+  supported_by:
+  - reference_id: file:yeast/MDJ1/MDJ1-deep-research-falcon.md
+    supporting_text: Mdj1 is a **J-protein co-chaperone** for the mitochondrial Hsp70 **Ssc1**
+proposed_new_terms: []
+suggested_questions:
+- question: Should MDJ1 receive an explicit mitochondrial genome maintenance process annotation based on nucleoid localization and mtDNA-loss phenotypes?
+- question: Is direct DNA-binding/nucleoid association sufficiently represented by current GO cellular-component and process annotations?
+suggested_experiments:
+- description: Test whether Mdj1 client-binding domain mutants separate mitochondrial protein-refolding activity from mtDNA maintenance in the same strain background.
+- description: Map nucleoid-associated Mdj1 clients by proximity labeling under respiratory growth and heat-stress conditions.
 </code></pre>
             </div>
         </details>
     </div>
 
     <!-- Pathway Visualization Link -->
-    
+
 
     <style>
         /* Markdown Section Styles */

--- a/genes/yeast/MDJ1/MDJ1-ai-review.yaml
+++ b/genes/yeast/MDJ1/MDJ1-ai-review.yaml
@@ -1,11 +1,16 @@
 id: P35191
 gene_symbol: MDJ1
 product_type: PROTEIN
-status: DRAFT
+status: COMPLETE
 taxon:
   id: NCBITaxon:559292
   label: Saccharomyces cerevisiae
-description: 'TODO: Add description for MDJ1'
+description: >-
+  MDJ1 encodes the major mitochondrial matrix DnaJ/Hsp40 cochaperone for the
+  mtHsp70 Ssc1 system. Mdj1 stimulates Hsp70-dependent folding/refolding cycles,
+  protects mitochondrial matrix proteins from misfolding and heat-induced
+  aggregation, and is enriched at mitochondrial nucleoids where it supports
+  maintenance of functional mitochondrial DNA.
 existing_annotations:
 - term:
     id: GO:0005737
@@ -25,6 +30,9 @@ existing_annotations:
     summary: 'Manual review: protein refolding is consistent with known biology of MDJ1.'
     action: ACCEPT
     reason: Retained as supported or plausible for this gene and evidence context.
+    supported_by:
+    - reference_id: file:yeast/MDJ1/MDJ1-deep-research-falcon.md
+      supporting_text: Mdj1 participates in **de novo folding** and **protection of mitochondrial proteins against heat-induced unfolding/aggregation**
 - term:
     id: GO:0051082
     label: unfolded protein binding
@@ -290,3 +298,34 @@ references:
 - id: PMID:9973563
   title: Two distinct mechanisms operate in the reactivation of heat-denatured proteins by the mitochondrial Hsp70/Mdj1p/Yge1p chaperone system.
   findings: []
+- id: file:yeast/MDJ1/MDJ1-deep-research-falcon.md
+  title: Falcon deep research report for MDJ1
+  findings: []
+core_functions:
+- description: >-
+    Mitochondrial matrix J-domain cochaperone activity for the Ssc1/Mge1
+    mtHsp70 system. Mdj1 stimulates Hsp70-dependent folding and refolding of
+    mitochondrial proteins, protects against heat-induced aggregation, and
+    concentrates chaperone activity at mitochondrial nucleoids to support
+    functional mtDNA maintenance.
+  molecular_function:
+    id: GO:0001671
+    label: ATPase activator activity
+  directly_involved_in:
+  - id: GO:0006457
+    label: protein folding
+  - id: GO:0006515
+    label: protein quality control for misfolded or incompletely synthesized proteins
+  locations:
+  - id: GO:0005759
+    label: mitochondrial matrix
+  supported_by:
+  - reference_id: file:yeast/MDJ1/MDJ1-deep-research-falcon.md
+    supporting_text: Mdj1 is a **J-protein co-chaperone** for the mitochondrial Hsp70 **Ssc1**
+proposed_new_terms: []
+suggested_questions:
+- question: Should MDJ1 receive an explicit mitochondrial genome maintenance process annotation based on nucleoid localization and mtDNA-loss phenotypes?
+- question: Is direct DNA-binding/nucleoid association sufficiently represented by current GO cellular-component and process annotations?
+suggested_experiments:
+- description: Test whether Mdj1 client-binding domain mutants separate mitochondrial protein-refolding activity from mtDNA maintenance in the same strain background.
+- description: Map nucleoid-associated Mdj1 clients by proximity labeling under respiratory growth and heat-stress conditions.

--- a/genes/yeast/MDJ1/MDJ1-ai-review.yaml
+++ b/genes/yeast/MDJ1/MDJ1-ai-review.yaml
@@ -51,9 +51,15 @@ existing_annotations:
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
   review:
-    summary: 'Manual review: ATP binding is consistent with known biology of MDJ1.'
-    action: ACCEPT
-    reason: Retained as supported or plausible for this gene and evidence context.
+    summary: 'Manual review: ATP binding is likely an automated over-annotation for MDJ1; ATPase activator activity captures the supported biology.'
+    action: MODIFY
+    reason: Mdj1 is a J-domain cochaperone that stimulates ATP hydrolysis by mitochondrial Hsp70 Ssc1 rather than an ATP-binding protein itself.
+    supported_by:
+    - reference_id: file:yeast/MDJ1/MDJ1-deep-research-falcon.md
+      supporting_text: a J-protein stimulates Hsp70 ATP hydrolysis
+    proposed_replacement_terms:
+    - id: GO:0001671
+      label: ATPase activator activity
 - term:
     id: GO:0005739
     label: mitochondrion

--- a/genes/yeast/MDJ1/MDJ1-deep-research-falcon.md
+++ b/genes/yeast/MDJ1/MDJ1-deep-research-falcon.md
@@ -1,0 +1,343 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-11T09:00:25.567296'
+end_time: '2026-05-11T09:20:46.755054'
+duration_seconds: 1221.19
+template_file: templates/gene_research_go_focused.md
+template_variables:
+  organism: yeast
+  gene_id: MDJ1
+  gene_symbol: MDJ1
+  uniprot_accession: P35191
+  protein_description: 'RecName: Full=DnaJ homolog 1, mitochondrial; Flags: Precursor;'
+  gene_info: Name=MDJ1; OrderedLocusNames=YFL016C;
+  organism_full: Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+  protein_family: Not specified in UniProt
+  protein_domains: DnaJ. (IPR012724); DnaJ_C. (IPR002939); DnaJ_domain. (IPR001623);
+    DnaJ_domain_CS. (IPR018253); HSP40/DnaJ_pept-bd. (IPR008971)
+provider_config:
+  timeout: 600
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 35
+---
+
+## Question
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** P35191
+- **Protein Description:** RecName: Full=DnaJ homolog 1, mitochondrial; Flags: Precursor;
+- **Gene Information:** Name=MDJ1; OrderedLocusNames=YFL016C;
+- **Organism (full):** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+- **Protein Family:** Not specified in UniProt
+- **Key Domains:** DnaJ. (IPR012724); DnaJ_C. (IPR002939); DnaJ_domain. (IPR001623); DnaJ_domain_CS. (IPR018253); HSP40/DnaJ_pept-bd. (IPR008971)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "MDJ1" matches the protein description above**
+2. **Verify the organism is correct:** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'MDJ1' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **MDJ1** (gene ID: MDJ1, UniProt: P35191) in yeast.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** P35191
+- **Protein Description:** RecName: Full=DnaJ homolog 1, mitochondrial; Flags: Precursor;
+- **Gene Information:** Name=MDJ1; OrderedLocusNames=YFL016C;
+- **Organism (full):** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+- **Protein Family:** Not specified in UniProt
+- **Key Domains:** DnaJ. (IPR012724); DnaJ_C. (IPR002939); DnaJ_domain. (IPR001623); DnaJ_domain_CS. (IPR018253); HSP40/DnaJ_pept-bd. (IPR008971)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "MDJ1" matches the protein description above**
+2. **Verify the organism is correct:** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'MDJ1' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **MDJ1** (gene ID: MDJ1, UniProt: P35191) in yeast.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+# Research Report: **MDJ1 (UniProt P35191; YFL016C)** in *Saccharomyces cerevisiae* (S288c)
+
+## 0) Target verification (critical)
+The gene symbol **MDJ1** in this report refers specifically to *Saccharomyces cerevisiae* **MDJ1/YFL016C** encoding **DnaJ homolog 1, mitochondrial (precursor)**, a mitochondrial **J-domain protein (Hsp40/J-protein)** that functions with mitochondrial Hsp70 **Ssc1**. This identity and functional class are explicitly supported by yeast primary literature and authoritative reviews describing Mdj1 as a mitochondrial matrix J-protein cooperating with Ssc1 and enriched at mitochondrial nucleoids. (ciesielski2016nucleoidlocalizationof pages 1-2, craig2011hsp70chaperones pages 3-5, craig2014yeasthsp70and pages 9-12)
+
+## 1) Key concepts and definitions (current understanding)
+### 1.1 J-proteins (Hsp40s) and the mtHsp70 chaperone cycle
+Mdj1 is a **J-protein co-chaperone** for the mitochondrial Hsp70 **Ssc1**. In the canonical Hsp70 reaction cycle, a J-protein stimulates Hsp70 ATP hydrolysis, stabilizing client capture; the nucleotide exchange factor **Mge1** promotes ADP release and ATP rebinding, triggering client release and enabling iterative folding cycles. (craig2011hsp70chaperones pages 3-5, craig2014yeasthsp70and pages 9-12, craig2011hsp70chaperones pages 2-3)
+
+A key conceptual distinction in yeast mitochondria is that **Mdj1 is a general matrix folding J-protein**, whereas **Pam18 (Tim14)** is a membrane-anchored J-protein specialized for the **TIM23 import motor**; thus Mdj1 is not the primary J-protein driving presequence translocation across the inner membrane. (craig2011hsp70chaperones pages 3-5, craig2014yeasthsp70and pages 9-12)
+
+### 1.2 Mitochondrial nucleoids
+Mitochondrial DNA in yeast is packaged into **nucleoids**—discrete structures that contain mtDNA and associated proteins involved in mtDNA replication, transcription, and translation. Yeast cells contain **~40 nucleoids per cell**. (ciesielski2016nucleoidlocalizationof pages 1-2)
+
+## 2) MDJ1 protein: domains, localization, and molecular function
+### 2.1 Domain architecture and functional interpretation
+Mdj1 is a **class I J-protein** with an N-terminal **J-domain** followed by client-binding **C-terminal domains (CTDs)** typical of DnaJ/Hsp40 proteins. The J-domain is required for functional interaction with Ssc1, while CTDs contribute to client interactions and, in Mdj1, are required for DNA binding/nucleoid enrichment and mtDNA maintenance. (ciesielski2016nucleoidlocalizationof pages 2-3, ciesielski2016nucleoidlocalizationof pages 8-9)
+
+### 2.2 Subcellular localization: mitochondrial matrix and nucleoid enrichment
+Multiple independent lines of evidence place Mdj1 in the mitochondrial matrix and show that the **great majority is associated with mitochondrial nucleoids**:
+- **Fluorescence microscopy**: Mdj1-GFP appears as dot-like structures co-localizing with DAPI-stained mtDNA and resembles the nucleoid marker Abf2-GFP. (ciesielski2016nucleoidlocalizationof pages 3-4, ciesielski2016nucleoidlocalizationof media 498c76e6)
+- **Biochemical fractionation**: in sucrose gradients, Mdj1 co-migrates with mtDNA/nucleoid fractions and shifts away upon DNase I treatment, supporting DNA-dependent association. (ciesielski2016nucleoidlocalizationof pages 4-5)
+
+Notably, only **~15% of Ssc1** co-migrates with nucleoid fractions, indicating Mdj1 is far more nucleoid-enriched than its Hsp70 partner and supporting a model where Mdj1 tethers or concentrates Hsp70 activity at nucleoids. (ciesielski2016nucleoidlocalizationof pages 4-5)
+
+### 2.3 Core biochemical function: a nucleoid-enriched mtHsp70 co-chaperone
+Mechanistically, Mdj1 binds the ATP state of Ssc1 and stimulates ATP hydrolysis, promoting productive folding transitions of mtHsp70.
+
+Single-molecule/kinetic analyses of the mitochondrial Hsp70 system show that Mdj1–Ssc1 association can be relatively stable (**half-life ~5 min**) in some states, yet within the active folding cycle **Mge1 + ATP can trigger Mdj1 release within ~1 s**, supporting rapid cycling during matrix protein folding. (mapa2010theconformationaldynamics pages 9-10, mapa2010theconformationaldynamics pages 7-9)
+
+## 3) Biological roles and pathways
+### 3.1 Maintenance of functional mtDNA (primary physiological role)
+A central experimentally supported role of Mdj1 is **maintenance of functional mitochondrial DNA**. Cells lacking Mdj1 (or expressing J-domain-defective variants) are unable to maintain functional mtDNA and progressively lose respiratory competence, consistent with Mdj1’s nucleoid-centered activity and Ssc1 partnership. (ciesielski2016nucleoidlocalizationof pages 9-10, craig2014yeasthsp70and pages 9-12)
+
+### 3.2 Protein folding/anti-aggregation protection in the matrix and under stress
+Mdj1 participates in **de novo folding** and **protection of mitochondrial proteins against heat-induced unfolding/aggregation**, consistent with its role as the major matrix J-protein for Ssc1. (ciesielski2016nucleoidlocalizationof pages 10-11, craig2014yeasthsp70and pages 9-12)
+
+### 3.3 Candidate native clients at nucleoids
+Authoritative synthesis highlights **Mip1** (mitochondrial DNA polymerase) and **Var1** (mitochondrial ribosomal subunit) as native nucleoid-associated clients for the Mdj1–Ssc1 system. (craig2014yeasthsp70and pages 9-12)
+
+Ciesielski et al. report that Mdj1 plays a critical role in protecting the enzymatic activity of **Mip1** under extreme heat stress, and note co-immunoprecipitation evidence linking mitochondrial polymerase to the mammalian ortholog (DnajA3/Tid1), supporting polymerase as a plausible conserved client. (ciesielski2016nucleoidlocalizationof pages 10-11)
+
+## 4) Mutant phenotypes and quantitative data (recently emphasized statistics)
+### 4.1 Inducible depletion kinetics and petite formation
+Using **TETr-MDJ1** with doxycycline-mediated repression, Mdj1 depletion yields a quantitative time course for mtDNA functional loss:
+- Baseline (no doxycycline): **~83–85%** colonies are respiratory-competent (red). (ciesielski2016nucleoidlocalizationof pages 4-5)
+- Mdj1 protein drops to **~50% after 4 generations**, and is **undetectable after 8 generations**. (ciesielski2016nucleoidlocalizationof pages 4-5)
+- Respiratory deficiency accumulates to **~50% after 10 generations** and **>90% after 20 generations**. (ciesielski2016nucleoidlocalizationof pages 4-5)
+
+These kinetics support Mdj1 as an experimentally tractable control point for mtDNA stability and respiratory competence. (ciesielski2016nucleoidlocalizationof pages 4-5)
+
+### 4.2 Domain/function mapping (quantitative highlights)
+- A dimerization-domain deletion (**Mdj1ΔD**) shows slower mtDNA loss, with **~70%** of cells remaining respiratory-competent **20 generations** after full-length Mdj1 repression. (ciesielski2016nucleoidlocalizationof pages 7-8)
+- The isolated J-domain fragment cannot maintain mtDNA at native expression but, when overexpressed to **~5-fold** higher levels, partially delays mtDNA loss (though it does not fully prevent it). (ciesielski2016nucleoidlocalizationof pages 7-8)
+
+### 4.3 Direct DNA binding (quantitative binding constant)
+Purified Mdj1 binds DNA in vitro. In gel-shift assays using a **71 bp ori5 fragment** at **0.36 nM**, Mdj1 titration yields an apparent DNA-binding **Kd ≈ 0.21 μM**. (ciesielski2016nucleoidlocalizationof pages 10-11)
+
+## 5) Recent developments (prioritized 2023–2024)
+While dedicated MDJ1-only papers are relatively sparse in 2023–2024, two high-authority yeast mitochondrial biogenesis/proteostasis studies explicitly leverage Mdj1 as a readout and place it into new mechanistic context.
+
+### 5.1 2023 Nature: complexome profiling and protein import quality control
+A high-resolution yeast mitochondrial complexome (MitCOM) and associated import quality-control analyses report that the **Mdj1 precursor** **moderately accumulates** in **pth2Δ ubx2Δ** mitochondria, supporting redundancy between Pth2 and Ubx2 pathways in clearing accumulated precursor proteins at/near the mitochondrial entry gate. Here, Mdj1 precursor vs mature forms are used as an import-stress/precursor-handling readout. (schulte2023mitochondrialcomplexomereveals pages 28-32)
+
+**Publication date/URL:** January 2023, *Nature*, https://doi.org/10.1038/s41586-022-05641-w (schulte2023mitochondrialcomplexomereveals pages 28-32)
+
+### 5.2 2023 MBoC: ER buffering of nonimported mitochondrial proteins
+In a study connecting mitochondrial import stress to ER proteostasis responses, acute import block using a **b2-DHFR clogger** leads to detectable accumulation of the **precursor form of Mdj1** by immunoblot after **4.5 h** induction. This places Mdj1 among mitochondrial precursors that accumulate when import is perturbed and supports the broader model that nonimported proteins can be buffered at the ER, triggering **UPRER**. (knoringer2023theunfoldedprotein pages 1-3)
+
+**Publication date/URL:** September 2023, *Molecular Biology of the Cell*, https://doi.org/10.1091/mbc.e23-05-0205 (knoringer2023theunfoldedprotein pages 1-3)
+
+### 5.3 2024 (preprint): Mdj1 as an import reporter readout
+A 2024 bioRxiv preprint uses anti-Mdj1 immunoblotting to distinguish cytosolic **precursor (P)** and mature mitochondrial **(M)** forms of Mdj1 as a proxy for mitochondrial import efficiency in yeast complementation backgrounds. (lal2024cytosolicclassi pages 28-32)
+
+**Publication date/URL:** April 2024, bioRxiv, https://doi.org/10.1101/2024.04.19.590371 (lal2024cytosolicclassi pages 28-32)
+
+## 6) Current applications and real-world implementations
+### 6.1 Mdj1 as a perturbation handle for mtDNA maintenance studies
+The TETr-MDJ1 + doxycycline depletion system provides a controlled, time-resolved method to induce mtDNA instability and respiratory loss, enabling downstream assays on mtDNA integrity, rho−/rho0 progression, and proteostasis controls (e.g., aggregation assays to distinguish direct mtDNA maintenance effects from global misfolding). (ciesielski2016nucleoidlocalizationof pages 5-5, ciesielski2016nucleoidlocalizationof pages 4-5)
+
+### 6.2 Mdj1 as a nucleoid localization reporter
+Mdj1-GFP and mutant Mdj1-GFP fusions, combined with DAPI staining and DNase-sensitive fractionation, function as practical **nucleoid association reporters** and enable domain-function dissection of nucleoid tethering. (ciesielski2016nucleoidlocalizationof pages 7-8, ciesielski2016nucleoidlocalizationof pages 4-5)
+
+### 6.3 Mdj1 as an import/precursor-stress reporter
+Because mature vs precursor Mdj1 can be resolved by SDS–PAGE and immunodetection, Mdj1 serves as a convenient endogenous reporter in mitochondrial import stress and precursor quality-control experiments, including MitCOM quality-control pathway characterization and import-clogger assays. (knoringer2023theunfoldedprotein pages 1-3, schulte2023mitochondrialcomplexomereveals pages 28-32)
+
+## 7) Expert opinions and analysis (authoritative synthesis)
+Authoritative reviews and syntheses (Craig & Marszalek) position Mdj1 as the principal mitochondrial matrix J-protein working with Ssc1 (mtHsp70) and Mge1 (NEF), orthologous to the bacterial DnaK/DnaJ/GrpE system. They emphasize (i) Mdj1’s **general folding/anti-aggregation role** in the matrix, (ii) its **nucleoid enrichment** and correlation with mtDNA maintenance, and (iii) the mechanistic separation between Mdj1-driven folding and Pam18-driven import motor activity. (craig2011hsp70chaperones pages 3-5, craig2014yeasthsp70and pages 9-12, craig2014yeasthsp70and pages 6-9)
+
+A mechanistic interpretation consistent with primary data is that Mdj1’s **DNA binding and nucleoid enrichment** locally concentrate Hsp70 chaperoning activity at nucleoids, enabling robust folding/assembly or remodeling of nucleoid-associated protein complexes required for mtDNA propagation—an idea supported by Mdj1’s strong nucleoid association, weak Ssc1 nucleoid enrichment (~15%), and strict mtDNA maintenance requirement for a functional J-domain/Ssc1 interaction. (ciesielski2016nucleoidlocalizationof pages 4-5, ciesielski2016nucleoidlocalizationof pages 9-10, ciesielski2016nucleoidlocalizationof pages 8-9)
+
+## 8) Summary table of evidence
+The following table consolidates localization, function, pathway context, quantitative values, recent 2023 findings, and the best supporting sources.
+
+| Aspect | Key finding | Evidence type | Best source(s) with year and URL |
+|---|---|---|---|
+| Localization | MDJ1 encodes a mitochondrial matrix class I J-protein (Hsp40) whose **great majority localizes to mitochondrial nucleoids**; Mdj1-GFP forms dot-like structures that co-localize with DAPI-stained mtDNA and Abf2-GFP. Yeast cells contain **~40 nucleoids per cell**. (ciesielski2016nucleoidlocalizationof pages 2-3, ciesielski2016nucleoidlocalizationof pages 1-2, ciesielski2016nucleoidlocalizationof pages 3-4, ciesielski2016nucleoidlocalizationof media 498c76e6) | Imaging, cell biology | Ciesielski et al., 2016, *BBA Mol Cell Res*, https://doi.org/10.1016/j.bbamcr.2013.05.012 |
+| Nucleoid association vs Ssc1 | On sucrose gradients, the **vast majority of Mdj1** co-migrates with mtDNA/nucleoid fractions, whereas only **~15% of Ssc1** co-migrates, indicating Mdj1 is much more nucleoid-enriched than its Hsp70 partner. (ciesielski2016nucleoidlocalizationof pages 4-5) | Biochemistry, fractionation | Ciesielski et al., 2016, *BBA Mol Cell Res*, https://doi.org/10.1016/j.bbamcr.2013.05.012 |
+| Molecular function | Mdj1 is the principal **J-protein co-chaperone for mitochondrial Hsp70 Ssc1**, stimulating Ssc1 ATPase activity and promoting client capture/folding in the mitochondrial matrix; Mge1 acts as the nucleotide exchange factor to complete the cycle. (craig2011hsp70chaperones pages 3-5, craig2014yeasthsp70and pages 9-12, craig2011hsp70chaperones pages 2-3, craig2014yeasthsp70and pages 6-9) | Biochemistry, review synthesis | Craig & Marszalek, 2011, *ELS*, https://doi.org/10.1002/9780470015902.a0023188; Craig & Marszalek, 2014, https://doi.org/10.1007/978-1-4939-1130-1_3 |
+| Mechanistic chaperone cycle | Mdj1 binds the **ATP form of Ssc1**, stimulates ATP hydrolysis, and accelerates conformational changes associated with substrate trapping. Mdj1 can form a relatively stable complex with Ssc1, but during the folding cycle **Mge1 + ATP trigger rapid Mdj1 release (~1 s)**; without ATP/Mge1, Mdj1 dissociates with **half-life ~5 min**. (mapa2010theconformationaldynamics pages 9-10, mapa2010theconformationaldynamics pages 4-5, mapa2010theconformationaldynamics pages 7-9, mapa2010theconformationaldynamics pages 5-7) | Biochemistry, kinetics, structural biophysics | Mapa et al., 2010, *Molecular Cell*, https://doi.org/10.1016/j.molcel.2010.03.010 |
+| Distinction from import motor J-proteins | Mdj1 functions as the **general matrix folding/refolding J-protein**, whereas **Pam18** is the membrane-anchored import-motor J-protein specialized for preprotein translocation and not general matrix client handling. (craig2011hsp70chaperones pages 3-5, craig2014yeasthsp70and pages 9-12) | Mechanistic review, genetics/biochemistry synthesis | Craig & Marszalek, 2011, *ELS*, https://doi.org/10.1002/9780470015902.a0023188; Craig & Marszalek, 2014, https://doi.org/10.1007/978-1-4939-1130-1_3 |
+| DNA binding | Mdj1 has intrinsic DNA-binding activity in vitro; gel-shift assays with a 71-bp ori5 fragment gave an apparent **Kd ~0.21 µM**. DNA binding appears separable from peptide binding and correlates with nucleoid localization. (ciesielski2016nucleoidlocalizationof pages 10-11, ciesielski2016nucleoidlocalizationof pages 8-9) | Biochemistry | Ciesielski et al., 2016, *BBA Mol Cell Res*, https://doi.org/10.1016/j.bbamcr.2013.05.012 |
+| Pathway/process | Mdj1 functions in the **core mtHsp70 chaperone machine** (Mdj1–Ssc1–Mge1), supporting **de novo folding, anti-aggregation/protection of matrix proteins, and maintenance of functional mtDNA**. It is especially linked to nucleoid-centered mitochondrial DNA maintenance rather than the TIM23 import motor itself. (craig2014yeasthsp70and pages 9-12, craig2011hsp70chaperones pages 3-5) | Genetics, biochemistry, review synthesis | Craig & Marszalek, 2014, https://doi.org/10.1007/978-1-4939-1130-1_3; Craig & Marszalek, 2011, *ELS*, https://doi.org/10.1002/9780470015902.a0023188 |
+| Native/likely clients | Two native nucleoid-associated clients highlighted are **Mip1** (mitochondrial DNA polymerase) and **Var1** (mitochondrial ribosomal subunit). Mdj1 also protects **Mip1 enzymatic activity during extreme heat stress**. (ciesielski2016nucleoidlocalizationof pages 10-11, craig2014yeasthsp70and pages 9-12) | Genetics, biochemistry | Ciesielski et al., 2016, *BBA Mol Cell Res*, https://doi.org/10.1016/j.bbamcr.2013.05.012; Craig & Marszalek, 2014, https://doi.org/10.1007/978-1-4939-1130-1_3 |
+| Domain-function relationships | The **J-domain and cooperation with Ssc1 are essential** for mtDNA maintenance; **CTD1/CTD2** are critical for DNA binding, nucleoid localization, and function. In contrast, deletion of the zinc-finger-like region or mutation of a substrate-binding cleft motif can preserve mtDNA maintenance under standard conditions. (ciesielski2016nucleoidlocalizationof pages 9-10, ciesielski2016nucleoidlocalizationof pages 2-3, ciesielski2016nucleoidlocalizationof pages 8-9) | Genetics, domain mutagenesis, biochemistry | Ciesielski et al., 2016, *BBA Mol Cell Res*, https://doi.org/10.1016/j.bbamcr.2013.05.012 |
+| Mutant phenotype: mtDNA loss | Cells lacking Mdj1 fail to maintain functional mtDNA. In a doxycycline-repressible system, Mdj1 fell to **~50% after 4 generations** and became **undetectable after 8 generations**; respiratory-deficient/petite cells then accumulated to **~50% after 10 generations** and **>90% after 20 generations**. (ciesielski2016nucleoidlocalizationof pages 4-5) | Genetics, depletion time course | Ciesielski et al., 2016, *BBA Mol Cell Res*, https://doi.org/10.1016/j.bbamcr.2013.05.012 |
+| Mutant phenotype: qualitative growth | mdj1 mutants show **temperature-sensitive growth** and inability to maintain mtDNA; J-domain defects that disrupt Ssc1 interaction phenocopy mdj1 loss for mtDNA maintenance. (craig2014yeasthsp70and pages 9-12, ciesielski2016nucleoidlocalizationof pages 9-10) | Genetics | Craig & Marszalek, 2014, https://doi.org/10.1007/978-1-4939-1130-1_3; Ciesielski et al., 2016, https://doi.org/10.1016/j.bbamcr.2013.05.012 |
+| Mutant phenotype: domain variants | **Mdj1ΔD** shows slower loss of respiratory competence, with **~70% cells still respiratory-competent after 20 generations**; the isolated J-domain cannot maintain mtDNA, but when overexpressed to **~5-fold higher levels**, it partially delays mtDNA loss. **ΔZ** and **LFI/AAA** variants keep mtDNA but show heat-sensitive growth, with **LFI/AAA barely forming colonies at 37°C**. (ciesielski2016nucleoidlocalizationof pages 7-8) | Genetics, domain mutagenesis | Ciesielski et al., 2016, *BBA Mol Cell Res*, https://doi.org/10.1016/j.bbamcr.2013.05.012 |
+| Heat-stress role | Beyond constitutive mtDNA maintenance, Mdj1 supports **de novo folding and protection from heat-induced unfolding/aggregation** of mitochondrial proteins and is important for preserving **Mip1 activity under extreme heat stress**. Under optimal growth, Mip1 biochemical activity is not detectably affected by MDJ1 deletion. (ciesielski2016nucleoidlocalizationof pages 10-11, ciesielski2016nucleoidlocalizationof pages 9-10, craig2014yeasthsp70and pages 9-12) | Biochemistry, stress genetics | Ciesielski et al., 2016, *BBA Mol Cell Res*, https://doi.org/10.1016/j.bbamcr.2013.05.012; Craig & Marszalek, 2014, https://doi.org/10.1007/978-1-4939-1130-1_3 |
+| Recent 2023 finding: import quality control | In the **MitCOM/quality-control** framework, the **Mdj1 precursor moderately accumulates** in **pth2Δ ubx2Δ** mitochondria, supporting a model where Pth2 and Ubx2 redundantly clear accumulated precursor proteins at the mitochondrial entry gate. (schulte2023mitochondrialcomplexomereveals pages 28-32) | Proteomics, mitochondrial quality control | Schulte et al., 2023, *Nature*, https://doi.org/10.1038/s41586-022-05641-w |
+| Recent 2023 finding: precursor buffering during import stress | Acute import blockade with a **b2-DHFR clogger** causes accumulation of the **precursor form of Mdj1** detectable by immunoblot after **4.5 h** induction, placing Mdj1 among mitochondrial proteins sensitive to import stress and linked to ER buffering/UPRER responses. (knoringer2023theunfoldedprotein pages 1-3) | Cell biology, immunoblot, proteostasis | Knöringer et al., 2023, *Molecular Biology of the Cell*, https://doi.org/10.1091/mbc.e23-05-0205 |
+| Key methods | Core evidence comes from **GFP imaging with DAPI/MitoTracker**, **sucrose-gradient co-fractionation**, **DNase-shift assays**, **DNA gel-shift binding**, **doxycycline depletion with respiratory colony scoring**, **growth on glycerol**, **mutational/domain analysis**, and **single-molecule/FRET-based kinetic analysis** of the Ssc1-Mdj1-Mge1 cycle. (ciesielski2016nucleoidlocalizationof pages 3-4, ciesielski2016nucleoidlocalizationof media 498c76e6, mapa2010theconformationaldynamics pages 9-10, mapa2010theconformationaldynamics pages 4-5, knoringer2023theunfoldedprotein pages 1-3, schulte2023mitochondrialcomplexomereveals pages 28-32) | Imaging, genetics, biochemistry, proteomics, biophysics | Ciesielski et al., 2016, https://doi.org/10.1016/j.bbamcr.2013.05.012; Mapa et al., 2010, https://doi.org/10.1016/j.molcel.2010.03.010; Schulte et al., 2023, https://doi.org/10.1038/s41586-022-05641-w; Knöringer et al., 2023, https://doi.org/10.1091/mbc.e23-05-0205 |
+
+
+*Table: This table summarizes experimentally supported functions, localization, pathway context, mutant phenotypes, quantitative measurements, and recent 2023 findings for Saccharomyces cerevisiae MDJ1/P35191. It condenses the most relevant evidence from primary papers and authoritative reviews into a citation-linked annotation aid.*
+
+## 9) Key references (with URLs and publication dates)
+- Mapa K. et al. **The conformational dynamics of the mitochondrial Hsp70 chaperone.** *Molecular Cell* (Apr 2010). https://doi.org/10.1016/j.molcel.2010.03.010 (mapa2010theconformationaldynamics pages 9-10)
+- Craig E.A., Marszalek J. **Hsp70 chaperones.** *Encyclopedia of Life Sciences* (Mar 2011). https://doi.org/10.1002/9780470015902.a0023188 (craig2011hsp70chaperones pages 3-5)
+- Craig E.A., Marszalek J. **Yeast Hsp70 and J-protein Chaperones: Function and Interaction Network.** (Jan 2014). https://doi.org/10.1007/978-1-4939-1130-1_3 (craig2014yeasthsp70and pages 9-12)
+- Ciesielski G.L. et al. **Nucleoid localization of Hsp40 Mdj1 is important for its function in maintenance of mitochondrial DNA.** *BBA – Molecular Cell Research* (Oct 2016). https://doi.org/10.1016/j.bbamcr.2013.05.012 (ciesielski2016nucleoidlocalizationof pages 4-5)
+- Schulte U. et al. **Mitochondrial complexome reveals quality-control pathways of protein import.** *Nature* (Jan 2023). https://doi.org/10.1038/s41586-022-05641-w (schulte2023mitochondrialcomplexomereveals pages 28-32)
+- Knöringer K. et al. **The unfolded protein response of the endoplasmic reticulum supports mitochondrial biogenesis by buffering nonimported proteins.** *Molecular Biology of the Cell* (Sep 2023). https://doi.org/10.1091/mbc.e23-05-0205 (knoringer2023theunfoldedprotein pages 1-3)
+- Lal S.S. et al. **Cytosolic Class I J-domain proteins aid mitochondrial protein import and influence homeostasis in Arabidopsis thaliana.** bioRxiv (Apr 2024). https://doi.org/10.1101/2024.04.19.590371 (lal2024cytosolicclassi pages 28-32)
+
+
+References
+
+1. (ciesielski2016nucleoidlocalizationof pages 1-2): Grzegorz L. Ciesielski, Magdalena Plotka, Mateusz Manicki, Brenda A. Schilke, Rafal Dutkiewicz, Chandan Sahi, Jaroslaw Marszalek, and Elizabeth A. Craig. Nucleoid localization of hsp40 mdj1 is important for its function in maintenance of mitochondrial dna. Biochimica et Biophysica Acta (BBA) - Molecular Cell Research, 1833:2233-2243, Oct 2016. URL: https://doi.org/10.1016/j.bbamcr.2013.05.012, doi:10.1016/j.bbamcr.2013.05.012. This article has 14 citations and is from a peer-reviewed journal.
+
+2. (craig2011hsp70chaperones pages 3-5): Elizabeth A Craig and Jaroslaw Marszalek. Hsp 70 chaperones. Encyclopedia of Life Sciences, Mar 2011. URL: https://doi.org/10.1002/9780470015902.a0023188, doi:10.1002/9780470015902.a0023188. This article has 11 citations.
+
+3. (craig2014yeasthsp70and pages 9-12): Elizabeth A. Craig and Jaroslaw Marszalek. Yeast hsp70 and j-protein chaperones: function and interaction network. ArXiv, pages 53-82, Jan 2014. URL: https://doi.org/10.1007/978-1-4939-1130-1\_3, doi:10.1007/978-1-4939-1130-1\_3. This article has 4 citations.
+
+4. (craig2011hsp70chaperones pages 2-3): Elizabeth A Craig and Jaroslaw Marszalek. Hsp 70 chaperones. Encyclopedia of Life Sciences, Mar 2011. URL: https://doi.org/10.1002/9780470015902.a0023188, doi:10.1002/9780470015902.a0023188. This article has 11 citations.
+
+5. (ciesielski2016nucleoidlocalizationof pages 2-3): Grzegorz L. Ciesielski, Magdalena Plotka, Mateusz Manicki, Brenda A. Schilke, Rafal Dutkiewicz, Chandan Sahi, Jaroslaw Marszalek, and Elizabeth A. Craig. Nucleoid localization of hsp40 mdj1 is important for its function in maintenance of mitochondrial dna. Biochimica et Biophysica Acta (BBA) - Molecular Cell Research, 1833:2233-2243, Oct 2016. URL: https://doi.org/10.1016/j.bbamcr.2013.05.012, doi:10.1016/j.bbamcr.2013.05.012. This article has 14 citations and is from a peer-reviewed journal.
+
+6. (ciesielski2016nucleoidlocalizationof pages 8-9): Grzegorz L. Ciesielski, Magdalena Plotka, Mateusz Manicki, Brenda A. Schilke, Rafal Dutkiewicz, Chandan Sahi, Jaroslaw Marszalek, and Elizabeth A. Craig. Nucleoid localization of hsp40 mdj1 is important for its function in maintenance of mitochondrial dna. Biochimica et Biophysica Acta (BBA) - Molecular Cell Research, 1833:2233-2243, Oct 2016. URL: https://doi.org/10.1016/j.bbamcr.2013.05.012, doi:10.1016/j.bbamcr.2013.05.012. This article has 14 citations and is from a peer-reviewed journal.
+
+7. (ciesielski2016nucleoidlocalizationof pages 3-4): Grzegorz L. Ciesielski, Magdalena Plotka, Mateusz Manicki, Brenda A. Schilke, Rafal Dutkiewicz, Chandan Sahi, Jaroslaw Marszalek, and Elizabeth A. Craig. Nucleoid localization of hsp40 mdj1 is important for its function in maintenance of mitochondrial dna. Biochimica et Biophysica Acta (BBA) - Molecular Cell Research, 1833:2233-2243, Oct 2016. URL: https://doi.org/10.1016/j.bbamcr.2013.05.012, doi:10.1016/j.bbamcr.2013.05.012. This article has 14 citations and is from a peer-reviewed journal.
+
+8. (ciesielski2016nucleoidlocalizationof media 498c76e6): Grzegorz L. Ciesielski, Magdalena Plotka, Mateusz Manicki, Brenda A. Schilke, Rafal Dutkiewicz, Chandan Sahi, Jaroslaw Marszalek, and Elizabeth A. Craig. Nucleoid localization of hsp40 mdj1 is important for its function in maintenance of mitochondrial dna. Biochimica et Biophysica Acta (BBA) - Molecular Cell Research, 1833:2233-2243, Oct 2016. URL: https://doi.org/10.1016/j.bbamcr.2013.05.012, doi:10.1016/j.bbamcr.2013.05.012. This article has 14 citations and is from a peer-reviewed journal.
+
+9. (ciesielski2016nucleoidlocalizationof pages 4-5): Grzegorz L. Ciesielski, Magdalena Plotka, Mateusz Manicki, Brenda A. Schilke, Rafal Dutkiewicz, Chandan Sahi, Jaroslaw Marszalek, and Elizabeth A. Craig. Nucleoid localization of hsp40 mdj1 is important for its function in maintenance of mitochondrial dna. Biochimica et Biophysica Acta (BBA) - Molecular Cell Research, 1833:2233-2243, Oct 2016. URL: https://doi.org/10.1016/j.bbamcr.2013.05.012, doi:10.1016/j.bbamcr.2013.05.012. This article has 14 citations and is from a peer-reviewed journal.
+
+10. (mapa2010theconformationaldynamics pages 9-10): Koyeli Mapa, Martin Sikor, Volodymyr Kudryavtsev, Karin Waegemann, Stanislav Kalinin, Claus A.M. Seidel, Walter Neupert, Don C. Lamb, and Dejana Mokranjac. The conformational dynamics of the mitochondrial hsp70 chaperone. Molecular cell, 38 1:89-100, Apr 2010. URL: https://doi.org/10.1016/j.molcel.2010.03.010, doi:10.1016/j.molcel.2010.03.010. This article has 207 citations and is from a highest quality peer-reviewed journal.
+
+11. (mapa2010theconformationaldynamics pages 7-9): Koyeli Mapa, Martin Sikor, Volodymyr Kudryavtsev, Karin Waegemann, Stanislav Kalinin, Claus A.M. Seidel, Walter Neupert, Don C. Lamb, and Dejana Mokranjac. The conformational dynamics of the mitochondrial hsp70 chaperone. Molecular cell, 38 1:89-100, Apr 2010. URL: https://doi.org/10.1016/j.molcel.2010.03.010, doi:10.1016/j.molcel.2010.03.010. This article has 207 citations and is from a highest quality peer-reviewed journal.
+
+12. (ciesielski2016nucleoidlocalizationof pages 9-10): Grzegorz L. Ciesielski, Magdalena Plotka, Mateusz Manicki, Brenda A. Schilke, Rafal Dutkiewicz, Chandan Sahi, Jaroslaw Marszalek, and Elizabeth A. Craig. Nucleoid localization of hsp40 mdj1 is important for its function in maintenance of mitochondrial dna. Biochimica et Biophysica Acta (BBA) - Molecular Cell Research, 1833:2233-2243, Oct 2016. URL: https://doi.org/10.1016/j.bbamcr.2013.05.012, doi:10.1016/j.bbamcr.2013.05.012. This article has 14 citations and is from a peer-reviewed journal.
+
+13. (ciesielski2016nucleoidlocalizationof pages 10-11): Grzegorz L. Ciesielski, Magdalena Plotka, Mateusz Manicki, Brenda A. Schilke, Rafal Dutkiewicz, Chandan Sahi, Jaroslaw Marszalek, and Elizabeth A. Craig. Nucleoid localization of hsp40 mdj1 is important for its function in maintenance of mitochondrial dna. Biochimica et Biophysica Acta (BBA) - Molecular Cell Research, 1833:2233-2243, Oct 2016. URL: https://doi.org/10.1016/j.bbamcr.2013.05.012, doi:10.1016/j.bbamcr.2013.05.012. This article has 14 citations and is from a peer-reviewed journal.
+
+14. (ciesielski2016nucleoidlocalizationof pages 7-8): Grzegorz L. Ciesielski, Magdalena Plotka, Mateusz Manicki, Brenda A. Schilke, Rafal Dutkiewicz, Chandan Sahi, Jaroslaw Marszalek, and Elizabeth A. Craig. Nucleoid localization of hsp40 mdj1 is important for its function in maintenance of mitochondrial dna. Biochimica et Biophysica Acta (BBA) - Molecular Cell Research, 1833:2233-2243, Oct 2016. URL: https://doi.org/10.1016/j.bbamcr.2013.05.012, doi:10.1016/j.bbamcr.2013.05.012. This article has 14 citations and is from a peer-reviewed journal.
+
+15. (schulte2023mitochondrialcomplexomereveals pages 28-32): Uwe Schulte, Fabian den Brave, Alexander Haupt, Arushi Gupta, Jiyao Song, Catrin S. Müller, Jeannine Engelke, Swadha Mishra, Christoph Mårtensson, Lars Ellenrieder, Chantal Priesnitz, Sebastian P. Straub, Kim Nguyen Doan, Bogusz Kulawiak, Wolfgang Bildl, Heike Rampelt, Nils Wiedemann, Nikolaus Pfanner, Bernd Fakler, and Thomas Becker. Mitochondrial complexome reveals quality-control pathways of protein import. Nature, 614:153-159, Jan 2023. URL: https://doi.org/10.1038/s41586-022-05641-w, doi:10.1038/s41586-022-05641-w. This article has 141 citations and is from a highest quality peer-reviewed journal.
+
+16. (knoringer2023theunfoldedprotein pages 1-3): Katharina Knöringer, Carina Groh, Lena Krämer, Kevin C. Stein, Katja G. Hansen, Jannik Zimmermann, Bruce Morgan, Johannes M. Herrmann, Judith Frydman, and Felix Boos. The unfolded protein response of the endoplasmic reticulum supports mitochondrial biogenesis by buffering nonimported proteins. Molecular Biology of the Cell, Sep 2023. URL: https://doi.org/10.1091/mbc.e23-05-0205, doi:10.1091/mbc.e23-05-0205. This article has 18 citations and is from a domain leading peer-reviewed journal.
+
+17. (lal2024cytosolicclassi pages 28-32): Silviya S. Lal, Neha, Yadvendradatta Rajendra Prasad Yadav, Sreehari P., Amit K. Verma, and Chandan Sahi. Cytosolic class i j-domain proteins aid mitochondrial protein import and influence homeostasis in arabidopsis thaliana. bioRxiv, Apr 2024. URL: https://doi.org/10.1101/2024.04.19.590371, doi:10.1101/2024.04.19.590371. This article has 0 citations.
+
+18. (ciesielski2016nucleoidlocalizationof pages 5-5): Grzegorz L. Ciesielski, Magdalena Plotka, Mateusz Manicki, Brenda A. Schilke, Rafal Dutkiewicz, Chandan Sahi, Jaroslaw Marszalek, and Elizabeth A. Craig. Nucleoid localization of hsp40 mdj1 is important for its function in maintenance of mitochondrial dna. Biochimica et Biophysica Acta (BBA) - Molecular Cell Research, 1833:2233-2243, Oct 2016. URL: https://doi.org/10.1016/j.bbamcr.2013.05.012, doi:10.1016/j.bbamcr.2013.05.012. This article has 14 citations and is from a peer-reviewed journal.
+
+19. (craig2014yeasthsp70and pages 6-9): Elizabeth A. Craig and Jaroslaw Marszalek. Yeast hsp70 and j-protein chaperones: function and interaction network. ArXiv, pages 53-82, Jan 2014. URL: https://doi.org/10.1007/978-1-4939-1130-1\_3, doi:10.1007/978-1-4939-1130-1\_3. This article has 4 citations.
+
+20. (mapa2010theconformationaldynamics pages 4-5): Koyeli Mapa, Martin Sikor, Volodymyr Kudryavtsev, Karin Waegemann, Stanislav Kalinin, Claus A.M. Seidel, Walter Neupert, Don C. Lamb, and Dejana Mokranjac. The conformational dynamics of the mitochondrial hsp70 chaperone. Molecular cell, 38 1:89-100, Apr 2010. URL: https://doi.org/10.1016/j.molcel.2010.03.010, doi:10.1016/j.molcel.2010.03.010. This article has 207 citations and is from a highest quality peer-reviewed journal.
+
+21. (mapa2010theconformationaldynamics pages 5-7): Koyeli Mapa, Martin Sikor, Volodymyr Kudryavtsev, Karin Waegemann, Stanislav Kalinin, Claus A.M. Seidel, Walter Neupert, Don C. Lamb, and Dejana Mokranjac. The conformational dynamics of the mitochondrial hsp70 chaperone. Molecular cell, 38 1:89-100, Apr 2010. URL: https://doi.org/10.1016/j.molcel.2010.03.010, doi:10.1016/j.molcel.2010.03.010. This article has 207 citations and is from a highest quality peer-reviewed journal.
+
+## Citations
+
+1. ciesielski2016nucleoidlocalizationof pages 1-2
+2. ciesielski2016nucleoidlocalizationof pages 4-5
+3. ciesielski2016nucleoidlocalizationof pages 10-11
+4. ciesielski2016nucleoidlocalizationof pages 7-8
+5. schulte2023mitochondrialcomplexomereveals pages 28-32
+6. knoringer2023theunfoldedprotein pages 1-3
+7. lal2024cytosolicclassi pages 28-32
+8. mapa2010theconformationaldynamics pages 9-10
+9. ciesielski2016nucleoidlocalizationof pages 2-3
+10. ciesielski2016nucleoidlocalizationof pages 8-9
+11. ciesielski2016nucleoidlocalizationof pages 3-4
+12. mapa2010theconformationaldynamics pages 7-9
+13. ciesielski2016nucleoidlocalizationof pages 9-10
+14. ciesielski2016nucleoidlocalizationof pages 5-5
+15. mapa2010theconformationaldynamics pages 4-5
+16. mapa2010theconformationaldynamics pages 5-7
+17. https://doi.org/10.1038/s41586-022-05641-w
+18. https://doi.org/10.1091/mbc.e23-05-0205
+19. https://doi.org/10.1101/2024.04.19.590371
+20. https://doi.org/10.1016/j.bbamcr.2013.05.012
+21. https://doi.org/10.1002/9780470015902.a0023188;
+22. https://doi.org/10.1007/978-1-4939-1130-1_3
+23. https://doi.org/10.1016/j.molcel.2010.03.010
+24. https://doi.org/10.1007/978-1-4939-1130-1_3;
+25. https://doi.org/10.1002/9780470015902.a0023188
+26. https://doi.org/10.1016/j.bbamcr.2013.05.012;
+27. https://doi.org/10.1016/j.molcel.2010.03.010;
+28. https://doi.org/10.1038/s41586-022-05641-w;
+29. https://doi.org/10.1016/j.bbamcr.2013.05.012,
+30. https://doi.org/10.1002/9780470015902.a0023188,
+31. https://doi.org/10.1007/978-1-4939-1130-1\_3,
+32. https://doi.org/10.1016/j.molcel.2010.03.010,
+33. https://doi.org/10.1038/s41586-022-05641-w,
+34. https://doi.org/10.1091/mbc.e23-05-0205,
+35. https://doi.org/10.1101/2024.04.19.590371,

--- a/genes/yeast/NTE1/NTE1-ai-review.html
+++ b/genes/yeast/NTE1/NTE1-ai-review.html
@@ -671,44 +671,44 @@
     <div class="header">
         <h1>NTE1</h1>
         <div class="gene-info">
-            
+
             <div class="info-item">
-                
+
                 <span class="info-label">UniProt ID:</span>
                 <span>
                     <a href="https://www.uniprot.org/uniprotkb/Q04958" target="_blank" class="term-link">
                         Q04958
                     </a>
                 </span>
-                
+
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Organism:</span>
                 <span>Saccharomyces cerevisiae S288C</span>
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
                 <span class="status-badge status-complete">
                     COMPLETE
                 </span>
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Aliases:</span>
                 <div class="aliases">
-                    
+
                     <span class="badge">YML059C</span>
-                    
+
                     <span class="badge">YM9958.03C</span>
-                    
+
                 </div>
             </div>
-            
+
         </div>
         <div style="margin-top: 1rem; text-align: center;">
             <a id="feedback-form-link"
@@ -739,7 +739,7 @@
         </div>
     </div>
 
-    
+
     <div class="description-card">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <h2>Gene Description</h2>
@@ -750,13 +750,13 @@
         </div>
         <p>NTE1 (Neuropathy Target Esterase homolog) is an intracellular phospholipase B that catalyzes the double deacylation of phosphatidylcholine (PC) to glycerophosphocholine. This lysophospholipase enzyme plays a critical role in membrane lipid homeostasis and phospholipid turnover, particularly in response to environmental conditions like inositol availability, temperature stress, and choline presence. NTE1 activity functionally interacts with the phosphatidylinositol/phosphatidylcholine transfer protein Sec14p and influences transcriptional regulation of phospholipid biosynthetic genes through its impact on the OPI1 repressor.</p>
     </div>
-    
 
-    
 
-    
 
-    
+
+
+
+
     <div class="section">
         <h2 class="section-title">Existing Annotations Review</h2>
         <table class="annotations-table">
@@ -769,32 +769,32 @@
                 </tr>
             </thead>
             <tbody>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004622" target="_blank" class="term-link">
                                     GO:0004622
                                 </a>
                             </span>
                             <span class="term-label">phosphatidylcholine lysophospholipase A1 activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -806,62 +806,73 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> NTE1 has well-characterized lysophospholipase activity, specifically phosphatidylcholine lysophospholipase activity (EC 3.1.1.5). This annotation correctly captures the primary catalytic function of NTE1 in membrane lipid metabolism.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This annotation accurately reflects NTE1 core enzymatic function as demonstrated experimentally. The protein catalyzes the deacylation of phosphatidylcholine, which is precisely what this GO term describes.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     UniProt:Q04958
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">RecName: Full=Lysophospholipase NTE1; EC=3.1.1.5</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/NTE1/NTE1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">NTE1/YML059C encodes a **patatin-like serine esterase/phospholipase**</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005783" target="_blank" class="term-link">
                                     GO:0005783
                                 </a>
                             </span>
                             <span class="term-label">endoplasmic reticulum</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -873,62 +884,62 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> NTE1 has well-characterized lysophospholipase activity, specifically phosphatidylcholine lysophospholipase activity (EC 3.1.1.5). This annotation correctly captures the primary catalytic function of NTE1 in membrane lipid metabolism.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This annotation accurately reflects NTE1 core enzymatic function as demonstrated experimentally. The protein catalyzes the deacylation of phosphatidylcholine, which is precisely what this GO term describes.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     UniProt:Q04958
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">RecName: Full=Lysophospholipase NTE1; EC=3.1.1.5</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004622" target="_blank" class="term-link">
                                     GO:0004622
                                 </a>
                             </span>
                             <span class="term-label">phosphatidylcholine lysophospholipase A1 activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -940,62 +951,62 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> NTE1 has well-characterized lysophospholipase activity, specifically phosphatidylcholine lysophospholipase activity (EC 3.1.1.5). This annotation correctly captures the primary catalytic function of NTE1 in membrane lipid metabolism.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This annotation accurately reflects NTE1 core enzymatic function as demonstrated experimentally. The protein catalyzes the deacylation of phosphatidylcholine, which is precisely what this GO term describes.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     UniProt:Q04958
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">RecName: Full=Lysophospholipase NTE1; EC=3.1.1.5</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
                                     GO:0005789
                                 </a>
                             </span>
                             <span class="term-label">endoplasmic reticulum membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1007,62 +1018,62 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> NTE1 has well-characterized lysophospholipase activity, specifically phosphatidylcholine lysophospholipase activity (EC 3.1.1.5). This annotation correctly captures the primary catalytic function of NTE1 in membrane lipid metabolism.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This annotation accurately reflects NTE1 core enzymatic function as demonstrated experimentally. The protein catalyzes the deacylation of phosphatidylcholine, which is precisely what this GO term describes.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     UniProt:Q04958
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">RecName: Full=Lysophospholipase NTE1; EC=3.1.1.5</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005811" target="_blank" class="term-link">
                                     GO:0005811
                                 </a>
                             </span>
                             <span class="term-label">lipid droplet</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1074,62 +1085,62 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> NTE1 has well-characterized lysophospholipase activity, specifically phosphatidylcholine lysophospholipase activity (EC 3.1.1.5). This annotation correctly captures the primary catalytic function of NTE1 in membrane lipid metabolism.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This annotation accurately reflects NTE1 core enzymatic function as demonstrated experimentally. The protein catalyzes the deacylation of phosphatidylcholine, which is precisely what this GO term describes.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     UniProt:Q04958
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">RecName: Full=Lysophospholipase NTE1; EC=3.1.1.5</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006629" target="_blank" class="term-link">
                                     GO:0006629
                                 </a>
                             </span>
                             <span class="term-label">lipid metabolic process</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1141,62 +1152,62 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> NTE1 has well-characterized lysophospholipase activity, specifically phosphatidylcholine lysophospholipase activity (EC 3.1.1.5). This annotation correctly captures the primary catalytic function of NTE1 in membrane lipid metabolism.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This annotation accurately reflects NTE1 core enzymatic function as demonstrated experimentally. The protein catalyzes the deacylation of phosphatidylcholine, which is precisely what this GO term describes.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     UniProt:Q04958
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">RecName: Full=Lysophospholipase NTE1; EC=3.1.1.5</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016042" target="_blank" class="term-link">
                                     GO:0016042
                                 </a>
                             </span>
                             <span class="term-label">lipid catabolic process</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1208,62 +1219,62 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> NTE1 has well-characterized lysophospholipase activity, specifically phosphatidylcholine lysophospholipase activity (EC 3.1.1.5). This annotation correctly captures the primary catalytic function of NTE1 in membrane lipid metabolism.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This annotation accurately reflects NTE1 core enzymatic function as demonstrated experimentally. The protein catalyzes the deacylation of phosphatidylcholine, which is precisely what this GO term describes.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     UniProt:Q04958
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">RecName: Full=Lysophospholipase NTE1; EC=3.1.1.5</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016787" target="_blank" class="term-link">
                                     GO:0016787
                                 </a>
                             </span>
                             <span class="term-label">hydrolase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1275,62 +1286,62 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> NTE1 has well-characterized lysophospholipase activity, specifically phosphatidylcholine lysophospholipase activity (EC 3.1.1.5). This annotation correctly captures the primary catalytic function of NTE1 in membrane lipid metabolism.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This annotation accurately reflects NTE1 core enzymatic function as demonstrated experimentally. The protein catalyzes the deacylation of phosphatidylcholine, which is precisely what this GO term describes.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     UniProt:Q04958
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">RecName: Full=Lysophospholipase NTE1; EC=3.1.1.5</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046470" target="_blank" class="term-link">
                                     GO:0046470
                                 </a>
                             </span>
                             <span class="term-label">phosphatidylcholine metabolic process</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1342,62 +1353,62 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> NTE1 has well-characterized lysophospholipase activity, specifically phosphatidylcholine lysophospholipase activity (EC 3.1.1.5). This annotation correctly captures the primary catalytic function of NTE1 in membrane lipid metabolism.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This annotation accurately reflects NTE1 core enzymatic function as demonstrated experimentally. The protein catalyzes the deacylation of phosphatidylcholine, which is precisely what this GO term describes.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     UniProt:Q04958
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">RecName: Full=Lysophospholipase NTE1; EC=3.1.1.5</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046486" target="_blank" class="term-link">
                                     GO:0046486
                                 </a>
                             </span>
                             <span class="term-label">glycerolipid metabolic process</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1409,62 +1420,62 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> NTE1 has well-characterized lysophospholipase activity, specifically phosphatidylcholine lysophospholipase activity (EC 3.1.1.5). This annotation correctly captures the primary catalytic function of NTE1 in membrane lipid metabolism.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This annotation accurately reflects NTE1 core enzymatic function as demonstrated experimentally. The protein catalyzes the deacylation of phosphatidylcholine, which is precisely what this GO term describes.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     UniProt:Q04958
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">RecName: Full=Lysophospholipase NTE1; EC=3.1.1.5</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0102545" target="_blank" class="term-link">
                                     GO:0102545
                                 </a>
                             </span>
                             <span class="term-label">B-type glycerophospholipase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000116
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1476,73 +1487,73 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> NTE1 has well-characterized lysophospholipase activity, specifically phosphatidylcholine lysophospholipase activity (EC 3.1.1.5). This annotation correctly captures the primary catalytic function of NTE1 in membrane lipid metabolism.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This annotation accurately reflects NTE1 core enzymatic function as demonstrated experimentally. The protein catalyzes the deacylation of phosphatidylcholine, which is precisely what this GO term describes.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     UniProt:Q04958
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">RecName: Full=Lysophospholipase NTE1; EC=3.1.1.5</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005783" target="_blank" class="term-link">
                                     GO:0005783
                                 </a>
                             </span>
                             <span class="term-label">endoplasmic reticulum</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/26928762" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:26928762
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     One library to make them all: streamlining the creation of y...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1554,73 +1565,73 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> NTE1 has well-characterized lysophospholipase activity, specifically phosphatidylcholine lysophospholipase activity (EC 3.1.1.5). This annotation correctly captures the primary catalytic function of NTE1 in membrane lipid metabolism.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This annotation accurately reflects NTE1 core enzymatic function as demonstrated experimentally. The protein catalyzes the deacylation of phosphatidylcholine, which is precisely what this GO term describes.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     UniProt:Q04958
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">RecName: Full=Lysophospholipase NTE1; EC=3.1.1.5</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005783" target="_blank" class="term-link">
                                     GO:0005783
                                 </a>
                             </span>
                             <span class="term-label">endoplasmic reticulum</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/14562095" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:14562095
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Global analysis of protein localization in budding yeast.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1632,73 +1643,73 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> NTE1 has well-characterized lysophospholipase activity, specifically phosphatidylcholine lysophospholipase activity (EC 3.1.1.5). This annotation correctly captures the primary catalytic function of NTE1 in membrane lipid metabolism.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This annotation accurately reflects NTE1 core enzymatic function as demonstrated experimentally. The protein catalyzes the deacylation of phosphatidylcholine, which is precisely what this GO term describes.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     UniProt:Q04958
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">RecName: Full=Lysophospholipase NTE1; EC=3.1.1.5</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004622" target="_blank" class="term-link">
                                     GO:0004622
                                 </a>
                             </span>
                             <span class="term-label">phosphatidylcholine lysophospholipase A1 activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/15044461" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:15044461
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Neuropathy target esterase and its yeast homologue degrade p...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1710,73 +1721,73 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> NTE1 has well-characterized lysophospholipase activity, specifically phosphatidylcholine lysophospholipase activity (EC 3.1.1.5). This annotation correctly captures the primary catalytic function of NTE1 in membrane lipid metabolism.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This annotation accurately reflects NTE1 core enzymatic function as demonstrated experimentally. The protein catalyzes the deacylation of phosphatidylcholine, which is precisely what this GO term describes.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     UniProt:Q04958
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">RecName: Full=Lysophospholipase NTE1; EC=3.1.1.5</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005783" target="_blank" class="term-link">
                                     GO:0005783
                                 </a>
                             </span>
                             <span class="term-label">endoplasmic reticulum</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/15044461" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:15044461
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Neuropathy target esterase and its yeast homologue degrade p...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1788,73 +1799,73 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> NTE1 has well-characterized lysophospholipase activity, specifically phosphatidylcholine lysophospholipase activity (EC 3.1.1.5). This annotation correctly captures the primary catalytic function of NTE1 in membrane lipid metabolism.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This annotation accurately reflects NTE1 core enzymatic function as demonstrated experimentally. The protein catalyzes the deacylation of phosphatidylcholine, which is precisely what this GO term describes.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     UniProt:Q04958
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">RecName: Full=Lysophospholipase NTE1; EC=3.1.1.5</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034638" target="_blank" class="term-link">
                                     GO:0034638
                                 </a>
                             </span>
                             <span class="term-label">phosphatidylcholine catabolic process</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/15044461" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:15044461
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Neuropathy target esterase and its yeast homologue degrade p...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1866,73 +1877,73 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> NTE1 has well-characterized lysophospholipase activity, specifically phosphatidylcholine lysophospholipase activity (EC 3.1.1.5). This annotation correctly captures the primary catalytic function of NTE1 in membrane lipid metabolism.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This annotation accurately reflects NTE1 core enzymatic function as demonstrated experimentally. The protein catalyzes the deacylation of phosphatidylcholine, which is precisely what this GO term describes.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     UniProt:Q04958
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">RecName: Full=Lysophospholipase NTE1; EC=3.1.1.5</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0071071" target="_blank" class="term-link">
                                     GO:0071071
                                 </a>
                             </span>
                             <span class="term-label">regulation of phospholipid biosynthetic process</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19841481" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19841481
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     NTE1-encoded phosphatidylcholine phospholipase b regulates t...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1944,48 +1955,48 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> NTE1 has well-characterized lysophospholipase activity, specifically phosphatidylcholine lysophospholipase activity (EC 3.1.1.5). This annotation correctly captures the primary catalytic function of NTE1 in membrane lipid metabolism.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This annotation accurately reflects NTE1 core enzymatic function as demonstrated experimentally. The protein catalyzes the deacylation of phosphatidylcholine, which is precisely what this GO term describes.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     UniProt:Q04958
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">RecName: Full=Lysophospholipase NTE1; EC=3.1.1.5</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
             </tbody>
         </table>
     </div>
-    
 
-    
+
+
     <div class="section">
         <h2 class="section-title">Core Functions</h2>
-        
+
         <div class="core-function-card">
-            
+
             <div style="display: flex; justify-content: space-between; align-items: center;">
                 <h3>Phosphatidylcholine lysophospholipase activity - catalyzes the double deacylation of phosphatidylcholine to glycerophosphocholine for membrane lipid homeostasis</h3>
                 <span class="vote-buttons" data-g="Q04958" data-a="FUNCTION: Phosphatidylcholine lysophospholipase activity - c..." data-r="" data-act="CORE_FUNCTION">
@@ -1993,10 +2004,10 @@
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
             </div>
-            
+
 
             <div class="core-function-terms">
-                
+
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
@@ -2005,250 +2016,282 @@
                         </a>
                     </span>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Directly Involved In:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006629" target="_blank" class="term-link">
                                 lipid metabolic process
                             </a>
                         </span>
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034638" target="_blank" class="term-link">
                                 phosphatidylcholine catabolic process
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Cellular Locations:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
                                 endoplasmic reticulum membrane
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
 
-                
+
+
+
             </div>
 
-            
-        </div>
-        
-    </div>
-    
 
-    
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:yeast/NTE1/NTE1-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">ER-localized patatin-like serine phospholipase/lysophospholipase that catalyzes complete deacylation of phosphatidylcholine to glycerophosphocholine plus free fatty acids</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class="section">
         <h2 class="section-title collapsible">References</h2>
         <div class="collapse-content">
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
                             GO_REF:0000002
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
                             GO_REF:0000033
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Annotation inferences using phylogenetic trees</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000043.md" target="_blank" class="term-link">
                             GO_REF:0000043
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
                             GO_REF:0000044
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000116.md" target="_blank" class="term-link">
                             GO_REF:0000116
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Automatic Gene Ontology annotation based on Rhea mapping.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
                             GO_REF:0000117
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
                             GO_REF:0000120
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/14562095" target="_blank" class="term-link">
                             PMID:14562095
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Global analysis of protein localization in budding yeast.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/15044461" target="_blank" class="term-link">
                             PMID:15044461
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Neuropathy target esterase and its yeast homologue degrade phosphatidylcholine to glycerophosphocholine in living cells.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/19841481" target="_blank" class="term-link">
                             PMID:19841481
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">NTE1-encoded phosphatidylcholine phospholipase b regulates transcription of phospholipid biosynthetic genes.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/26928762" target="_blank" class="term-link">
                             PMID:26928762
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">One library to make them all: streamlining the creation of yeast libraries via a SWAp-Tag strategy.</div>
-                
-                
+
+
             </div>
-            
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:yeast/NTE1/NTE1-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research report for NTE1</div>
+
+
+            </div>
+
         </div>
     </div>
-    
 
 
-    
+
+
     <div class="section">
         <h2 class="section-title">Suggested Questions for Experts</h2>
-        
+
         <div class="question-card">
             <div style="display: flex; justify-content: space-between; align-items: start;">
                 <div style="flex: 1;">
                     <p><strong>Q:</strong> How does NTE1 regulate phospholipid homeostasis in the endoplasmic reticulum and what determines its substrate specificity?</p>
-                    
+
                 </div>
                 <span class="vote-buttons" data-g="Q04958" data-a="Q: How does NTE1 regulate phospholipid homeostasis in..." data-r="" data-act="QUESTION">
                     <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
@@ -2256,12 +2299,12 @@
                 </span>
             </div>
         </div>
-        
+
         <div class="question-card">
             <div style="display: flex; justify-content: space-between; align-items: start;">
                 <div style="flex: 1;">
                     <p><strong>Q:</strong> What role does NTE1 play in membrane remodeling and how does its activity affect ER morphology and function?</p>
-                    
+
                 </div>
                 <span class="vote-buttons" data-g="Q04958" data-a="Q: What role does NTE1 play in membrane remodeling an..." data-r="" data-act="QUESTION">
                     <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
@@ -2269,12 +2312,12 @@
                 </span>
             </div>
         </div>
-        
+
         <div class="question-card">
             <div style="display: flex; justify-content: space-between; align-items: start;">
                 <div style="flex: 1;">
                     <p><strong>Q:</strong> How is NTE1 expression and activity regulated in response to lipid stress and membrane composition changes?</p>
-                    
+
                 </div>
                 <span class="vote-buttons" data-g="Q04958" data-a="Q: How is NTE1 expression and activity regulated in r..." data-r="" data-act="QUESTION">
                     <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
@@ -2282,12 +2325,12 @@
                 </span>
             </div>
         </div>
-        
+
         <div class="question-card">
             <div style="display: flex; justify-content: space-between; align-items: start;">
                 <div style="flex: 1;">
                     <p><strong>Q:</strong> What are the relationships between NTE1 and other phospholipid metabolic enzymes in maintaining cellular lipid balance?</p>
-                    
+
                 </div>
                 <span class="vote-buttons" data-g="Q04958" data-a="Q: What are the relationships between NTE1 and other ..." data-r="" data-act="QUESTION">
                     <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
@@ -2295,22 +2338,22 @@
                 </span>
             </div>
         </div>
-        
-    </div>
-    
 
-    
+    </div>
+
+
+
     <div class="section">
         <h2 class="section-title">Suggested Experiments</h2>
-        
+
         <div class="experiment-card">
             <div style="display: flex; justify-content: space-between; align-items: start;">
                 <div style="flex: 1;">
-                    
+
                     <p><strong>Experiment:</strong> Lipidomics analysis of NTE1 knockout strains to characterize changes in phospholipid composition and membrane properties</p>
-                    
-                    
-                    
+
+
+
                 </div>
                 <span class="vote-buttons" data-g="Q04958" data-a="EXPERIMENT: Lipidomics analysis of NTE1 knockout strains to ch..." data-r="" data-act="EXPERIMENT">
                     <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
@@ -2318,15 +2361,15 @@
                 </span>
             </div>
         </div>
-        
+
         <div class="experiment-card">
             <div style="display: flex; justify-content: space-between; align-items: start;">
                 <div style="flex: 1;">
-                    
+
                     <p><strong>Experiment:</strong> Electron microscopy analysis of ER morphology in NTE1-deficient cells to assess its role in membrane organization</p>
-                    
-                    
-                    
+
+
+
                 </div>
                 <span class="vote-buttons" data-g="Q04958" data-a="EXPERIMENT: Electron microscopy analysis of ER morphology in N..." data-r="" data-act="EXPERIMENT">
                     <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
@@ -2334,15 +2377,15 @@
                 </span>
             </div>
         </div>
-        
+
         <div class="experiment-card">
             <div style="display: flex; justify-content: space-between; align-items: start;">
                 <div style="flex: 1;">
-                    
+
                     <p><strong>Experiment:</strong> Enzyme kinetics studies to characterize NTE1 substrate specificity and regulatory mechanisms</p>
-                    
-                    
-                    
+
+
+
                 </div>
                 <span class="vote-buttons" data-g="Q04958" data-a="EXPERIMENT: Enzyme kinetics studies to characterize NTE1 subst..." data-r="" data-act="EXPERIMENT">
                     <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
@@ -2350,15 +2393,15 @@
                 </span>
             </div>
         </div>
-        
+
         <div class="experiment-card">
             <div style="display: flex; justify-content: space-between; align-items: start;">
                 <div style="flex: 1;">
-                    
+
                     <p><strong>Experiment:</strong> Subcellular fractionation and mass spectrometry to study NTE1 localization and protein interactions in different membrane compartments</p>
-                    
-                    
-                    
+
+
+
                 </div>
                 <span class="vote-buttons" data-g="Q04958" data-a="EXPERIMENT: Subcellular fractionation and mass spectrometry to..." data-r="" data-act="EXPERIMENT">
                     <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
@@ -2366,17 +2409,391 @@
                 </span>
             </div>
         </div>
-        
-    </div>
-    
 
-    
+    </div>
+
+
+
 
     <!-- Computational Predictions Section -->
-    
+
 
     <!-- Additional Documentation Sections -->
-    
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Deep Research Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(NTE1-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q04958" data-a="DOC: Deep Research Falcon" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <hr />
+<p>provider: falcon<br />
+model: Edison Scientific Literature<br />
+cached: false<br />
+start_time: '2026-05-11T09:09:27.162441'<br />
+end_time: '2026-05-11T09:27:38.764919'<br />
+duration_seconds: 1091.6<br />
+template_file: templates/gene_research_go_focused.md<br />
+template_variables:<br />
+  organism: yeast<br />
+  gene_id: NTE1<br />
+  gene_symbol: NTE1<br />
+  uniprot_accession: Q04958<br />
+  protein_description: 'RecName: Full=Lysophospholipase NTE1; EC=3.1.1.5 {ECO:0000269|PubMed:15044461};<br />
+    AltName: Full=Intracellular phospholipase B; AltName: Full=Neuropathy target esterase<br />
+    homolog;'<br />
+  gene_info: Name=NTE1; OrderedLocusNames=YML059C; ORFNames=YM9958.03C;<br />
+  organism_full: Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).<br />
+  protein_family: Belongs to the NTE family. .<br />
+  protein_domains: Acyl_Trfase/lysoPLipase. (IPR016035); cNMP-bd_dom. (IPR000595);<br />
+    cNMP-bd_dom_sf. (IPR018490); LysoPLipase_patatin_CS. (IPR001423); NTE. (IPR050301)<br />
+provider_config:<br />
+  timeout: 600<br />
+  max_retries: 3<br />
+  parameters:<br />
+    allowed_domains: []<br />
+    temperature: 0.1<br />
+citation_count: 25</p>
+<hr />
+<h2 id="question">Question</h2>
+<h1 id="gene-research-for-functional-annotation">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> Q04958</li>
+<li><strong>Protein Description:</strong> RecName: Full=Lysophospholipase NTE1; EC=3.1.1.5 {ECO:0000269|PubMed:15044461}; AltName: Full=Intracellular phospholipase B; AltName: Full=Neuropathy target esterase homolog;</li>
+<li><strong>Gene Information:</strong> Name=NTE1; OrderedLocusNames=YML059C; ORFNames=YM9958.03C;</li>
+<li><strong>Organism (full):</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Protein Family:</strong> Belongs to the NTE family. .</li>
+<li><strong>Key Domains:</strong> Acyl_Trfase/lysoPLipase. (IPR016035); cNMP-bd_dom. (IPR000595); cNMP-bd_dom_sf. (IPR018490); LysoPLipase_patatin_CS. (IPR001423); NTE. (IPR050301)</li>
+</ul>
+<h3 id="mandatory-verification-steps">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "NTE1" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'NTE1' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>NTE1</strong> (gene ID: NTE1, UniProt: Q04958) in yeast.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="output">Output</h2>
+<p>Question: You are an expert researcher providing comprehensive, well-cited information.</p>
+<p>Provide detailed information focusing on:<br />
+1. Key concepts and definitions with current understanding<br />
+2. Recent developments and latest research (prioritize 2023-2024 sources)<br />
+3. Current applications and real-world implementations<br />
+4. Expert opinions and analysis from authoritative sources<br />
+5. Relevant statistics and data from recent studies</p>
+<p>Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.<br />
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.</p>
+<h1 id="gene-research-for-functional-annotation_1">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context_1">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot_1">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> Q04958</li>
+<li><strong>Protein Description:</strong> RecName: Full=Lysophospholipase NTE1; EC=3.1.1.5 {ECO:0000269|PubMed:15044461}; AltName: Full=Intracellular phospholipase B; AltName: Full=Neuropathy target esterase homolog;</li>
+<li><strong>Gene Information:</strong> Name=NTE1; OrderedLocusNames=YML059C; ORFNames=YM9958.03C;</li>
+<li><strong>Organism (full):</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Protein Family:</strong> Belongs to the NTE family. .</li>
+<li><strong>Key Domains:</strong> Acyl_Trfase/lysoPLipase. (IPR016035); cNMP-bd_dom. (IPR000595); cNMP-bd_dom_sf. (IPR018490); LysoPLipase_patatin_CS. (IPR001423); NTE. (IPR050301)</li>
+</ul>
+<h3 id="mandatory-verification-steps_1">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "NTE1" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature_1">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'NTE1' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target_1">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>NTE1</strong> (gene ID: NTE1, UniProt: Q04958) in yeast.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="research-report-saccharomyces-cerevisiae-nte1-yml059c-uniprot-q04958-functional-annotation">Research report: <em>Saccharomyces cerevisiae</em> NTE1 (YML059C; UniProt Q04958) – functional annotation</h1>
+<h2 id="1-target-verification-and-nomenclature-critical-disambiguation">1) Target verification and nomenclature (critical disambiguation)</h2>
+<p>Multiple yeast-focused sources explicitly identify <em>S. cerevisiae</em> ORF <strong>YML059C</strong> as the yeast homolog of vertebrate neuropathy target esterase and note it was renamed <strong>NTE1</strong> (protein: Nte1p). (glynn2005neuropathytargetesterase pages 2-4, murray2005nte1pmediateddeacylationof pages 3-4)</p>
+<h2 id="2-key-concepts-and-definitions-current-understanding">2) Key concepts and definitions (current understanding)</h2>
+<h3 id="21-what-does-lysophospholipase-phospholipase-b-like-activity-mean-here">2.1 What does “lysophospholipase / phospholipase B-like activity” mean here?</h3>
+<p>In the yeast NTE1 context, the core biochemical activity is <strong>complete deacylation of phosphatidylcholine (PC/PtdCho)</strong>, producing <strong>glycerophosphocholine (GPC/GroPCho)</strong> and <strong>two free fatty acids (FFAs)</strong>—a reaction consistent with a phospholipase B-type outcome (removal of both acyl chains), potentially via sequential sn-2 then sn-1 deacylation steps. (zaccheo2004neuropathytargetesterase pages 2-3, zaccheo2004neuropathytargetesterase pages 1-1, zaccheo2004neuropathytargetesterase pages 7-9)</p>
+<h3 id="22-pc-deacylationreacylation-pathway-pc-drp">2.2 PC deacylation/reacylation pathway (PC-DRP)</h3>
+<p>A distinct <strong>PC deacylation/reacylation pathway (PC-DRP)</strong> in yeast begins with PC deacylation to <strong>GPC</strong> by phospholipase B-type enzymes including <strong>Nte1p (NTE1)</strong> (and also PLB1 in the broader pathway literature), followed by GPC reacylation by <strong>Gpc1</strong> to form <strong>lyso-PC</strong>, and then reacylation by <strong>Ale1</strong> to regenerate PC. This pathway is now understood to function as a PC remodeling/salvage route that can influence PC molecular-species composition and ER membrane homeostasis. (anaokar2019theglycerophosphocholineacyltransferase pages 1-2, hrach2023theacyltransferasegpc1 pages 1-2)</p>
+<h2 id="3-molecular-function-reaction-substrates-and-catalytic-features">3) Molecular function: reaction, substrates, and catalytic features</h2>
+<h3 id="31-primary-in-vivo-reaction-and-physiological-product">3.1 Primary in vivo reaction and physiological product</h3>
+<p>In vivo labeling experiments show that yeast NTE1/YML059C is required to convert PC to GPC: <strong>YML059C-null strains fail to produce intracellular GPC from PC</strong>, while wild-type cells generate GPC as the dominant soluble metabolite under the tested conditions. (zaccheo2004neuropathytargetesterase pages 1-1, zaccheo2004neuropathytargetesterase pages 7-9)</p>
+<p>A quantitative feature from these experiments is that in wild-type cells at 37°C, <strong>~85% of soluble intracellular radiolabeled metabolite was GPC</strong>, whereas this product was absent in the YML059C-null background. (zaccheo2004neuropathytargetesterase pages 7-9)</p>
+<h3 id="32-substrate-specificity-and-pathway-coupling">3.2 Substrate specificity and pathway coupling</h3>
+<p>Nte1p-mediated deacylation particularly acts on <strong>PC derived from the CDP-choline pathway</strong> (Kennedy pathway) rather than PC made through alternative routes such as phosphatidylethanolamine methylation, based on radiolabeling pathway-tracing cited in later pathway syntheses. (pattonvogt2020phospholipidturnoverand pages 3-4)</p>
+<p>In microsomal assays, the yeast protein also displays <strong>lysophospholipase activity</strong> toward <strong>lysophosphatidylcholine (LysoPC/LysoPtdCho)</strong>, with <strong>half-maximal activity at ~0.05 mM LysoPC</strong> reported. (zaccheo2004neuropathytargetesterase pages 4-5)</p>
+<h3 id="33-enzyme-class-and-catalytic-residue">3.3 Enzyme class and catalytic residue</h3>
+<p>NTE1/YML059C encodes a <strong>patatin-like serine esterase/phospholipase</strong>. Mutation of the <strong>putative active-site serine (Ser-1406→Ala)</strong> abolishes the activity increase associated with overexpression, supporting a serine-dependent catalytic mechanism. (zaccheo2004neuropathytargetesterase pages 1-2, zaccheo2004neuropathytargetesterase pages 4-5)</p>
+<h3 id="34-sensitivity-to-organophosphates-ops">3.4 Sensitivity to organophosphates (OPs)</h3>
+<p>Nte1p/YML059C shows conserved biochemical similarity to vertebrate NTE, including <strong>inhibition by neuropathic organophosphorus compounds</strong> with similar rank-order sensitivity, though potency for the yeast enzyme was reported as <strong>~5–10× lower</strong> than mammalian NTE in the cited comparisons. (zaccheo2004neuropathytargetesterase pages 3-4, zaccheo2004neuropathytargetesterase pages 4-5)</p>
+<h2 id="4-subcellular-localization-where-nte1p-works-in-the-cell">4) Subcellular localization: where Nte1p works in the cell</h2>
+<h3 id="41-er-localization">4.1 ER localization</h3>
+<p>Localization experiments using GFP-tagged YML059C show a <strong>reticular pattern consistent with endoplasmic reticulum (ER)</strong>, and immunogold electron microscopy places the protein on <strong>ER tubules/tubuloreticular complexes</strong>, not mitochondria in adjacent regions. (zaccheo2004neuropathytargetesterase pages 3-4, zaccheo2004neuropathytargetesterase pages 5-6, zaccheo2004neuropathytargetesterase media 21adca93)</p>
+<h3 id="42-abundance-estimate">4.2 Abundance estimate</h3>
+<p>One analysis summarized in the primary literature reports endogenous abundance on the order of <strong>~500 copies/cell</strong>, supporting the view that Nte1p is not an extremely high-abundance lipase but can still drive substantial PC turnover flux. (zaccheo2004neuropathytargetesterase pages 4-5)</p>
+<h2 id="5-pathways-biological-processes-and-phenotypes">5) Pathways, biological processes, and phenotypes</h2>
+<h3 id="51-pc-turnover-and-membrane-lipid-homeostasis">5.1 PC turnover and membrane lipid homeostasis</h3>
+<p>NTE1/YML059C is a central enzymatic contributor to intracellular PC turnover to GPC. In pulse-chase experiments, <strong>PC turnover is markedly slowed in nte1Δ</strong> relative to wild type, with <strong>~60% of label remaining in PC after 90 min in nte1Δ vs ~20% in wild type</strong>, demonstrating that Nte1p is a major contributor to PC deacylation flux. (murray2005nte1pmediateddeacylationof pages 3-4)</p>
+<p>Although <strong>nte1Δ cells were viable and showed no strong general growth defect under tested conditions</strong>, the metabolic phenotype is clear: loss of intracellular GPC formation from PC. (zaccheo2004neuropathytargetesterase pages 1-1, zaccheo2004neuropathytargetesterase pages 4-5)</p>
+<h3 id="52-functional-interaction-with-sec14p-membrane-traffickinglipid-homeostasis-interface">5.2 Functional interaction with Sec14p (membrane trafficking–lipid homeostasis interface)</h3>
+<p>Nte1p-mediated PC deacylation functionally interfaces with <strong>Sec14p</strong>, a key regulator linking secretory trafficking and lipid metabolism. When Sec14p function is compromised, intracellular GPC accumulation is reduced, and Sec14p is described as a <strong>positive regulator of Nte1p-mediated PC deacylation</strong> with functional consequences for growth at restrictive temperature in sec14ts backgrounds. (glynn2005neuropathytargetesterase pages 2-4, murray2005nte1pmediateddeacylationof pages 3-4)</p>
+<h3 id="53-regulation-by-choline-supply-and-temperature-induction-of-deacylation-flux">5.3 Regulation by choline supply and temperature (induction of deacylation flux)</h3>
+<p>Nte1p-dependent intracellular PC deacylation is reported to be stimulated by <strong>exogenous choline</strong> and enhanced at <strong>higher temperature (e.g., 37°C)</strong> in the classical radiolabel pulse-chase frameworks. (zaccheo2004neuropathytargetesterase pages 7-9, murray2005nte1pmediateddeacylationof pages 1-2)</p>
+<p>Loss of NTE1 also changes choline handling during chase, including <strong>~3-fold increased radiolabeled choline excretion</strong> under conditions tested at 37°C. (murray2005nte1pmediateddeacylationof pages 3-4)</p>
+<h3 id="54-connection-to-pc-remodeling-and-er-membrane-state-via-pc-drp">5.4 Connection to PC remodeling and ER membrane state (via PC-DRP)</h3>
+<p>Because NTE1 generates GPC used by downstream PC-DRP enzymes, NTE1 is upstream of a remodeling loop that can alter PC molecular species. In the PC-DRP literature, Gpc1 activity is shown to influence PC species composition (loss of Gpc1 shifts PC toward more diunsaturated species), underscoring how the Nte1p-generated GPC pool can feed a pathway that tunes membrane properties. (anaokar2019theglycerophosphocholineacyltransferase pages 1-2)</p>
+<h2 id="6-recent-developments-and-latest-research-prioritizing-20232024">6) Recent developments and latest research (prioritizing 2023–2024)</h2>
+<h3 id="61-2023-pc-drp-as-an-er-stress-upr-relevant-membrane-homeostasis-module">6.1 2023: PC-DRP as an ER stress / UPR-relevant membrane-homeostasis module</h3>
+<p>A 2023 JBC study provides an updated, mechanistic link between the PC-DRP pathway and ER homeostasis: <strong>GPC1 is induced by unfolded protein response (UPR) stimuli in a Hac1-dependent manner</strong> and <strong>gpc1Δ both increases stress sensitivity and itself activates the UPR</strong>, consistent with PC-DRP supporting ER membrane (bilayer) homeostasis. The same work reports ER localization for Gpc1 with <strong>~85% colocalization</strong> with an ER marker in their imaging assay. (hrach2023theacyltransferasegpc1 pages 1-2, hrach2023theacyltransferasegpc1 pages 2-4)</p>
+<p>Although this paper focuses on Gpc1 rather than NTE1 directly, it strengthens the current interpretation that <strong>NTE1-initiated PC deacylation (GPC production) is part of a broader ER membrane-quality control and lipid-composition maintenance network</strong>, because NTE1 supplies the pathway’s substrate (GPC). (hrach2023theacyltransferasegpc1 pages 1-2)</p>
+<p>Publication details: <em>Journal of Biological Chemistry</em> (July 2023), DOI URL: https://doi.org/10.1016/j.jbc.2023.104884. (hrach2023theacyltransferasegpc1 pages 1-2)</p>
+<h3 id="62-2024-pc-drp-importance-in-fungi-and-potential-antifungal-relevance-comparative-context">6.2 2024: PC-DRP importance in fungi and potential antifungal relevance (comparative context)</h3>
+<p>A 2024 JBC study in <em>Candida albicans</em> demonstrates that PC-DRP contributes to PC homeostasis and fungal physiology (viability, hyphal growth) and highlights conservation of the pathway across fungi and the potential to target fungus-specific components (e.g., Gpc1 without human homologs). While not yeast NTE1 per se, it supports the broader view that the NTE1→GPC→(Gpc1/Ale1) logic is physiologically meaningful beyond <em>S. cerevisiae</em>. (king2024theglycerophosphocholineacyltransferase pages 1-2)</p>
+<p>Publication details: <em>Journal of Biological Chemistry</em> (January 2024), DOI URL: https://doi.org/10.1016/j.jbc.2023.105543. (king2024theglycerophosphocholineacyltransferase pages 1-2)</p>
+<h3 id="63-2024-applied-lipidomicsfermentation-work-explicitly-tracking-nte1-as-a-lysophospholipase-marker">6.3 2024: Applied lipidomics/fermentation work explicitly tracking “NTE1” as a lysophospholipase marker</h3>
+<p>In an industrially motivated fungal fermentation study (Monascus pigments), ammonium chloride stress (15 g/L) altered lysophospholipid profiles and was associated with increased expression of genes annotated as lysophospholipases including <strong>NTE1 (reported 1.74× upregulation)</strong>. The same study reported lipidomics fold changes including <strong>LPC(16) increased 2.15×</strong> and <strong>LPS(10) increased 2.6×</strong> under the stress condition. (jiang2024phospholipidbiosynthesisregulation pages 6-11)</p>
+<p>Publication details: <em>Applied and Environmental Microbiology</em> (October 2024), DOI URL: https://doi.org/10.1128/aem.01146-24. (jiang2024phospholipidbiosynthesisregulation pages 6-11)</p>
+<h2 id="7-current-applications-and-real-world-implementations">7) Current applications and real-world implementations</h2>
+<h3 id="71-yeast-as-a-tractable-model-for-nte-family-enzymology-and-lipid-homeostasis">7.1 Yeast as a tractable model for NTE-family enzymology and lipid homeostasis</h3>
+<p>The core NTE/NTE1 framework is used widely as a <strong>model system for ER-localized phospholipid deacylation</strong> and membrane lipid homeostasis, with viable yeast knockouts enabling clean in vivo pathway attribution (loss of GPC production) while maintaining growth. (zaccheo2004neuropathytargetesterase pages 1-1, zaccheo2004neuropathytargetesterase pages 7-9)</p>
+<h3 id="72-organophosphate-neuropathy-screening-and-biochemical-assay-frameworks">7.2 Organophosphate neuropathy screening and biochemical assay frameworks</h3>
+<p>A major applied context for the NTE family is organophosphate toxicology: NTE activity assays (e.g., phenyl valerate hydrolysis) are used in screening frameworks for neuropathic potential, and recombinant catalytic-domain preparations can be purified and reconstituted for biochemical testing. Yeast Nte1p serves as a genetically tractable homolog supporting mechanistic interpretation of OP-sensitive phospholipid deacylation. (glynn2005neuropathytargetesterase pages 2-4)</p>
+<h3 id="73-lipidomics-guided-process-optimization-and-membrane-homeostasis-engineering-in-fungi">7.3 Lipidomics-guided process optimization and membrane homeostasis engineering in fungi</h3>
+<p>The Monascus study illustrates a real-world approach where <strong>absolute quantitative lipidomics + quantitative proteomics</strong> are used to diagnose membrane lipid imbalances during production fermentation, and where <strong>NTE1 upregulation</strong> is interpreted as part of a response to modulate lysophospholipid pools under stress, connecting NTE1-like functions to industrially relevant phenotypes. (jiang2024phospholipidbiosynthesisregulation pages 6-11)</p>
+<h2 id="8-expert-opinions-and-authoritative-synthesis-interpretive-analysis-from-reviews">8) Expert opinions and authoritative synthesis (interpretive analysis from reviews)</h2>
+<p>A focused review framed NTE/Nte1p as catalyzing <strong>ER-localized PC deacylation to GPC + FFAs</strong>, and emphasized yeast genetics showing Nte1p as the <strong>sole source of intracellular GPC</strong> under studied conditions, positioning NTE-family enzymes as central to phosphatidylcholine homeostasis. (glynn2005neuropathytargetesterase pages 2-4)</p>
+<p>Publication details: <em>Biochimica et Biophysica Acta</em> (September 2005), DOI URL: https://doi.org/10.1016/j.bbalip.2005.08.002. (glynn2005neuropathytargetesterase pages 2-4)</p>
+<h2 id="9-key-statistics-and-data-highlights-from-primary-studies">9) Key statistics and data highlights (from primary studies)</h2>
+<table>
+<thead>
+<tr>
+<th>Property</th>
+<th>Experimentally supported finding</th>
+<th>Key quantitative data</th>
+<th>Most relevant citations</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Target identity</td>
+<td><strong>NTE1</strong> is the renamed <strong>YML059C</strong> ORF in <em>S. cerevisiae</em> and encodes the yeast homolog of neuropathy target esterase; UniProt Q04958 is consistent with this mapping.</td>
+<td>Catalytic-domain sequence identity to mammalian NTE reported as <strong>39%</strong>.</td>
+<td>(glynn2005neuropathytargetesterase pages 2-4, zaccheo2004neuropathytargetesterase pages 3-4, murray2005nte1pmediateddeacylationof pages 3-4)</td>
+</tr>
+<tr>
+<td>Primary reaction catalyzed</td>
+<td>Nte1p deacylates <strong>phosphatidylcholine (PC/PtdCho)</strong> to <strong>glycerophosphocholine (GPC/GroPCho)</strong> plus <strong>two free fatty acids</strong>; mechanism is consistent with phospholipase B activity or sequential PLA2 + lysophospholipase reactions.</td>
+<td>In vivo soluble radiolabeled metabolite in WT after PC turnover was predominantly <strong>~85% GPC</strong> at 37°C.</td>
+<td>(glynn2005neuropathytargetesterase pages 2-4, zaccheo2004neuropathytargetesterase pages 2-3, zaccheo2004neuropathytargetesterase pages 1-1, zaccheo2004neuropathytargetesterase pages 7-9)</td>
+</tr>
+<tr>
+<td>Substrate specificity</td>
+<td>Nte1p acts on <strong>CDP-choline pathway-derived PC</strong> and also hydrolyzes <strong>lysophosphatidylcholine (LysoPC/LysoPtdCho)</strong> in microsomal assays.</td>
+<td>LysoPC-dependent microsomal activity showed <strong>half-maximal activity at ~0.05 mM LysoPC</strong>.</td>
+<td>(zaccheo2004neuropathytargetesterase pages 4-5, murray2005nte1pmediateddeacylationof pages 3-4, pattonvogt2020phospholipidturnoverand pages 3-4)</td>
+</tr>
+<tr>
+<td>Catalytic residues / enzyme class</td>
+<td>Nte1p is a <strong>patatin-like serine esterase/phospholipase</strong> with an essential catalytic serine. Mutation of <strong>Ser-1406→Ala</strong> abolishes the overexpression-associated activity increase.</td>
+<td>Essential residue: <strong>Ser-1406</strong>.</td>
+<td>(zaccheo2004neuropathytargetesterase pages 1-2, zaccheo2004neuropathytargetesterase pages 4-5, pattonvogt2020phospholipidturnoverand pages 3-4)</td>
+</tr>
+<tr>
+<td>Subcellular localization</td>
+<td>GFP-YML059c/Nte1p shows a <strong>reticular ER pattern</strong>; immunogold EM associates the protein with <strong>ER tubules/tubuloreticular complexes</strong>, not mitochondria.</td>
+<td>Endogenous abundance estimated at <strong>~500 copies/cell</strong>.</td>
+<td>(zaccheo2004neuropathytargetesterase pages 3-4, zaccheo2004neuropathytargetesterase pages 5-6, zaccheo2004neuropathytargetesterase pages 4-5, zaccheo2004neuropathytargetesterase media 21adca93)</td>
+</tr>
+<tr>
+<td>Null phenotype in basic growth assays</td>
+<td><strong>nte1Δ/yml059cΔ</strong> cells are viable under tested conditions and lack a strong general growth phenotype, but they lose the major intracellular PC-to-GPC deacylation route.</td>
+<td>Deletion caused <strong>no detectable growth phenotype</strong> in tested conditions.</td>
+<td>(zaccheo2004neuropathytargetesterase pages 1-1, zaccheo2004neuropathytargetesterase pages 4-5, zaccheo2004neuropathytargetesterase pages 7-9)</td>
+</tr>
+<tr>
+<td>Requirement for intracellular GPC production</td>
+<td>Deletion of NTE1 abolishes or nearly abolishes intracellular <strong>GPC/GroPCho</strong> formation from PC in vivo, identifying Nte1p as the major, likely sole, intracellular PC deacylase for this route.</td>
+<td>WT soluble radiolabel was <strong>~85% GPC</strong>; null strain <strong>did not convert PC to GPC</strong>.</td>
+<td>(glynn2005neuropathytargetesterase pages 2-4, zaccheo2004neuropathytargetesterase pages 1-1, zaccheo2004neuropathytargetesterase pages 7-9, zaccheo2004neuropathytargetesterase media 21adca93)</td>
+</tr>
+<tr>
+<td>PC turnover phenotype</td>
+<td>During [14C]choline pulse-chase, PC is turned over much more slowly in <strong>nte1Δ</strong> than WT, showing Nte1p is a major PC turnover enzyme.</td>
+<td>After <strong>90 min</strong> chase, <strong>~60%</strong> of label remained in PC in <strong>nte1Δ</strong> vs <strong>~20%</strong> in WT.</td>
+<td>(murray2005nte1pmediateddeacylationof pages 3-4)</td>
+</tr>
+<tr>
+<td>Choline-related regulation</td>
+<td>Nte1p-dependent intracellular PC deacylation is stimulated by <strong>exogenous choline</strong> and depends on an active <strong>CDP-choline pathway</strong>; NTE1 loss alters choline handling.</td>
+<td>In <strong>nte1Δ</strong>, radiolabeled choline excretion increased <strong>~3-fold</strong> at 37°C; chase medium commonly contained <strong>10 mM choline</strong>.</td>
+<td>(murray2005nte1pmediateddeacylationof pages 3-4, murray2005nte1pmediateddeacylationof pages 1-2)</td>
+</tr>
+<tr>
+<td>Temperature dependence</td>
+<td>PC deacylation/GPC accumulation is enhanced at elevated temperature, with stronger turnover at <strong>37°C</strong> than 30°C/25°C in the cited labeling experiments.</td>
+<td>Faster turnover reported at <strong>37°C</strong>; pulse-chase comparisons performed at <strong>25°C vs 37°C</strong>.</td>
+<td>(zaccheo2004neuropathytargetesterase pages 7-9, murray2005nte1pmediateddeacylationof pages 3-4, murray2005nte1pmediateddeacylationof pages 1-2)</td>
+</tr>
+<tr>
+<td>Organophosphate sensitivity</td>
+<td>Nte1p is an <strong>OP-sensitive</strong> esterase, like mammalian NTE; inhibition rank order is similar, though yeast enzyme is less sensitive.</td>
+<td>OP potency toward YML059c reported as <strong>5–10-fold lower</strong> than mammalian NTE.</td>
+<td>(zaccheo2004neuropathytargetesterase pages 3-4, zaccheo2004neuropathytargetesterase pages 5-6, zaccheo2004neuropathytargetesterase pages 4-5)</td>
+</tr>
+<tr>
+<td>SEC14 genetic/functional interaction</td>
+<td><strong>Sec14p positively regulates Nte1p-mediated PC deacylation</strong>; sec14 dysfunction reduces intracellular GPC accumulation and rewires PC metabolism toward alternate routes (e.g., Spo14p-dependent turnover).</td>
+<td>sec14-related defects showed reduced GPCho accumulation; increased Nte1p activity increased the permissive temperature for <strong>sec14ts</strong> growth.</td>
+<td>(glynn2005neuropathytargetesterase pages 2-4, murray2005nte1pmediateddeacylationof pages 3-4, murray2005nte1pmediateddeacylationof pages 1-2)</td>
+</tr>
+<tr>
+<td>Pathway placement: PC-DRP</td>
+<td>NTE1 functions at the first step of the <strong>PC deacylation/reacylation pathway (PC-DRP)</strong>, generating GPC that can be reacylated by <strong>Gpc1</strong> to lyso-PC and by <strong>Ale1</strong> to PC, contributing to PC remodeling.</td>
+<td>Loss of <strong>Gpc1</strong> shifts PC species toward more di-unsaturated forms; Gpc1 ER colocalization seen in <strong>~85%</strong> of cells.</td>
+<td>(anaokar2019theglycerophosphocholineacyltransferase pages 1-2, hrach2023theacyltransferasegpc1 pages 1-2, hrach2023theacyltransferasegpc1 pages 2-4)</td>
+</tr>
+<tr>
+<td>Recent 2023–2024 pathway developments</td>
+<td>Direct 2023–2024 NTE1-specific studies are sparse, but recent work strengthens the importance of the downstream PC-DRP branch in <strong>ER bilayer homeostasis/UPR</strong> and in fungal physiology. Gpc1 is UPR-regulated and loss of GPC1 triggers bilayer-stress signaling, refining the functional context in which NTE1-generated GPC is used.</td>
+<td><strong>~85%</strong> ER colocalization reported for Gpc1; <strong>gpc1Δ</strong> blocks GPC reincorporation into PC and induces UPR.</td>
+<td>(hrach2023theacyltransferasegpc1 pages 1-2, king2024theglycerophosphocholineacyltransferase pages 1-2, hrach2023theacyltransferasegpc1 pages 2-4)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the main experimentally supported annotations for yeast NTE1/YML059C, including reaction, localization, regulation, pathway context, and quantitative findings. It is useful as a compact evidence map linking classic NTE1 studies to more recent PC-remodeling and ER-homeostasis work.</em></p>
+<p>Two core figure-based results supporting localization and function are available directly from the primary paper:<br />
+- <strong>ER localization</strong> of GFP-YML059C/Nte1p by fluorescence and immunogold EM. (zaccheo2004neuropathytargetesterase media 21adca93)<br />
+- <strong>Loss of GPC formation and altered PC turnover</strong> in YML059C-null compared with wild type in radiolabel turnover experiments. (zaccheo2004neuropathytargetesterase media c7f4ddec)</p>
+<h2 id="10-summary-functional-annotation-evidence-weighted">10) Summary functional annotation (evidence-weighted)</h2>
+<p><strong>NTE1 (YML059C; UniProt Q04958) encodes Nte1p, an ER-localized patatin-like serine phospholipase/lysophospholipase that catalyzes complete deacylation of phosphatidylcholine to glycerophosphocholine plus free fatty acids.</strong> Genetic deletion abolishes intracellular GPC production and substantially slows PC turnover, and Nte1p-driven PC deacylation functionally interfaces with Sec14p-regulated lipid homeostasis at the trafficking–metabolism nexus. NTE1 also serves as the initiating step for the PC deacylation/reacylation remodeling pathway (PC-DRP) whose downstream arm (Gpc1/Ale1) has been linked in 2023–2024 work to ER membrane stress/UPR and fungal physiology, underscoring the broader importance of NTE1-generated GPC as a remodeling substrate. (glynn2005neuropathytargetesterase pages 2-4, zaccheo2004neuropathytargetesterase pages 7-9, murray2005nte1pmediateddeacylationof pages 3-4, hrach2023theacyltransferasegpc1 pages 1-2)</p>
+<h2 id="evidence-limitations-scope-control">Evidence limitations (scope control)</h2>
+<p>Within the retrieved 2023–2024 literature corpus, <strong>direct NTE1-focused mechanistic updates in <em>S. cerevisiae</em></strong> were sparse; the most substantive recent advances affecting interpretation of NTE1’s biological role arise from <strong>downstream PC-DRP work (Gpc1/Ale1; UPR/bilayer stress)</strong> and from comparative fungal studies. (hrach2023theacyltransferasegpc1 pages 1-2, king2024theglycerophosphocholineacyltransferase pages 1-2)</p>
+<p>References</p>
+<ol>
+<li>
+<p>(glynn2005neuropathytargetesterase pages 2-4): Paul Glynn. Neuropathy target esterase and phospholipid deacylation. Biochimica et biophysica acta, 1736 2:87-93, Sep 2005. URL: https://doi.org/10.1016/j.bbalip.2005.08.002, doi:10.1016/j.bbalip.2005.08.002. This article has 87 citations.</p>
+</li>
+<li>
+<p>(murray2005nte1pmediateddeacylationof pages 3-4): J. Pedro Fernández Murray and Christopher R. McMaster. Nte1p-mediated deacylation of phosphatidylcholine functionally interacts with sec14p*. Journal of Biological Chemistry, 280:8544-8552, Mar 2005. URL: https://doi.org/10.1074/jbc.m413999200, doi:10.1074/jbc.m413999200. This article has 56 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(zaccheo2004neuropathytargetesterase pages 2-3): Oliver Zaccheo, David Dinsdale, Peter A. Meacock, and Paul Glynn. Neuropathy target esterase and its yeast homologue degrade phosphatidylcholine to glycerophosphocholine in living cells*. Journal of Biological Chemistry, 279:24024-24033, Jun 2004. URL: https://doi.org/10.1074/jbc.m400830200, doi:10.1074/jbc.m400830200. This article has 261 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(zaccheo2004neuropathytargetesterase pages 1-1): Oliver Zaccheo, David Dinsdale, Peter A. Meacock, and Paul Glynn. Neuropathy target esterase and its yeast homologue degrade phosphatidylcholine to glycerophosphocholine in living cells*. Journal of Biological Chemistry, 279:24024-24033, Jun 2004. URL: https://doi.org/10.1074/jbc.m400830200, doi:10.1074/jbc.m400830200. This article has 261 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(zaccheo2004neuropathytargetesterase pages 7-9): Oliver Zaccheo, David Dinsdale, Peter A. Meacock, and Paul Glynn. Neuropathy target esterase and its yeast homologue degrade phosphatidylcholine to glycerophosphocholine in living cells*. Journal of Biological Chemistry, 279:24024-24033, Jun 2004. URL: https://doi.org/10.1074/jbc.m400830200, doi:10.1074/jbc.m400830200. This article has 261 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(anaokar2019theglycerophosphocholineacyltransferase pages 1-2): Sanket Anaokar, Ravindra Kodali, Benjamin Jonik, Mike F. Renne, Jos F.H.M. Brouwers, Ida Lager, Anton I.P.M. de Kroon, and Jana Patton-Vogt. The glycerophosphocholine acyltransferase gpc1 is part of a phosphatidylcholine (pc)-remodeling pathway that alters pc species in yeast. Journal of Biological Chemistry, 294:1189-1201, Jan 2019. URL: https://doi.org/10.1074/jbc.ra118.005232, doi:10.1074/jbc.ra118.005232. This article has 36 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(hrach2023theacyltransferasegpc1 pages 1-2): Victoria Lee Hrach, William R. King, Laura D. Nelson, Shane Conklin, John A. Pollock, and Jana Patton-Vogt. The acyltransferase gpc1 is both a target and an effector of the unfolded protein response in saccharomyces cerevisiae. Journal of Biological Chemistry, 299:104884, Jul 2023. URL: https://doi.org/10.1016/j.jbc.2023.104884, doi:10.1016/j.jbc.2023.104884. This article has 3 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(pattonvogt2020phospholipidturnoverand pages 3-4): Jana Patton-Vogt and Anton I.P.M. de Kroon. Phospholipid turnover and acyl chain remodeling in the yeast er. Biochimica et Biophysica Acta (BBA) - Molecular and Cell Biology of Lipids, 1865:158462, Jan 2020. URL: https://doi.org/10.1016/j.bbalip.2019.05.006, doi:10.1016/j.bbalip.2019.05.006. This article has 55 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(zaccheo2004neuropathytargetesterase pages 4-5): Oliver Zaccheo, David Dinsdale, Peter A. Meacock, and Paul Glynn. Neuropathy target esterase and its yeast homologue degrade phosphatidylcholine to glycerophosphocholine in living cells*. Journal of Biological Chemistry, 279:24024-24033, Jun 2004. URL: https://doi.org/10.1074/jbc.m400830200, doi:10.1074/jbc.m400830200. This article has 261 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(zaccheo2004neuropathytargetesterase pages 1-2): Oliver Zaccheo, David Dinsdale, Peter A. Meacock, and Paul Glynn. Neuropathy target esterase and its yeast homologue degrade phosphatidylcholine to glycerophosphocholine in living cells*. Journal of Biological Chemistry, 279:24024-24033, Jun 2004. URL: https://doi.org/10.1074/jbc.m400830200, doi:10.1074/jbc.m400830200. This article has 261 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(zaccheo2004neuropathytargetesterase pages 3-4): Oliver Zaccheo, David Dinsdale, Peter A. Meacock, and Paul Glynn. Neuropathy target esterase and its yeast homologue degrade phosphatidylcholine to glycerophosphocholine in living cells*. Journal of Biological Chemistry, 279:24024-24033, Jun 2004. URL: https://doi.org/10.1074/jbc.m400830200, doi:10.1074/jbc.m400830200. This article has 261 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(zaccheo2004neuropathytargetesterase pages 5-6): Oliver Zaccheo, David Dinsdale, Peter A. Meacock, and Paul Glynn. Neuropathy target esterase and its yeast homologue degrade phosphatidylcholine to glycerophosphocholine in living cells*. Journal of Biological Chemistry, 279:24024-24033, Jun 2004. URL: https://doi.org/10.1074/jbc.m400830200, doi:10.1074/jbc.m400830200. This article has 261 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(zaccheo2004neuropathytargetesterase media 21adca93): Oliver Zaccheo, David Dinsdale, Peter A. Meacock, and Paul Glynn. Neuropathy target esterase and its yeast homologue degrade phosphatidylcholine to glycerophosphocholine in living cells*. Journal of Biological Chemistry, 279:24024-24033, Jun 2004. URL: https://doi.org/10.1074/jbc.m400830200, doi:10.1074/jbc.m400830200. This article has 261 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(murray2005nte1pmediateddeacylationof pages 1-2): J. Pedro Fernández Murray and Christopher R. McMaster. Nte1p-mediated deacylation of phosphatidylcholine functionally interacts with sec14p*. Journal of Biological Chemistry, 280:8544-8552, Mar 2005. URL: https://doi.org/10.1074/jbc.m413999200, doi:10.1074/jbc.m413999200. This article has 56 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(hrach2023theacyltransferasegpc1 pages 2-4): Victoria Lee Hrach, William R. King, Laura D. Nelson, Shane Conklin, John A. Pollock, and Jana Patton-Vogt. The acyltransferase gpc1 is both a target and an effector of the unfolded protein response in saccharomyces cerevisiae. Journal of Biological Chemistry, 299:104884, Jul 2023. URL: https://doi.org/10.1016/j.jbc.2023.104884, doi:10.1016/j.jbc.2023.104884. This article has 3 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(king2024theglycerophosphocholineacyltransferase pages 1-2): William R. King, Justin Singer, Mitchell Warman, Duncan Wilson, Bernard Hube, Ida Lager, and Jana Patton-Vogt. The glycerophosphocholine acyltransferase gpc1 contributes to phosphatidylcholine biosynthesis, long-term viability, and embedded hyphal growth in candida albicans. Journal of Biological Chemistry, 300:105543, Jan 2024. URL: https://doi.org/10.1016/j.jbc.2023.105543, doi:10.1016/j.jbc.2023.105543. This article has 11 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(jiang2024phospholipidbiosynthesisregulation pages 6-11): Xiao-ying Jiang, Xiya Hong, Zhulin Wang, Jun Liu, Haiyan Zhong, Jiali Ren, and Bo Zhou. Phospholipid biosynthesis regulation for improving pigment production by <i>monascus</i> in response to ammonium chloride stress. Applied and Environmental Microbiology, Oct 2024. URL: https://doi.org/10.1128/aem.01146-24, doi:10.1128/aem.01146-24. This article has 3 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(zaccheo2004neuropathytargetesterase media c7f4ddec): Oliver Zaccheo, David Dinsdale, Peter A. Meacock, and Paul Glynn. Neuropathy target esterase and its yeast homologue degrade phosphatidylcholine to glycerophosphocholine in living cells*. Journal of Biological Chemistry, 279:24024-24033, Jun 2004. URL: https://doi.org/10.1074/jbc.m400830200, doi:10.1074/jbc.m400830200. This article has 261 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>zaccheo2004neuropathytargetesterase pages 7-9</li>
+<li>pattonvogt2020phospholipidturnoverand pages 3-4</li>
+<li>zaccheo2004neuropathytargetesterase pages 4-5</li>
+<li>anaokar2019theglycerophosphocholineacyltransferase pages 1-2</li>
+<li>king2024theglycerophosphocholineacyltransferase pages 1-2</li>
+<li>jiang2024phospholipidbiosynthesisregulation pages 6-11</li>
+<li>glynn2005neuropathytargetesterase pages 2-4</li>
+<li>zaccheo2004neuropathytargetesterase pages 2-3</li>
+<li>zaccheo2004neuropathytargetesterase pages 1-1</li>
+<li>zaccheo2004neuropathytargetesterase pages 1-2</li>
+<li>zaccheo2004neuropathytargetesterase pages 3-4</li>
+<li>zaccheo2004neuropathytargetesterase pages 5-6</li>
+<li>14C</li>
+<li>https://doi.org/10.1016/j.jbc.2023.104884.</li>
+<li>https://doi.org/10.1016/j.jbc.2023.105543.</li>
+<li>https://doi.org/10.1128/aem.01146-24.</li>
+<li>https://doi.org/10.1016/j.bbalip.2005.08.002.</li>
+<li>https://doi.org/10.1016/j.bbalip.2005.08.002,</li>
+<li>https://doi.org/10.1074/jbc.m413999200,</li>
+<li>https://doi.org/10.1074/jbc.m400830200,</li>
+<li>https://doi.org/10.1074/jbc.ra118.005232,</li>
+<li>https://doi.org/10.1016/j.jbc.2023.104884,</li>
+<li>https://doi.org/10.1016/j.bbalip.2019.05.006,</li>
+<li>https://doi.org/10.1016/j.jbc.2023.105543,</li>
+<li>https://doi.org/10.1128/aem.01146-24,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -2407,6 +2824,8 @@ existing_annotations:
     supported_by:
     - reference_id: UniProt:Q04958
       supporting_text: &#39;RecName: Full=Lysophospholipase NTE1; EC=3.1.1.5&#39;
+    - reference_id: file:yeast/NTE1/NTE1-deep-research-falcon.md
+      supporting_text: NTE1/YML059C encodes a **patatin-like serine esterase/phospholipase**
 - term:
     id: GO:0005783
     label: endoplasmic reticulum
@@ -2633,6 +3052,9 @@ references:
 - id: PMID:26928762
   title: &#39;One library to make them all: streamlining the creation of yeast libraries via a SWAp-Tag strategy.&#39;
   findings: []
+- id: file:yeast/NTE1/NTE1-deep-research-falcon.md
+  title: Falcon deep research report for NTE1
+  findings: []
 core_functions:
 - description: Phosphatidylcholine lysophospholipase activity - catalyzes the double deacylation of phosphatidylcholine to glycerophosphocholine for membrane lipid homeostasis
   molecular_function:
@@ -2646,6 +3068,9 @@ core_functions:
   locations:
   - id: GO:0005789
     label: endoplasmic reticulum membrane
+  supported_by:
+  - reference_id: file:yeast/NTE1/NTE1-deep-research-falcon.md
+    supporting_text: ER-localized patatin-like serine phospholipase/lysophospholipase that catalyzes complete deacylation of phosphatidylcholine to glycerophosphocholine plus free fatty acids
 suggested_questions:
 - question: How does NTE1 regulate phospholipid homeostasis in the endoplasmic reticulum and what determines its substrate specificity?
 - question: What role does NTE1 play in membrane remodeling and how does its activity affect ER morphology and function?
@@ -2663,7 +3088,7 @@ status: COMPLETE
     </div>
 
     <!-- Pathway Visualization Link -->
-    
+
     <div class="section">
         <div class="pathway-link">
             <div style="display: flex; justify-content: space-between; align-items: center;">
@@ -2683,7 +3108,7 @@ status: COMPLETE
             </p>
         </div>
     </div>
-    
+
 
     <style>
         /* Markdown Section Styles */

--- a/genes/yeast/NTE1/NTE1-ai-review.yaml
+++ b/genes/yeast/NTE1/NTE1-ai-review.yaml
@@ -20,6 +20,8 @@ existing_annotations:
     supported_by:
     - reference_id: UniProt:Q04958
       supporting_text: 'RecName: Full=Lysophospholipase NTE1; EC=3.1.1.5'
+    - reference_id: file:yeast/NTE1/NTE1-deep-research-falcon.md
+      supporting_text: NTE1/YML059C encodes a **patatin-like serine esterase/phospholipase**
 - term:
     id: GO:0005783
     label: endoplasmic reticulum
@@ -246,6 +248,9 @@ references:
 - id: PMID:26928762
   title: 'One library to make them all: streamlining the creation of yeast libraries via a SWAp-Tag strategy.'
   findings: []
+- id: file:yeast/NTE1/NTE1-deep-research-falcon.md
+  title: Falcon deep research report for NTE1
+  findings: []
 core_functions:
 - description: Phosphatidylcholine lysophospholipase activity - catalyzes the double deacylation of phosphatidylcholine to glycerophosphocholine for membrane lipid homeostasis
   molecular_function:
@@ -259,6 +264,9 @@ core_functions:
   locations:
   - id: GO:0005789
     label: endoplasmic reticulum membrane
+  supported_by:
+  - reference_id: file:yeast/NTE1/NTE1-deep-research-falcon.md
+    supporting_text: ER-localized patatin-like serine phospholipase/lysophospholipase that catalyzes complete deacylation of phosphatidylcholine to glycerophosphocholine plus free fatty acids
 suggested_questions:
 - question: How does NTE1 regulate phospholipid homeostasis in the endoplasmic reticulum and what determines its substrate specificity?
 - question: What role does NTE1 play in membrane remodeling and how does its activity affect ER morphology and function?

--- a/genes/yeast/NTE1/NTE1-deep-research-falcon.md
+++ b/genes/yeast/NTE1/NTE1-deep-research-falcon.md
@@ -1,0 +1,328 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-11T09:09:27.162441'
+end_time: '2026-05-11T09:27:38.764919'
+duration_seconds: 1091.6
+template_file: templates/gene_research_go_focused.md
+template_variables:
+  organism: yeast
+  gene_id: NTE1
+  gene_symbol: NTE1
+  uniprot_accession: Q04958
+  protein_description: 'RecName: Full=Lysophospholipase NTE1; EC=3.1.1.5 {ECO:0000269|PubMed:15044461};
+    AltName: Full=Intracellular phospholipase B; AltName: Full=Neuropathy target esterase
+    homolog;'
+  gene_info: Name=NTE1; OrderedLocusNames=YML059C; ORFNames=YM9958.03C;
+  organism_full: Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+  protein_family: Belongs to the NTE family. .
+  protein_domains: Acyl_Trfase/lysoPLipase. (IPR016035); cNMP-bd_dom. (IPR000595);
+    cNMP-bd_dom_sf. (IPR018490); LysoPLipase_patatin_CS. (IPR001423); NTE. (IPR050301)
+provider_config:
+  timeout: 600
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 25
+---
+
+## Question
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** Q04958
+- **Protein Description:** RecName: Full=Lysophospholipase NTE1; EC=3.1.1.5 {ECO:0000269|PubMed:15044461}; AltName: Full=Intracellular phospholipase B; AltName: Full=Neuropathy target esterase homolog;
+- **Gene Information:** Name=NTE1; OrderedLocusNames=YML059C; ORFNames=YM9958.03C;
+- **Organism (full):** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+- **Protein Family:** Belongs to the NTE family. .
+- **Key Domains:** Acyl_Trfase/lysoPLipase. (IPR016035); cNMP-bd_dom. (IPR000595); cNMP-bd_dom_sf. (IPR018490); LysoPLipase_patatin_CS. (IPR001423); NTE. (IPR050301)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "NTE1" matches the protein description above**
+2. **Verify the organism is correct:** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'NTE1' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **NTE1** (gene ID: NTE1, UniProt: Q04958) in yeast.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** Q04958
+- **Protein Description:** RecName: Full=Lysophospholipase NTE1; EC=3.1.1.5 {ECO:0000269|PubMed:15044461}; AltName: Full=Intracellular phospholipase B; AltName: Full=Neuropathy target esterase homolog;
+- **Gene Information:** Name=NTE1; OrderedLocusNames=YML059C; ORFNames=YM9958.03C;
+- **Organism (full):** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+- **Protein Family:** Belongs to the NTE family. .
+- **Key Domains:** Acyl_Trfase/lysoPLipase. (IPR016035); cNMP-bd_dom. (IPR000595); cNMP-bd_dom_sf. (IPR018490); LysoPLipase_patatin_CS. (IPR001423); NTE. (IPR050301)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "NTE1" matches the protein description above**
+2. **Verify the organism is correct:** Saccharomyces cerevisiae (strain ATCC 204508 / S288c) (Baker's yeast).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'NTE1' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **NTE1** (gene ID: NTE1, UniProt: Q04958) in yeast.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+# Research report: *Saccharomyces cerevisiae* NTE1 (YML059C; UniProt Q04958) – functional annotation
+
+## 1) Target verification and nomenclature (critical disambiguation)
+Multiple yeast-focused sources explicitly identify *S. cerevisiae* ORF **YML059C** as the yeast homolog of vertebrate neuropathy target esterase and note it was renamed **NTE1** (protein: Nte1p). (glynn2005neuropathytargetesterase pages 2-4, murray2005nte1pmediateddeacylationof pages 3-4)
+
+## 2) Key concepts and definitions (current understanding)
+
+### 2.1 What does “lysophospholipase / phospholipase B-like activity” mean here?
+In the yeast NTE1 context, the core biochemical activity is **complete deacylation of phosphatidylcholine (PC/PtdCho)**, producing **glycerophosphocholine (GPC/GroPCho)** and **two free fatty acids (FFAs)**—a reaction consistent with a phospholipase B-type outcome (removal of both acyl chains), potentially via sequential sn-2 then sn-1 deacylation steps. (zaccheo2004neuropathytargetesterase pages 2-3, zaccheo2004neuropathytargetesterase pages 1-1, zaccheo2004neuropathytargetesterase pages 7-9)
+
+### 2.2 PC deacylation/reacylation pathway (PC-DRP)
+A distinct **PC deacylation/reacylation pathway (PC-DRP)** in yeast begins with PC deacylation to **GPC** by phospholipase B-type enzymes including **Nte1p (NTE1)** (and also PLB1 in the broader pathway literature), followed by GPC reacylation by **Gpc1** to form **lyso-PC**, and then reacylation by **Ale1** to regenerate PC. This pathway is now understood to function as a PC remodeling/salvage route that can influence PC molecular-species composition and ER membrane homeostasis. (anaokar2019theglycerophosphocholineacyltransferase pages 1-2, hrach2023theacyltransferasegpc1 pages 1-2)
+
+## 3) Molecular function: reaction, substrates, and catalytic features
+
+### 3.1 Primary in vivo reaction and physiological product
+In vivo labeling experiments show that yeast NTE1/YML059C is required to convert PC to GPC: **YML059C-null strains fail to produce intracellular GPC from PC**, while wild-type cells generate GPC as the dominant soluble metabolite under the tested conditions. (zaccheo2004neuropathytargetesterase pages 1-1, zaccheo2004neuropathytargetesterase pages 7-9)
+
+A quantitative feature from these experiments is that in wild-type cells at 37°C, **~85% of soluble intracellular radiolabeled metabolite was GPC**, whereas this product was absent in the YML059C-null background. (zaccheo2004neuropathytargetesterase pages 7-9)
+
+### 3.2 Substrate specificity and pathway coupling
+Nte1p-mediated deacylation particularly acts on **PC derived from the CDP-choline pathway** (Kennedy pathway) rather than PC made through alternative routes such as phosphatidylethanolamine methylation, based on radiolabeling pathway-tracing cited in later pathway syntheses. (pattonvogt2020phospholipidturnoverand pages 3-4)
+
+In microsomal assays, the yeast protein also displays **lysophospholipase activity** toward **lysophosphatidylcholine (LysoPC/LysoPtdCho)**, with **half-maximal activity at ~0.05 mM LysoPC** reported. (zaccheo2004neuropathytargetesterase pages 4-5)
+
+### 3.3 Enzyme class and catalytic residue
+NTE1/YML059C encodes a **patatin-like serine esterase/phospholipase**. Mutation of the **putative active-site serine (Ser-1406→Ala)** abolishes the activity increase associated with overexpression, supporting a serine-dependent catalytic mechanism. (zaccheo2004neuropathytargetesterase pages 1-2, zaccheo2004neuropathytargetesterase pages 4-5)
+
+### 3.4 Sensitivity to organophosphates (OPs)
+Nte1p/YML059C shows conserved biochemical similarity to vertebrate NTE, including **inhibition by neuropathic organophosphorus compounds** with similar rank-order sensitivity, though potency for the yeast enzyme was reported as **~5–10× lower** than mammalian NTE in the cited comparisons. (zaccheo2004neuropathytargetesterase pages 3-4, zaccheo2004neuropathytargetesterase pages 4-5)
+
+## 4) Subcellular localization: where Nte1p works in the cell
+
+### 4.1 ER localization
+Localization experiments using GFP-tagged YML059C show a **reticular pattern consistent with endoplasmic reticulum (ER)**, and immunogold electron microscopy places the protein on **ER tubules/tubuloreticular complexes**, not mitochondria in adjacent regions. (zaccheo2004neuropathytargetesterase pages 3-4, zaccheo2004neuropathytargetesterase pages 5-6, zaccheo2004neuropathytargetesterase media 21adca93)
+
+### 4.2 Abundance estimate
+One analysis summarized in the primary literature reports endogenous abundance on the order of **~500 copies/cell**, supporting the view that Nte1p is not an extremely high-abundance lipase but can still drive substantial PC turnover flux. (zaccheo2004neuropathytargetesterase pages 4-5)
+
+## 5) Pathways, biological processes, and phenotypes
+
+### 5.1 PC turnover and membrane lipid homeostasis
+NTE1/YML059C is a central enzymatic contributor to intracellular PC turnover to GPC. In pulse-chase experiments, **PC turnover is markedly slowed in nte1Δ** relative to wild type, with **~60% of label remaining in PC after 90 min in nte1Δ vs ~20% in wild type**, demonstrating that Nte1p is a major contributor to PC deacylation flux. (murray2005nte1pmediateddeacylationof pages 3-4)
+
+Although **nte1Δ cells were viable and showed no strong general growth defect under tested conditions**, the metabolic phenotype is clear: loss of intracellular GPC formation from PC. (zaccheo2004neuropathytargetesterase pages 1-1, zaccheo2004neuropathytargetesterase pages 4-5)
+
+### 5.2 Functional interaction with Sec14p (membrane trafficking–lipid homeostasis interface)
+Nte1p-mediated PC deacylation functionally interfaces with **Sec14p**, a key regulator linking secretory trafficking and lipid metabolism. When Sec14p function is compromised, intracellular GPC accumulation is reduced, and Sec14p is described as a **positive regulator of Nte1p-mediated PC deacylation** with functional consequences for growth at restrictive temperature in sec14ts backgrounds. (glynn2005neuropathytargetesterase pages 2-4, murray2005nte1pmediateddeacylationof pages 3-4)
+
+### 5.3 Regulation by choline supply and temperature (induction of deacylation flux)
+Nte1p-dependent intracellular PC deacylation is reported to be stimulated by **exogenous choline** and enhanced at **higher temperature (e.g., 37°C)** in the classical radiolabel pulse-chase frameworks. (zaccheo2004neuropathytargetesterase pages 7-9, murray2005nte1pmediateddeacylationof pages 1-2)
+
+Loss of NTE1 also changes choline handling during chase, including **~3-fold increased radiolabeled choline excretion** under conditions tested at 37°C. (murray2005nte1pmediateddeacylationof pages 3-4)
+
+### 5.4 Connection to PC remodeling and ER membrane state (via PC-DRP)
+Because NTE1 generates GPC used by downstream PC-DRP enzymes, NTE1 is upstream of a remodeling loop that can alter PC molecular species. In the PC-DRP literature, Gpc1 activity is shown to influence PC species composition (loss of Gpc1 shifts PC toward more diunsaturated species), underscoring how the Nte1p-generated GPC pool can feed a pathway that tunes membrane properties. (anaokar2019theglycerophosphocholineacyltransferase pages 1-2)
+
+## 6) Recent developments and latest research (prioritizing 2023–2024)
+
+### 6.1 2023: PC-DRP as an ER stress / UPR-relevant membrane-homeostasis module
+A 2023 JBC study provides an updated, mechanistic link between the PC-DRP pathway and ER homeostasis: **GPC1 is induced by unfolded protein response (UPR) stimuli in a Hac1-dependent manner** and **gpc1Δ both increases stress sensitivity and itself activates the UPR**, consistent with PC-DRP supporting ER membrane (bilayer) homeostasis. The same work reports ER localization for Gpc1 with **~85% colocalization** with an ER marker in their imaging assay. (hrach2023theacyltransferasegpc1 pages 1-2, hrach2023theacyltransferasegpc1 pages 2-4)
+
+Although this paper focuses on Gpc1 rather than NTE1 directly, it strengthens the current interpretation that **NTE1-initiated PC deacylation (GPC production) is part of a broader ER membrane-quality control and lipid-composition maintenance network**, because NTE1 supplies the pathway’s substrate (GPC). (hrach2023theacyltransferasegpc1 pages 1-2)
+
+Publication details: *Journal of Biological Chemistry* (July 2023), DOI URL: https://doi.org/10.1016/j.jbc.2023.104884. (hrach2023theacyltransferasegpc1 pages 1-2)
+
+### 6.2 2024: PC-DRP importance in fungi and potential antifungal relevance (comparative context)
+A 2024 JBC study in *Candida albicans* demonstrates that PC-DRP contributes to PC homeostasis and fungal physiology (viability, hyphal growth) and highlights conservation of the pathway across fungi and the potential to target fungus-specific components (e.g., Gpc1 without human homologs). While not yeast NTE1 per se, it supports the broader view that the NTE1→GPC→(Gpc1/Ale1) logic is physiologically meaningful beyond *S. cerevisiae*. (king2024theglycerophosphocholineacyltransferase pages 1-2)
+
+Publication details: *Journal of Biological Chemistry* (January 2024), DOI URL: https://doi.org/10.1016/j.jbc.2023.105543. (king2024theglycerophosphocholineacyltransferase pages 1-2)
+
+### 6.3 2024: Applied lipidomics/fermentation work explicitly tracking “NTE1” as a lysophospholipase marker
+In an industrially motivated fungal fermentation study (Monascus pigments), ammonium chloride stress (15 g/L) altered lysophospholipid profiles and was associated with increased expression of genes annotated as lysophospholipases including **NTE1 (reported 1.74× upregulation)**. The same study reported lipidomics fold changes including **LPC(16) increased 2.15×** and **LPS(10) increased 2.6×** under the stress condition. (jiang2024phospholipidbiosynthesisregulation pages 6-11)
+
+Publication details: *Applied and Environmental Microbiology* (October 2024), DOI URL: https://doi.org/10.1128/aem.01146-24. (jiang2024phospholipidbiosynthesisregulation pages 6-11)
+
+## 7) Current applications and real-world implementations
+
+### 7.1 Yeast as a tractable model for NTE-family enzymology and lipid homeostasis
+The core NTE/NTE1 framework is used widely as a **model system for ER-localized phospholipid deacylation** and membrane lipid homeostasis, with viable yeast knockouts enabling clean in vivo pathway attribution (loss of GPC production) while maintaining growth. (zaccheo2004neuropathytargetesterase pages 1-1, zaccheo2004neuropathytargetesterase pages 7-9)
+
+### 7.2 Organophosphate neuropathy screening and biochemical assay frameworks
+A major applied context for the NTE family is organophosphate toxicology: NTE activity assays (e.g., phenyl valerate hydrolysis) are used in screening frameworks for neuropathic potential, and recombinant catalytic-domain preparations can be purified and reconstituted for biochemical testing. Yeast Nte1p serves as a genetically tractable homolog supporting mechanistic interpretation of OP-sensitive phospholipid deacylation. (glynn2005neuropathytargetesterase pages 2-4)
+
+### 7.3 Lipidomics-guided process optimization and membrane homeostasis engineering in fungi
+The Monascus study illustrates a real-world approach where **absolute quantitative lipidomics + quantitative proteomics** are used to diagnose membrane lipid imbalances during production fermentation, and where **NTE1 upregulation** is interpreted as part of a response to modulate lysophospholipid pools under stress, connecting NTE1-like functions to industrially relevant phenotypes. (jiang2024phospholipidbiosynthesisregulation pages 6-11)
+
+## 8) Expert opinions and authoritative synthesis (interpretive analysis from reviews)
+A focused review framed NTE/Nte1p as catalyzing **ER-localized PC deacylation to GPC + FFAs**, and emphasized yeast genetics showing Nte1p as the **sole source of intracellular GPC** under studied conditions, positioning NTE-family enzymes as central to phosphatidylcholine homeostasis. (glynn2005neuropathytargetesterase pages 2-4)
+
+Publication details: *Biochimica et Biophysica Acta* (September 2005), DOI URL: https://doi.org/10.1016/j.bbalip.2005.08.002. (glynn2005neuropathytargetesterase pages 2-4)
+
+## 9) Key statistics and data highlights (from primary studies)
+
+| Property | Experimentally supported finding | Key quantitative data | Most relevant citations |
+|---|---|---|---|
+| Target identity | **NTE1** is the renamed **YML059C** ORF in *S. cerevisiae* and encodes the yeast homolog of neuropathy target esterase; UniProt Q04958 is consistent with this mapping. | Catalytic-domain sequence identity to mammalian NTE reported as **39%**. | (glynn2005neuropathytargetesterase pages 2-4, zaccheo2004neuropathytargetesterase pages 3-4, murray2005nte1pmediateddeacylationof pages 3-4) |
+| Primary reaction catalyzed | Nte1p deacylates **phosphatidylcholine (PC/PtdCho)** to **glycerophosphocholine (GPC/GroPCho)** plus **two free fatty acids**; mechanism is consistent with phospholipase B activity or sequential PLA2 + lysophospholipase reactions. | In vivo soluble radiolabeled metabolite in WT after PC turnover was predominantly **~85% GPC** at 37°C. | (glynn2005neuropathytargetesterase pages 2-4, zaccheo2004neuropathytargetesterase pages 2-3, zaccheo2004neuropathytargetesterase pages 1-1, zaccheo2004neuropathytargetesterase pages 7-9) |
+| Substrate specificity | Nte1p acts on **CDP-choline pathway-derived PC** and also hydrolyzes **lysophosphatidylcholine (LysoPC/LysoPtdCho)** in microsomal assays. | LysoPC-dependent microsomal activity showed **half-maximal activity at ~0.05 mM LysoPC**. | (zaccheo2004neuropathytargetesterase pages 4-5, murray2005nte1pmediateddeacylationof pages 3-4, pattonvogt2020phospholipidturnoverand pages 3-4) |
+| Catalytic residues / enzyme class | Nte1p is a **patatin-like serine esterase/phospholipase** with an essential catalytic serine. Mutation of **Ser-1406→Ala** abolishes the overexpression-associated activity increase. | Essential residue: **Ser-1406**. | (zaccheo2004neuropathytargetesterase pages 1-2, zaccheo2004neuropathytargetesterase pages 4-5, pattonvogt2020phospholipidturnoverand pages 3-4) |
+| Subcellular localization | GFP-YML059c/Nte1p shows a **reticular ER pattern**; immunogold EM associates the protein with **ER tubules/tubuloreticular complexes**, not mitochondria. | Endogenous abundance estimated at **~500 copies/cell**. | (zaccheo2004neuropathytargetesterase pages 3-4, zaccheo2004neuropathytargetesterase pages 5-6, zaccheo2004neuropathytargetesterase pages 4-5, zaccheo2004neuropathytargetesterase media 21adca93) |
+| Null phenotype in basic growth assays | **nte1Δ/yml059cΔ** cells are viable under tested conditions and lack a strong general growth phenotype, but they lose the major intracellular PC-to-GPC deacylation route. | Deletion caused **no detectable growth phenotype** in tested conditions. | (zaccheo2004neuropathytargetesterase pages 1-1, zaccheo2004neuropathytargetesterase pages 4-5, zaccheo2004neuropathytargetesterase pages 7-9) |
+| Requirement for intracellular GPC production | Deletion of NTE1 abolishes or nearly abolishes intracellular **GPC/GroPCho** formation from PC in vivo, identifying Nte1p as the major, likely sole, intracellular PC deacylase for this route. | WT soluble radiolabel was **~85% GPC**; null strain **did not convert PC to GPC**. | (glynn2005neuropathytargetesterase pages 2-4, zaccheo2004neuropathytargetesterase pages 1-1, zaccheo2004neuropathytargetesterase pages 7-9, zaccheo2004neuropathytargetesterase media 21adca93) |
+| PC turnover phenotype | During [14C]choline pulse-chase, PC is turned over much more slowly in **nte1Δ** than WT, showing Nte1p is a major PC turnover enzyme. | After **90 min** chase, **~60%** of label remained in PC in **nte1Δ** vs **~20%** in WT. | (murray2005nte1pmediateddeacylationof pages 3-4) |
+| Choline-related regulation | Nte1p-dependent intracellular PC deacylation is stimulated by **exogenous choline** and depends on an active **CDP-choline pathway**; NTE1 loss alters choline handling. | In **nte1Δ**, radiolabeled choline excretion increased **~3-fold** at 37°C; chase medium commonly contained **10 mM choline**. | (murray2005nte1pmediateddeacylationof pages 3-4, murray2005nte1pmediateddeacylationof pages 1-2) |
+| Temperature dependence | PC deacylation/GPC accumulation is enhanced at elevated temperature, with stronger turnover at **37°C** than 30°C/25°C in the cited labeling experiments. | Faster turnover reported at **37°C**; pulse-chase comparisons performed at **25°C vs 37°C**. | (zaccheo2004neuropathytargetesterase pages 7-9, murray2005nte1pmediateddeacylationof pages 3-4, murray2005nte1pmediateddeacylationof pages 1-2) |
+| Organophosphate sensitivity | Nte1p is an **OP-sensitive** esterase, like mammalian NTE; inhibition rank order is similar, though yeast enzyme is less sensitive. | OP potency toward YML059c reported as **5–10-fold lower** than mammalian NTE. | (zaccheo2004neuropathytargetesterase pages 3-4, zaccheo2004neuropathytargetesterase pages 5-6, zaccheo2004neuropathytargetesterase pages 4-5) |
+| SEC14 genetic/functional interaction | **Sec14p positively regulates Nte1p-mediated PC deacylation**; sec14 dysfunction reduces intracellular GPC accumulation and rewires PC metabolism toward alternate routes (e.g., Spo14p-dependent turnover). | sec14-related defects showed reduced GPCho accumulation; increased Nte1p activity increased the permissive temperature for **sec14ts** growth. | (glynn2005neuropathytargetesterase pages 2-4, murray2005nte1pmediateddeacylationof pages 3-4, murray2005nte1pmediateddeacylationof pages 1-2) |
+| Pathway placement: PC-DRP | NTE1 functions at the first step of the **PC deacylation/reacylation pathway (PC-DRP)**, generating GPC that can be reacylated by **Gpc1** to lyso-PC and by **Ale1** to PC, contributing to PC remodeling. | Loss of **Gpc1** shifts PC species toward more di-unsaturated forms; Gpc1 ER colocalization seen in **~85%** of cells. | (anaokar2019theglycerophosphocholineacyltransferase pages 1-2, hrach2023theacyltransferasegpc1 pages 1-2, hrach2023theacyltransferasegpc1 pages 2-4) |
+| Recent 2023–2024 pathway developments | Direct 2023–2024 NTE1-specific studies are sparse, but recent work strengthens the importance of the downstream PC-DRP branch in **ER bilayer homeostasis/UPR** and in fungal physiology. Gpc1 is UPR-regulated and loss of GPC1 triggers bilayer-stress signaling, refining the functional context in which NTE1-generated GPC is used. | **~85%** ER colocalization reported for Gpc1; **gpc1Δ** blocks GPC reincorporation into PC and induces UPR. | (hrach2023theacyltransferasegpc1 pages 1-2, king2024theglycerophosphocholineacyltransferase pages 1-2, hrach2023theacyltransferasegpc1 pages 2-4) |
+
+
+*Table: This table summarizes the main experimentally supported annotations for yeast NTE1/YML059C, including reaction, localization, regulation, pathway context, and quantitative findings. It is useful as a compact evidence map linking classic NTE1 studies to more recent PC-remodeling and ER-homeostasis work.*
+
+Two core figure-based results supporting localization and function are available directly from the primary paper:
+- **ER localization** of GFP-YML059C/Nte1p by fluorescence and immunogold EM. (zaccheo2004neuropathytargetesterase media 21adca93)
+- **Loss of GPC formation and altered PC turnover** in YML059C-null compared with wild type in radiolabel turnover experiments. (zaccheo2004neuropathytargetesterase media c7f4ddec)
+
+## 10) Summary functional annotation (evidence-weighted)
+**NTE1 (YML059C; UniProt Q04958) encodes Nte1p, an ER-localized patatin-like serine phospholipase/lysophospholipase that catalyzes complete deacylation of phosphatidylcholine to glycerophosphocholine plus free fatty acids.** Genetic deletion abolishes intracellular GPC production and substantially slows PC turnover, and Nte1p-driven PC deacylation functionally interfaces with Sec14p-regulated lipid homeostasis at the trafficking–metabolism nexus. NTE1 also serves as the initiating step for the PC deacylation/reacylation remodeling pathway (PC-DRP) whose downstream arm (Gpc1/Ale1) has been linked in 2023–2024 work to ER membrane stress/UPR and fungal physiology, underscoring the broader importance of NTE1-generated GPC as a remodeling substrate. (glynn2005neuropathytargetesterase pages 2-4, zaccheo2004neuropathytargetesterase pages 7-9, murray2005nte1pmediateddeacylationof pages 3-4, hrach2023theacyltransferasegpc1 pages 1-2)
+
+## Evidence limitations (scope control)
+Within the retrieved 2023–2024 literature corpus, **direct NTE1-focused mechanistic updates in *S. cerevisiae*** were sparse; the most substantive recent advances affecting interpretation of NTE1’s biological role arise from **downstream PC-DRP work (Gpc1/Ale1; UPR/bilayer stress)** and from comparative fungal studies. (hrach2023theacyltransferasegpc1 pages 1-2, king2024theglycerophosphocholineacyltransferase pages 1-2)
+
+
+References
+
+1. (glynn2005neuropathytargetesterase pages 2-4): Paul Glynn. Neuropathy target esterase and phospholipid deacylation. Biochimica et biophysica acta, 1736 2:87-93, Sep 2005. URL: https://doi.org/10.1016/j.bbalip.2005.08.002, doi:10.1016/j.bbalip.2005.08.002. This article has 87 citations.
+
+2. (murray2005nte1pmediateddeacylationof pages 3-4): J. Pedro Fernández Murray and Christopher R. McMaster. Nte1p-mediated deacylation of phosphatidylcholine functionally interacts with sec14p*. Journal of Biological Chemistry, 280:8544-8552, Mar 2005. URL: https://doi.org/10.1074/jbc.m413999200, doi:10.1074/jbc.m413999200. This article has 56 citations and is from a domain leading peer-reviewed journal.
+
+3. (zaccheo2004neuropathytargetesterase pages 2-3): Oliver Zaccheo, David Dinsdale, Peter A. Meacock, and Paul Glynn. Neuropathy target esterase and its yeast homologue degrade phosphatidylcholine to glycerophosphocholine in living cells*. Journal of Biological Chemistry, 279:24024-24033, Jun 2004. URL: https://doi.org/10.1074/jbc.m400830200, doi:10.1074/jbc.m400830200. This article has 261 citations and is from a domain leading peer-reviewed journal.
+
+4. (zaccheo2004neuropathytargetesterase pages 1-1): Oliver Zaccheo, David Dinsdale, Peter A. Meacock, and Paul Glynn. Neuropathy target esterase and its yeast homologue degrade phosphatidylcholine to glycerophosphocholine in living cells*. Journal of Biological Chemistry, 279:24024-24033, Jun 2004. URL: https://doi.org/10.1074/jbc.m400830200, doi:10.1074/jbc.m400830200. This article has 261 citations and is from a domain leading peer-reviewed journal.
+
+5. (zaccheo2004neuropathytargetesterase pages 7-9): Oliver Zaccheo, David Dinsdale, Peter A. Meacock, and Paul Glynn. Neuropathy target esterase and its yeast homologue degrade phosphatidylcholine to glycerophosphocholine in living cells*. Journal of Biological Chemistry, 279:24024-24033, Jun 2004. URL: https://doi.org/10.1074/jbc.m400830200, doi:10.1074/jbc.m400830200. This article has 261 citations and is from a domain leading peer-reviewed journal.
+
+6. (anaokar2019theglycerophosphocholineacyltransferase pages 1-2): Sanket Anaokar, Ravindra Kodali, Benjamin Jonik, Mike F. Renne, Jos F.H.M. Brouwers, Ida Lager, Anton I.P.M. de Kroon, and Jana Patton-Vogt. The glycerophosphocholine acyltransferase gpc1 is part of a phosphatidylcholine (pc)-remodeling pathway that alters pc species in yeast. Journal of Biological Chemistry, 294:1189-1201, Jan 2019. URL: https://doi.org/10.1074/jbc.ra118.005232, doi:10.1074/jbc.ra118.005232. This article has 36 citations and is from a domain leading peer-reviewed journal.
+
+7. (hrach2023theacyltransferasegpc1 pages 1-2): Victoria Lee Hrach, William R. King, Laura D. Nelson, Shane Conklin, John A. Pollock, and Jana Patton-Vogt. The acyltransferase gpc1 is both a target and an effector of the unfolded protein response in saccharomyces cerevisiae. Journal of Biological Chemistry, 299:104884, Jul 2023. URL: https://doi.org/10.1016/j.jbc.2023.104884, doi:10.1016/j.jbc.2023.104884. This article has 3 citations and is from a domain leading peer-reviewed journal.
+
+8. (pattonvogt2020phospholipidturnoverand pages 3-4): Jana Patton-Vogt and Anton I.P.M. de Kroon. Phospholipid turnover and acyl chain remodeling in the yeast er. Biochimica et Biophysica Acta (BBA) - Molecular and Cell Biology of Lipids, 1865:158462, Jan 2020. URL: https://doi.org/10.1016/j.bbalip.2019.05.006, doi:10.1016/j.bbalip.2019.05.006. This article has 55 citations and is from a peer-reviewed journal.
+
+9. (zaccheo2004neuropathytargetesterase pages 4-5): Oliver Zaccheo, David Dinsdale, Peter A. Meacock, and Paul Glynn. Neuropathy target esterase and its yeast homologue degrade phosphatidylcholine to glycerophosphocholine in living cells*. Journal of Biological Chemistry, 279:24024-24033, Jun 2004. URL: https://doi.org/10.1074/jbc.m400830200, doi:10.1074/jbc.m400830200. This article has 261 citations and is from a domain leading peer-reviewed journal.
+
+10. (zaccheo2004neuropathytargetesterase pages 1-2): Oliver Zaccheo, David Dinsdale, Peter A. Meacock, and Paul Glynn. Neuropathy target esterase and its yeast homologue degrade phosphatidylcholine to glycerophosphocholine in living cells*. Journal of Biological Chemistry, 279:24024-24033, Jun 2004. URL: https://doi.org/10.1074/jbc.m400830200, doi:10.1074/jbc.m400830200. This article has 261 citations and is from a domain leading peer-reviewed journal.
+
+11. (zaccheo2004neuropathytargetesterase pages 3-4): Oliver Zaccheo, David Dinsdale, Peter A. Meacock, and Paul Glynn. Neuropathy target esterase and its yeast homologue degrade phosphatidylcholine to glycerophosphocholine in living cells*. Journal of Biological Chemistry, 279:24024-24033, Jun 2004. URL: https://doi.org/10.1074/jbc.m400830200, doi:10.1074/jbc.m400830200. This article has 261 citations and is from a domain leading peer-reviewed journal.
+
+12. (zaccheo2004neuropathytargetesterase pages 5-6): Oliver Zaccheo, David Dinsdale, Peter A. Meacock, and Paul Glynn. Neuropathy target esterase and its yeast homologue degrade phosphatidylcholine to glycerophosphocholine in living cells*. Journal of Biological Chemistry, 279:24024-24033, Jun 2004. URL: https://doi.org/10.1074/jbc.m400830200, doi:10.1074/jbc.m400830200. This article has 261 citations and is from a domain leading peer-reviewed journal.
+
+13. (zaccheo2004neuropathytargetesterase media 21adca93): Oliver Zaccheo, David Dinsdale, Peter A. Meacock, and Paul Glynn. Neuropathy target esterase and its yeast homologue degrade phosphatidylcholine to glycerophosphocholine in living cells*. Journal of Biological Chemistry, 279:24024-24033, Jun 2004. URL: https://doi.org/10.1074/jbc.m400830200, doi:10.1074/jbc.m400830200. This article has 261 citations and is from a domain leading peer-reviewed journal.
+
+14. (murray2005nte1pmediateddeacylationof pages 1-2): J. Pedro Fernández Murray and Christopher R. McMaster. Nte1p-mediated deacylation of phosphatidylcholine functionally interacts with sec14p*. Journal of Biological Chemistry, 280:8544-8552, Mar 2005. URL: https://doi.org/10.1074/jbc.m413999200, doi:10.1074/jbc.m413999200. This article has 56 citations and is from a domain leading peer-reviewed journal.
+
+15. (hrach2023theacyltransferasegpc1 pages 2-4): Victoria Lee Hrach, William R. King, Laura D. Nelson, Shane Conklin, John A. Pollock, and Jana Patton-Vogt. The acyltransferase gpc1 is both a target and an effector of the unfolded protein response in saccharomyces cerevisiae. Journal of Biological Chemistry, 299:104884, Jul 2023. URL: https://doi.org/10.1016/j.jbc.2023.104884, doi:10.1016/j.jbc.2023.104884. This article has 3 citations and is from a domain leading peer-reviewed journal.
+
+16. (king2024theglycerophosphocholineacyltransferase pages 1-2): William R. King, Justin Singer, Mitchell Warman, Duncan Wilson, Bernard Hube, Ida Lager, and Jana Patton-Vogt. The glycerophosphocholine acyltransferase gpc1 contributes to phosphatidylcholine biosynthesis, long-term viability, and embedded hyphal growth in candida albicans. Journal of Biological Chemistry, 300:105543, Jan 2024. URL: https://doi.org/10.1016/j.jbc.2023.105543, doi:10.1016/j.jbc.2023.105543. This article has 11 citations and is from a domain leading peer-reviewed journal.
+
+17. (jiang2024phospholipidbiosynthesisregulation pages 6-11): Xiao-ying Jiang, Xiya Hong, Zhulin Wang, Jun Liu, Haiyan Zhong, Jiali Ren, and Bo Zhou. Phospholipid biosynthesis regulation for improving pigment production by <i>monascus</i> in response to ammonium chloride stress. Applied and Environmental Microbiology, Oct 2024. URL: https://doi.org/10.1128/aem.01146-24, doi:10.1128/aem.01146-24. This article has 3 citations and is from a peer-reviewed journal.
+
+18. (zaccheo2004neuropathytargetesterase media c7f4ddec): Oliver Zaccheo, David Dinsdale, Peter A. Meacock, and Paul Glynn. Neuropathy target esterase and its yeast homologue degrade phosphatidylcholine to glycerophosphocholine in living cells*. Journal of Biological Chemistry, 279:24024-24033, Jun 2004. URL: https://doi.org/10.1074/jbc.m400830200, doi:10.1074/jbc.m400830200. This article has 261 citations and is from a domain leading peer-reviewed journal.
+
+## Citations
+
+1. zaccheo2004neuropathytargetesterase pages 7-9
+2. pattonvogt2020phospholipidturnoverand pages 3-4
+3. zaccheo2004neuropathytargetesterase pages 4-5
+4. anaokar2019theglycerophosphocholineacyltransferase pages 1-2
+5. king2024theglycerophosphocholineacyltransferase pages 1-2
+6. jiang2024phospholipidbiosynthesisregulation pages 6-11
+7. glynn2005neuropathytargetesterase pages 2-4
+8. zaccheo2004neuropathytargetesterase pages 2-3
+9. zaccheo2004neuropathytargetesterase pages 1-1
+10. zaccheo2004neuropathytargetesterase pages 1-2
+11. zaccheo2004neuropathytargetesterase pages 3-4
+12. zaccheo2004neuropathytargetesterase pages 5-6
+13. 14C
+14. https://doi.org/10.1016/j.jbc.2023.104884.
+15. https://doi.org/10.1016/j.jbc.2023.105543.
+16. https://doi.org/10.1128/aem.01146-24.
+17. https://doi.org/10.1016/j.bbalip.2005.08.002.
+18. https://doi.org/10.1016/j.bbalip.2005.08.002,
+19. https://doi.org/10.1074/jbc.m413999200,
+20. https://doi.org/10.1074/jbc.m400830200,
+21. https://doi.org/10.1074/jbc.ra118.005232,
+22. https://doi.org/10.1016/j.jbc.2023.104884,
+23. https://doi.org/10.1016/j.bbalip.2019.05.006,
+24. https://doi.org/10.1016/j.jbc.2023.105543,
+25. https://doi.org/10.1128/aem.01146-24,


### PR DESCRIPTION
## Summary

Adds Falcon deep research reports and integrates them into yeast gene reviews for:

- APJ1
- CPR6
- EUG1
- MDJ1
- NTE1

The YAML updates add Falcon report references, exact-source `supported_by` evidence snippets for key existing annotations/core functions, descriptions/core functions where missing, and refreshed rendered HTML. APJ1, CPR6, EUG1, and MDJ1 are moved to `COMPLETE`; NTE1 was already complete and now has Falcon support added.

## Validation

- `uv run python scripts/validate_deep_research.py genes/yeast/APJ1/APJ1-deep-research-falcon.md genes/yeast/CPR6/CPR6-deep-research-falcon.md genes/yeast/EUG1/EUG1-deep-research-falcon.md genes/yeast/MDJ1/MDJ1-deep-research-falcon.md genes/yeast/NTE1/NTE1-deep-research-falcon.md`
- `just validate yeast APJ1`
- `just validate yeast CPR6`
- `just validate yeast EUG1`
- `just validate yeast MDJ1`
- `just validate yeast NTE1`
- `just render yeast APJ1`
- `just render yeast CPR6`
- `just render yeast EUG1`
- `just render yeast MDJ1`
- `just render yeast NTE1`
- `git diff --check`

Notes: validation passes. APJ1 and EUG1 retain non-fatal pre-existing best-practice warnings for older accepted PMID-backed annotations lacking `supported_by`.