### PR TITLE
Add Falcon deep research reviews for TOMM6, TOMM5, and MTX1

### DIFF
--- a/genes/human/MTX1/MTX1-ai-review.html
+++ b/genes/human/MTX1/MTX1-ai-review.html
@@ -1,0 +1,3085 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>MTX1 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>MTX1</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q13505" target="_blank" class="term-link">
+                        Q13505
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "MTX1";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q13505" data-a="DESCRIPTION: MTX1 (metaxin-1) is a non-enzymatic mitochondrial ..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>MTX1 (metaxin-1) is a non-enzymatic mitochondrial outer membrane metaxin-family accessory subunit of the mammalian SAM complex. Its best-supported core role is structural support of SAM-mediated insertion and assembly of beta-barrel outer membrane proteins such as VDACs and TOM40, with additional non-core links to MIB/MICOS-associated organization and mitochondrial quality control.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045040" target="_blank" class="term-link">
+                                    GO:0045040
+                                </a>
+                            </span>
+                            <span class="term-label">protein insertion into mitochondrial outer membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q13505" data-a="GO:0045040" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct phylogenetic inference. MTX1 is an accessory SAM subunit involved in SAM-mediated insertion/assembly of beta-barrel proteins into the mitochondrial outer membrane.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MTX1/MTX1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">MTX1 is best supported as an **accessory subunit of the mitochondrial Sorting and Assembly Machinery (SAM)** required for efficient **import/assembly of β-barrel proteins** into the OMM</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070096" target="_blank" class="term-link">
+                                    GO:0070096
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial outer membrane translocase complex assembly</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q13505" data-a="GO:0070096" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Accepted as a SAM-related assembly role. MTX1 supports assembly of beta-barrel outer membrane proteins, including TOM complex components such as TOM40, rather than acting as a catalytic enzyme.
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001401" target="_blank" class="term-link">
+                                    GO:0001401
+                                </a>
+                            </span>
+                            <span class="term-label">SAM complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q13505" data-a="GO:0001401" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct. MTX1 is a metaxin-family accessory subunit of the mammalian SAM complex with SAMM50, MTX2, and MTX3.
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001401" target="_blank" class="term-link">
+                                    GO:0001401
+                                </a>
+                            </span>
+                            <span class="term-label">SAM complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q13505" data-a="GO:0001401" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct InterPro-derived complex annotation. The Falcon review identifies MTX1 as a mammalian SAM complex accessory subunit.
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005741" target="_blank" class="term-link">
+                                    GO:0005741
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial outer membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q13505" data-a="GO:0005741" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct UniProt-derived localization. MTX1 is an outer mitochondrial membrane SAM/metaxin protein.
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                    GO:0016020
+                                </a>
+                            </span>
+                            <span class="term-label">membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q13505" data-a="GO:0016020" data-r="GO_REF:0000044" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct but overly general. MTX1 is specifically localized to the mitochondrial outer membrane and SAM complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Subsumed by mitochondrial outer membrane and SAM complex annotations.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007595" target="_blank" class="term-link">
+                                    GO:0007595
+                                </a>
+                            </span>
+                            <span class="term-label">lactation</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="Q13505" data-a="GO:0007595" data-r="GO_REF:0000107" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> This automatic orthology transfer does not match the synthesized function of human MTX1 as a mitochondrial SAM accessory factor. Falcon research did not identify MTX1-specific evidence for lactation as a gene-level core process.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Unsupported organism-level phenotype transfer; not part of the curated MTX1 mitochondrial SAM function.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001401" target="_blank" class="term-link">
+                                    GO:0001401
+                                </a>
+                            </span>
+                            <span class="term-label">SAM complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/17510655" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:17510655
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Conserved roles of Sam50 and metaxins in VDAC biogenesis.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q13505" data-a="GO:0001401" data-r="PMID:17510655" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Accepted. Conserved roles of metaxins and Sam50 in VDAC biogenesis support MTX1 membership in the SAM complex.
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005741" target="_blank" class="term-link">
+                                    GO:0005741
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial outer membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/31387448" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:31387448
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mitochondria-hubs for regulating cellular biochemistry: emer...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q13505" data-a="GO:0005741" data-r="PMID:31387448" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Accepted. MTX1 is consistently described as a mitochondrial outer membrane metaxin/SAM component.
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045040" target="_blank" class="term-link">
+                                    GO:0045040
+                                </a>
+                            </span>
+                            <span class="term-label">protein insertion into mitochondrial outer membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/31387448" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:31387448
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mitochondria-hubs for regulating cellular biochemistry: emer...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q13505" data-a="GO:0045040" data-r="PMID:31387448" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Accepted as the core MTX1 process. MTX1 acts as a non-catalytic accessory factor for SAM-mediated insertion/assembly of beta-barrel proteins into the mitochondrial outer membrane.
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HTP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:34800366
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Quantitative high-confidence human mitochondrial proteome an...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q13505" data-a="GO:0005739" data-r="PMID:34800366" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct but too general. MTX1 is specifically localized to the mitochondrial outer membrane and SAM complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Subsumed by mitochondrial outer membrane and SAM complex annotations.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/31644573" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:31644573
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Armadillo repeat-containing protein 1 is a dual localization...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="Q13505" data-a="GO:0005515" data-r="PMID:31644573" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Protein binding is too generic to represent MTX1 function. The relevant biology is membership in SAM and non-core association with MIB/MICOS-linked assemblies.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Generic protein binding is uninformative; complex membership and mitochondrial assembly terms capture the supported function.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001401" target="_blank" class="term-link">
+                                    GO:0001401
+                                </a>
+                            </span>
+                            <span class="term-label">SAM complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26477565" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:26477565
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Evolution and structural organization of the mitochondrial c...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q13505" data-a="GO:0001401" data-r="PMID:26477565" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Accepted. Affinity/proteomics evidence supports MTX1 in SAM-containing mitochondrial outer membrane assemblies.
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007007" target="_blank" class="term-link">
+                                    GO:0007007
+                                </a>
+                            </span>
+                            <span class="term-label">inner mitochondrial membrane organization</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IC</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26477565" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:26477565
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Evolution and structural organization of the mitochondrial c...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q13505" data-a="GO:0007007" data-r="PMID:26477565" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Plausible secondary consequence of MTX1 association with MIB/MICOS-linked assemblies, but not the primary curated function compared with SAM-mediated outer membrane beta-barrel biogenesis.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> MIB/MICOS-associated architecture is supported as an additional role, not the core MTX1 function.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140275" target="_blank" class="term-link">
+                                    GO:0140275
+                                </a>
+                            </span>
+                            <span class="term-label">MIB complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26477565" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:26477565
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Evolution and structural organization of the mitochondrial c...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q13505" data-a="GO:0140275" data-r="PMID:26477565" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Supported as an additional MTX1-associated complex context. Keep as non-core because the strongest synthesized function is SAM-mediated beta-barrel outer membrane protein biogenesis.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> MIB/MICOS association is secondary to the core SAM complex role.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                    GO:0016020
+                                </a>
+                            </span>
+                            <span class="term-label">membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8660965" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:8660965
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structure and organization of the human metaxin gene (MTX) a...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q13505" data-a="GO:0016020" data-r="PMID:8660965" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct but too general. MTX1 is specifically a mitochondrial outer membrane metaxin/SAM protein.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Subsumed by mitochondrial outer membrane and SAM complex annotations.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>MTX1 is a structural/accessory metaxin subunit of the mammalian SAM complex that supports insertion and assembly of beta-barrel proteins into the mitochondrial outer membrane.</h3>
+                <span class="vote-buttons" data-g="Q13505" data-a="FUNCTION: MTX1 is a structural/accessory metaxin subunit of ..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045040" target="_blank" class="term-link">
+                                protein insertion into mitochondrial outer membrane
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070096" target="_blank" class="term-link">
+                                mitochondrial outer membrane translocase complex assembly
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005741" target="_blank" class="term-link">
+                                mitochondrial outer membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001401" target="_blank" class="term-link">
+                            SAM complex
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/MTX1/MTX1-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">MTX1 is best supported as an **accessory subunit of the mitochondrial Sorting and Assembly Machinery (SAM)** required for efficient **import/assembly of β-barrel proteins** into the OMM</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/MTX1/MTX1-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">Mammalian SAM contains **SAMM50/SAM50** plus **MTX1, MTX2, MTX3**</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/MTX1/MTX1-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">MTX1 is an **outer mitochondrial membrane (OMM)** protein</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000107.md" target="_blank" class="term-link">
+                            GO_REF:0000107
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Automatic transfer of experimentally verified manual GO annotation data to orthologs using Ensembl Compara</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/17510655" target="_blank" class="term-link">
+                            PMID:17510655
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Conserved roles of Sam50 and metaxins in VDAC biogenesis.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/26477565" target="_blank" class="term-link">
+                            PMID:26477565
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Evolution and structural organization of the mitochondrial contact site (MICOS) complex and the mitochondrial intermembrane space bridging (MIB) complex.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/31387448" target="_blank" class="term-link">
+                            PMID:31387448
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Mitochondria-hubs for regulating cellular biochemistry: emerging concepts and networks.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/31644573" target="_blank" class="term-link">
+                            PMID:31644573
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Armadillo repeat-containing protein 1 is a dual localization protein associated with mitochondrial intermembrane space bridging complex.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link">
+                            PMID:34800366
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Quantitative high-confidence human mitochondrial proteome and its dynamics in cellular context.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/8660965" target="_blank" class="term-link">
+                            PMID:8660965
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Structure and organization of the human metaxin gene (MTX) and pseudogene.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/MTX1/MTX1-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research report for human MTX1</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Which human MTX1 surfaces are required for SAM-mediated VDAC/TOM40 beta-barrel assembly versus MIB/MICOS-associated interactions?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q13505" data-a="Q: Which human MTX1 surfaces are required for SAM-med..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Is MTX1 turnover by LC3C/p62-linked piecemeal mitophagy regulated by the same interfaces used for SAM complex assembly?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q13505" data-a="Q: Is MTX1 turnover by LC3C/p62-linked piecemeal mito..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Use endogenous MTX1 knockout/rescue with domain or interface mutants, then assay SAM complex assembly, VDAC1/TOM40 import and assembly, mitochondrial ultrastructure, and LC3C/p62-dependent MTX1 turnover.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: MTX1 contributes separable interfaces for SAM beta-barrel assembly and MIB/MICOS-associated mitochondrial architecture.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: endogenous rescue, import assay, and mitochondrial proteomics</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q13505" data-a="EXPERIMENT: Use endogenous MTX1 knockout/rescue with domain or..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Deep Research Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(MTX1-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q13505" data-a="DOC: Deep Research Falcon" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <hr />
+<p>provider: falcon<br />
+model: Edison Scientific Literature<br />
+cached: false<br />
+start_time: '2026-05-11T11:12:54.848400'<br />
+end_time: '2026-05-11T11:27:26.615390'<br />
+duration_seconds: 871.77<br />
+template_file: templates/gene_research_go_focused.md<br />
+template_variables:<br />
+  organism: human<br />
+  gene_id: MTX1<br />
+  gene_symbol: MTX1<br />
+  uniprot_accession: Q13505<br />
+  protein_description: 'RecName: Full=Metaxin-1; AltName: Full=Mitochondrial outer<br />
+    membrane import complex protein 1;'<br />
+  gene_info: Name=MTX1; Synonyms=MTX, MTXN;<br />
+  organism_full: Homo sapiens (Human).<br />
+  protein_family: Belongs to the metaxin family. .<br />
+  protein_domains: Glutathione-S-Trfase_C_sf. (IPR036282); Glutathione_S-Trfase. (IPR040079);<br />
+    Metaxin_GST. (IPR033468); Mito_Protein_Transport_Metaxin. (IPR050931); Sam37/metaxin_N.<br />
+    (IPR019564)<br />
+provider_config:<br />
+  timeout: 600<br />
+  max_retries: 3<br />
+  parameters:<br />
+    allowed_domains: []<br />
+    temperature: 0.1<br />
+citation_count: 30</p>
+<hr />
+<h2 id="question">Question</h2>
+<h1 id="gene-research-for-functional-annotation">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> Q13505</li>
+<li><strong>Protein Description:</strong> RecName: Full=Metaxin-1; AltName: Full=Mitochondrial outer membrane import complex protein 1;</li>
+<li><strong>Gene Information:</strong> Name=MTX1; Synonyms=MTX, MTXN;</li>
+<li><strong>Organism (full):</strong> Homo sapiens (Human).</li>
+<li><strong>Protein Family:</strong> Belongs to the metaxin family. .</li>
+<li><strong>Key Domains:</strong> Glutathione-S-Trfase_C_sf. (IPR036282); Glutathione_S-Trfase. (IPR040079); Metaxin_GST. (IPR033468); Mito_Protein_Transport_Metaxin. (IPR050931); Sam37/metaxin_N. (IPR019564)</li>
+</ul>
+<h3 id="mandatory-verification-steps">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "MTX1" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Homo sapiens (Human).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'MTX1' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>MTX1</strong> (gene ID: MTX1, UniProt: Q13505) in human.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="output">Output</h2>
+<p>Question: You are an expert researcher providing comprehensive, well-cited information.</p>
+<p>Provide detailed information focusing on:<br />
+1. Key concepts and definitions with current understanding<br />
+2. Recent developments and latest research (prioritize 2023-2024 sources)<br />
+3. Current applications and real-world implementations<br />
+4. Expert opinions and analysis from authoritative sources<br />
+5. Relevant statistics and data from recent studies</p>
+<p>Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.<br />
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.</p>
+<h1 id="gene-research-for-functional-annotation_1">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context_1">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot_1">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> Q13505</li>
+<li><strong>Protein Description:</strong> RecName: Full=Metaxin-1; AltName: Full=Mitochondrial outer membrane import complex protein 1;</li>
+<li><strong>Gene Information:</strong> Name=MTX1; Synonyms=MTX, MTXN;</li>
+<li><strong>Organism (full):</strong> Homo sapiens (Human).</li>
+<li><strong>Protein Family:</strong> Belongs to the metaxin family. .</li>
+<li><strong>Key Domains:</strong> Glutathione-S-Trfase_C_sf. (IPR036282); Glutathione_S-Trfase. (IPR040079); Metaxin_GST. (IPR033468); Mito_Protein_Transport_Metaxin. (IPR050931); Sam37/metaxin_N. (IPR019564)</li>
+</ul>
+<h3 id="mandatory-verification-steps_1">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "MTX1" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Homo sapiens (Human).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature_1">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'MTX1' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target_1">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>MTX1</strong> (gene ID: MTX1, UniProt: Q13505) in human.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="research-report-human-mtx1-metaxin-1-uniprot-q13505">Research Report: Human MTX1 (Metaxin-1; UniProt Q13505)</h2>
+<h3 id="0-target-verification-required-disambiguation">0) Target verification (required disambiguation)</h3>
+<p>The research target is <strong>human MTX1 (metaxin 1)</strong>, UniProt <strong>Q13505</strong>, a <strong>metaxin-family</strong> protein homologous to yeast <strong>Sam37/Tom37/Mas37</strong> and discussed in the literature as a <strong>mitochondrial outer membrane (OMM) factor</strong> involved in mitochondrial protein biogenesis—not an unrelated “MTX1” symbol from another organism or pathway. This identity is consistent across recent reviews of mitochondrial β‑barrel assembly and mitochondrial transport adaptor biology. (ganesan2024biogenesisofmitochondrial pages 2-4, zhao2021metaxinsarecore pages 1-2)</p>
+<hr />
+<h3 id="1-key-concepts-and-definitions-current-understanding">1) Key concepts and definitions (current understanding)</h3>
+<h4 id="11-what-mtx1-is-conceptual-definition">1.1 What MTX1 is (conceptual definition)</h4>
+<p><strong>Metaxin-1 (MTX1)</strong> is best understood as a <strong>non-enzymatic, structural/accessory component</strong> of the mammalian <strong>Sorting and Assembly Machinery (SAM)</strong> that supports <strong>biogenesis of mitochondrial outer-membrane β‑barrel proteins</strong>. In this context, MTX1 is not a classical glutathione S‑transferase enzyme despite GST-like domains; instead, it functions as part of a membrane protein assembly/import system. (ganesan2024biogenesisofmitochondrial pages 2-4)</p>
+<h4 id="12-the-barrel-importassembly-pathway-in-mitochondria">1.2 The β‑barrel import/assembly pathway in mitochondria</h4>
+<p>Mitochondrial β‑barrel proteins are nuclear-encoded and translated in the cytosol, then:<br />
+1) <strong>Targeted to and translocated across the OMM via the TOM complex</strong>, <br />
+2) <strong>Chaperoned through the intermembrane space by TIM transfer chaperones (e.g., Tim9/Tim10, Tim8/Tim13)</strong>, and <br />
+3) <strong>Inserted into the OMM by the SAM complex</strong>. (ganesan2024biogenesisofmitochondrial pages 2-4)</p>
+<p>A recent review emphasizes that SAM’s core subunit Sam50 (human SAMM50) assembles precursor β‑strands at a lateral gate via a <strong>Sam50–preprotein hybrid barrel</strong>, and releases the mature β‑barrel by a <strong>β‑barrel switching mechanism</strong>. (ganesan2024biogenesisofmitochondrial pages 1-2)</p>
+<h4 id="13-sam-complex-composition-in-mammals-including-mtx1">1.3 SAM complex composition in mammals (including MTX1)</h4>
+<p>A 2024 review explicitly lists the <strong>mammalian SAM complex</strong> components as <strong>SAMM50</strong> plus <strong>Metaxin-1 (MTX1; canonical sequence mass ~51 kDa), Metaxin-2 (MTX2; ~30 kDa), and Metaxin-3 (MTX3; ~35 kDa)</strong>. (ganesan2024biogenesisofmitochondrial pages 2-4)</p>
+<hr />
+<h3 id="2-subcellular-localization-and-complex-membership">2) Subcellular localization and complex membership</h3>
+<h4 id="21-mtx1-localizes-to-the-mitochondrial-outer-membrane">2.1 MTX1 localizes to the mitochondrial outer membrane</h4>
+<p>Across mechanistic reviews and pathway models, metaxins (including MTX1) are placed in the <strong>outer mitochondrial membrane protein import/assembly apparatus</strong>, consistent with a primary action site at the OMM. (ganesan2024biogenesisofmitochondrial pages 2-4)</p>
+<h4 id="22-mtx1-as-a-sam-accessory-subunit-and-a-hub-associated-factor">2.2 MTX1 as a SAM accessory subunit and a hub-associated factor</h4>
+<p>A key theme in recent mechanistic synthesis is that <strong>SAM is not only a β‑barrel insertase</strong> but also <strong>a hub for interactions between mitochondrial outer and inner membrane complexes</strong>, including physical and functional coupling with TOM and contacts with MICOS/MIB. (ganesan2024biogenesisofmitochondrial pages 1-2)</p>
+<hr />
+<h3 id="3-primary-molecular-function-of-mtx1-functional-annotation">3) Primary molecular function of MTX1 (functional annotation)</h3>
+<h4 id="31-functional-role-barrel-protein-biogenesis-not-a-catalytic-enzyme">3.1 Functional role: β‑barrel protein biogenesis (not a catalytic enzyme)</h4>
+<p>MTX1’s primary functional annotation is as an accessory component of <strong>SAM-mediated insertion/assembly of β‑barrel OMM proteins</strong> (e.g., VDACs and TOM40). (ganesan2024biogenesisofmitochondrial pages 2-4)</p>
+<h4 id="32-likely-substrates-and-pathway-placement">3.2 Likely substrates and pathway placement</h4>
+<p>A 2024 review lists canonical mammalian SAM substrates including <strong>SAMM50, TOMM40, VDAC1/2/3</strong> (β‑barrel proteins) and provides a mechanistic pathway diagram tying TOM→TIM chaperones→SAM insertion. MTX1 sits in this pathway as part of the mammalian SAM complex composition rather than as a substrate itself in this table. (ganesan2024biogenesisofmitochondrial pages 2-4)</p>
+<hr />
+<h3 id="4-recent-developments-and-latest-research-prioritized-20232024">4) Recent developments and latest research (prioritized 2023–2024)</h3>
+<h4 id="41-2024-review-update-mechanistic-model-of-barrel-assembly-and-sam-as-interaction-hub">4.1 2024 review update: mechanistic model of β‑barrel assembly and SAM as interaction hub</h4>
+<p>The 2024 FEBS Open Bio review emphasizes two points relevant to MTX1 annotation: (i) <strong>mammalian SAM includes MTX1/2/3</strong>, and (ii) the SAM complex is increasingly viewed as an <strong>interaction hub</strong> linking β‑barrel biogenesis to broader mitochondrial organization (including TOM supercomplexes and MICOS/MIB contact-site biology). (ganesan2024biogenesisofmitochondrial pages 1-2, ganesan2024biogenesisofmitochondrial pages 2-4)</p>
+<h4 id="42-2024-cancer-proteomics-mtx1-as-part-of-an-enhanced-mitochondrial-importbiogenesis-signature">4.2 2024 cancer proteomics: MTX1 as part of an “enhanced mitochondrial import/biogenesis” signature</h4>
+<p>A 2024 letter analyzing proteomic data from melanoma lymph node metastases reports that <strong>mitochondrial dynamics and biogenesis are enhanced in BRAF V600E-mutated metastatic melanomas</strong>, citing <strong>upregulation of Metaxin‑1 and Metaxin‑2 (MTX1/2)</strong> and TOM import-associated proteins in that context. The study uses cohorts including <strong>127 metastasis samples</strong> overall and analyzes BRAF-status subsets (e.g., 78 with known BRAF status) and a progression-focused subset of <strong>88 metastases</strong>, using enrichment analyses (e.g., volcano plots with <strong>FDR &lt; 0.02</strong>). (almeida2024mitochondrialdysfunctionand pages 1-4, almeida2024mitochondrialdysfunctionand media 1ca45a9d, almeida2024mitochondrialdysfunctionand media 3236bfaf, almeida2024mitochondrialdysfunctionand media 09168aed, almeida2024mitochondrialdysfunctionand media efcaeb08)</p>
+<p><em>Interpretation:</em> This work does not demonstrate MTX1 mechanism directly, but it reflects <strong>real-world, large-cohort proteomics</strong> where MTX1 abundance tracks with mitochondrial import/biogenesis states in tumors. (almeida2024mitochondrialdysfunctionand pages 1-4, almeida2024mitochondrialdysfunctionand media 1ca45a9d)</p>
+<h4 id="43-2024-clinical-genetics-context-indirect-mtx1-relevance-via-mtx2">4.3 2024 clinical genetics context (indirect MTX1 relevance via MTX2)</h4>
+<p>A 2024 case report on <strong>MTX2-associated mandibuloacral dysplasia progeroid syndrome (MADaM)</strong> provides clinical context that MTX2 encodes an OMM protein and situates MADaM as due to recessive MTX2 mutations; MTX2 is repeatedly described in the literature as tightly partnered with MTX1 in OMM biology. (fu2024casereporta pages 1-2)</p>
+<hr />
+<h3 id="5-mtx1-interaction-partners-and-connected-pathways">5) MTX1 interaction partners and connected pathways</h3>
+<h4 id="51-mtx1mtx2-partnership-and-sam-context">5.1 MTX1–MTX2 partnership and SAM context</h4>
+<p>Metaxins (MTX1/2) are repeatedly treated as a functional pair in SAM-related biology and mitochondrial trafficking. In a metaxin-focused transport study, the authors explicitly state that the metaxin complex (metaxin1 = Sam37/Tom37 homolog; metaxin2 = Sam35/Tom38/Tob38 homolog) functions with SAM50 to form SAM for β‑barrel insertion. (zhao2021metaxinsarecore pages 1-2)</p>
+<h4 id="52-mitochondrial-trafficking-adaptor-biology-conserved-with-human-neuron-relevance">5.2 Mitochondrial trafficking adaptor biology (conserved, with human-neuron relevance)</h4>
+<p>A high-impact study on mitochondrial transport adaptor complexes reports that metaxins <strong>bind MIRO and kinesin/dynein adaptor machinery</strong> in <em>C. elegans</em> neurons and that <strong>metaxin homologs are also required for mitochondrial transport in human iPSC-derived neurons</strong>, indicating evolutionary conservation of a trafficking-related role for metaxins at the OMM. (zhao2021metaxinsarecore pages 1-2)</p>
+<p><em>Note:</em> This evidence supports a metaxin-family role in trafficking; it is not MTX1-only human biochemistry. (zhao2021metaxinsarecore pages 1-2)</p>
+<hr />
+<h3 id="6-mtx1-in-selective-autophagymitophagy-mechanistic-primary-evidence">6) MTX1 in selective autophagy/mitophagy (mechanistic primary evidence)</h3>
+<p>Although MTX1’s primary annotation is SAM accessory function, there is strong mechanistic evidence that MTX1 can also be a <strong>selective mitophagy cargo</strong> under basal “piecemeal mitophagy” conditions.</p>
+<h4 id="61-lc3c-dependent-piecemeal-mitophagy-identifies-mtx1-as-cargo-primary-evidence">6.1 LC3C-dependent piecemeal mitophagy identifies MTX1 as cargo (primary evidence)</h4>
+<p>A primary study (“Autophagosomal content profiling…”, 2017) used APEX2-tagged LC3C proximity labeling plus proteinase K protection and quantitative MS, identifying <strong>1,147</strong> protK-protected candidate autophagosomal substrates, including <strong>762 proteins in LC3C-labelled samples</strong>, and identifying <strong>MTX1</strong> among LC3C-positive autophagosomal cargo candidates. The authors report replicate correlation (Pearson <strong>0.7</strong>) and identify a large MTX1-associated set in the LC3C proximity labeling context (including a set of <strong>560</strong> protK-protected biotinylated proteins in the MTX1-associated analysis described in the excerpt). (guerroue2017autophagosomalcontentprofiling pages 4-6, guerroue2017autophagosomalcontentprofiling pages 8-10)</p>
+<p>Mechanistically, they present multiple lines of evidence consistent with MTX1 being delivered to lysosomes via a <strong>basal, Parkin-independent, LC3C- and p62-associated pathway</strong>, including: MTX1 colocalization with LC3C and lysosomal markers; increased MTX1 abundance upon LC3C knockdown and lysosomal protease inhibition; and mapping of non-canonical LIR motifs enabling MTX1 binding to hATG8 proteins. (guerroue2017autophagosomalcontentprofiling pages 6-8)</p>
+<h4 id="62-samm50p62-pathway-for-basal-mitophagy-of-sammicos-components-implicates-mtx1">6.2 SAMM50/p62 pathway for basal mitophagy of SAM/MICOS components implicates MTX1</h4>
+<p>A 2021 Journal of Cell Biology paper extends this concept by showing that SAMM50 (SAM core) acts with <strong>p62</strong> to mediate <strong>piecemeal basal- and OXPHOS-induced mitophagy</strong> of SAM/MICOS components. It reports quantitative binding affinities of SAMM50 to hATG8 proteins (including LC3C) with <strong>Kd values ~10–57 μM</strong>, and discusses MTX1 as strongly interacting with hATG8 proteins; the authors propose a mechanism where SAMM50–hATG8 binding can permit strong MTX1 binding to the same hATG8. (abudu2021samm50actswith pages 12-14)</p>
+<p>Additionally, direct interaction relationships among SAM components and p62 are described, supporting a mechanistic route by which MTX1 can be recognized in a piecemeal mitophagy quality-control pathway at SAM/MICOS sites. (abudu2021samm50actswith pages 2-4)</p>
+<p><em>Interpretation:</em> These studies suggest MTX1 can be both (i) a <strong>core biogenesis factor</strong> at the OMM and (ii) a <strong>regulated quality-control cargo</strong>, consistent with SAM/MICOS acting as a mitochondrial homeostasis hub. (ganesan2024biogenesisofmitochondrial pages 1-2, guerroue2017autophagosomalcontentprofiling pages 6-8, abudu2021samm50actswith pages 12-14)</p>
+<hr />
+<h3 id="7-current-applications-and-real-world-implementations">7) Current applications and real-world implementations</h3>
+<h4 id="71-systems-biology-proteomics-biomarkers-of-mitochondrial-states-in-cancer">7.1 Systems biology / proteomics biomarkers of mitochondrial states in cancer</h4>
+<p>In metastatic melanoma proteomics, MTX1/2 appear as part of a signature of enhanced mitochondrial dynamics/biogenesis/import. This is a real-world implementation of mitochondrial proteome profiling to stratify disease biology and potential therapeutic vulnerabilities (metabolism and immune suppression). (almeida2024mitochondrialdysfunctionand pages 1-4, almeida2024mitochondrialdysfunctionand media 1ca45a9d)</p>
+<h4 id="72-clinical-genetics-adjacent-relevance">7.2 Clinical genetics (adjacent relevance)</h4>
+<p>While MTX1 itself is not the direct diagnostic gene in the cited 2024 case report, <strong>MTX2-related disease</strong> provides clinically actionable insight into the metaxin/SAM axis (with MTX1 often discussed as functionally interdependent with MTX2 in OMM biology). (fu2024casereporta pages 1-2)</p>
+<h4 id="73-neuronal-mitochondrial-distribution-models">7.3 Neuronal mitochondrial distribution models</h4>
+<p>Metaxin-dependent mitochondrial transport is studied in genetically tractable organisms and translated to <strong>human iPSC-derived neurons</strong>, providing a model system for evaluating mitochondrial trafficking defects relevant to neurodegeneration. (zhao2021metaxinsarecore pages 1-2)</p>
+<hr />
+<h3 id="8-relevant-statistics-and-data-points-recent-studies-emphasized">8) Relevant statistics and data points (recent studies emphasized)</h3>
+<ul>
+<li><strong>Mammalian SAM composition &amp; sizes:</strong> MTX1 listed as ~<strong>51 kDa</strong> (canonical isoform) in a 2024 review table of SAM components. (ganesan2024biogenesisofmitochondrial pages 2-4)</li>
+<li><strong>Melanoma proteomics cohorts (2024):</strong> 127 total metastasis samples; 78 with known BRAF status (45 BRAF V600E, 33 WT); progression analysis on 88 lymph node metastases (54 progressed vs 34 non-progressed). (almeida2024mitochondrialdysfunctionand pages 1-4)</li>
+<li><strong>Significance threshold in pathway enrichment (2024 melanoma):</strong> volcano plot enrichment analysis used <strong>FDR &lt; 0.02</strong>. (almeida2024mitochondrialdysfunctionand pages 1-4)</li>
+<li><strong>MASLD prevalence statistic (2024 liver mitophagy review):</strong> MASLD affects approximately <strong>one-third of the global population</strong> (used here as disease-burden context for mitophagy relevance). (chen2024livercellmitophagy pages 1-2)</li>
+<li><strong>Autophagosomal content profiling (2017; foundational for MTX1 autophagy biology):</strong> 1,147 protK-protected autophagosomal substrate candidates; 762 in LC3C-labelled set; Pearson correlation 0.7; MTX1-associated analysis included 560 protK-protected biotinylated proteins (as described in excerpt). (guerroue2017autophagosomalcontentprofiling pages 4-6, guerroue2017autophagosomalcontentprofiling pages 8-10)</li>
+<li><strong>SAMM50–hATG8 affinity (2021 JCB):</strong> Kd values reported in the range <strong>10–57 μM</strong> for SAMM50 binding to multiple hATG8s including LC3C. (abudu2021samm50actswith pages 12-14)</li>
+</ul>
+<hr />
+<h3 id="9-expert-synthesis-and-analysis-authoritative-interpretation">9) Expert synthesis and analysis (authoritative interpretation)</h3>
+<p>The strongest, most consistently supported annotation for <strong>human MTX1 (Q13505)</strong> is that it is an <strong>OMM metaxin-family assembly factor</strong> functioning as an accessory component of mammalian <strong>SAM</strong> for <strong>β‑barrel membrane protein biogenesis</strong>, positioned at the terminal insertion/assembly step downstream of TOM import and TIM chaperoning. (ganesan2024biogenesisofmitochondrial pages 2-4)</p>
+<p>Two broader expert-level themes emerge from recent authoritative reviews and mechanistic studies:<br />
+1) <strong>SAM is increasingly conceptualized as an interaction hub</strong>, physically and functionally coupled to other mitochondrial architectural systems (TOM, MICOS/MIB), implying that MTX1 perturbations could influence more than just β‑barrel insertion (e.g., membrane contacts and organelle architecture). (ganesan2024biogenesisofmitochondrial pages 1-2)<br />
+2) <strong>MTX1 can be selectively turned over by piecemeal/basal mitophagy pathways</strong>, especially those involving LC3C/p62 and SAMM50 at SAM/MICOS sites, suggesting an endogenous quality-control axis acting on the same machinery responsible for building the OMM. (guerroue2017autophagosomalcontentprofiling pages 6-8, abudu2021samm50actswith pages 12-14)</p>
+<hr />
+<h3 id="summary-table">Summary table</h3>
+<p>The following table provides a compact reference linking MTX1’s localization, function, complexes, interactions, phenotypes, and evidence types.</p>
+<table>
+<thead>
+<tr>
+<th>Aspect</th>
+<th>Summary for human MTX1 (Metaxin-1; UniProt Q13505)</th>
+<th>Key evidence / methods</th>
+<th>Most relevant citations</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Identity</td>
+<td>Human <strong>MTX1 / Metaxin-1</strong> is a metaxin-family protein, homologous to yeast <strong>Sam37/Tom37/Mas37</strong>, and is discussed in the context of mitochondrial outer membrane protein import rather than an unrelated MTX1 symbol.</td>
+<td>Comparative/functional review synthesis; orthology assignments; mitochondrial import literature.</td>
+<td>2024, <em>FEBS Open Bio</em>, https://doi.org/10.1002/2211-5463.13905 (ganesan2024biogenesisofmitochondrial pages 1-2, ganesan2024biogenesisofmitochondrial pages 2-4); 2021, <em>Nature Communications</em>, https://doi.org/10.1038/s41467-020-20346-2 (zhao2021metaxinsarecore pages 1-2)</td>
+</tr>
+<tr>
+<td>Subcellular localization</td>
+<td>MTX1 is an <strong>outer mitochondrial membrane (OMM)</strong> protein; recent reviews place metaxins among cytosolically exposed SAM peripheral subunits on the OMM. MTX1 also appears in OMM-associated higher-order assemblies linked to MICOS/MIB.</td>
+<td>Review of mitochondrial β-barrel biogenesis; BN-PAGE/assembly-state analysis; affinity-enrichment MS; mitochondrial isolation.</td>
+<td>2024, <em>FEBS Open Bio</em>, https://doi.org/10.1002/2211-5463.13905 (ganesan2024biogenesisofmitochondrial pages 1-2, ganesan2024biogenesisofmitochondrial pages 2-4); 2026, <em>bioRxiv</em>, https://doi.org/10.64898/2026.03.15.711473 (morf2026characterizationofhuman pages 1-4, morf2026characterizationofhuman pages 11-14)</td>
+</tr>
+<tr>
+<td>Primary molecular function</td>
+<td>MTX1 is best supported as an <strong>accessory subunit of the mitochondrial Sorting and Assembly Machinery (SAM)</strong> required for efficient <strong>import/assembly of β-barrel proteins</strong> into the OMM; this is a structural/assembly role, not an enzymatic catalytic activity.</td>
+<td>In vitro [35S]-import/assembly assays for VDAC1 and TOM40; mitochondrial proteomics; knockout/complementation.</td>
+<td>2024, <em>FEBS Open Bio</em>, https://doi.org/10.1002/2211-5463.13905 (ganesan2024biogenesisofmitochondrial pages 1-2, ganesan2024biogenesisofmitochondrial pages 2-4); 2026, <em>bioRxiv</em>, https://doi.org/10.64898/2026.03.15.711473 (morf2026characterizationofhuman pages 1-4, morf2026characterizationofhuman pages 4-8)</td>
+</tr>
+<tr>
+<td>Pathway context</td>
+<td>β-barrel precursors are synthesized in the cytosol, pass through <strong>TOM</strong>, are escorted across the intermembrane space by <strong>TIM chaperones</strong>, and are inserted into the OMM by <strong>SAM</strong>. MTX1 functions at the terminal OMM assembly step with SAM50/metaxins.</td>
+<td>Mechanistic pathway review and model figure synthesis.</td>
+<td>2024, <em>FEBS Open Bio</em>, https://doi.org/10.1002/2211-5463.13905 (ganesan2024biogenesisofmitochondrial pages 1-2, ganesan2024biogenesisofmitochondrial pages 2-4)</td>
+</tr>
+<tr>
+<td>Key complex: SAM</td>
+<td>Mammalian SAM contains <strong>SAMM50/SAM50</strong> plus <strong>MTX1, MTX2, MTX3</strong>; MTX1 is one of the peripheral/accessory SAM components linked to β-barrel membrane protein insertion.</td>
+<td>Review synthesis; KO/assembly analysis in human cells.</td>
+<td>2024, <em>FEBS Open Bio</em>, https://doi.org/10.1002/2211-5463.13905 (ganesan2024biogenesisofmitochondrial pages 2-4); 2026, <em>bioRxiv</em>, https://doi.org/10.64898/2026.03.15.711473 (morf2026characterizationofhuman pages 1-4, morf2026characterizationofhuman pages 4-8)</td>
+</tr>
+<tr>
+<td>Key complex: MIB / MICOS-associated assemblies</td>
+<td>MTX1 is also positioned in <strong>MIB (mitochondrial intermembrane space bridging) / MICOS-associated</strong> assemblies, supporting a role at outer–inner membrane contact architecture in addition to β-barrel biogenesis.</td>
+<td>BN-PAGE co-migration; affinity-enrichment MS; review context on SAM as interaction hub.</td>
+<td>2026, <em>bioRxiv</em>, https://doi.org/10.64898/2026.03.15.711473 (morf2026characterizationofhuman pages 1-4, morf2026characterizationofhuman pages 11-14, morf2026characterizationofhuman pages 14-17); 2024, <em>FEBS Open Bio</em>, https://doi.org/10.1002/2211-5463.13905 (ganesan2024biogenesisofmitochondrial pages 1-2)</td>
+</tr>
+<tr>
+<td>Interaction partner: MTX2</td>
+<td><strong>MTX2</strong> is the most consistently supported partner. MTX2 is required for <strong>steady-state stability of MTX1</strong> in human cells, although MTX1 can assemble/import independently of MTX2. Clinical MTX2 deficiency is reported to secondarily reduce MTX1 protein levels.</td>
+<td>CRISPR KO + immunoblot/BN-PAGE/complementation; clinical genetics review/case report.</td>
+<td>2026, <em>bioRxiv</em>, https://doi.org/10.64898/2026.03.15.711473 (morf2026characterizationofhuman pages 4-8, morf2026characterizationofhuman pages 11-14); 2024, <em>Frontiers in Endocrinology</em>, https://doi.org/10.3389/fendo.2024.1345067 (fu2024casereporta pages 1-2)</td>
+</tr>
+<tr>
+<td>Interaction partner: SAMM50 / SAM50</td>
+<td>MTX1 is functionally and physically linked to <strong>SAM50</strong>, consistent with membership in SAM-containing OMM assemblies.</td>
+<td>SAM-complex biochemical characterization; review of mammalian SAM composition.</td>
+<td>2024, <em>FEBS Open Bio</em>, https://doi.org/10.1002/2211-5463.13905 (ganesan2024biogenesisofmitochondrial pages 2-4); 2026, <em>bioRxiv</em>, https://doi.org/10.64898/2026.03.15.711473 (morf2026characterizationofhuman pages 1-4, morf2026characterizationofhuman pages 4-8)</td>
+</tr>
+<tr>
+<td>Interaction partners: TOM components</td>
+<td>Functionally, MTX1 loss impairs <strong>TOM40</strong> biogenesis/steady-state abundance, fitting a role in β-barrel assembly. Direct stable interaction with TOM receptors is less consistent: older work and reviews connect metaxins to TOM/SAM handoff, but one recent human interactome dataset did <strong>not</strong> enrich TOM20/TOM22 with FLAG-MTX1.</td>
+<td>[35S]-TOM40 import assays; steady-state proteomics; affinity-enrichment MS.</td>
+<td>2026, <em>bioRxiv</em>, https://doi.org/10.64898/2026.03.15.711473 (morf2026characterizationofhuman pages 14-17, morf2026characterizationofhuman pages 4-8); 2024, <em>FEBS Open Bio</em>, https://doi.org/10.1002/2211-5463.13905 (ganesan2024biogenesisofmitochondrial pages 1-2, ganesan2024biogenesisofmitochondrial pages 2-4)</td>
+</tr>
+<tr>
+<td>Interaction partners: MICOS/MIB-associated factors</td>
+<td>MTX1 interactomes are enriched for <strong>DNAJC11, ARMC1, TMEM11, CARD19</strong>, and other MIB/MICOS-associated factors, arguing that part of MTX1 biology extends beyond minimal SAM composition.</td>
+<td>Affinity-enrichment mass spectrometry; BN-PAGE co-migration.</td>
+<td>2026, <em>bioRxiv</em>, https://doi.org/10.64898/2026.03.15.711473 (morf2026characterizationofhuman pages 11-14, morf2026characterizationofhuman pages 14-17)</td>
+</tr>
+<tr>
+<td>Interaction partners: MIRO / trafficking machinery</td>
+<td>Metaxins are reported as core components of mitochondrial <strong>transport adaptor complexes</strong>. In neurons, MTX proteins associate with <strong>MIRO</strong>, <strong>KLC/kinesin light chain</strong>, and <strong>TRAK</strong>-containing transport machinery; this is strongest in nonhuman systems plus human-neuron conservation, while human MTX1-specific biochemical detail remains limited. Recent human MTX1 interactomes also enriched <strong>MIRO1/MIRO2</strong>.</td>
+<td>Genetics/biochemistry in <em>C. elegans</em> and human iPSC-derived neurons; AE-MS in human cells.</td>
+<td>2021, <em>Nature Communications</em>, https://doi.org/10.1038/s41467-020-20346-2 (zhao2021metaxinsarecore pages 1-2); 2026, <em>bioRxiv</em>, https://doi.org/10.64898/2026.03.15.711473 (morf2026characterizationofhuman pages 11-14)</td>
+</tr>
+<tr>
+<td>Loss-of-function phenotypes</td>
+<td>Human MTX1 loss causes <strong>defective VDAC1 import/assembly</strong>, reduced <strong>TOM40</strong> levels, decreased overall mitochondrial protein abundance, <strong>reduced mitochondrial volume</strong>, punctate/swollen mitochondria, altered network interconnectivity, and abnormal mtDNA distribution; rescue is seen with FLAG-MTX1 re-expression.</td>
+<td>CRISPR/Cas9 KO in U2OS; mitochondrial proteomics; BN-PAGE; [35S]-import assays; TEM; complementation.</td>
+<td>2026, <em>bioRxiv</em>, https://doi.org/10.64898/2026.03.15.711473 (morf2026characterizationofhuman pages 14-17, morf2026characterizationofhuman pages 1-4, morf2026characterizationofhuman pages 4-8, morf2026characterizationofhuman pages 11-14)</td>
+</tr>
+<tr>
+<td>Roles beyond import</td>
+<td>2024 literature mainly treats MTX1 as an <strong>OMM protein import/mitochondrial homeostasis factor</strong>. Reviews also cite MTX1 as a <strong>cargo in LC3C-dependent piecemeal mitophagy</strong>, but this appears secondary to its primary import role. Proteomic studies in melanoma report <strong>upregulation of MTX1/2</strong> alongside mitochondrial biogenesis/import signatures in BRAF V600E metastases.</td>
+<td>Disease review; cancer proteomics; visual figure extraction for MTX1/2 upregulation statement.</td>
+<td>2024, <em>Antioxidants</em>, https://doi.org/10.3390/antiox13060729 (chen2024livercellmitophagy pages 1-2); 2024, <em>Clinical and Translational Medicine</em>, https://doi.org/10.1002/ctm2.1773 (almeida2024mitochondrialdysfunctionand pages 1-4, almeida2024mitochondrialdysfunctionand media 1ca45a9d, almeida2024mitochondrialdysfunctionand media 3236bfaf, almeida2024mitochondrialdysfunctionand media 09168aed, almeida2024mitochondrialdysfunctionand media efcaeb08)</td>
+</tr>
+<tr>
+<td>Current confidence</td>
+<td><strong>Highest-confidence annotation:</strong> MTX1 is a human mitochondrial OMM metaxin-family protein that acts mainly as a <strong>non-enzymatic accessory factor in SAM-mediated β-barrel protein biogenesis</strong>, with additional links to MICOS/MIB organization and mitochondrial trafficking/homeostasis.</td>
+<td>Convergent support across peer-reviewed reviews, mechanistic studies, and recent human-cell functional work.</td>
+<td>Synthesis of 2024 reviews and human-cell functional data (morf2026characterizationofhuman pages 1-4, morf2026characterizationofhuman pages 4-8, morf2026characterizationofhuman pages 11-14, ganesan2024biogenesisofmitochondrial pages 1-2, ganesan2024biogenesisofmitochondrial pages 2-4)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table compiles the main functional annotation points for human MTX1, including localization, molecular function, complex membership, interaction partners, and supporting evidence. It is useful as a compact reference linking each claim to the strongest available recent and foundational citations.</em></p>
+<hr />
+<h3 id="urls-and-publication-dates-key-sources-cited">URLs and publication dates (key sources cited)</h3>
+<ul>
+<li>Ganesan et al. <strong>Sep 2024</strong>. <em>FEBS Open Bio</em>. “Biogenesis of mitochondrial β‑barrel membrane proteins.” https://doi.org/10.1002/2211-5463.13905 (ganesan2024biogenesisofmitochondrial pages 1-2, ganesan2024biogenesisofmitochondrial pages 2-4)</li>
+<li>de Almeida et al. <strong>Accepted 8 Jul 2024</strong>. <em>Clinical and Translational Medicine</em>. “Mitochondrial dysfunction and immune suppression in BRAF V600E‑mutated metastatic melanoma.” https://doi.org/10.1002/ctm2.1773 (almeida2024mitochondrialdysfunctionand pages 1-4, almeida2024mitochondrialdysfunctionand media 1ca45a9d)</li>
+<li>Chen et al. <strong>Published 15 Jun 2024</strong>. <em>Antioxidants</em>. “Liver Cell Mitophagy in MASLD and Liver Fibrosis.” https://doi.org/10.3390/antiox13060729 (chen2024livercellmitophagy pages 1-2)</li>
+<li>Fu et al. <strong>Published 13 Mar 2024</strong>. <em>Frontiers in Endocrinology</em>. MTX2 MADaM case report. https://doi.org/10.3389/fendo.2024.1345067 (fu2024casereporta pages 1-2)</li>
+<li>Zhao et al. <strong>Jan 2021</strong>. <em>Nature Communications</em>. “Metaxins are core components of mitochondrial transport adaptor complexes.” https://doi.org/10.1038/s41467-020-20346-2 (zhao2021metaxinsarecore pages 1-2)</li>
+<li>Le Guerroué et al. <strong>Nov 2017</strong>. <em>Molecular Cell</em>. LC3C-dependent piecemeal mitophagy (MTX1 cargo). https://doi.org/10.1016/j.molcel.2017.10.029 (guerroue2017autophagosomalcontentprofiling pages 6-8)</li>
+<li>Abudu et al. <strong>May 2021</strong>. <em>Journal of Cell Biology</em>. SAMM50/p62 piecemeal mitophagy of SAM/MICOS (MTX1 implicated). https://doi.org/10.1083/jcb.202009092 (abudu2021samm50actswith pages 12-14)</li>
+</ul>
+<h3 id="notes-on-evidence-limitations">Notes on evidence limitations</h3>
+<p>Human-cell, MTX1-specific loss-of-function phenotypes in <strong>2023–2024</strong> primary literature were not prominent in the retrieved set; the most detailed mechanistic loss-of-function dataset available in this run is a 2026 preprint (used cautiously in the background table as supportive context but not required for the 2023–2024 emphasis). Accordingly, the most robust 2023–2024 MTX1 statements in this report come from authoritative reviews and large-cohort proteomics rather than MTX1-targeted genetic perturbation studies published in 2024. (ganesan2024biogenesisofmitochondrial pages 2-4, almeida2024mitochondrialdysfunctionand pages 1-4)</p>
+<p>References</p>
+<ol>
+<li>
+<p>(ganesan2024biogenesisofmitochondrial pages 2-4): Iniyan Ganesan, Jon V. Busto, Nikolaus Pfanner, and Nils Wiedemann. Biogenesis of mitochondrial β‐barrel membrane proteins. FEBS Open Bio, 14:1595-1609, Sep 2024. URL: https://doi.org/10.1002/2211-5463.13905, doi:10.1002/2211-5463.13905. This article has 20 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(zhao2021metaxinsarecore pages 1-2): Yinsuo Zhao, Eli Song, Wenjuan Wang, Chung-Han Hsieh, Xinnan Wang, Wei Feng, Xiangming Wang, and Kang Shen. Metaxins are core components of mitochondrial transport adaptor complexes. Nature Communications, Jan 2021. URL: https://doi.org/10.1038/s41467-020-20346-2, doi:10.1038/s41467-020-20346-2. This article has 112 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ganesan2024biogenesisofmitochondrial pages 1-2): Iniyan Ganesan, Jon V. Busto, Nikolaus Pfanner, and Nils Wiedemann. Biogenesis of mitochondrial β‐barrel membrane proteins. FEBS Open Bio, 14:1595-1609, Sep 2024. URL: https://doi.org/10.1002/2211-5463.13905, doi:10.1002/2211-5463.13905. This article has 20 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(almeida2024mitochondrialdysfunctionand pages 1-4): Natália Pinto de Almeida, Ágnes Judit Jánosi, Runyu Hong, Ahmad Rajeh, Fábio Nogueira, Leticia Szadai, Beata Szeitz, Indira Pla Parada, Viktória Doma, Nicole Woldmar, Jéssica Guedes, Zsuzsanna Újfaludi, Aron Bartha, Yonghyo Kim, Charlotte Welinder, Bo Baldetorp, Lajos Vince Kemény, Zoltan Pahi, Guihong Wan, Nga Nguyen, Tibor Pankotai, Balázs Győrffy, Krzysztof Pawłowski, Peter Horvatovich, Attila Marcell Szasz, Aniel Sanchez, Magdalena Kuras, Jimmy Rodriguez Murillo, Lazaro Betancourt, Gilberto B. Domont, Yevgeniy R. Semenov, Kun‐Hsing Yu, Ho Jeong Kwon, István Balázs Németh, David Fenyő, Elisabet Wieslander, György Marko‐Varga, and Jeovanis Gil. Mitochondrial dysfunction and immune suppression in braf v600e‐mutated metastatic melanoma. Clinical and Translational Medicine, Jul 2024. URL: https://doi.org/10.1002/ctm2.1773, doi:10.1002/ctm2.1773. This article has 5 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(almeida2024mitochondrialdysfunctionand media 1ca45a9d): Natália Pinto de Almeida, Ágnes Judit Jánosi, Runyu Hong, Ahmad Rajeh, Fábio Nogueira, Leticia Szadai, Beata Szeitz, Indira Pla Parada, Viktória Doma, Nicole Woldmar, Jéssica Guedes, Zsuzsanna Újfaludi, Aron Bartha, Yonghyo Kim, Charlotte Welinder, Bo Baldetorp, Lajos Vince Kemény, Zoltan Pahi, Guihong Wan, Nga Nguyen, Tibor Pankotai, Balázs Győrffy, Krzysztof Pawłowski, Peter Horvatovich, Attila Marcell Szasz, Aniel Sanchez, Magdalena Kuras, Jimmy Rodriguez Murillo, Lazaro Betancourt, Gilberto B. Domont, Yevgeniy R. Semenov, Kun‐Hsing Yu, Ho Jeong Kwon, István Balázs Németh, David Fenyő, Elisabet Wieslander, György Marko‐Varga, and Jeovanis Gil. Mitochondrial dysfunction and immune suppression in braf v600e‐mutated metastatic melanoma. Clinical and Translational Medicine, Jul 2024. URL: https://doi.org/10.1002/ctm2.1773, doi:10.1002/ctm2.1773. This article has 5 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(almeida2024mitochondrialdysfunctionand media 3236bfaf): Natália Pinto de Almeida, Ágnes Judit Jánosi, Runyu Hong, Ahmad Rajeh, Fábio Nogueira, Leticia Szadai, Beata Szeitz, Indira Pla Parada, Viktória Doma, Nicole Woldmar, Jéssica Guedes, Zsuzsanna Újfaludi, Aron Bartha, Yonghyo Kim, Charlotte Welinder, Bo Baldetorp, Lajos Vince Kemény, Zoltan Pahi, Guihong Wan, Nga Nguyen, Tibor Pankotai, Balázs Győrffy, Krzysztof Pawłowski, Peter Horvatovich, Attila Marcell Szasz, Aniel Sanchez, Magdalena Kuras, Jimmy Rodriguez Murillo, Lazaro Betancourt, Gilberto B. Domont, Yevgeniy R. Semenov, Kun‐Hsing Yu, Ho Jeong Kwon, István Balázs Németh, David Fenyő, Elisabet Wieslander, György Marko‐Varga, and Jeovanis Gil. Mitochondrial dysfunction and immune suppression in braf v600e‐mutated metastatic melanoma. Clinical and Translational Medicine, Jul 2024. URL: https://doi.org/10.1002/ctm2.1773, doi:10.1002/ctm2.1773. This article has 5 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(almeida2024mitochondrialdysfunctionand media 09168aed): Natália Pinto de Almeida, Ágnes Judit Jánosi, Runyu Hong, Ahmad Rajeh, Fábio Nogueira, Leticia Szadai, Beata Szeitz, Indira Pla Parada, Viktória Doma, Nicole Woldmar, Jéssica Guedes, Zsuzsanna Újfaludi, Aron Bartha, Yonghyo Kim, Charlotte Welinder, Bo Baldetorp, Lajos Vince Kemény, Zoltan Pahi, Guihong Wan, Nga Nguyen, Tibor Pankotai, Balázs Győrffy, Krzysztof Pawłowski, Peter Horvatovich, Attila Marcell Szasz, Aniel Sanchez, Magdalena Kuras, Jimmy Rodriguez Murillo, Lazaro Betancourt, Gilberto B. Domont, Yevgeniy R. Semenov, Kun‐Hsing Yu, Ho Jeong Kwon, István Balázs Németh, David Fenyő, Elisabet Wieslander, György Marko‐Varga, and Jeovanis Gil. Mitochondrial dysfunction and immune suppression in braf v600e‐mutated metastatic melanoma. Clinical and Translational Medicine, Jul 2024. URL: https://doi.org/10.1002/ctm2.1773, doi:10.1002/ctm2.1773. This article has 5 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(almeida2024mitochondrialdysfunctionand media efcaeb08): Natália Pinto de Almeida, Ágnes Judit Jánosi, Runyu Hong, Ahmad Rajeh, Fábio Nogueira, Leticia Szadai, Beata Szeitz, Indira Pla Parada, Viktória Doma, Nicole Woldmar, Jéssica Guedes, Zsuzsanna Újfaludi, Aron Bartha, Yonghyo Kim, Charlotte Welinder, Bo Baldetorp, Lajos Vince Kemény, Zoltan Pahi, Guihong Wan, Nga Nguyen, Tibor Pankotai, Balázs Győrffy, Krzysztof Pawłowski, Peter Horvatovich, Attila Marcell Szasz, Aniel Sanchez, Magdalena Kuras, Jimmy Rodriguez Murillo, Lazaro Betancourt, Gilberto B. Domont, Yevgeniy R. Semenov, Kun‐Hsing Yu, Ho Jeong Kwon, István Balázs Németh, David Fenyő, Elisabet Wieslander, György Marko‐Varga, and Jeovanis Gil. Mitochondrial dysfunction and immune suppression in braf v600e‐mutated metastatic melanoma. Clinical and Translational Medicine, Jul 2024. URL: https://doi.org/10.1002/ctm2.1773, doi:10.1002/ctm2.1773. This article has 5 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(fu2024casereporta pages 1-2): Xiaohui Fu, Shuli Chen, Xiao Huang, Qinghua Lu, Yunfei Cui, Weinan Lin, and Qin Yang. Case report: a novel splice-site mutation of mtx2 gene caused mandibuloacral dysplasia progeroid syndrome: the first report from china and literature review. Frontiers in Endocrinology, Mar 2024. URL: https://doi.org/10.3389/fendo.2024.1345067, doi:10.3389/fendo.2024.1345067. This article has 4 citations.</p>
+</li>
+<li>
+<p>(guerroue2017autophagosomalcontentprofiling pages 4-6): François Le Guerroué, Franziska Eck, Jennifer Jung, Tatjana Starzetz, Michel Mittelbronn, Manuel Kaulich, and Christian Behrends. Autophagosomal content profiling reveals an lc3c-dependent piecemeal mitophagy pathway. Molecular cell, 68 4:786-796.e6, Nov 2017. URL: https://doi.org/10.1016/j.molcel.2017.10.029, doi:10.1016/j.molcel.2017.10.029. This article has 171 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(guerroue2017autophagosomalcontentprofiling pages 8-10): François Le Guerroué, Franziska Eck, Jennifer Jung, Tatjana Starzetz, Michel Mittelbronn, Manuel Kaulich, and Christian Behrends. Autophagosomal content profiling reveals an lc3c-dependent piecemeal mitophagy pathway. Molecular cell, 68 4:786-796.e6, Nov 2017. URL: https://doi.org/10.1016/j.molcel.2017.10.029, doi:10.1016/j.molcel.2017.10.029. This article has 171 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(guerroue2017autophagosomalcontentprofiling pages 6-8): François Le Guerroué, Franziska Eck, Jennifer Jung, Tatjana Starzetz, Michel Mittelbronn, Manuel Kaulich, and Christian Behrends. Autophagosomal content profiling reveals an lc3c-dependent piecemeal mitophagy pathway. Molecular cell, 68 4:786-796.e6, Nov 2017. URL: https://doi.org/10.1016/j.molcel.2017.10.029, doi:10.1016/j.molcel.2017.10.029. This article has 171 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(abudu2021samm50actswith pages 12-14): Yakubu Princely Abudu, Birendra Kumar Shrestha, Wenxin Zhang, Anthimi Palara, Hanne Britt Brenne, Kenneth Bowitz Larsen, Deanna Lynn Wolfson, Gianina Dumitriu, Cristina Ionica Øie, Balpreet Singh Ahluwalia, Gahl Levy, Christian Behrends, Sharon A. Tooze, Stephane Mouilleron, Trond Lamark, and Terje Johansen. Samm50 acts with p62 in piecemeal basal- and oxphos-induced mitophagy of sam and micos components. Journal of Cell Biology, May 2021. URL: https://doi.org/10.1083/jcb.202009092, doi:10.1083/jcb.202009092. This article has 73 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(abudu2021samm50actswith pages 2-4): Yakubu Princely Abudu, Birendra Kumar Shrestha, Wenxin Zhang, Anthimi Palara, Hanne Britt Brenne, Kenneth Bowitz Larsen, Deanna Lynn Wolfson, Gianina Dumitriu, Cristina Ionica Øie, Balpreet Singh Ahluwalia, Gahl Levy, Christian Behrends, Sharon A. Tooze, Stephane Mouilleron, Trond Lamark, and Terje Johansen. Samm50 acts with p62 in piecemeal basal- and oxphos-induced mitophagy of sam and micos components. Journal of Cell Biology, May 2021. URL: https://doi.org/10.1083/jcb.202009092, doi:10.1083/jcb.202009092. This article has 73 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(chen2024livercellmitophagy pages 1-2): Jiaxin Chen, Linge Jian, Yangkun Guo, Chengwei Tang, Zhiyin Huang, and Jinhang Gao. Liver cell mitophagy in metabolic dysfunction-associated steatotic liver disease and liver fibrosis. Antioxidants, 13:729, Jun 2024. URL: https://doi.org/10.3390/antiox13060729, doi:10.3390/antiox13060729. This article has 27 citations.</p>
+</li>
+<li>
+<p>(morf2026characterizationofhuman pages 1-4): Sarah E. J. Morf, Matthew P. Challis, Sanjeev Uthishtran, Caitlin L. Rowe, Alice J. Sharpe, Natasha Kapoor-Kaushik, Senthil Arumugam, Luke E. Formosa, Kate McArthur, and Michael T. Ryan. Characterization of human metaxin proteins reveals functional diversification of sam37 homologs mtx1 and mtx3. bioRxiv, Mar 2026. URL: https://doi.org/10.64898/2026.03.15.711473, doi:10.64898/2026.03.15.711473. This article has 0 citations.</p>
+</li>
+<li>
+<p>(morf2026characterizationofhuman pages 11-14): Sarah E. J. Morf, Matthew P. Challis, Sanjeev Uthishtran, Caitlin L. Rowe, Alice J. Sharpe, Natasha Kapoor-Kaushik, Senthil Arumugam, Luke E. Formosa, Kate McArthur, and Michael T. Ryan. Characterization of human metaxin proteins reveals functional diversification of sam37 homologs mtx1 and mtx3. bioRxiv, Mar 2026. URL: https://doi.org/10.64898/2026.03.15.711473, doi:10.64898/2026.03.15.711473. This article has 0 citations.</p>
+</li>
+<li>
+<p>(morf2026characterizationofhuman pages 4-8): Sarah E. J. Morf, Matthew P. Challis, Sanjeev Uthishtran, Caitlin L. Rowe, Alice J. Sharpe, Natasha Kapoor-Kaushik, Senthil Arumugam, Luke E. Formosa, Kate McArthur, and Michael T. Ryan. Characterization of human metaxin proteins reveals functional diversification of sam37 homologs mtx1 and mtx3. bioRxiv, Mar 2026. URL: https://doi.org/10.64898/2026.03.15.711473, doi:10.64898/2026.03.15.711473. This article has 0 citations.</p>
+</li>
+<li>
+<p>(morf2026characterizationofhuman pages 14-17): Sarah E. J. Morf, Matthew P. Challis, Sanjeev Uthishtran, Caitlin L. Rowe, Alice J. Sharpe, Natasha Kapoor-Kaushik, Senthil Arumugam, Luke E. Formosa, Kate McArthur, and Michael T. Ryan. Characterization of human metaxin proteins reveals functional diversification of sam37 homologs mtx1 and mtx3. bioRxiv, Mar 2026. URL: https://doi.org/10.64898/2026.03.15.711473, doi:10.64898/2026.03.15.711473. This article has 0 citations.</p>
+</li>
+</ol>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>ganesan2024biogenesisofmitochondrial pages 2-4</li>
+<li>ganesan2024biogenesisofmitochondrial pages 1-2</li>
+<li>fu2024casereporta pages 1-2</li>
+<li>zhao2021metaxinsarecore pages 1-2</li>
+<li>guerroue2017autophagosomalcontentprofiling pages 6-8</li>
+<li>almeida2024mitochondrialdysfunctionand pages 1-4</li>
+<li>chen2024livercellmitophagy pages 1-2</li>
+<li>morf2026characterizationofhuman pages 11-14</li>
+<li>guerroue2017autophagosomalcontentprofiling pages 4-6</li>
+<li>guerroue2017autophagosomalcontentprofiling pages 8-10</li>
+<li>morf2026characterizationofhuman pages 1-4</li>
+<li>morf2026characterizationofhuman pages 4-8</li>
+<li>morf2026characterizationofhuman pages 14-17</li>
+<li>35S</li>
+<li>https://doi.org/10.1002/2211-5463.13905</li>
+<li>https://doi.org/10.1038/s41467-020-20346-2</li>
+<li>https://doi.org/10.64898/2026.03.15.711473</li>
+<li>https://doi.org/10.3389/fendo.2024.1345067</li>
+<li>https://doi.org/10.3390/antiox13060729</li>
+<li>https://doi.org/10.1002/ctm2.1773</li>
+<li>https://doi.org/10.1016/j.molcel.2017.10.029</li>
+<li>https://doi.org/10.1083/jcb.202009092</li>
+<li>https://doi.org/10.1002/2211-5463.13905,</li>
+<li>https://doi.org/10.1038/s41467-020-20346-2,</li>
+<li>https://doi.org/10.1002/ctm2.1773,</li>
+<li>https://doi.org/10.3389/fendo.2024.1345067,</li>
+<li>https://doi.org/10.1016/j.molcel.2017.10.029,</li>
+<li>https://doi.org/10.1083/jcb.202009092,</li>
+<li>https://doi.org/10.3390/antiox13060729,</li>
+<li>https://doi.org/10.64898/2026.03.15.711473,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q13505
+gene_symbol: MTX1
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: &gt;-
+  MTX1 (metaxin-1) is a non-enzymatic mitochondrial outer membrane metaxin-family
+  accessory subunit of the mammalian SAM complex. Its best-supported core role
+  is structural support of SAM-mediated insertion and assembly of beta-barrel
+  outer membrane proteins such as VDACs and TOM40, with additional non-core
+  links to MIB/MICOS-associated organization and mitochondrial quality control.
+alternative_products:
+- name: &#39;1&#39;
+  id: Q13505-1
+- name: &#39;2&#39;
+  id: Q13505-2
+  sequence_note: VSP_035742
+- name: &#39;3&#39;
+  id: Q13505-3
+  sequence_note: VSP_035741
+existing_annotations:
+- term:
+    id: GO:0045040
+    label: protein insertion into mitochondrial outer membrane
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: &gt;-
+      Correct phylogenetic inference. MTX1 is an accessory SAM subunit involved
+      in SAM-mediated insertion/assembly of beta-barrel proteins into the
+      mitochondrial outer membrane.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/MTX1/MTX1-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/MTX1/MTX1-deep-research-falcon.md
+      supporting_text: &#34;MTX1 is best supported as an **accessory subunit of the mitochondrial Sorting and Assembly Machinery (SAM)** required for efficient **import/assembly of β-barrel proteins** into the OMM&#34;
+- term:
+    id: GO:0070096
+    label: mitochondrial outer membrane translocase complex assembly
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: &gt;-
+      Accepted as a SAM-related assembly role. MTX1 supports assembly of
+      beta-barrel outer membrane proteins, including TOM complex components such
+      as TOM40, rather than acting as a catalytic enzyme.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/MTX1/MTX1-deep-research-falcon.md
+- term:
+    id: GO:0001401
+    label: SAM complex
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: &gt;-
+      Correct. MTX1 is a metaxin-family accessory subunit of the mammalian SAM
+      complex with SAMM50, MTX2, and MTX3.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/MTX1/MTX1-deep-research-falcon.md
+- term:
+    id: GO:0001401
+    label: SAM complex
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  review:
+    summary: &gt;-
+      Correct InterPro-derived complex annotation. The Falcon review identifies
+      MTX1 as a mammalian SAM complex accessory subunit.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/MTX1/MTX1-deep-research-falcon.md
+- term:
+    id: GO:0005741
+    label: mitochondrial outer membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  review:
+    summary: &gt;-
+      Correct UniProt-derived localization. MTX1 is an outer mitochondrial
+      membrane SAM/metaxin protein.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/MTX1/MTX1-deep-research-falcon.md
+- term:
+    id: GO:0016020
+    label: membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  review:
+    summary: &gt;-
+      Correct but overly general. MTX1 is specifically localized to the
+      mitochondrial outer membrane and SAM complex.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Subsumed by mitochondrial outer membrane and SAM complex annotations.
+    additional_reference_ids:
+    - file:human/MTX1/MTX1-deep-research-falcon.md
+- term:
+    id: GO:0007595
+    label: lactation
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  review:
+    summary: &gt;-
+      This automatic orthology transfer does not match the synthesized function
+      of human MTX1 as a mitochondrial SAM accessory factor. Falcon research did
+      not identify MTX1-specific evidence for lactation as a gene-level core
+      process.
+    action: REMOVE
+    reason: &gt;-
+      Unsupported organism-level phenotype transfer; not part of the curated
+      MTX1 mitochondrial SAM function.
+    additional_reference_ids:
+    - file:human/MTX1/MTX1-deep-research-falcon.md
+- term:
+    id: GO:0001401
+    label: SAM complex
+  evidence_type: IPI
+  original_reference_id: PMID:17510655
+  review:
+    summary: &gt;-
+      Accepted. Conserved roles of metaxins and Sam50 in VDAC biogenesis support
+      MTX1 membership in the SAM complex.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/MTX1/MTX1-deep-research-falcon.md
+- term:
+    id: GO:0005741
+    label: mitochondrial outer membrane
+  evidence_type: NAS
+  original_reference_id: PMID:31387448
+  review:
+    summary: &gt;-
+      Accepted. MTX1 is consistently described as a mitochondrial outer membrane
+      metaxin/SAM component.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/MTX1/MTX1-deep-research-falcon.md
+- term:
+    id: GO:0045040
+    label: protein insertion into mitochondrial outer membrane
+  evidence_type: NAS
+  original_reference_id: PMID:31387448
+  review:
+    summary: &gt;-
+      Accepted as the core MTX1 process. MTX1 acts as a non-catalytic accessory
+      factor for SAM-mediated insertion/assembly of beta-barrel proteins into
+      the mitochondrial outer membrane.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/MTX1/MTX1-deep-research-falcon.md
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: HTP
+  original_reference_id: PMID:34800366
+  review:
+    summary: &gt;-
+      Correct but too general. MTX1 is specifically localized to the
+      mitochondrial outer membrane and SAM complex.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Subsumed by mitochondrial outer membrane and SAM complex annotations.
+    additional_reference_ids:
+    - file:human/MTX1/MTX1-deep-research-falcon.md
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:31644573
+  review:
+    summary: &gt;-
+      Protein binding is too generic to represent MTX1 function. The relevant
+      biology is membership in SAM and non-core association with MIB/MICOS-linked
+      assemblies.
+    action: REMOVE
+    reason: &gt;-
+      Generic protein binding is uninformative; complex membership and
+      mitochondrial assembly terms capture the supported function.
+    additional_reference_ids:
+    - file:human/MTX1/MTX1-deep-research-falcon.md
+- term:
+    id: GO:0001401
+    label: SAM complex
+  evidence_type: HDA
+  original_reference_id: PMID:26477565
+  review:
+    summary: &gt;-
+      Accepted. Affinity/proteomics evidence supports MTX1 in SAM-containing
+      mitochondrial outer membrane assemblies.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/MTX1/MTX1-deep-research-falcon.md
+- term:
+    id: GO:0007007
+    label: inner mitochondrial membrane organization
+  evidence_type: IC
+  original_reference_id: PMID:26477565
+  review:
+    summary: &gt;-
+      Plausible secondary consequence of MTX1 association with MIB/MICOS-linked
+      assemblies, but not the primary curated function compared with SAM-mediated
+      outer membrane beta-barrel biogenesis.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      MIB/MICOS-associated architecture is supported as an additional role, not
+      the core MTX1 function.
+    additional_reference_ids:
+    - file:human/MTX1/MTX1-deep-research-falcon.md
+- term:
+    id: GO:0140275
+    label: MIB complex
+  evidence_type: HDA
+  original_reference_id: PMID:26477565
+  review:
+    summary: &gt;-
+      Supported as an additional MTX1-associated complex context. Keep as
+      non-core because the strongest synthesized function is SAM-mediated
+      beta-barrel outer membrane protein biogenesis.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      MIB/MICOS association is secondary to the core SAM complex role.
+    additional_reference_ids:
+    - file:human/MTX1/MTX1-deep-research-falcon.md
+- term:
+    id: GO:0016020
+    label: membrane
+  evidence_type: TAS
+  original_reference_id: PMID:8660965
+  review:
+    summary: &gt;-
+      Correct but too general. MTX1 is specifically a mitochondrial outer
+      membrane metaxin/SAM protein.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Subsumed by mitochondrial outer membrane and SAM complex annotations.
+    additional_reference_ids:
+    - file:human/MTX1/MTX1-deep-research-falcon.md
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: GO_REF:0000107
+  title: Automatic transfer of experimentally verified manual GO annotation data to
+    orthologs using Ensembl Compara
+  findings: []
+- id: PMID:17510655
+  title: Conserved roles of Sam50 and metaxins in VDAC biogenesis.
+  findings: []
+- id: PMID:26477565
+  title: Evolution and structural organization of the mitochondrial contact site (MICOS)
+    complex and the mitochondrial intermembrane space bridging (MIB) complex.
+  findings: []
+- id: PMID:31387448
+  title: &#39;Mitochondria-hubs for regulating cellular biochemistry: emerging concepts
+    and networks.&#39;
+  findings: []
+- id: PMID:31644573
+  title: Armadillo repeat-containing protein 1 is a dual localization protein associated
+    with mitochondrial intermembrane space bridging complex.
+  findings: []
+- id: PMID:34800366
+  title: Quantitative high-confidence human mitochondrial proteome and its dynamics
+    in cellular context.
+  findings: []
+- id: PMID:8660965
+  title: Structure and organization of the human metaxin gene (MTX) and pseudogene.
+  findings: []
+- id: file:human/MTX1/MTX1-deep-research-falcon.md
+  title: Falcon deep research report for human MTX1
+  findings: []
+core_functions:
+- description: &gt;-
+    MTX1 is a structural/accessory metaxin subunit of the mammalian SAM complex
+    that supports insertion and assembly of beta-barrel proteins into the
+    mitochondrial outer membrane.
+  supported_by:
+  - reference_id: file:human/MTX1/MTX1-deep-research-falcon.md
+    supporting_text: &#34;MTX1 is best supported as an **accessory subunit of the mitochondrial Sorting and Assembly Machinery (SAM)** required for efficient **import/assembly of β-barrel proteins** into the OMM&#34;
+  - reference_id: file:human/MTX1/MTX1-deep-research-falcon.md
+    supporting_text: &#34;Mammalian SAM contains **SAMM50/SAM50** plus **MTX1, MTX2, MTX3**&#34;
+  - reference_id: file:human/MTX1/MTX1-deep-research-falcon.md
+    supporting_text: &#34;MTX1 is an **outer mitochondrial membrane (OMM)** protein&#34;
+  directly_involved_in:
+  - id: GO:0045040
+    label: protein insertion into mitochondrial outer membrane
+  - id: GO:0070096
+    label: mitochondrial outer membrane translocase complex assembly
+  locations:
+  - id: GO:0005741
+    label: mitochondrial outer membrane
+  in_complex:
+    id: GO:0001401
+    label: SAM complex
+proposed_new_terms: []
+suggested_questions:
+- question: &gt;-
+    Which human MTX1 surfaces are required for SAM-mediated VDAC/TOM40
+    beta-barrel assembly versus MIB/MICOS-associated interactions?
+  experts: []
+- question: &gt;-
+    Is MTX1 turnover by LC3C/p62-linked piecemeal mitophagy regulated by the same
+    interfaces used for SAM complex assembly?
+  experts: []
+suggested_experiments:
+- hypothesis: &gt;-
+    MTX1 contributes separable interfaces for SAM beta-barrel assembly and
+    MIB/MICOS-associated mitochondrial architecture.
+  description: &gt;-
+    Use endogenous MTX1 knockout/rescue with domain or interface mutants, then
+    assay SAM complex assembly, VDAC1/TOM40 import and assembly, mitochondrial
+    ultrastructure, and LC3C/p62-dependent MTX1 turnover.
+  experiment_type: endogenous rescue, import assay, and mitochondrial proteomics
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/human/MTX1/MTX1-ai-review.yaml
+++ b/genes/human/MTX1/MTX1-ai-review.yaml
@@ -1,11 +1,16 @@
 id: Q13505
 gene_symbol: MTX1
 product_type: PROTEIN
-status: INITIALIZED
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
-description: 'TODO: Add description for MTX1'
+description: >-
+  MTX1 (metaxin-1) is a non-enzymatic mitochondrial outer membrane metaxin-family
+  accessory subunit of the mammalian SAM complex. Its best-supported core role
+  is structural support of SAM-mediated insertion and assembly of beta-barrel
+  outer membrane proteins such as VDACs and TOM40, with additional non-core
+  links to MIB/MICOS-associated organization and mitochondrial quality control.
 alternative_products:
 - name: '1'
   id: Q13505-1
@@ -22,128 +27,217 @@ existing_annotations:
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Correct phylogenetic inference. MTX1 is an accessory SAM subunit involved
+      in SAM-mediated insertion/assembly of beta-barrel proteins into the
+      mitochondrial outer membrane.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/MTX1/MTX1-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/MTX1/MTX1-deep-research-falcon.md
+      supporting_text: "MTX1 is best supported as an **accessory subunit of the mitochondrial Sorting and Assembly Machinery (SAM)** required for efficient **import/assembly of β-barrel proteins** into the OMM"
 - term:
     id: GO:0070096
     label: mitochondrial outer membrane translocase complex assembly
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Accepted as a SAM-related assembly role. MTX1 supports assembly of
+      beta-barrel outer membrane proteins, including TOM complex components such
+      as TOM40, rather than acting as a catalytic enzyme.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/MTX1/MTX1-deep-research-falcon.md
 - term:
     id: GO:0001401
     label: SAM complex
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Correct. MTX1 is a metaxin-family accessory subunit of the mammalian SAM
+      complex with SAMM50, MTX2, and MTX3.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/MTX1/MTX1-deep-research-falcon.md
 - term:
     id: GO:0001401
     label: SAM complex
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Correct InterPro-derived complex annotation. The Falcon review identifies
+      MTX1 as a mammalian SAM complex accessory subunit.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/MTX1/MTX1-deep-research-falcon.md
 - term:
     id: GO:0005741
     label: mitochondrial outer membrane
   evidence_type: IEA
   original_reference_id: GO_REF:0000044
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Correct UniProt-derived localization. MTX1 is an outer mitochondrial
+      membrane SAM/metaxin protein.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/MTX1/MTX1-deep-research-falcon.md
 - term:
     id: GO:0016020
     label: membrane
   evidence_type: IEA
   original_reference_id: GO_REF:0000044
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Correct but overly general. MTX1 is specifically localized to the
+      mitochondrial outer membrane and SAM complex.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Subsumed by mitochondrial outer membrane and SAM complex annotations.
+    additional_reference_ids:
+    - file:human/MTX1/MTX1-deep-research-falcon.md
 - term:
     id: GO:0007595
     label: lactation
   evidence_type: IEA
   original_reference_id: GO_REF:0000107
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      This automatic orthology transfer does not match the synthesized function
+      of human MTX1 as a mitochondrial SAM accessory factor. Falcon research did
+      not identify MTX1-specific evidence for lactation as a gene-level core
+      process.
+    action: REMOVE
+    reason: >-
+      Unsupported organism-level phenotype transfer; not part of the curated
+      MTX1 mitochondrial SAM function.
+    additional_reference_ids:
+    - file:human/MTX1/MTX1-deep-research-falcon.md
 - term:
     id: GO:0001401
     label: SAM complex
   evidence_type: IPI
   original_reference_id: PMID:17510655
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Accepted. Conserved roles of metaxins and Sam50 in VDAC biogenesis support
+      MTX1 membership in the SAM complex.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/MTX1/MTX1-deep-research-falcon.md
 - term:
     id: GO:0005741
     label: mitochondrial outer membrane
   evidence_type: NAS
   original_reference_id: PMID:31387448
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Accepted. MTX1 is consistently described as a mitochondrial outer membrane
+      metaxin/SAM component.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/MTX1/MTX1-deep-research-falcon.md
 - term:
     id: GO:0045040
     label: protein insertion into mitochondrial outer membrane
   evidence_type: NAS
   original_reference_id: PMID:31387448
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Accepted as the core MTX1 process. MTX1 acts as a non-catalytic accessory
+      factor for SAM-mediated insertion/assembly of beta-barrel proteins into
+      the mitochondrial outer membrane.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/MTX1/MTX1-deep-research-falcon.md
 - term:
     id: GO:0005739
     label: mitochondrion
   evidence_type: HTP
   original_reference_id: PMID:34800366
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Correct but too general. MTX1 is specifically localized to the
+      mitochondrial outer membrane and SAM complex.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Subsumed by mitochondrial outer membrane and SAM complex annotations.
+    additional_reference_ids:
+    - file:human/MTX1/MTX1-deep-research-falcon.md
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:31644573
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Protein binding is too generic to represent MTX1 function. The relevant
+      biology is membership in SAM and non-core association with MIB/MICOS-linked
+      assemblies.
+    action: REMOVE
+    reason: >-
+      Generic protein binding is uninformative; complex membership and
+      mitochondrial assembly terms capture the supported function.
+    additional_reference_ids:
+    - file:human/MTX1/MTX1-deep-research-falcon.md
 - term:
     id: GO:0001401
     label: SAM complex
   evidence_type: HDA
   original_reference_id: PMID:26477565
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Accepted. Affinity/proteomics evidence supports MTX1 in SAM-containing
+      mitochondrial outer membrane assemblies.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/MTX1/MTX1-deep-research-falcon.md
 - term:
     id: GO:0007007
     label: inner mitochondrial membrane organization
   evidence_type: IC
   original_reference_id: PMID:26477565
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Plausible secondary consequence of MTX1 association with MIB/MICOS-linked
+      assemblies, but not the primary curated function compared with SAM-mediated
+      outer membrane beta-barrel biogenesis.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      MIB/MICOS-associated architecture is supported as an additional role, not
+      the core MTX1 function.
+    additional_reference_ids:
+    - file:human/MTX1/MTX1-deep-research-falcon.md
 - term:
     id: GO:0140275
     label: MIB complex
   evidence_type: HDA
   original_reference_id: PMID:26477565
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Supported as an additional MTX1-associated complex context. Keep as
+      non-core because the strongest synthesized function is SAM-mediated
+      beta-barrel outer membrane protein biogenesis.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      MIB/MICOS association is secondary to the core SAM complex role.
+    additional_reference_ids:
+    - file:human/MTX1/MTX1-deep-research-falcon.md
 - term:
     id: GO:0016020
     label: membrane
   evidence_type: TAS
   original_reference_id: PMID:8660965
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Correct but too general. MTX1 is specifically a mitochondrial outer
+      membrane metaxin/SAM protein.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Subsumed by mitochondrial outer membrane and SAM complex annotations.
+    additional_reference_ids:
+    - file:human/MTX1/MTX1-deep-research-falcon.md
 references:
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO
@@ -183,3 +277,48 @@ references:
 - id: PMID:8660965
   title: Structure and organization of the human metaxin gene (MTX) and pseudogene.
   findings: []
+- id: file:human/MTX1/MTX1-deep-research-falcon.md
+  title: Falcon deep research report for human MTX1
+  findings: []
+core_functions:
+- description: >-
+    MTX1 is a structural/accessory metaxin subunit of the mammalian SAM complex
+    that supports insertion and assembly of beta-barrel proteins into the
+    mitochondrial outer membrane.
+  supported_by:
+  - reference_id: file:human/MTX1/MTX1-deep-research-falcon.md
+    supporting_text: "MTX1 is best supported as an **accessory subunit of the mitochondrial Sorting and Assembly Machinery (SAM)** required for efficient **import/assembly of β-barrel proteins** into the OMM"
+  - reference_id: file:human/MTX1/MTX1-deep-research-falcon.md
+    supporting_text: "Mammalian SAM contains **SAMM50/SAM50** plus **MTX1, MTX2, MTX3**"
+  - reference_id: file:human/MTX1/MTX1-deep-research-falcon.md
+    supporting_text: "MTX1 is an **outer mitochondrial membrane (OMM)** protein"
+  directly_involved_in:
+  - id: GO:0045040
+    label: protein insertion into mitochondrial outer membrane
+  - id: GO:0070096
+    label: mitochondrial outer membrane translocase complex assembly
+  locations:
+  - id: GO:0005741
+    label: mitochondrial outer membrane
+  in_complex:
+    id: GO:0001401
+    label: SAM complex
+proposed_new_terms: []
+suggested_questions:
+- question: >-
+    Which human MTX1 surfaces are required for SAM-mediated VDAC/TOM40
+    beta-barrel assembly versus MIB/MICOS-associated interactions?
+  experts: []
+- question: >-
+    Is MTX1 turnover by LC3C/p62-linked piecemeal mitophagy regulated by the same
+    interfaces used for SAM complex assembly?
+  experts: []
+suggested_experiments:
+- hypothesis: >-
+    MTX1 contributes separable interfaces for SAM beta-barrel assembly and
+    MIB/MICOS-associated mitochondrial architecture.
+  description: >-
+    Use endogenous MTX1 knockout/rescue with domain or interface mutants, then
+    assay SAM complex assembly, VDAC1/TOM40 import and assembly, mitochondrial
+    ultrastructure, and LC3C/p62-dependent MTX1 turnover.
+  experiment_type: endogenous rescue, import assay, and mitochondrial proteomics

--- a/genes/human/MTX1/MTX1-deep-research-falcon.md
+++ b/genes/human/MTX1/MTX1-deep-research-falcon.md
@@ -1,0 +1,370 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-11T11:12:54.848400'
+end_time: '2026-05-11T11:27:26.615390'
+duration_seconds: 871.77
+template_file: templates/gene_research_go_focused.md
+template_variables:
+  organism: human
+  gene_id: MTX1
+  gene_symbol: MTX1
+  uniprot_accession: Q13505
+  protein_description: 'RecName: Full=Metaxin-1; AltName: Full=Mitochondrial outer
+    membrane import complex protein 1;'
+  gene_info: Name=MTX1; Synonyms=MTX, MTXN;
+  organism_full: Homo sapiens (Human).
+  protein_family: Belongs to the metaxin family. .
+  protein_domains: Glutathione-S-Trfase_C_sf. (IPR036282); Glutathione_S-Trfase. (IPR040079);
+    Metaxin_GST. (IPR033468); Mito_Protein_Transport_Metaxin. (IPR050931); Sam37/metaxin_N.
+    (IPR019564)
+provider_config:
+  timeout: 600
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 30
+---
+
+## Question
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** Q13505
+- **Protein Description:** RecName: Full=Metaxin-1; AltName: Full=Mitochondrial outer membrane import complex protein 1;
+- **Gene Information:** Name=MTX1; Synonyms=MTX, MTXN;
+- **Organism (full):** Homo sapiens (Human).
+- **Protein Family:** Belongs to the metaxin family. .
+- **Key Domains:** Glutathione-S-Trfase_C_sf. (IPR036282); Glutathione_S-Trfase. (IPR040079); Metaxin_GST. (IPR033468); Mito_Protein_Transport_Metaxin. (IPR050931); Sam37/metaxin_N. (IPR019564)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "MTX1" matches the protein description above**
+2. **Verify the organism is correct:** Homo sapiens (Human).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'MTX1' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **MTX1** (gene ID: MTX1, UniProt: Q13505) in human.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** Q13505
+- **Protein Description:** RecName: Full=Metaxin-1; AltName: Full=Mitochondrial outer membrane import complex protein 1;
+- **Gene Information:** Name=MTX1; Synonyms=MTX, MTXN;
+- **Organism (full):** Homo sapiens (Human).
+- **Protein Family:** Belongs to the metaxin family. .
+- **Key Domains:** Glutathione-S-Trfase_C_sf. (IPR036282); Glutathione_S-Trfase. (IPR040079); Metaxin_GST. (IPR033468); Mito_Protein_Transport_Metaxin. (IPR050931); Sam37/metaxin_N. (IPR019564)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "MTX1" matches the protein description above**
+2. **Verify the organism is correct:** Homo sapiens (Human).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'MTX1' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **MTX1** (gene ID: MTX1, UniProt: Q13505) in human.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Research Report: Human MTX1 (Metaxin-1; UniProt Q13505)
+
+### 0) Target verification (required disambiguation)
+The research target is **human MTX1 (metaxin 1)**, UniProt **Q13505**, a **metaxin-family** protein homologous to yeast **Sam37/Tom37/Mas37** and discussed in the literature as a **mitochondrial outer membrane (OMM) factor** involved in mitochondrial protein biogenesis—not an unrelated “MTX1” symbol from another organism or pathway. This identity is consistent across recent reviews of mitochondrial β‑barrel assembly and mitochondrial transport adaptor biology. (ganesan2024biogenesisofmitochondrial pages 2-4, zhao2021metaxinsarecore pages 1-2)
+
+---
+
+### 1) Key concepts and definitions (current understanding)
+
+#### 1.1 What MTX1 is (conceptual definition)
+**Metaxin-1 (MTX1)** is best understood as a **non-enzymatic, structural/accessory component** of the mammalian **Sorting and Assembly Machinery (SAM)** that supports **biogenesis of mitochondrial outer-membrane β‑barrel proteins**. In this context, MTX1 is not a classical glutathione S‑transferase enzyme despite GST-like domains; instead, it functions as part of a membrane protein assembly/import system. (ganesan2024biogenesisofmitochondrial pages 2-4)
+
+#### 1.2 The β‑barrel import/assembly pathway in mitochondria
+Mitochondrial β‑barrel proteins are nuclear-encoded and translated in the cytosol, then:
+1) **Targeted to and translocated across the OMM via the TOM complex**,
+2) **Chaperoned through the intermembrane space by TIM transfer chaperones (e.g., Tim9/Tim10, Tim8/Tim13)**, and
+3) **Inserted into the OMM by the SAM complex**. (ganesan2024biogenesisofmitochondrial pages 2-4)
+
+A recent review emphasizes that SAM’s core subunit Sam50 (human SAMM50) assembles precursor β‑strands at a lateral gate via a **Sam50–preprotein hybrid barrel**, and releases the mature β‑barrel by a **β‑barrel switching mechanism**. (ganesan2024biogenesisofmitochondrial pages 1-2)
+
+#### 1.3 SAM complex composition in mammals (including MTX1)
+A 2024 review explicitly lists the **mammalian SAM complex** components as **SAMM50** plus **Metaxin-1 (MTX1; canonical sequence mass ~51 kDa), Metaxin-2 (MTX2; ~30 kDa), and Metaxin-3 (MTX3; ~35 kDa)**. (ganesan2024biogenesisofmitochondrial pages 2-4)
+
+---
+
+### 2) Subcellular localization and complex membership
+
+#### 2.1 MTX1 localizes to the mitochondrial outer membrane
+Across mechanistic reviews and pathway models, metaxins (including MTX1) are placed in the **outer mitochondrial membrane protein import/assembly apparatus**, consistent with a primary action site at the OMM. (ganesan2024biogenesisofmitochondrial pages 2-4)
+
+#### 2.2 MTX1 as a SAM accessory subunit and a hub-associated factor
+A key theme in recent mechanistic synthesis is that **SAM is not only a β‑barrel insertase** but also **a hub for interactions between mitochondrial outer and inner membrane complexes**, including physical and functional coupling with TOM and contacts with MICOS/MIB. (ganesan2024biogenesisofmitochondrial pages 1-2)
+
+---
+
+### 3) Primary molecular function of MTX1 (functional annotation)
+
+#### 3.1 Functional role: β‑barrel protein biogenesis (not a catalytic enzyme)
+MTX1’s primary functional annotation is as an accessory component of **SAM-mediated insertion/assembly of β‑barrel OMM proteins** (e.g., VDACs and TOM40). (ganesan2024biogenesisofmitochondrial pages 2-4)
+
+#### 3.2 Likely substrates and pathway placement
+A 2024 review lists canonical mammalian SAM substrates including **SAMM50, TOMM40, VDAC1/2/3** (β‑barrel proteins) and provides a mechanistic pathway diagram tying TOM→TIM chaperones→SAM insertion. MTX1 sits in this pathway as part of the mammalian SAM complex composition rather than as a substrate itself in this table. (ganesan2024biogenesisofmitochondrial pages 2-4)
+
+---
+
+### 4) Recent developments and latest research (prioritized 2023–2024)
+
+#### 4.1 2024 review update: mechanistic model of β‑barrel assembly and SAM as interaction hub
+The 2024 FEBS Open Bio review emphasizes two points relevant to MTX1 annotation: (i) **mammalian SAM includes MTX1/2/3**, and (ii) the SAM complex is increasingly viewed as an **interaction hub** linking β‑barrel biogenesis to broader mitochondrial organization (including TOM supercomplexes and MICOS/MIB contact-site biology). (ganesan2024biogenesisofmitochondrial pages 1-2, ganesan2024biogenesisofmitochondrial pages 2-4)
+
+#### 4.2 2024 cancer proteomics: MTX1 as part of an “enhanced mitochondrial import/biogenesis” signature
+A 2024 letter analyzing proteomic data from melanoma lymph node metastases reports that **mitochondrial dynamics and biogenesis are enhanced in BRAF V600E-mutated metastatic melanomas**, citing **upregulation of Metaxin‑1 and Metaxin‑2 (MTX1/2)** and TOM import-associated proteins in that context. The study uses cohorts including **127 metastasis samples** overall and analyzes BRAF-status subsets (e.g., 78 with known BRAF status) and a progression-focused subset of **88 metastases**, using enrichment analyses (e.g., volcano plots with **FDR < 0.02**). (almeida2024mitochondrialdysfunctionand pages 1-4, almeida2024mitochondrialdysfunctionand media 1ca45a9d, almeida2024mitochondrialdysfunctionand media 3236bfaf, almeida2024mitochondrialdysfunctionand media 09168aed, almeida2024mitochondrialdysfunctionand media efcaeb08)
+
+*Interpretation:* This work does not demonstrate MTX1 mechanism directly, but it reflects **real-world, large-cohort proteomics** where MTX1 abundance tracks with mitochondrial import/biogenesis states in tumors. (almeida2024mitochondrialdysfunctionand pages 1-4, almeida2024mitochondrialdysfunctionand media 1ca45a9d)
+
+#### 4.3 2024 clinical genetics context (indirect MTX1 relevance via MTX2)
+A 2024 case report on **MTX2-associated mandibuloacral dysplasia progeroid syndrome (MADaM)** provides clinical context that MTX2 encodes an OMM protein and situates MADaM as due to recessive MTX2 mutations; MTX2 is repeatedly described in the literature as tightly partnered with MTX1 in OMM biology. (fu2024casereporta pages 1-2)
+
+---
+
+### 5) MTX1 interaction partners and connected pathways
+
+#### 5.1 MTX1–MTX2 partnership and SAM context
+Metaxins (MTX1/2) are repeatedly treated as a functional pair in SAM-related biology and mitochondrial trafficking. In a metaxin-focused transport study, the authors explicitly state that the metaxin complex (metaxin1 = Sam37/Tom37 homolog; metaxin2 = Sam35/Tom38/Tob38 homolog) functions with SAM50 to form SAM for β‑barrel insertion. (zhao2021metaxinsarecore pages 1-2)
+
+#### 5.2 Mitochondrial trafficking adaptor biology (conserved, with human-neuron relevance)
+A high-impact study on mitochondrial transport adaptor complexes reports that metaxins **bind MIRO and kinesin/dynein adaptor machinery** in *C. elegans* neurons and that **metaxin homologs are also required for mitochondrial transport in human iPSC-derived neurons**, indicating evolutionary conservation of a trafficking-related role for metaxins at the OMM. (zhao2021metaxinsarecore pages 1-2)
+
+*Note:* This evidence supports a metaxin-family role in trafficking; it is not MTX1-only human biochemistry. (zhao2021metaxinsarecore pages 1-2)
+
+---
+
+### 6) MTX1 in selective autophagy/mitophagy (mechanistic primary evidence)
+Although MTX1’s primary annotation is SAM accessory function, there is strong mechanistic evidence that MTX1 can also be a **selective mitophagy cargo** under basal “piecemeal mitophagy” conditions.
+
+#### 6.1 LC3C-dependent piecemeal mitophagy identifies MTX1 as cargo (primary evidence)
+A primary study (“Autophagosomal content profiling…”, 2017) used APEX2-tagged LC3C proximity labeling plus proteinase K protection and quantitative MS, identifying **1,147** protK-protected candidate autophagosomal substrates, including **762 proteins in LC3C-labelled samples**, and identifying **MTX1** among LC3C-positive autophagosomal cargo candidates. The authors report replicate correlation (Pearson **0.7**) and identify a large MTX1-associated set in the LC3C proximity labeling context (including a set of **560** protK-protected biotinylated proteins in the MTX1-associated analysis described in the excerpt). (guerroue2017autophagosomalcontentprofiling pages 4-6, guerroue2017autophagosomalcontentprofiling pages 8-10)
+
+Mechanistically, they present multiple lines of evidence consistent with MTX1 being delivered to lysosomes via a **basal, Parkin-independent, LC3C- and p62-associated pathway**, including: MTX1 colocalization with LC3C and lysosomal markers; increased MTX1 abundance upon LC3C knockdown and lysosomal protease inhibition; and mapping of non-canonical LIR motifs enabling MTX1 binding to hATG8 proteins. (guerroue2017autophagosomalcontentprofiling pages 6-8)
+
+#### 6.2 SAMM50/p62 pathway for basal mitophagy of SAM/MICOS components implicates MTX1
+A 2021 Journal of Cell Biology paper extends this concept by showing that SAMM50 (SAM core) acts with **p62** to mediate **piecemeal basal- and OXPHOS-induced mitophagy** of SAM/MICOS components. It reports quantitative binding affinities of SAMM50 to hATG8 proteins (including LC3C) with **Kd values ~10–57 μM**, and discusses MTX1 as strongly interacting with hATG8 proteins; the authors propose a mechanism where SAMM50–hATG8 binding can permit strong MTX1 binding to the same hATG8. (abudu2021samm50actswith pages 12-14)
+
+Additionally, direct interaction relationships among SAM components and p62 are described, supporting a mechanistic route by which MTX1 can be recognized in a piecemeal mitophagy quality-control pathway at SAM/MICOS sites. (abudu2021samm50actswith pages 2-4)
+
+*Interpretation:* These studies suggest MTX1 can be both (i) a **core biogenesis factor** at the OMM and (ii) a **regulated quality-control cargo**, consistent with SAM/MICOS acting as a mitochondrial homeostasis hub. (ganesan2024biogenesisofmitochondrial pages 1-2, guerroue2017autophagosomalcontentprofiling pages 6-8, abudu2021samm50actswith pages 12-14)
+
+---
+
+### 7) Current applications and real-world implementations
+
+#### 7.1 Systems biology / proteomics biomarkers of mitochondrial states in cancer
+In metastatic melanoma proteomics, MTX1/2 appear as part of a signature of enhanced mitochondrial dynamics/biogenesis/import. This is a real-world implementation of mitochondrial proteome profiling to stratify disease biology and potential therapeutic vulnerabilities (metabolism and immune suppression). (almeida2024mitochondrialdysfunctionand pages 1-4, almeida2024mitochondrialdysfunctionand media 1ca45a9d)
+
+#### 7.2 Clinical genetics (adjacent relevance)
+While MTX1 itself is not the direct diagnostic gene in the cited 2024 case report, **MTX2-related disease** provides clinically actionable insight into the metaxin/SAM axis (with MTX1 often discussed as functionally interdependent with MTX2 in OMM biology). (fu2024casereporta pages 1-2)
+
+#### 7.3 Neuronal mitochondrial distribution models
+Metaxin-dependent mitochondrial transport is studied in genetically tractable organisms and translated to **human iPSC-derived neurons**, providing a model system for evaluating mitochondrial trafficking defects relevant to neurodegeneration. (zhao2021metaxinsarecore pages 1-2)
+
+---
+
+### 8) Relevant statistics and data points (recent studies emphasized)
+
+- **Mammalian SAM composition & sizes:** MTX1 listed as ~**51 kDa** (canonical isoform) in a 2024 review table of SAM components. (ganesan2024biogenesisofmitochondrial pages 2-4)
+- **Melanoma proteomics cohorts (2024):** 127 total metastasis samples; 78 with known BRAF status (45 BRAF V600E, 33 WT); progression analysis on 88 lymph node metastases (54 progressed vs 34 non-progressed). (almeida2024mitochondrialdysfunctionand pages 1-4)
+- **Significance threshold in pathway enrichment (2024 melanoma):** volcano plot enrichment analysis used **FDR < 0.02**. (almeida2024mitochondrialdysfunctionand pages 1-4)
+- **MASLD prevalence statistic (2024 liver mitophagy review):** MASLD affects approximately **one-third of the global population** (used here as disease-burden context for mitophagy relevance). (chen2024livercellmitophagy pages 1-2)
+- **Autophagosomal content profiling (2017; foundational for MTX1 autophagy biology):** 1,147 protK-protected autophagosomal substrate candidates; 762 in LC3C-labelled set; Pearson correlation 0.7; MTX1-associated analysis included 560 protK-protected biotinylated proteins (as described in excerpt). (guerroue2017autophagosomalcontentprofiling pages 4-6, guerroue2017autophagosomalcontentprofiling pages 8-10)
+- **SAMM50–hATG8 affinity (2021 JCB):** Kd values reported in the range **10–57 μM** for SAMM50 binding to multiple hATG8s including LC3C. (abudu2021samm50actswith pages 12-14)
+
+---
+
+### 9) Expert synthesis and analysis (authoritative interpretation)
+The strongest, most consistently supported annotation for **human MTX1 (Q13505)** is that it is an **OMM metaxin-family assembly factor** functioning as an accessory component of mammalian **SAM** for **β‑barrel membrane protein biogenesis**, positioned at the terminal insertion/assembly step downstream of TOM import and TIM chaperoning. (ganesan2024biogenesisofmitochondrial pages 2-4)
+
+Two broader expert-level themes emerge from recent authoritative reviews and mechanistic studies:
+1) **SAM is increasingly conceptualized as an interaction hub**, physically and functionally coupled to other mitochondrial architectural systems (TOM, MICOS/MIB), implying that MTX1 perturbations could influence more than just β‑barrel insertion (e.g., membrane contacts and organelle architecture). (ganesan2024biogenesisofmitochondrial pages 1-2)
+2) **MTX1 can be selectively turned over by piecemeal/basal mitophagy pathways**, especially those involving LC3C/p62 and SAMM50 at SAM/MICOS sites, suggesting an endogenous quality-control axis acting on the same machinery responsible for building the OMM. (guerroue2017autophagosomalcontentprofiling pages 6-8, abudu2021samm50actswith pages 12-14)
+
+---
+
+### Summary table
+The following table provides a compact reference linking MTX1’s localization, function, complexes, interactions, phenotypes, and evidence types.
+
+| Aspect | Summary for human MTX1 (Metaxin-1; UniProt Q13505) | Key evidence / methods | Most relevant citations |
+|---|---|---|---|
+| Identity | Human **MTX1 / Metaxin-1** is a metaxin-family protein, homologous to yeast **Sam37/Tom37/Mas37**, and is discussed in the context of mitochondrial outer membrane protein import rather than an unrelated MTX1 symbol. | Comparative/functional review synthesis; orthology assignments; mitochondrial import literature. | 2024, *FEBS Open Bio*, https://doi.org/10.1002/2211-5463.13905 (ganesan2024biogenesisofmitochondrial pages 1-2, ganesan2024biogenesisofmitochondrial pages 2-4); 2021, *Nature Communications*, https://doi.org/10.1038/s41467-020-20346-2 (zhao2021metaxinsarecore pages 1-2) |
+| Subcellular localization | MTX1 is an **outer mitochondrial membrane (OMM)** protein; recent reviews place metaxins among cytosolically exposed SAM peripheral subunits on the OMM. MTX1 also appears in OMM-associated higher-order assemblies linked to MICOS/MIB. | Review of mitochondrial β-barrel biogenesis; BN-PAGE/assembly-state analysis; affinity-enrichment MS; mitochondrial isolation. | 2024, *FEBS Open Bio*, https://doi.org/10.1002/2211-5463.13905 (ganesan2024biogenesisofmitochondrial pages 1-2, ganesan2024biogenesisofmitochondrial pages 2-4); 2026, *bioRxiv*, https://doi.org/10.64898/2026.03.15.711473 (morf2026characterizationofhuman pages 1-4, morf2026characterizationofhuman pages 11-14) |
+| Primary molecular function | MTX1 is best supported as an **accessory subunit of the mitochondrial Sorting and Assembly Machinery (SAM)** required for efficient **import/assembly of β-barrel proteins** into the OMM; this is a structural/assembly role, not an enzymatic catalytic activity. | In vitro [35S]-import/assembly assays for VDAC1 and TOM40; mitochondrial proteomics; knockout/complementation. | 2024, *FEBS Open Bio*, https://doi.org/10.1002/2211-5463.13905 (ganesan2024biogenesisofmitochondrial pages 1-2, ganesan2024biogenesisofmitochondrial pages 2-4); 2026, *bioRxiv*, https://doi.org/10.64898/2026.03.15.711473 (morf2026characterizationofhuman pages 1-4, morf2026characterizationofhuman pages 4-8) |
+| Pathway context | β-barrel precursors are synthesized in the cytosol, pass through **TOM**, are escorted across the intermembrane space by **TIM chaperones**, and are inserted into the OMM by **SAM**. MTX1 functions at the terminal OMM assembly step with SAM50/metaxins. | Mechanistic pathway review and model figure synthesis. | 2024, *FEBS Open Bio*, https://doi.org/10.1002/2211-5463.13905 (ganesan2024biogenesisofmitochondrial pages 1-2, ganesan2024biogenesisofmitochondrial pages 2-4) |
+| Key complex: SAM | Mammalian SAM contains **SAMM50/SAM50** plus **MTX1, MTX2, MTX3**; MTX1 is one of the peripheral/accessory SAM components linked to β-barrel membrane protein insertion. | Review synthesis; KO/assembly analysis in human cells. | 2024, *FEBS Open Bio*, https://doi.org/10.1002/2211-5463.13905 (ganesan2024biogenesisofmitochondrial pages 2-4); 2026, *bioRxiv*, https://doi.org/10.64898/2026.03.15.711473 (morf2026characterizationofhuman pages 1-4, morf2026characterizationofhuman pages 4-8) |
+| Key complex: MIB / MICOS-associated assemblies | MTX1 is also positioned in **MIB (mitochondrial intermembrane space bridging) / MICOS-associated** assemblies, supporting a role at outer–inner membrane contact architecture in addition to β-barrel biogenesis. | BN-PAGE co-migration; affinity-enrichment MS; review context on SAM as interaction hub. | 2026, *bioRxiv*, https://doi.org/10.64898/2026.03.15.711473 (morf2026characterizationofhuman pages 1-4, morf2026characterizationofhuman pages 11-14, morf2026characterizationofhuman pages 14-17); 2024, *FEBS Open Bio*, https://doi.org/10.1002/2211-5463.13905 (ganesan2024biogenesisofmitochondrial pages 1-2) |
+| Interaction partner: MTX2 | **MTX2** is the most consistently supported partner. MTX2 is required for **steady-state stability of MTX1** in human cells, although MTX1 can assemble/import independently of MTX2. Clinical MTX2 deficiency is reported to secondarily reduce MTX1 protein levels. | CRISPR KO + immunoblot/BN-PAGE/complementation; clinical genetics review/case report. | 2026, *bioRxiv*, https://doi.org/10.64898/2026.03.15.711473 (morf2026characterizationofhuman pages 4-8, morf2026characterizationofhuman pages 11-14); 2024, *Frontiers in Endocrinology*, https://doi.org/10.3389/fendo.2024.1345067 (fu2024casereporta pages 1-2) |
+| Interaction partner: SAMM50 / SAM50 | MTX1 is functionally and physically linked to **SAM50**, consistent with membership in SAM-containing OMM assemblies. | SAM-complex biochemical characterization; review of mammalian SAM composition. | 2024, *FEBS Open Bio*, https://doi.org/10.1002/2211-5463.13905 (ganesan2024biogenesisofmitochondrial pages 2-4); 2026, *bioRxiv*, https://doi.org/10.64898/2026.03.15.711473 (morf2026characterizationofhuman pages 1-4, morf2026characterizationofhuman pages 4-8) |
+| Interaction partners: TOM components | Functionally, MTX1 loss impairs **TOM40** biogenesis/steady-state abundance, fitting a role in β-barrel assembly. Direct stable interaction with TOM receptors is less consistent: older work and reviews connect metaxins to TOM/SAM handoff, but one recent human interactome dataset did **not** enrich TOM20/TOM22 with FLAG-MTX1. | [35S]-TOM40 import assays; steady-state proteomics; affinity-enrichment MS. | 2026, *bioRxiv*, https://doi.org/10.64898/2026.03.15.711473 (morf2026characterizationofhuman pages 14-17, morf2026characterizationofhuman pages 4-8); 2024, *FEBS Open Bio*, https://doi.org/10.1002/2211-5463.13905 (ganesan2024biogenesisofmitochondrial pages 1-2, ganesan2024biogenesisofmitochondrial pages 2-4) |
+| Interaction partners: MICOS/MIB-associated factors | MTX1 interactomes are enriched for **DNAJC11, ARMC1, TMEM11, CARD19**, and other MIB/MICOS-associated factors, arguing that part of MTX1 biology extends beyond minimal SAM composition. | Affinity-enrichment mass spectrometry; BN-PAGE co-migration. | 2026, *bioRxiv*, https://doi.org/10.64898/2026.03.15.711473 (morf2026characterizationofhuman pages 11-14, morf2026characterizationofhuman pages 14-17) |
+| Interaction partners: MIRO / trafficking machinery | Metaxins are reported as core components of mitochondrial **transport adaptor complexes**. In neurons, MTX proteins associate with **MIRO**, **KLC/kinesin light chain**, and **TRAK**-containing transport machinery; this is strongest in nonhuman systems plus human-neuron conservation, while human MTX1-specific biochemical detail remains limited. Recent human MTX1 interactomes also enriched **MIRO1/MIRO2**. | Genetics/biochemistry in *C. elegans* and human iPSC-derived neurons; AE-MS in human cells. | 2021, *Nature Communications*, https://doi.org/10.1038/s41467-020-20346-2 (zhao2021metaxinsarecore pages 1-2); 2026, *bioRxiv*, https://doi.org/10.64898/2026.03.15.711473 (morf2026characterizationofhuman pages 11-14) |
+| Loss-of-function phenotypes | Human MTX1 loss causes **defective VDAC1 import/assembly**, reduced **TOM40** levels, decreased overall mitochondrial protein abundance, **reduced mitochondrial volume**, punctate/swollen mitochondria, altered network interconnectivity, and abnormal mtDNA distribution; rescue is seen with FLAG-MTX1 re-expression. | CRISPR/Cas9 KO in U2OS; mitochondrial proteomics; BN-PAGE; [35S]-import assays; TEM; complementation. | 2026, *bioRxiv*, https://doi.org/10.64898/2026.03.15.711473 (morf2026characterizationofhuman pages 14-17, morf2026characterizationofhuman pages 1-4, morf2026characterizationofhuman pages 4-8, morf2026characterizationofhuman pages 11-14) |
+| Roles beyond import | 2024 literature mainly treats MTX1 as an **OMM protein import/mitochondrial homeostasis factor**. Reviews also cite MTX1 as a **cargo in LC3C-dependent piecemeal mitophagy**, but this appears secondary to its primary import role. Proteomic studies in melanoma report **upregulation of MTX1/2** alongside mitochondrial biogenesis/import signatures in BRAF V600E metastases. | Disease review; cancer proteomics; visual figure extraction for MTX1/2 upregulation statement. | 2024, *Antioxidants*, https://doi.org/10.3390/antiox13060729 (chen2024livercellmitophagy pages 1-2); 2024, *Clinical and Translational Medicine*, https://doi.org/10.1002/ctm2.1773 (almeida2024mitochondrialdysfunctionand pages 1-4, almeida2024mitochondrialdysfunctionand media 1ca45a9d, almeida2024mitochondrialdysfunctionand media 3236bfaf, almeida2024mitochondrialdysfunctionand media 09168aed, almeida2024mitochondrialdysfunctionand media efcaeb08) |
+| Current confidence | **Highest-confidence annotation:** MTX1 is a human mitochondrial OMM metaxin-family protein that acts mainly as a **non-enzymatic accessory factor in SAM-mediated β-barrel protein biogenesis**, with additional links to MICOS/MIB organization and mitochondrial trafficking/homeostasis. | Convergent support across peer-reviewed reviews, mechanistic studies, and recent human-cell functional work. | Synthesis of 2024 reviews and human-cell functional data (morf2026characterizationofhuman pages 1-4, morf2026characterizationofhuman pages 4-8, morf2026characterizationofhuman pages 11-14, ganesan2024biogenesisofmitochondrial pages 1-2, ganesan2024biogenesisofmitochondrial pages 2-4) |
+
+
+*Table: This table compiles the main functional annotation points for human MTX1, including localization, molecular function, complex membership, interaction partners, and supporting evidence. It is useful as a compact reference linking each claim to the strongest available recent and foundational citations.*
+
+---
+
+### URLs and publication dates (key sources cited)
+- Ganesan et al. **Sep 2024**. *FEBS Open Bio*. “Biogenesis of mitochondrial β‑barrel membrane proteins.” https://doi.org/10.1002/2211-5463.13905 (ganesan2024biogenesisofmitochondrial pages 1-2, ganesan2024biogenesisofmitochondrial pages 2-4)
+- de Almeida et al. **Accepted 8 Jul 2024**. *Clinical and Translational Medicine*. “Mitochondrial dysfunction and immune suppression in BRAF V600E‑mutated metastatic melanoma.” https://doi.org/10.1002/ctm2.1773 (almeida2024mitochondrialdysfunctionand pages 1-4, almeida2024mitochondrialdysfunctionand media 1ca45a9d)
+- Chen et al. **Published 15 Jun 2024**. *Antioxidants*. “Liver Cell Mitophagy in MASLD and Liver Fibrosis.” https://doi.org/10.3390/antiox13060729 (chen2024livercellmitophagy pages 1-2)
+- Fu et al. **Published 13 Mar 2024**. *Frontiers in Endocrinology*. MTX2 MADaM case report. https://doi.org/10.3389/fendo.2024.1345067 (fu2024casereporta pages 1-2)
+- Zhao et al. **Jan 2021**. *Nature Communications*. “Metaxins are core components of mitochondrial transport adaptor complexes.” https://doi.org/10.1038/s41467-020-20346-2 (zhao2021metaxinsarecore pages 1-2)
+- Le Guerroué et al. **Nov 2017**. *Molecular Cell*. LC3C-dependent piecemeal mitophagy (MTX1 cargo). https://doi.org/10.1016/j.molcel.2017.10.029 (guerroue2017autophagosomalcontentprofiling pages 6-8)
+- Abudu et al. **May 2021**. *Journal of Cell Biology*. SAMM50/p62 piecemeal mitophagy of SAM/MICOS (MTX1 implicated). https://doi.org/10.1083/jcb.202009092 (abudu2021samm50actswith pages 12-14)
+
+### Notes on evidence limitations
+Human-cell, MTX1-specific loss-of-function phenotypes in **2023–2024** primary literature were not prominent in the retrieved set; the most detailed mechanistic loss-of-function dataset available in this run is a 2026 preprint (used cautiously in the background table as supportive context but not required for the 2023–2024 emphasis). Accordingly, the most robust 2023–2024 MTX1 statements in this report come from authoritative reviews and large-cohort proteomics rather than MTX1-targeted genetic perturbation studies published in 2024. (ganesan2024biogenesisofmitochondrial pages 2-4, almeida2024mitochondrialdysfunctionand pages 1-4)
+
+
+References
+
+1. (ganesan2024biogenesisofmitochondrial pages 2-4): Iniyan Ganesan, Jon V. Busto, Nikolaus Pfanner, and Nils Wiedemann. Biogenesis of mitochondrial β‐barrel membrane proteins. FEBS Open Bio, 14:1595-1609, Sep 2024. URL: https://doi.org/10.1002/2211-5463.13905, doi:10.1002/2211-5463.13905. This article has 20 citations and is from a peer-reviewed journal.
+
+2. (zhao2021metaxinsarecore pages 1-2): Yinsuo Zhao, Eli Song, Wenjuan Wang, Chung-Han Hsieh, Xinnan Wang, Wei Feng, Xiangming Wang, and Kang Shen. Metaxins are core components of mitochondrial transport adaptor complexes. Nature Communications, Jan 2021. URL: https://doi.org/10.1038/s41467-020-20346-2, doi:10.1038/s41467-020-20346-2. This article has 112 citations and is from a highest quality peer-reviewed journal.
+
+3. (ganesan2024biogenesisofmitochondrial pages 1-2): Iniyan Ganesan, Jon V. Busto, Nikolaus Pfanner, and Nils Wiedemann. Biogenesis of mitochondrial β‐barrel membrane proteins. FEBS Open Bio, 14:1595-1609, Sep 2024. URL: https://doi.org/10.1002/2211-5463.13905, doi:10.1002/2211-5463.13905. This article has 20 citations and is from a peer-reviewed journal.
+
+4. (almeida2024mitochondrialdysfunctionand pages 1-4): Natália Pinto de Almeida, Ágnes Judit Jánosi, Runyu Hong, Ahmad Rajeh, Fábio Nogueira, Leticia Szadai, Beata Szeitz, Indira Pla Parada, Viktória Doma, Nicole Woldmar, Jéssica Guedes, Zsuzsanna Újfaludi, Aron Bartha, Yonghyo Kim, Charlotte Welinder, Bo Baldetorp, Lajos Vince Kemény, Zoltan Pahi, Guihong Wan, Nga Nguyen, Tibor Pankotai, Balázs Győrffy, Krzysztof Pawłowski, Peter Horvatovich, Attila Marcell Szasz, Aniel Sanchez, Magdalena Kuras, Jimmy Rodriguez Murillo, Lazaro Betancourt, Gilberto B. Domont, Yevgeniy R. Semenov, Kun‐Hsing Yu, Ho Jeong Kwon, István Balázs Németh, David Fenyő, Elisabet Wieslander, György Marko‐Varga, and Jeovanis Gil. Mitochondrial dysfunction and immune suppression in braf v600e‐mutated metastatic melanoma. Clinical and Translational Medicine, Jul 2024. URL: https://doi.org/10.1002/ctm2.1773, doi:10.1002/ctm2.1773. This article has 5 citations and is from a peer-reviewed journal.
+
+5. (almeida2024mitochondrialdysfunctionand media 1ca45a9d): Natália Pinto de Almeida, Ágnes Judit Jánosi, Runyu Hong, Ahmad Rajeh, Fábio Nogueira, Leticia Szadai, Beata Szeitz, Indira Pla Parada, Viktória Doma, Nicole Woldmar, Jéssica Guedes, Zsuzsanna Újfaludi, Aron Bartha, Yonghyo Kim, Charlotte Welinder, Bo Baldetorp, Lajos Vince Kemény, Zoltan Pahi, Guihong Wan, Nga Nguyen, Tibor Pankotai, Balázs Győrffy, Krzysztof Pawłowski, Peter Horvatovich, Attila Marcell Szasz, Aniel Sanchez, Magdalena Kuras, Jimmy Rodriguez Murillo, Lazaro Betancourt, Gilberto B. Domont, Yevgeniy R. Semenov, Kun‐Hsing Yu, Ho Jeong Kwon, István Balázs Németh, David Fenyő, Elisabet Wieslander, György Marko‐Varga, and Jeovanis Gil. Mitochondrial dysfunction and immune suppression in braf v600e‐mutated metastatic melanoma. Clinical and Translational Medicine, Jul 2024. URL: https://doi.org/10.1002/ctm2.1773, doi:10.1002/ctm2.1773. This article has 5 citations and is from a peer-reviewed journal.
+
+6. (almeida2024mitochondrialdysfunctionand media 3236bfaf): Natália Pinto de Almeida, Ágnes Judit Jánosi, Runyu Hong, Ahmad Rajeh, Fábio Nogueira, Leticia Szadai, Beata Szeitz, Indira Pla Parada, Viktória Doma, Nicole Woldmar, Jéssica Guedes, Zsuzsanna Újfaludi, Aron Bartha, Yonghyo Kim, Charlotte Welinder, Bo Baldetorp, Lajos Vince Kemény, Zoltan Pahi, Guihong Wan, Nga Nguyen, Tibor Pankotai, Balázs Győrffy, Krzysztof Pawłowski, Peter Horvatovich, Attila Marcell Szasz, Aniel Sanchez, Magdalena Kuras, Jimmy Rodriguez Murillo, Lazaro Betancourt, Gilberto B. Domont, Yevgeniy R. Semenov, Kun‐Hsing Yu, Ho Jeong Kwon, István Balázs Németh, David Fenyő, Elisabet Wieslander, György Marko‐Varga, and Jeovanis Gil. Mitochondrial dysfunction and immune suppression in braf v600e‐mutated metastatic melanoma. Clinical and Translational Medicine, Jul 2024. URL: https://doi.org/10.1002/ctm2.1773, doi:10.1002/ctm2.1773. This article has 5 citations and is from a peer-reviewed journal.
+
+7. (almeida2024mitochondrialdysfunctionand media 09168aed): Natália Pinto de Almeida, Ágnes Judit Jánosi, Runyu Hong, Ahmad Rajeh, Fábio Nogueira, Leticia Szadai, Beata Szeitz, Indira Pla Parada, Viktória Doma, Nicole Woldmar, Jéssica Guedes, Zsuzsanna Újfaludi, Aron Bartha, Yonghyo Kim, Charlotte Welinder, Bo Baldetorp, Lajos Vince Kemény, Zoltan Pahi, Guihong Wan, Nga Nguyen, Tibor Pankotai, Balázs Győrffy, Krzysztof Pawłowski, Peter Horvatovich, Attila Marcell Szasz, Aniel Sanchez, Magdalena Kuras, Jimmy Rodriguez Murillo, Lazaro Betancourt, Gilberto B. Domont, Yevgeniy R. Semenov, Kun‐Hsing Yu, Ho Jeong Kwon, István Balázs Németh, David Fenyő, Elisabet Wieslander, György Marko‐Varga, and Jeovanis Gil. Mitochondrial dysfunction and immune suppression in braf v600e‐mutated metastatic melanoma. Clinical and Translational Medicine, Jul 2024. URL: https://doi.org/10.1002/ctm2.1773, doi:10.1002/ctm2.1773. This article has 5 citations and is from a peer-reviewed journal.
+
+8. (almeida2024mitochondrialdysfunctionand media efcaeb08): Natália Pinto de Almeida, Ágnes Judit Jánosi, Runyu Hong, Ahmad Rajeh, Fábio Nogueira, Leticia Szadai, Beata Szeitz, Indira Pla Parada, Viktória Doma, Nicole Woldmar, Jéssica Guedes, Zsuzsanna Újfaludi, Aron Bartha, Yonghyo Kim, Charlotte Welinder, Bo Baldetorp, Lajos Vince Kemény, Zoltan Pahi, Guihong Wan, Nga Nguyen, Tibor Pankotai, Balázs Győrffy, Krzysztof Pawłowski, Peter Horvatovich, Attila Marcell Szasz, Aniel Sanchez, Magdalena Kuras, Jimmy Rodriguez Murillo, Lazaro Betancourt, Gilberto B. Domont, Yevgeniy R. Semenov, Kun‐Hsing Yu, Ho Jeong Kwon, István Balázs Németh, David Fenyő, Elisabet Wieslander, György Marko‐Varga, and Jeovanis Gil. Mitochondrial dysfunction and immune suppression in braf v600e‐mutated metastatic melanoma. Clinical and Translational Medicine, Jul 2024. URL: https://doi.org/10.1002/ctm2.1773, doi:10.1002/ctm2.1773. This article has 5 citations and is from a peer-reviewed journal.
+
+9. (fu2024casereporta pages 1-2): Xiaohui Fu, Shuli Chen, Xiao Huang, Qinghua Lu, Yunfei Cui, Weinan Lin, and Qin Yang. Case report: a novel splice-site mutation of mtx2 gene caused mandibuloacral dysplasia progeroid syndrome: the first report from china and literature review. Frontiers in Endocrinology, Mar 2024. URL: https://doi.org/10.3389/fendo.2024.1345067, doi:10.3389/fendo.2024.1345067. This article has 4 citations.
+
+10. (guerroue2017autophagosomalcontentprofiling pages 4-6): François Le Guerroué, Franziska Eck, Jennifer Jung, Tatjana Starzetz, Michel Mittelbronn, Manuel Kaulich, and Christian Behrends. Autophagosomal content profiling reveals an lc3c-dependent piecemeal mitophagy pathway. Molecular cell, 68 4:786-796.e6, Nov 2017. URL: https://doi.org/10.1016/j.molcel.2017.10.029, doi:10.1016/j.molcel.2017.10.029. This article has 171 citations and is from a highest quality peer-reviewed journal.
+
+11. (guerroue2017autophagosomalcontentprofiling pages 8-10): François Le Guerroué, Franziska Eck, Jennifer Jung, Tatjana Starzetz, Michel Mittelbronn, Manuel Kaulich, and Christian Behrends. Autophagosomal content profiling reveals an lc3c-dependent piecemeal mitophagy pathway. Molecular cell, 68 4:786-796.e6, Nov 2017. URL: https://doi.org/10.1016/j.molcel.2017.10.029, doi:10.1016/j.molcel.2017.10.029. This article has 171 citations and is from a highest quality peer-reviewed journal.
+
+12. (guerroue2017autophagosomalcontentprofiling pages 6-8): François Le Guerroué, Franziska Eck, Jennifer Jung, Tatjana Starzetz, Michel Mittelbronn, Manuel Kaulich, and Christian Behrends. Autophagosomal content profiling reveals an lc3c-dependent piecemeal mitophagy pathway. Molecular cell, 68 4:786-796.e6, Nov 2017. URL: https://doi.org/10.1016/j.molcel.2017.10.029, doi:10.1016/j.molcel.2017.10.029. This article has 171 citations and is from a highest quality peer-reviewed journal.
+
+13. (abudu2021samm50actswith pages 12-14): Yakubu Princely Abudu, Birendra Kumar Shrestha, Wenxin Zhang, Anthimi Palara, Hanne Britt Brenne, Kenneth Bowitz Larsen, Deanna Lynn Wolfson, Gianina Dumitriu, Cristina Ionica Øie, Balpreet Singh Ahluwalia, Gahl Levy, Christian Behrends, Sharon A. Tooze, Stephane Mouilleron, Trond Lamark, and Terje Johansen. Samm50 acts with p62 in piecemeal basal- and oxphos-induced mitophagy of sam and micos components. Journal of Cell Biology, May 2021. URL: https://doi.org/10.1083/jcb.202009092, doi:10.1083/jcb.202009092. This article has 73 citations and is from a highest quality peer-reviewed journal.
+
+14. (abudu2021samm50actswith pages 2-4): Yakubu Princely Abudu, Birendra Kumar Shrestha, Wenxin Zhang, Anthimi Palara, Hanne Britt Brenne, Kenneth Bowitz Larsen, Deanna Lynn Wolfson, Gianina Dumitriu, Cristina Ionica Øie, Balpreet Singh Ahluwalia, Gahl Levy, Christian Behrends, Sharon A. Tooze, Stephane Mouilleron, Trond Lamark, and Terje Johansen. Samm50 acts with p62 in piecemeal basal- and oxphos-induced mitophagy of sam and micos components. Journal of Cell Biology, May 2021. URL: https://doi.org/10.1083/jcb.202009092, doi:10.1083/jcb.202009092. This article has 73 citations and is from a highest quality peer-reviewed journal.
+
+15. (chen2024livercellmitophagy pages 1-2): Jiaxin Chen, Linge Jian, Yangkun Guo, Chengwei Tang, Zhiyin Huang, and Jinhang Gao. Liver cell mitophagy in metabolic dysfunction-associated steatotic liver disease and liver fibrosis. Antioxidants, 13:729, Jun 2024. URL: https://doi.org/10.3390/antiox13060729, doi:10.3390/antiox13060729. This article has 27 citations.
+
+16. (morf2026characterizationofhuman pages 1-4): Sarah E. J. Morf, Matthew P. Challis, Sanjeev Uthishtran, Caitlin L. Rowe, Alice J. Sharpe, Natasha Kapoor-Kaushik, Senthil Arumugam, Luke E. Formosa, Kate McArthur, and Michael T. Ryan. Characterization of human metaxin proteins reveals functional diversification of sam37 homologs mtx1 and mtx3. bioRxiv, Mar 2026. URL: https://doi.org/10.64898/2026.03.15.711473, doi:10.64898/2026.03.15.711473. This article has 0 citations.
+
+17. (morf2026characterizationofhuman pages 11-14): Sarah E. J. Morf, Matthew P. Challis, Sanjeev Uthishtran, Caitlin L. Rowe, Alice J. Sharpe, Natasha Kapoor-Kaushik, Senthil Arumugam, Luke E. Formosa, Kate McArthur, and Michael T. Ryan. Characterization of human metaxin proteins reveals functional diversification of sam37 homologs mtx1 and mtx3. bioRxiv, Mar 2026. URL: https://doi.org/10.64898/2026.03.15.711473, doi:10.64898/2026.03.15.711473. This article has 0 citations.
+
+18. (morf2026characterizationofhuman pages 4-8): Sarah E. J. Morf, Matthew P. Challis, Sanjeev Uthishtran, Caitlin L. Rowe, Alice J. Sharpe, Natasha Kapoor-Kaushik, Senthil Arumugam, Luke E. Formosa, Kate McArthur, and Michael T. Ryan. Characterization of human metaxin proteins reveals functional diversification of sam37 homologs mtx1 and mtx3. bioRxiv, Mar 2026. URL: https://doi.org/10.64898/2026.03.15.711473, doi:10.64898/2026.03.15.711473. This article has 0 citations.
+
+19. (morf2026characterizationofhuman pages 14-17): Sarah E. J. Morf, Matthew P. Challis, Sanjeev Uthishtran, Caitlin L. Rowe, Alice J. Sharpe, Natasha Kapoor-Kaushik, Senthil Arumugam, Luke E. Formosa, Kate McArthur, and Michael T. Ryan. Characterization of human metaxin proteins reveals functional diversification of sam37 homologs mtx1 and mtx3. bioRxiv, Mar 2026. URL: https://doi.org/10.64898/2026.03.15.711473, doi:10.64898/2026.03.15.711473. This article has 0 citations.
+
+## Citations
+
+1. ganesan2024biogenesisofmitochondrial pages 2-4
+2. ganesan2024biogenesisofmitochondrial pages 1-2
+3. fu2024casereporta pages 1-2
+4. zhao2021metaxinsarecore pages 1-2
+5. guerroue2017autophagosomalcontentprofiling pages 6-8
+6. almeida2024mitochondrialdysfunctionand pages 1-4
+7. chen2024livercellmitophagy pages 1-2
+8. morf2026characterizationofhuman pages 11-14
+9. guerroue2017autophagosomalcontentprofiling pages 4-6
+10. guerroue2017autophagosomalcontentprofiling pages 8-10
+11. morf2026characterizationofhuman pages 1-4
+12. morf2026characterizationofhuman pages 4-8
+13. morf2026characterizationofhuman pages 14-17
+14. 35S
+15. https://doi.org/10.1002/2211-5463.13905
+16. https://doi.org/10.1038/s41467-020-20346-2
+17. https://doi.org/10.64898/2026.03.15.711473
+18. https://doi.org/10.3389/fendo.2024.1345067
+19. https://doi.org/10.3390/antiox13060729
+20. https://doi.org/10.1002/ctm2.1773
+21. https://doi.org/10.1016/j.molcel.2017.10.029
+22. https://doi.org/10.1083/jcb.202009092
+23. https://doi.org/10.1002/2211-5463.13905,
+24. https://doi.org/10.1038/s41467-020-20346-2,
+25. https://doi.org/10.1002/ctm2.1773,
+26. https://doi.org/10.3389/fendo.2024.1345067,
+27. https://doi.org/10.1016/j.molcel.2017.10.029,
+28. https://doi.org/10.1083/jcb.202009092,
+29. https://doi.org/10.3390/antiox13060729,
+30. https://doi.org/10.64898/2026.03.15.711473,

--- a/genes/human/TOMM5/TOMM5-ai-review.html
+++ b/genes/human/TOMM5/TOMM5-ai-review.html
@@ -1,0 +1,2622 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>TOMM5 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>TOMM5</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q8N4H5" target="_blank" class="term-link">
+                        Q8N4H5
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "TOMM5";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q8N4H5" data-a="DESCRIPTION: TOMM5 is a very small single-pass mitochondrial ou..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>TOMM5 is a very small single-pass mitochondrial outer membrane subunit of the TOM translocase core. It is a structural/regulatory accessory component, not an enzyme or independent receptor, and supports TOM core organization, stability, and biogenesis around TOMM40.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005742" target="_blank" class="term-link">
+                                    GO:0005742
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial outer membrane translocase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8N4H5" data-a="GO:0005742" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct phylogenetic inference. TOMM5 is a conserved small Tom subunit of the TOM core complex.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOMM5/TOMM5-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">TOMM5 is a component of the TOM machinery embedded in the **mitochondrial outer membrane** as part of the detergent-stable TOM **core complex**</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005741" target="_blank" class="term-link">
+                                    GO:0005741
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial outer membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8N4H5" data-a="GO:0005741" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct UniProt-derived localization. Human structural and review evidence place TOMM5 in the mitochondrial outer membrane TOM core.
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005742" target="_blank" class="term-link">
+                                    GO:0005742
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial outer membrane translocase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8N4H5" data-a="GO:0005742" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct InterPro-derived complex annotation. TOMM5 is a small subunit of the mitochondrial TOM translocase complex.
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000052
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q8N4H5" data-a="GO:0005739" data-r="GO_REF:0000052" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct but less specific than the well-supported mitochondrial outer membrane/TOM complex localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Subsumed by mitochondrial outer membrane and TOM complex annotations.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005741" target="_blank" class="term-link">
+                                    GO:0005741
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial outer membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18331822" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:18331822
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Identification of Tom5 and Tom6 in the preprotein translocas...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8N4H5" data-a="GO:0005741" data-r="PMID:18331822" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Kato and Mihara identified human Tom5 in the outer membrane TOM preprotein translocase complex; this matches the Falcon synthesis of structural evidence.
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045040" target="_blank" class="term-link">
+                                    GO:0045040
+                                </a>
+                            </span>
+                            <span class="term-label">protein insertion into mitochondrial outer membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18331822" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:18331822
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Identification of Tom5 and Tom6 in the preprotein translocas...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="Q8N4H5" data-a="GO:0045040" data-r="PMID:18331822" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> TOMM5 supports TOM organization and biogenesis, but the evidence does not support TOMM5 as an independent insertase for outer membrane proteins. TOM complex assembly is the more precise process annotation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Replace the insertion term with TOM complex assembly/stability, which is the small Tom5 subunit role supported by structural and ortholog evidence.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070096" target="_blank" class="term-link">
+                                    mitochondrial outer membrane translocase complex assembly
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140596" target="_blank" class="term-link">
+                                    GO:0140596
+                                </a>
+                            </span>
+                            <span class="term-label">TOM complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18331822" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:18331822
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Identification of Tom5 and Tom6 in the preprotein translocas...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8N4H5" data-a="GO:0140596" data-r="PMID:18331822" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct and specific. TOMM5 is a detergent-stable TOM core subunit adjacent to TOMM40, TOMM6, TOMM7, and TOMM22.
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HTP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:34800366
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Quantitative high-confidence human mitochondrial proteome an...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q8N4H5" data-a="GO:0005739" data-r="PMID:34800366" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput mitochondrial proteome data support mitochondrial localization, but the term is too general for a TOM outer membrane core subunit.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Subsumed by mitochondrial outer membrane and TOM complex annotations.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005741" target="_blank" class="term-link">
+                                    GO:0005741
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial outer membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-5205661
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8N4H5" data-a="GO:0005741" data-r="Reactome:R-HSA-5205661" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome places TOMM5 at the mitochondrial outer membrane in TOM/PINK1 pathway context. This agrees with the TOM core localization.
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070585" target="_blank" class="term-link">
+                                    GO:0070585
+                                </a>
+                            </span>
+                            <span class="term-label">protein localization to mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IC</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18331822" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:18331822
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Identification of Tom5 and Tom6 in the preprotein translocas...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q8N4H5" data-a="GO:0070585" data-r="PMID:18331822" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct as a broad process annotation for a TOM complex subunit, but TOMM5&#39;s more specific role is structural support of TOM core assembly and organization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Broad process term; the synthesized core function emphasizes TOM complex assembly/stability.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005742" target="_blank" class="term-link">
+                                    GO:0005742
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial outer membrane translocase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18331822" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:18331822
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Identification of Tom5 and Tom6 in the preprotein translocas...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8N4H5" data-a="GO:0005742" data-r="PMID:18331822" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct evidence from Kato and Mihara supports human TOMM5 membership in the mitochondrial outer membrane translocase complex.
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>TOMM5 is a structural/regulatory small Tom subunit that contributes to the TOM core translocase by stabilizing TOMM40-containing assemblies and likely assisting TOM biogenesis.</h3>
+                <span class="vote-buttons" data-g="Q8N4H5" data-a="FUNCTION: TOMM5 is a structural/regulatory small Tom subunit..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070096" target="_blank" class="term-link">
+                                mitochondrial outer membrane translocase complex assembly
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005741" target="_blank" class="term-link">
+                                mitochondrial outer membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140596" target="_blank" class="term-link">
+                            TOM complex
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/TOMM5/TOMM5-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">TOMM5 is **not an enzyme** and has **no known catalytic reaction or substrate specificity** in the enzyme/transporter sense.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/TOMM5/TOMM5-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">TOMM5 is a component of the TOM machinery embedded in the **mitochondrial outer membrane** as part of the detergent-stable TOM **core complex**</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/TOMM5/TOMM5-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">Mechanistically, TOMM5 is best annotated as an **accessory structural/regulatory subunit** that supports TOM complex organization and likely assists biogenesis/assembly</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000052.md" target="_blank" class="term-link">
+                            GO_REF:0000052
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on curation of immunofluorescence data</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/18331822" target="_blank" class="term-link">
+                            PMID:18331822
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Identification of Tom5 and Tom6 in the preprotein translocase complex of human mitochondrial outer membrane.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link">
+                            PMID:34800366
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Quantitative high-confidence human mitochondrial proteome and its dynamics in cellular context.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-5205661
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Pink1 is recruited from the cytoplasm to the mitochondria</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/TOMM5/TOMM5-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research report for human TOMM5</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Which Tom5 contacts in the human TOM core are essential for TOMM40 assembly versus precursor routing?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q8N4H5" data-a="Q: Which Tom5 contacts in the human TOM core are esse..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> How much of TOMM5 function in human cells can be separated from conserved yeast Tom5 roles in late Tom40 assembly at SAM?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q8N4H5" data-a="Q: How much of TOMM5 function in human cells can be s..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Use endogenous TOMM5 depletion/rescue with structure-guided mutants and measure TOMM40 assembly intermediates, mature TOM complex abundance, and import of representative mitochondrial precursor classes.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: TOMM5 promotes stable TOM core biogenesis by contacting TOMM40 during or after TOMM40 assembly.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: endogenous rescue and mitochondrial import assay</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q8N4H5" data-a="EXPERIMENT: Use endogenous TOMM5 depletion/rescue with structu..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Deep Research Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(TOMM5-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q8N4H5" data-a="DOC: Deep Research Falcon" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <hr />
+<p>provider: falcon<br />
+model: Edison Scientific Literature<br />
+cached: false<br />
+start_time: '2026-05-11T10:59:40.604136'<br />
+end_time: '2026-05-11T11:14:28.477844'<br />
+duration_seconds: 887.87<br />
+template_file: templates/gene_research_go_focused.md<br />
+template_variables:<br />
+  organism: human<br />
+  gene_id: TOMM5<br />
+  gene_symbol: TOMM5<br />
+  uniprot_accession: Q8N4H5<br />
+  protein_description: 'RecName: Full=Mitochondrial import receptor subunit TOM5 homolog;'<br />
+  gene_info: Name=TOMM5; Synonyms=C9orf105, TOM5;<br />
+  organism_full: Homo sapiens (Human).<br />
+  protein_family: Belongs to the Tom5 family. .<br />
+  protein_domains: Tom5. (IPR019603); TOMM5_metazoa. (IPR029179); Tom5 (PF10642)<br />
+provider_config:<br />
+  timeout: 600<br />
+  max_retries: 3<br />
+  parameters:<br />
+    allowed_domains: []<br />
+    temperature: 0.1<br />
+citation_count: 42</p>
+<hr />
+<h2 id="question">Question</h2>
+<h1 id="gene-research-for-functional-annotation">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> Q8N4H5</li>
+<li><strong>Protein Description:</strong> RecName: Full=Mitochondrial import receptor subunit TOM5 homolog;</li>
+<li><strong>Gene Information:</strong> Name=TOMM5; Synonyms=C9orf105, TOM5;</li>
+<li><strong>Organism (full):</strong> Homo sapiens (Human).</li>
+<li><strong>Protein Family:</strong> Belongs to the Tom5 family. .</li>
+<li><strong>Key Domains:</strong> Tom5. (IPR019603); TOMM5_metazoa. (IPR029179); Tom5 (PF10642)</li>
+</ul>
+<h3 id="mandatory-verification-steps">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "TOMM5" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Homo sapiens (Human).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'TOMM5' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>TOMM5</strong> (gene ID: TOMM5, UniProt: Q8N4H5) in human.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="output">Output</h2>
+<p>Question: You are an expert researcher providing comprehensive, well-cited information.</p>
+<p>Provide detailed information focusing on:<br />
+1. Key concepts and definitions with current understanding<br />
+2. Recent developments and latest research (prioritize 2023-2024 sources)<br />
+3. Current applications and real-world implementations<br />
+4. Expert opinions and analysis from authoritative sources<br />
+5. Relevant statistics and data from recent studies</p>
+<p>Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.<br />
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.</p>
+<h1 id="gene-research-for-functional-annotation_1">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context_1">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot_1">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> Q8N4H5</li>
+<li><strong>Protein Description:</strong> RecName: Full=Mitochondrial import receptor subunit TOM5 homolog;</li>
+<li><strong>Gene Information:</strong> Name=TOMM5; Synonyms=C9orf105, TOM5;</li>
+<li><strong>Organism (full):</strong> Homo sapiens (Human).</li>
+<li><strong>Protein Family:</strong> Belongs to the Tom5 family. .</li>
+<li><strong>Key Domains:</strong> Tom5. (IPR019603); TOMM5_metazoa. (IPR029179); Tom5 (PF10642)</li>
+</ul>
+<h3 id="mandatory-verification-steps_1">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "TOMM5" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Homo sapiens (Human).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature_1">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'TOMM5' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target_1">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>TOMM5</strong> (gene ID: TOMM5, UniProt: Q8N4H5) in human.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="research-report-human-tomm5-uniprot-q8n4h5-tom5-family-functional-annotation">Research report: Human <strong>TOMM5</strong> (UniProt <strong>Q8N4H5</strong>; Tom5 family) functional annotation</h2>
+<h3 id="0-identity-verification-critical-disambiguation">0) Identity verification (critical disambiguation)</h3>
+<p>The gene <strong>TOMM5</strong> (synonyms <strong>TOM5</strong>, <strong>C9orf105</strong>) encodes the human homolog of the TOM-complex small subunit <strong>Tom5</strong>, a <strong>single-pass α-helical</strong> protein that is part of the mitochondrial <strong>translocase of the outer membrane (TOM) complex</strong> (pitt2021abiochemicaland pages 1-3, pitt2021abiochemicaland pages 6-9). The literature retrieved here consistently uses “Tom5/TOMM5” to denote this TOM-complex subunit and does not indicate an alternative human gene/protein with the same symbol in this context (pitt2021abiochemicaland pages 1-3).</p>
+<h3 id="1-key-concepts-and-definitions-current-understanding">1) Key concepts and definitions (current understanding)</h3>
+<h4 id="11-the-tom-complex-and-mitochondrial-protein-import">1.1 The TOM complex and mitochondrial protein import</h4>
+<p>Mammalian mitochondria import the vast majority of their proteins from the cytosol; reviews typically cite ~<strong>1,000–1,500</strong> mitochondrial proteins, with import across the outer membrane occurring primarily through the <strong>TOM complex</strong> (pitt2021abiochemicaland pages 16-17, pitt2021abiochemicaland pages 6-9). The TOM complex is organized around the β‑barrel channel <strong>TOMM40/Tom40</strong>, with additional receptor and small accessory subunits that contribute to recognition, translocation, and complex organization (pitt2021abiochemicaland pages 1-3, pitt2021abiochemicaland pages 6-9).</p>
+<h4 id="12-what-tomm5-is-and-is-not">1.2 What TOMM5 is (and is not)</h4>
+<p>TOMM5 is <strong>not an enzyme</strong> and has <strong>no known catalytic reaction or substrate specificity</strong> in the enzyme/transporter sense. Rather, TOMM5 is best understood as a <strong>structural/regulatory accessory subunit</strong> of a large membrane translocase, contributing to the assembly, stability, and/or mechanistic routing properties of the TOM pore (tucker2019cryoemstructureof pages 1-3, pitt2021abiochemicaland pages 6-9).</p>
+<h3 id="2-molecular-function-of-tomm5-in-the-tom-complex">2) Molecular function of TOMM5 in the TOM complex</h3>
+<h4 id="21-core-biochemical-role-inferred-from-structure-ortholog-experiments">2.1 Core biochemical role (inferred from structure + ortholog experiments)</h4>
+<p>Across species, Tom5-family proteins are described as <strong>small TOM subunits</strong> that directly associate with the Tom40 β‑barrel and are proposed to support: (i) <strong>TOM complex stability/organization</strong>, (ii) <strong>precursor handling/transfer</strong>, and (iii) <strong>biogenesis/assembly</strong> of TOM components (tucker2019cryoemstructureof pages 1-3, becker2010assemblyofthe pages 1-2, bausewein2020thestructureof pages 5-8).</p>
+<p>A key mechanistic idea emphasized in structural reviews is that Tom5 sits at a peripheral region of the TOM dimer and is positioned to participate in routing or recruitment events for particular classes of imported precursors (araiso2022structuraloverviewof pages 1-3). In particular, Araiso &amp; Endo summarize cryo‑EM-derived models in which the <strong>N‑terminal segment of Tom40</strong> traverses the channel and <strong>interacts with Tom5</strong> at the <strong>periphery</strong> of the TOM dimer; this site is discussed as a location where downstream components for <strong>presequence‑lacking precursors</strong> can be recruited (araiso2022structuraloverviewof pages 1-3).</p>
+<h4 id="22-role-in-tom-biogenesisassembly-strongest-direct-experimental-evidence-is-fungalyeast">2.2 Role in TOM biogenesis/assembly (strongest direct experimental evidence is fungal/yeast)</h4>
+<p>The most direct causal evidence for a Tom5-family protein in TOM assembly comes from yeast: Becker et al. identified a Tom40 assembly intermediate at the SAM complex and concluded that <strong>Tom5 associates with the Tom40 precursor at the SAM complex</strong> in a later stage that promotes Tom40 assembly; Tom5 thereby helps progress Tom40 from early SAM-associated intermediates toward mature TOM complexes (becker2010assemblyofthe pages 1-2). While this is not human TOMM5 per se, it is widely used as the mechanistic basis for inferring a conserved Tom5 contribution to TOM core biogenesis (becker2010assemblyofthe pages 1-2, pitt2021abiochemicaland pages 6-9).</p>
+<h3 id="3-subcellular-localization-and-topology-human-specific-structural-evidence">3) Subcellular localization and topology (human-specific structural evidence)</h3>
+<h4 id="31-localization">3.1 Localization</h4>
+<p>TOMM5 is a component of the TOM machinery embedded in the <strong>mitochondrial outer membrane</strong> as part of the detergent-stable TOM <strong>core complex</strong> (pitt2021abiochemicaland pages 6-9, guan2021structuralinsightsinto media bb38bae5).</p>
+<h4 id="32-topology-and-position-within-the-human-tom-core">3.2 Topology and position within the human TOM core</h4>
+<p>Human cryo‑EM structures of the TOM core complex resolve Tom5 (TOMM5) as a <strong>single-pass α‑helical</strong> subunit that <strong>surrounds</strong> the Tom40 β‑barrel together with Tom6 and Tom7 (pitt2021abiochemicaland pages 6-9). In the human TOM core complex structure presented by Guan et al., Tom5 is located on the <strong>periphery of each Tom40 barrel</strong> (rather than at the Tom22-bridged central interface), consistent with a peripheral accessory role (guan2021structuralinsightsinto media bb38bae5, guan2021structuralinsightsinto media 07568b50).</p>
+<h3 id="4-interaction-partners-and-complex-membership">4) Interaction partners and complex membership</h3>
+<h4 id="41-tom-core-membership-and-direct-contacts">4.1 TOM core membership and direct contacts</h4>
+<p>Structural and review evidence places TOMM5 as a β‑barrel-associated TOM core subunit that directly contacts <strong>TOMM40/Tom40</strong>, and resides adjacent to <strong>Tom6, Tom7, and Tom22</strong> in the assembled complex (pitt2021abiochemicaland pages 6-9, pitt2021abiochemicaland pages 3-6). The TOM core is observed in multiple oligomeric states (dimeric/tetrameric/trimeric forms) that all retain Tom5 as part of the assembly (pitt2021abiochemicaland pages 11-12).</p>
+<h4 id="42-oligomeric-state-statistics-structural">4.2 Oligomeric state statistics (structural)</h4>
+<p>A review synthesis of cryo‑EM findings reports TOM core oligomers that include:<br />
+* a <strong>dimeric</strong> core containing a dimer of Tom40 with Tom5, Tom6, Tom7, and Tom22;<br />
+* a <strong>tetrameric</strong> arrangement (dimer of dimers) with <strong>two copies each</strong> of Tom6, Tom22, and <strong>Tom5</strong> at the dimer–dimer interface; and<br />
+* a <strong>trimeric</strong> TOM containing three copies of Tom40, Tom5, Tom6, Tom7, Tom22 (pitt2021abiochemicaland pages 11-12).</p>
+<h3 id="5-recent-developments-and-latest-research-priority-20232024">5) Recent developments and latest research (priority 2023–2024)</h3>
+<h4 id="51-2023-tomm5-as-a-mitochondrial-microprotein-in-a-large-translocase">5.1 2023: TOMM5 as a mitochondrial microprotein in a large translocase</h4>
+<p>A 2023 review focused on mitochondrial microproteins explicitly catalogs TOMM5 as a <strong>51‑amino‑acid</strong> TOM component and describes Tom5/TOMM5 (with TOMM6 and TOMM7) as associating with TOMM40 and <strong>regulating stability</strong> of the import channel; the review also contextualizes the TOM complex as an ~<strong>440 kDa</strong> system (kamradt2023mitochondrialmicroproteinscritical pages 1-4). Although the excerpted text is review-level (not a new primary perturbation study), it represents current (2023) consensus framing of TOMM5’s role as a very small structural regulator embedded in a major import machine (kamradt2023mitochondrialmicroproteinscritical pages 1-4).</p>
+<h4 id="52-2024-structuredynamics-focused-tom-reviews-reinforce-tomm5s-role-as-a-small-core-subunit">5.2 2024: Structure/dynamics-focused TOM reviews reinforce TOMM5’s role as a small core subunit</h4>
+<p>A 2024 Biochemical Society Transactions review on TOM structure/dynamics lists Tom5 among the holo-complex subunits and emphasizes the structural context of a two‑pore Tom40 architecture revealed by cryo‑EM; it additionally notes that Tom5 shows relatively <strong>low sequence identity</strong> across fungi, consistent with evolutionary flexibility outside small conserved motifs (nussberger2024newinsightsinto pages 2-4). A complementary structure-centric synthesis also frames Tom5 among the “low molecular weight” TOM subunits implicated in assembly/stability and possible precursor handover at the cytosolic face (bausewein2020thestructureof pages 5-8).</p>
+<h3 id="6-disease-relevance-phenotypes-and-real-world-implementations">6) Disease relevance, phenotypes, and real-world implementations</h3>
+<h4 id="61-human-disease-genetics-limited-tomm5-specific-evidence-in-retrieved-primary-literature">6.1 Human disease genetics: limited TOMM5-specific evidence in retrieved primary literature</h4>
+<p>In the retrieved sources, there is <strong>no well-established monogenic human disease</strong> directly attributed to TOMM5 variants, and human TOMM5-specific functional perturbation datasets were not prominent in the accessible full texts (pitt2021abiochemicaland pages 16-17, pitt2021abiochemicaland pages 3-6). Database-level disease-target associations exist (e.g., Open Targets lists several diseases with low overall association scores and evidence largely driven by limited literature and functional genomics screens), but these should be treated as <strong>hypothesis-generating</strong> rather than confirmatory (OpenTargets Search: -TOMM5).</p>
+<h4 id="62-strongest-organismal-phenotype-evidence-tomm5-mice">6.2 Strongest organismal phenotype evidence: Tomm5−/− mice</h4>
+<p>A dedicated mouse knockout pathology study reported that <strong>Tomm5−/−</strong> mice develop a striking <strong>lung-restricted</strong> phenotype resembling human <strong>cryptogenic organizing pneumonia (COP)</strong>, with patchy intra-alveolar organizing lesions that evolve into fibrogenic buds containing extracellular matrix components and <strong>α‑SMA-positive myofibroblasts</strong>; the authors propose impaired mitochondrial function/import during neonatal transition to air and oxidative stress as plausible contributing mechanisms (vogel2013cryptogenicorganizingpneumonia pages 1-2, vogel2013cryptogenicorganizingpneumonia pages 5-7). This provides important in vivo evidence that Tomm5 can be physiologically important, though it does not by itself establish a direct human TOMM5 disease mechanism (vogel2013cryptogenicorganizingpneumonia pages 5-7).</p>
+<h4 id="63-applications-and-implementations-in-researchbiomedicine">6.3 Applications and implementations in research/biomedicine</h4>
+<ul>
+<li><strong>Structure-enabled mechanistic modeling:</strong> Human cryo‑EM structures (and their review syntheses) are actively used to infer how accessory subunits such as Tom5 position around Tom40 and may influence routing and complex dynamics (guan2021structuralinsightsinto media bb38bae5, araiso2022structuraloverviewof pages 1-3).</li>
+<li><strong>Mitochondrial targeting tools:</strong> A TOM review notes that human Tom5 has been used as a <strong>mitochondrial-targeting fusion</strong> in a cancer-cell context (e.g., to deliver p53 to mitochondria), illustrating use of TOMM5-derived sequences as experimental targeting elements; however, this is not yet a validated therapeutic approach (pitt2021abiochemicaland pages 16-17).</li>
+</ul>
+<h3 id="7-expert-synthesis-and-interpretation-authoritative-viewpoints">7) Expert synthesis and interpretation (authoritative viewpoints)</h3>
+<ol>
+<li><strong>Confidence-high statements (human structural context):</strong> TOMM5 is a small α‑helical TOM core subunit that directly contacts Tom40 and is positioned peripherally in human TOM core cryo‑EM reconstructions (guan2021structuralinsightsinto media bb38bae5, pitt2021abiochemicaland pages 6-9).</li>
+<li><strong>Moderate-confidence mechanistic role (cross-species inference):</strong> Tom5-family proteins likely contribute to <strong>TOM assembly/biogenesis and stability</strong>, supported strongly by yeast SAM-associated assembly intermediates and widely extrapolated to metazoans (becker2010assemblyofthe pages 1-2, pitt2021abiochemicaland pages 6-9).</li>
+<li><strong>Open questions emphasized by experts:</strong> Reviews explicitly state that functional knowledge for Tom5/TOMM5 in humans remains limited compared with other subunits; some yeast-specific mechanistic features (Tom40 regions implicated in Tom5 interactions) may not be conserved in human Tom40, implying that the exact human mechanism could differ (pitt2021abiochemicaland pages 16-17).</li>
+</ol>
+<h3 id="8-key-statistics-and-data-points-from-recentauthoritative-sources">8) Key statistics and data points (from recent/authoritative sources)</h3>
+<ul>
+<li>TOMM5 is described as <strong>~51 aa</strong> in a 2023 mitochondrial microprotein review (kamradt2023mitochondrialmicroproteinscritical pages 1-4).</li>
+<li>TOM (reviewed) is an ~<strong>440 kDa</strong> complex (kamradt2023mitochondrialmicroproteinscritical pages 1-4).</li>
+<li>TOM core oligomeric states reported from cryo‑EM include dimeric/tetrameric/trimeric assemblies containing Tom5, with <strong>two copies</strong> of Tom5 at the tetramer interface (review synthesis) (pitt2021abiochemicaland pages 11-12).</li>
+</ul>
+<h3 id="9-summary-table-of-evidence">9) Summary table of evidence</h3>
+<p>The following table consolidates high-confidence annotation statements, clearly separating human-structure-based evidence from inferences and remaining gaps.</p>
+<table>
+<thead>
+<tr>
+<th>Annotation topic</th>
+<th>Key points</th>
+<th>Best supporting sources</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Protein identity</td>
+<td>• Human gene/protein verified as <strong>TOMM5 / Tom5</strong>, UniProt <strong>Q8N4H5</strong> • Small <strong>Tom5-family</strong> subunit of the mitochondrial <strong>TOM</strong> (translocase of outer membrane) complex • Reviewed as one of the canonical TOM components in human mitochondria</td>
+<td>Pitt &amp; Buchanan, 2021, https://doi.org/10.3390/cells10051164 (pitt2021abiochemicaland pages 1-3, pitt2021abiochemicaland pages 3-6); Lionaki et al., 2023, https://doi.org/10.1002/bies.202200160</td>
+</tr>
+<tr>
+<td>Subcellular localization / topology</td>
+<td>• Localized to the <strong>mitochondrial outer membrane</strong> within the TOM core complex • <strong>Single-pass α-helical</strong> membrane protein; one of the small TOM subunits • In human cryo-EM structures, Tom5 lies on the <strong>periphery of each Tom40 barrel</strong>, opposite the Tom22-bridged central interface</td>
+<td>Guan et al., 2021, https://doi.org/10.1038/s41421-021-00252-7 (guan2021structuralinsightsinto media bb38bae5, guan2021structuralinsightsinto media 07568b50); Wang et al., 2020, https://doi.org/10.1038/s41421-020-00198-2; Araiso &amp; Endo, 2022, https://doi.org/10.2142/biophysico.bppb-v19.0022 (araiso2022structuraloverviewof pages 1-3)</td>
+</tr>
+<tr>
+<td>Molecular function</td>
+<td>• Not an enzyme; acts as a <strong>structural/regulatory accessory subunit</strong> of the TOM import channel • Proposed roles include <strong>precursor transfer</strong>, <strong>binding-site formation</strong>, and <strong>assembly/stability</strong> support for TOM • Functional assignment in humans remains partly inferred from structure and fungal homologs</td>
+<td>Tucker &amp; Park, 2019, https://doi.org/10.1038/s41594-019-0339-2 (tucker2019cryoemstructureof pages 1-3); Pitt &amp; Buchanan, 2021, https://doi.org/10.3390/cells10051164 (pitt2021abiochemicaland pages 6-9, pitt2021abiochemicaland pages 16-17)</td>
+</tr>
+<tr>
+<td>Complex membership / interactions</td>
+<td>• Member of the detergent-stable <strong>TOM core</strong> with <strong>Tom40, Tom22, Tom6, Tom7</strong> • Directly contacts <strong>Tom40</strong>; positioned near Tom22/Tom6/Tom7 in dimeric and higher-order assemblies • Human TOM cores resolved as <strong>dimers</strong>, with tetrameric/higher-order states also observed</td>
+<td>Pitt &amp; Buchanan, 2021, https://doi.org/10.3390/cells10051164 (pitt2021abiochemicaland pages 3-6, pitt2021abiochemicaland pages 11-12, pitt2021abiochemicaland pages 6-9); Guan et al., 2021, https://doi.org/10.1038/s41421-021-00252-7; Wang et al., 2020, https://doi.org/10.1038/s41421-020-00198-2</td>
+</tr>
+<tr>
+<td>Role in import mechanism</td>
+<td>• TOM is the main entry gate for most nuclear-encoded mitochondrial proteins; Tom5 contributes as an <strong>auxiliary subunit</strong> rather than a receptor with a known substrate specificity • Structural review places Tom5 near the <strong>Tom40 N-terminal segment</strong> and a peripheral route implicated in recruiting downstream factors for <strong>presequence-lacking precursors</strong> • Detailed <strong>human-specific mechanistic proof</strong> remains limited</td>
+<td>Araiso &amp; Endo, 2022, https://doi.org/10.2142/biophysico.bppb-v19.0022 (araiso2022structuraloverviewof pages 1-3); Pitt &amp; Buchanan, 2021, https://doi.org/10.3390/cells10051164 (pitt2021abiochemicaland pages 16-17)</td>
+</tr>
+<tr>
+<td>Role in TOM biogenesis / assembly</td>
+<td>• Best direct evidence comes from <strong>yeast/fungal ortholog</strong> studies: Tom5 promotes a later <strong>SAM-associated Tom40 assembly stage</strong> • Supports formation of stable intermediates for integration of newly synthesized TOM components • Human role is widely inferred to involve <strong>assembly and maintenance</strong> of TOM, but dedicated endogenous TOMM5 perturbation data are scarce</td>
+<td>Becker et al., 2010, https://doi.org/10.1091/mbc.e10-06-0518 (becker2010assemblyofthe pages 1-2); Pitt &amp; Buchanan, 2021, https://doi.org/10.3390/cells10051164 (pitt2021abiochemicaland pages 6-9, pitt2021abiochemicaland pages 16-17)</td>
+</tr>
+<tr>
+<td>Recent 2023–2024 developments</td>
+<td>• 2023 review highlights TOMM5 as a <strong>51-aa mitochondrial microprotein</strong> embedded in a large import machine • 2024 reviews emphasize evolutionary conservation of the TOM architecture and new structure/dynamics insights, reinforcing Tom5 as a <strong>small regulatory/core-surrounding subunit</strong> • Recent work refines <strong>complex architecture and dynamics</strong> more than TOMM5-specific biochemistry</td>
+<td>Kamradt &amp; Makarewich, 2023, https://doi.org/10.1152/ajpcell.00189.2023; Lionaki et al., 2023, https://doi.org/10.1002/bies.202200160; Nussberger et al., 2024, https://doi.org/10.1042/bst20231236; Özdemir &amp; Dennerlein, 2024, https://doi.org/10.1515/hsz-2024-0043</td>
+</tr>
+<tr>
+<td>Disease / phenotype links</td>
+<td>• No well-established <strong>monogenic human TOMM5 disease</strong> is supported by the retrieved primary literature • Broader TOM dysfunction is linked to neurodegeneration, cardiovascular disease, mitophagy defects, and cancer biology, but this is usually driven by other TOM subunits • Database-level disease associations for TOMM5 exist but are <strong>low-confidence / indirect</strong> and should be interpreted cautiously</td>
+<td>Heinemeyer et al., 2019, https://doi.org/10.1089/dna.2018.4292; Zhao &amp; Zou, 2021, https://doi.org/10.3389/fcvm.2021.749756; Open Targets (accessed via tool output) (OpenTargets Search: -TOMM5)</td>
+</tr>
+<tr>
+<td>Model-organism phenotype evidence</td>
+<td>• A mouse knockout report described <strong>cryptogenic organizing pneumonia</strong> in <strong>Tomm5−/−</strong> mice, indicating organism-level importance • This phenotype is informative but does <strong>not yet define the precise molecular lesion</strong> in human cells • Separate TOM-complex small-subunit disease precedent exists for <strong>TOMM7</strong>, underscoring plausibility of TOM small-subunit pathology</td>
+<td>Vogel et al., 2013, https://doi.org/10.1177/0300985812450723; Young et al., 2023, https://doi.org/10.1016/j.xhgg.2022.100148</td>
+</tr>
+<tr>
+<td>Knowledge gaps / confidence limits</td>
+<td>• Human <strong>endogenous TOMM5 loss-of-function</strong> studies are very limited • No clear human <strong>substrate specificity</strong>, catalytic activity, or direct disease-causing variants established • Many functional claims are extrapolated from <strong>fungal orthologs</strong> and from TOM-complex structural context rather than TOMM5-specific perturbation experiments</td>
+<td>Pitt &amp; Buchanan, 2021, https://doi.org/10.3390/cells10051164 (pitt2021abiochemicaland pages 16-17, pitt2021abiochemicaland pages 3-6); Nussberger et al., 2024, https://doi.org/10.1042/bst20231236</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the strongest currently available evidence for human TOMM5 functional annotation, emphasizing what is directly supported in humans versus what is inferred from TOM-complex structure or fungal ortholog studies. It is useful for distinguishing high-confidence facts from remaining knowledge gaps.</em></p>
+<h3 id="10-conclusions-functional-annotation-statement">10) Conclusions (functional annotation statement)</h3>
+<p>Human <strong>TOMM5 (Q8N4H5)</strong> encodes a <strong>very small</strong>, single-pass α‑helical subunit of the mitochondrial <strong>TOM</strong> protein import machinery. The highest-confidence human evidence is structural: TOMM5 is a peripheral β‑barrel-associated component of the TOM core that directly contacts <strong>TOMM40/Tom40</strong> and sits adjacent to Tom6/Tom7/Tom22 in the assembled pore complex (guan2021structuralinsightsinto media bb38bae5, pitt2021abiochemicaland pages 6-9). Mechanistically, TOMM5 is best annotated as an <strong>accessory structural/regulatory subunit</strong> that supports TOM complex organization and likely assists biogenesis/assembly (strongest causal evidence from yeast) rather than acting as a receptor with defined substrate specificity (becker2010assemblyofthe pages 1-2, pitt2021abiochemicaland pages 16-17). TOMM5-specific human disease genetics remain underdeveloped in the retrieved literature, but a Tomm5 knockout mouse phenotype indicates potential organism-level importance and motivates deeper human functional and genetic studies (vogel2013cryptogenicorganizingpneumonia pages 5-7).</p>
+<h3 id="urls-most-central-sources">URLs (most central sources)</h3>
+<ul>
+<li>Guan et al. 2021 (Cell Discovery; human TOM core structures): https://doi.org/10.1038/s41421-021-00252-7 (guan2021structuralinsightsinto media bb38bae5, guan2021structuralinsightsinto media 07568b50)</li>
+<li>Wang et al. 2020 (Cell Discovery; atomic human TOM core): https://doi.org/10.1038/s41421-020-00198-2</li>
+<li>Pitt &amp; Buchanan 2021 (Cells; TOM complex interactions/disease context): https://doi.org/10.3390/cells10051164 (pitt2021abiochemicaland pages 6-9, pitt2021abiochemicaland pages 16-17)</li>
+<li>Kamradt &amp; Makarewich 2023 (AJP-Cell; mitochondrial microproteins): https://doi.org/10.1152/ajpcell.00189.2023 (kamradt2023mitochondrialmicroproteinscritical pages 1-4)</li>
+<li>Nussberger et al. 2024 (Biochem Soc Trans; TOM structure/dynamics): https://doi.org/10.1042/bst20231236 (nussberger2024newinsightsinto pages 2-4)</li>
+<li>Araiso &amp; Endo 2022 (Biophysics and Physicobiology; TOM structural overview): https://doi.org/10.2142/biophysico.bppb-v19.0022 (araiso2022structuraloverviewof pages 1-3)</li>
+<li>Becker et al. 2010 (MBoC; Tom5 in Tom40 assembly, yeast): https://doi.org/10.1091/mbc.e10-06-0518 (becker2010assemblyofthe pages 1-2)</li>
+<li>Vogel et al. 2013 (Vet Pathol; Tomm5−/− mouse COP-like phenotype): https://doi.org/10.1177/0300985812450723 (vogel2013cryptogenicorganizingpneumonia pages 5-7, vogel2013cryptogenicorganizingpneumonia pages 1-2)</li>
+</ul>
+<p>References</p>
+<ol>
+<li>
+<p>(pitt2021abiochemicaland pages 1-3): Ashley S. Pitt and Susan K. Buchanan. A biochemical and structural understanding of tom complex interactions and implications for human health and disease. Cells, 10:1164, May 2021. URL: https://doi.org/10.3390/cells10051164, doi:10.3390/cells10051164. This article has 46 citations.</p>
+</li>
+<li>
+<p>(pitt2021abiochemicaland pages 6-9): Ashley S. Pitt and Susan K. Buchanan. A biochemical and structural understanding of tom complex interactions and implications for human health and disease. Cells, 10:1164, May 2021. URL: https://doi.org/10.3390/cells10051164, doi:10.3390/cells10051164. This article has 46 citations.</p>
+</li>
+<li>
+<p>(pitt2021abiochemicaland pages 16-17): Ashley S. Pitt and Susan K. Buchanan. A biochemical and structural understanding of tom complex interactions and implications for human health and disease. Cells, 10:1164, May 2021. URL: https://doi.org/10.3390/cells10051164, doi:10.3390/cells10051164. This article has 46 citations.</p>
+</li>
+<li>
+<p>(tucker2019cryoemstructureof pages 1-3): Kyle Tucker and Eunyong Park. Cryo-em structure of the mitochondrial protein-import channel tom complex at near-atomic resolution. Nature Structural &amp; Molecular Biology, 26:1158-1166, Nov 2019. URL: https://doi.org/10.1038/s41594-019-0339-2, doi:10.1038/s41594-019-0339-2. This article has 208 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(becker2010assemblyofthe pages 1-2): Thomas Becker, Bernard Guiard, Nicolas Thornton, Nicole Zufall, David A. Stroud, Nils Wiedemann, and Nikolaus Pfanner. Assembly of the mitochondrial protein import channel. Molecular Biology of the Cell, 21:3106-3113, Sep 2010. URL: https://doi.org/10.1091/mbc.e10-06-0518, doi:10.1091/mbc.e10-06-0518. This article has 77 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(bausewein2020thestructureof pages 5-8): Thomas Bausewein, Hammad Naveed, Jie Liang, and Stephan Nussberger. The structure of the tom core complex in the mitochondrial outer membrane. Biological Chemistry, 401:687-697, Apr 2020. URL: https://doi.org/10.1515/hsz-2020-0104, doi:10.1515/hsz-2020-0104. This article has 25 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(araiso2022structuraloverviewof pages 1-3): Yuhei Araiso and Toshiya Endo. Structural overview of the translocase of the mitochondrial outer membrane complex. Biophysics and Physicobiology, 19:n/a, Jun 2022. URL: https://doi.org/10.2142/biophysico.bppb-v19.0022, doi:10.2142/biophysico.bppb-v19.0022. This article has 21 citations.</p>
+</li>
+<li>
+<p>(guan2021structuralinsightsinto media bb38bae5): Zeyuan Guan, Ling Yan, Qiang Wang, Liangbo Qi, Sixing Hong, Zhou Gong, Chuangye Yan, and Ping Yin. Structural insights into assembly of human mitochondrial translocase tom complex. Cell Discovery, Apr 2021. URL: https://doi.org/10.1038/s41421-021-00252-7, doi:10.1038/s41421-021-00252-7. This article has 50 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(guan2021structuralinsightsinto media 07568b50): Zeyuan Guan, Ling Yan, Qiang Wang, Liangbo Qi, Sixing Hong, Zhou Gong, Chuangye Yan, and Ping Yin. Structural insights into assembly of human mitochondrial translocase tom complex. Cell Discovery, Apr 2021. URL: https://doi.org/10.1038/s41421-021-00252-7, doi:10.1038/s41421-021-00252-7. This article has 50 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(pitt2021abiochemicaland pages 3-6): Ashley S. Pitt and Susan K. Buchanan. A biochemical and structural understanding of tom complex interactions and implications for human health and disease. Cells, 10:1164, May 2021. URL: https://doi.org/10.3390/cells10051164, doi:10.3390/cells10051164. This article has 46 citations.</p>
+</li>
+<li>
+<p>(pitt2021abiochemicaland pages 11-12): Ashley S. Pitt and Susan K. Buchanan. A biochemical and structural understanding of tom complex interactions and implications for human health and disease. Cells, 10:1164, May 2021. URL: https://doi.org/10.3390/cells10051164, doi:10.3390/cells10051164. This article has 46 citations.</p>
+</li>
+<li>
+<p>(kamradt2023mitochondrialmicroproteinscritical pages 1-4): Michael L. Kamradt and Catherine A. Makarewich. Mitochondrial microproteins: critical regulators of protein import, energy production, stress response pathways, and programmed cell death. American Journal of Physiology-Cell Physiology, 325:C807-C816, Oct 2023. URL: https://doi.org/10.1152/ajpcell.00189.2023, doi:10.1152/ajpcell.00189.2023. This article has 12 citations.</p>
+</li>
+<li>
+<p>(nussberger2024newinsightsinto pages 2-4): Stephan Nussberger, Robin Ghosh, and Shuo Wang. New insights into the structure and dynamics of the tom complex in mitochondria. Biochemical Society Transactions, 52:911-922, Apr 2024. URL: https://doi.org/10.1042/bst20231236, doi:10.1042/bst20231236. This article has 5 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(OpenTargets Search: -TOMM5): Open Targets Query (-TOMM5, 5 results). Buniello, A. et al. (2025). Open Targets Platform: facilitating therapeutic hypotheses building in drug discovery. Nucleic Acids Research.</p>
+</li>
+<li>
+<p>(vogel2013cryptogenicorganizingpneumonia pages 1-2): P. Vogel, R. W. Read, J. E. Rehg, and G. M. Hansen. Cryptogenic organizing pneumonia in tomm5–/– mice. Veterinary Pathology, 50:65-75, Jan 2013. URL: https://doi.org/10.1177/0300985812450723, doi:10.1177/0300985812450723. This article has 19 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(vogel2013cryptogenicorganizingpneumonia pages 5-7): P. Vogel, R. W. Read, J. E. Rehg, and G. M. Hansen. Cryptogenic organizing pneumonia in tomm5–/– mice. Veterinary Pathology, 50:65-75, Jan 2013. URL: https://doi.org/10.1177/0300985812450723, doi:10.1177/0300985812450723. This article has 19 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>pitt2021abiochemicaland pages 1-3</li>
+<li>araiso2022structuraloverviewof pages 1-3</li>
+<li>becker2010assemblyofthe pages 1-2</li>
+<li>pitt2021abiochemicaland pages 6-9</li>
+<li>pitt2021abiochemicaland pages 11-12</li>
+<li>kamradt2023mitochondrialmicroproteinscritical pages 1-4</li>
+<li>nussberger2024newinsightsinto pages 2-4</li>
+<li>bausewein2020thestructureof pages 5-8</li>
+<li>vogel2013cryptogenicorganizingpneumonia pages 5-7</li>
+<li>pitt2021abiochemicaland pages 16-17</li>
+<li>tucker2019cryoemstructureof pages 1-3</li>
+<li>pitt2021abiochemicaland pages 3-6</li>
+<li>vogel2013cryptogenicorganizingpneumonia pages 1-2</li>
+<li>https://doi.org/10.3390/cells10051164</li>
+<li>https://doi.org/10.1002/bies.202200160</li>
+<li>https://doi.org/10.1038/s41421-021-00252-7</li>
+<li>https://doi.org/10.1038/s41421-020-00198-2;</li>
+<li>https://doi.org/10.2142/biophysico.bppb-v19.0022</li>
+<li>https://doi.org/10.1038/s41594-019-0339-2</li>
+<li>https://doi.org/10.1038/s41421-021-00252-7;</li>
+<li>https://doi.org/10.1038/s41421-020-00198-2</li>
+<li>https://doi.org/10.1091/mbc.e10-06-0518</li>
+<li>https://doi.org/10.1152/ajpcell.00189.2023;</li>
+<li>https://doi.org/10.1002/bies.202200160;</li>
+<li>https://doi.org/10.1042/bst20231236;</li>
+<li>https://doi.org/10.1515/hsz-2024-0043</li>
+<li>https://doi.org/10.1089/dna.2018.4292;</li>
+<li>https://doi.org/10.3389/fcvm.2021.749756;</li>
+<li>https://doi.org/10.1177/0300985812450723;</li>
+<li>https://doi.org/10.1016/j.xhgg.2022.100148</li>
+<li>https://doi.org/10.1042/bst20231236</li>
+<li>https://doi.org/10.1152/ajpcell.00189.2023</li>
+<li>https://doi.org/10.1177/0300985812450723</li>
+<li>https://doi.org/10.3390/cells10051164,</li>
+<li>https://doi.org/10.1038/s41594-019-0339-2,</li>
+<li>https://doi.org/10.1091/mbc.e10-06-0518,</li>
+<li>https://doi.org/10.1515/hsz-2020-0104,</li>
+<li>https://doi.org/10.2142/biophysico.bppb-v19.0022,</li>
+<li>https://doi.org/10.1038/s41421-021-00252-7,</li>
+<li>https://doi.org/10.1152/ajpcell.00189.2023,</li>
+<li>https://doi.org/10.1042/bst20231236,</li>
+<li>https://doi.org/10.1177/0300985812450723,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q8N4H5
+gene_symbol: TOMM5
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: &gt;-
+  TOMM5 is a very small single-pass mitochondrial outer membrane subunit of the
+  TOM translocase core. It is a structural/regulatory accessory component, not
+  an enzyme or independent receptor, and supports TOM core organization,
+  stability, and biogenesis around TOMM40.
+alternative_products:
+- name: &#39;1&#39;
+  id: Q8N4H5-1
+- name: &#39;2&#39;
+  id: Q8N4H5-2
+  sequence_note: VSP_046982
+- name: &#39;3&#39;
+  id: Q8N4H5-3
+  sequence_note: VSP_046983
+existing_annotations:
+- term:
+    id: GO:0005742
+    label: mitochondrial outer membrane translocase complex
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: &gt;-
+      Correct phylogenetic inference. TOMM5 is a conserved small Tom subunit of
+      the TOM core complex.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM5/TOMM5-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TOMM5/TOMM5-deep-research-falcon.md
+      supporting_text: &#34;TOMM5 is a component of the TOM machinery embedded in the **mitochondrial outer membrane** as part of the detergent-stable TOM **core complex**&#34;
+- term:
+    id: GO:0005741
+    label: mitochondrial outer membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  review:
+    summary: &gt;-
+      Correct UniProt-derived localization. Human structural and review evidence
+      place TOMM5 in the mitochondrial outer membrane TOM core.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM5/TOMM5-deep-research-falcon.md
+- term:
+    id: GO:0005742
+    label: mitochondrial outer membrane translocase complex
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  review:
+    summary: &gt;-
+      Correct InterPro-derived complex annotation. TOMM5 is a small subunit of
+      the mitochondrial TOM translocase complex.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM5/TOMM5-deep-research-falcon.md
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IDA
+  original_reference_id: GO_REF:0000052
+  review:
+    summary: &gt;-
+      Correct but less specific than the well-supported mitochondrial outer
+      membrane/TOM complex localization.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Subsumed by mitochondrial outer membrane and TOM complex annotations.
+    additional_reference_ids:
+    - file:human/TOMM5/TOMM5-deep-research-falcon.md
+- term:
+    id: GO:0005741
+    label: mitochondrial outer membrane
+  evidence_type: NAS
+  original_reference_id: PMID:18331822
+  review:
+    summary: &gt;-
+      Kato and Mihara identified human Tom5 in the outer membrane TOM
+      preprotein translocase complex; this matches the Falcon synthesis of
+      structural evidence.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM5/TOMM5-deep-research-falcon.md
+- term:
+    id: GO:0045040
+    label: protein insertion into mitochondrial outer membrane
+  evidence_type: NAS
+  original_reference_id: PMID:18331822
+  review:
+    summary: &gt;-
+      TOMM5 supports TOM organization and biogenesis, but the evidence does not
+      support TOMM5 as an independent insertase for outer membrane proteins.
+      TOM complex assembly is the more precise process annotation.
+    action: MODIFY
+    reason: &gt;-
+      Replace the insertion term with TOM complex assembly/stability, which is
+      the small Tom5 subunit role supported by structural and ortholog evidence.
+    proposed_replacement_terms:
+    - id: GO:0070096
+      label: mitochondrial outer membrane translocase complex assembly
+    additional_reference_ids:
+    - file:human/TOMM5/TOMM5-deep-research-falcon.md
+- term:
+    id: GO:0140596
+    label: TOM complex
+  evidence_type: NAS
+  original_reference_id: PMID:18331822
+  review:
+    summary: &gt;-
+      Correct and specific. TOMM5 is a detergent-stable TOM core subunit
+      adjacent to TOMM40, TOMM6, TOMM7, and TOMM22.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM5/TOMM5-deep-research-falcon.md
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: HTP
+  original_reference_id: PMID:34800366
+  review:
+    summary: &gt;-
+      High-throughput mitochondrial proteome data support mitochondrial
+      localization, but the term is too general for a TOM outer membrane core
+      subunit.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Subsumed by mitochondrial outer membrane and TOM complex annotations.
+    additional_reference_ids:
+    - file:human/TOMM5/TOMM5-deep-research-falcon.md
+- term:
+    id: GO:0005741
+    label: mitochondrial outer membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-5205661
+  review:
+    summary: &gt;-
+      Reactome places TOMM5 at the mitochondrial outer membrane in TOM/PINK1
+      pathway context. This agrees with the TOM core localization.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM5/TOMM5-deep-research-falcon.md
+- term:
+    id: GO:0070585
+    label: protein localization to mitochondrion
+  evidence_type: IC
+  original_reference_id: PMID:18331822
+  review:
+    summary: &gt;-
+      Correct as a broad process annotation for a TOM complex subunit, but
+      TOMM5&#39;s more specific role is structural support of TOM core assembly and
+      organization.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Broad process term; the synthesized core function emphasizes TOM complex
+      assembly/stability.
+    additional_reference_ids:
+    - file:human/TOMM5/TOMM5-deep-research-falcon.md
+- term:
+    id: GO:0005742
+    label: mitochondrial outer membrane translocase complex
+  evidence_type: IDA
+  original_reference_id: PMID:18331822
+  review:
+    summary: &gt;-
+      Direct evidence from Kato and Mihara supports human TOMM5 membership in
+      the mitochondrial outer membrane translocase complex.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM5/TOMM5-deep-research-falcon.md
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: GO_REF:0000052
+  title: Gene Ontology annotation based on curation of immunofluorescence data
+  findings: []
+- id: PMID:18331822
+  title: Identification of Tom5 and Tom6 in the preprotein translocase complex of
+    human mitochondrial outer membrane.
+  findings: []
+- id: PMID:34800366
+  title: Quantitative high-confidence human mitochondrial proteome and its dynamics
+    in cellular context.
+  findings: []
+- id: Reactome:R-HSA-5205661
+  title: Pink1 is recruited from the cytoplasm to the mitochondria
+  findings: []
+- id: file:human/TOMM5/TOMM5-deep-research-falcon.md
+  title: Falcon deep research report for human TOMM5
+  findings: []
+core_functions:
+- description: &gt;-
+    TOMM5 is a structural/regulatory small Tom subunit that contributes to the
+    TOM core translocase by stabilizing TOMM40-containing assemblies and likely
+    assisting TOM biogenesis.
+  supported_by:
+  - reference_id: file:human/TOMM5/TOMM5-deep-research-falcon.md
+    supporting_text: &#34;TOMM5 is **not an enzyme** and has **no known catalytic reaction or substrate specificity** in the enzyme/transporter sense.&#34;
+  - reference_id: file:human/TOMM5/TOMM5-deep-research-falcon.md
+    supporting_text: &#34;TOMM5 is a component of the TOM machinery embedded in the **mitochondrial outer membrane** as part of the detergent-stable TOM **core complex**&#34;
+  - reference_id: file:human/TOMM5/TOMM5-deep-research-falcon.md
+    supporting_text: &#34;Mechanistically, TOMM5 is best annotated as an **accessory structural/regulatory subunit** that supports TOM complex organization and likely assists biogenesis/assembly&#34;
+  contributes_to_molecular_function:
+    id: GO:0008320
+    label: protein transmembrane transporter activity
+  directly_involved_in:
+  - id: GO:0070096
+    label: mitochondrial outer membrane translocase complex assembly
+  locations:
+  - id: GO:0005741
+    label: mitochondrial outer membrane
+  in_complex:
+    id: GO:0140596
+    label: TOM complex
+proposed_new_terms: []
+suggested_questions:
+- question: &gt;-
+    Which Tom5 contacts in the human TOM core are essential for TOMM40 assembly
+    versus precursor routing?
+  experts: []
+- question: &gt;-
+    How much of TOMM5 function in human cells can be separated from conserved
+    yeast Tom5 roles in late Tom40 assembly at SAM?
+  experts: []
+suggested_experiments:
+- hypothesis: &gt;-
+    TOMM5 promotes stable TOM core biogenesis by contacting TOMM40 during or
+    after TOMM40 assembly.
+  description: &gt;-
+    Use endogenous TOMM5 depletion/rescue with structure-guided mutants and
+    measure TOMM40 assembly intermediates, mature TOM complex abundance, and
+    import of representative mitochondrial precursor classes.
+  experiment_type: endogenous rescue and mitochondrial import assay
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/human/TOMM5/TOMM5-ai-review.yaml
+++ b/genes/human/TOMM5/TOMM5-ai-review.yaml
@@ -1,11 +1,15 @@
 id: Q8N4H5
 gene_symbol: TOMM5
 product_type: PROTEIN
-status: INITIALIZED
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
-description: 'TODO: Add description for TOMM5'
+description: >-
+  TOMM5 is a very small single-pass mitochondrial outer membrane subunit of the
+  TOM translocase core. It is a structural/regulatory accessory component, not
+  an enzyme or independent receptor, and supports TOM core organization,
+  stability, and biogenesis around TOMM40.
 alternative_products:
 - name: '1'
   id: Q8N4H5-1
@@ -22,88 +26,150 @@ existing_annotations:
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Correct phylogenetic inference. TOMM5 is a conserved small Tom subunit of
+      the TOM core complex.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM5/TOMM5-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TOMM5/TOMM5-deep-research-falcon.md
+      supporting_text: "TOMM5 is a component of the TOM machinery embedded in the **mitochondrial outer membrane** as part of the detergent-stable TOM **core complex**"
 - term:
     id: GO:0005741
     label: mitochondrial outer membrane
   evidence_type: IEA
   original_reference_id: GO_REF:0000044
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Correct UniProt-derived localization. Human structural and review evidence
+      place TOMM5 in the mitochondrial outer membrane TOM core.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM5/TOMM5-deep-research-falcon.md
 - term:
     id: GO:0005742
     label: mitochondrial outer membrane translocase complex
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Correct InterPro-derived complex annotation. TOMM5 is a small subunit of
+      the mitochondrial TOM translocase complex.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM5/TOMM5-deep-research-falcon.md
 - term:
     id: GO:0005739
     label: mitochondrion
   evidence_type: IDA
   original_reference_id: GO_REF:0000052
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Correct but less specific than the well-supported mitochondrial outer
+      membrane/TOM complex localization.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Subsumed by mitochondrial outer membrane and TOM complex annotations.
+    additional_reference_ids:
+    - file:human/TOMM5/TOMM5-deep-research-falcon.md
 - term:
     id: GO:0005741
     label: mitochondrial outer membrane
   evidence_type: NAS
   original_reference_id: PMID:18331822
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Kato and Mihara identified human Tom5 in the outer membrane TOM
+      preprotein translocase complex; this matches the Falcon synthesis of
+      structural evidence.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM5/TOMM5-deep-research-falcon.md
 - term:
     id: GO:0045040
     label: protein insertion into mitochondrial outer membrane
   evidence_type: NAS
   original_reference_id: PMID:18331822
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      TOMM5 supports TOM organization and biogenesis, but the evidence does not
+      support TOMM5 as an independent insertase for outer membrane proteins.
+      TOM complex assembly is the more precise process annotation.
+    action: MODIFY
+    reason: >-
+      Replace the insertion term with TOM complex assembly/stability, which is
+      the small Tom5 subunit role supported by structural and ortholog evidence.
+    proposed_replacement_terms:
+    - id: GO:0070096
+      label: mitochondrial outer membrane translocase complex assembly
+    additional_reference_ids:
+    - file:human/TOMM5/TOMM5-deep-research-falcon.md
 - term:
     id: GO:0140596
     label: TOM complex
   evidence_type: NAS
   original_reference_id: PMID:18331822
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Correct and specific. TOMM5 is a detergent-stable TOM core subunit
+      adjacent to TOMM40, TOMM6, TOMM7, and TOMM22.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM5/TOMM5-deep-research-falcon.md
 - term:
     id: GO:0005739
     label: mitochondrion
   evidence_type: HTP
   original_reference_id: PMID:34800366
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      High-throughput mitochondrial proteome data support mitochondrial
+      localization, but the term is too general for a TOM outer membrane core
+      subunit.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Subsumed by mitochondrial outer membrane and TOM complex annotations.
+    additional_reference_ids:
+    - file:human/TOMM5/TOMM5-deep-research-falcon.md
 - term:
     id: GO:0005741
     label: mitochondrial outer membrane
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-5205661
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Reactome places TOMM5 at the mitochondrial outer membrane in TOM/PINK1
+      pathway context. This agrees with the TOM core localization.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM5/TOMM5-deep-research-falcon.md
 - term:
     id: GO:0070585
     label: protein localization to mitochondrion
   evidence_type: IC
   original_reference_id: PMID:18331822
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Correct as a broad process annotation for a TOM complex subunit, but
+      TOMM5's more specific role is structural support of TOM core assembly and
+      organization.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      Broad process term; the synthesized core function emphasizes TOM complex
+      assembly/stability.
+    additional_reference_ids:
+    - file:human/TOMM5/TOMM5-deep-research-falcon.md
 - term:
     id: GO:0005742
     label: mitochondrial outer membrane translocase complex
   evidence_type: IDA
   original_reference_id: PMID:18331822
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Direct evidence from Kato and Mihara supports human TOMM5 membership in
+      the mitochondrial outer membrane translocase complex.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM5/TOMM5-deep-research-falcon.md
 references:
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO
@@ -131,3 +197,49 @@ references:
 - id: Reactome:R-HSA-5205661
   title: Pink1 is recruited from the cytoplasm to the mitochondria
   findings: []
+- id: file:human/TOMM5/TOMM5-deep-research-falcon.md
+  title: Falcon deep research report for human TOMM5
+  findings: []
+core_functions:
+- description: >-
+    TOMM5 is a structural/regulatory small Tom subunit that contributes to the
+    TOM core translocase by stabilizing TOMM40-containing assemblies and likely
+    assisting TOM biogenesis.
+  supported_by:
+  - reference_id: file:human/TOMM5/TOMM5-deep-research-falcon.md
+    supporting_text: "TOMM5 is **not an enzyme** and has **no known catalytic reaction or substrate specificity** in the enzyme/transporter sense."
+  - reference_id: file:human/TOMM5/TOMM5-deep-research-falcon.md
+    supporting_text: "TOMM5 is a component of the TOM machinery embedded in the **mitochondrial outer membrane** as part of the detergent-stable TOM **core complex**"
+  - reference_id: file:human/TOMM5/TOMM5-deep-research-falcon.md
+    supporting_text: "Mechanistically, TOMM5 is best annotated as an **accessory structural/regulatory subunit** that supports TOM complex organization and likely assists biogenesis/assembly"
+  contributes_to_molecular_function:
+    id: GO:0008320
+    label: protein transmembrane transporter activity
+  directly_involved_in:
+  - id: GO:0070096
+    label: mitochondrial outer membrane translocase complex assembly
+  locations:
+  - id: GO:0005741
+    label: mitochondrial outer membrane
+  in_complex:
+    id: GO:0140596
+    label: TOM complex
+proposed_new_terms: []
+suggested_questions:
+- question: >-
+    Which Tom5 contacts in the human TOM core are essential for TOMM40 assembly
+    versus precursor routing?
+  experts: []
+- question: >-
+    How much of TOMM5 function in human cells can be separated from conserved
+    yeast Tom5 roles in late Tom40 assembly at SAM?
+  experts: []
+suggested_experiments:
+- hypothesis: >-
+    TOMM5 promotes stable TOM core biogenesis by contacting TOMM40 during or
+    after TOMM40 assembly.
+  description: >-
+    Use endogenous TOMM5 depletion/rescue with structure-guided mutants and
+    measure TOMM40 assembly intermediates, mature TOM complex abundance, and
+    import of representative mitochondrial precursor classes.
+  experiment_type: endogenous rescue and mitochondrial import assay

--- a/genes/human/TOMM5/TOMM5-deep-research-falcon.md
+++ b/genes/human/TOMM5/TOMM5-deep-research-falcon.md
@@ -1,0 +1,319 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-11T10:59:40.604136'
+end_time: '2026-05-11T11:14:28.477844'
+duration_seconds: 887.87
+template_file: templates/gene_research_go_focused.md
+template_variables:
+  organism: human
+  gene_id: TOMM5
+  gene_symbol: TOMM5
+  uniprot_accession: Q8N4H5
+  protein_description: 'RecName: Full=Mitochondrial import receptor subunit TOM5 homolog;'
+  gene_info: Name=TOMM5; Synonyms=C9orf105, TOM5;
+  organism_full: Homo sapiens (Human).
+  protein_family: Belongs to the Tom5 family. .
+  protein_domains: Tom5. (IPR019603); TOMM5_metazoa. (IPR029179); Tom5 (PF10642)
+provider_config:
+  timeout: 600
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 42
+---
+
+## Question
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** Q8N4H5
+- **Protein Description:** RecName: Full=Mitochondrial import receptor subunit TOM5 homolog;
+- **Gene Information:** Name=TOMM5; Synonyms=C9orf105, TOM5;
+- **Organism (full):** Homo sapiens (Human).
+- **Protein Family:** Belongs to the Tom5 family. .
+- **Key Domains:** Tom5. (IPR019603); TOMM5_metazoa. (IPR029179); Tom5 (PF10642)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "TOMM5" matches the protein description above**
+2. **Verify the organism is correct:** Homo sapiens (Human).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'TOMM5' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **TOMM5** (gene ID: TOMM5, UniProt: Q8N4H5) in human.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** Q8N4H5
+- **Protein Description:** RecName: Full=Mitochondrial import receptor subunit TOM5 homolog;
+- **Gene Information:** Name=TOMM5; Synonyms=C9orf105, TOM5;
+- **Organism (full):** Homo sapiens (Human).
+- **Protein Family:** Belongs to the Tom5 family. .
+- **Key Domains:** Tom5. (IPR019603); TOMM5_metazoa. (IPR029179); Tom5 (PF10642)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "TOMM5" matches the protein description above**
+2. **Verify the organism is correct:** Homo sapiens (Human).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'TOMM5' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **TOMM5** (gene ID: TOMM5, UniProt: Q8N4H5) in human.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Research report: Human **TOMM5** (UniProt **Q8N4H5**; Tom5 family) functional annotation
+
+### 0) Identity verification (critical disambiguation)
+The gene **TOMM5** (synonyms **TOM5**, **C9orf105**) encodes the human homolog of the TOM-complex small subunit **Tom5**, a **single-pass α-helical** protein that is part of the mitochondrial **translocase of the outer membrane (TOM) complex** (pitt2021abiochemicaland pages 1-3, pitt2021abiochemicaland pages 6-9). The literature retrieved here consistently uses “Tom5/TOMM5” to denote this TOM-complex subunit and does not indicate an alternative human gene/protein with the same symbol in this context (pitt2021abiochemicaland pages 1-3).
+
+### 1) Key concepts and definitions (current understanding)
+
+#### 1.1 The TOM complex and mitochondrial protein import
+Mammalian mitochondria import the vast majority of their proteins from the cytosol; reviews typically cite ~**1,000–1,500** mitochondrial proteins, with import across the outer membrane occurring primarily through the **TOM complex** (pitt2021abiochemicaland pages 16-17, pitt2021abiochemicaland pages 6-9). The TOM complex is organized around the β‑barrel channel **TOMM40/Tom40**, with additional receptor and small accessory subunits that contribute to recognition, translocation, and complex organization (pitt2021abiochemicaland pages 1-3, pitt2021abiochemicaland pages 6-9).
+
+#### 1.2 What TOMM5 is (and is not)
+TOMM5 is **not an enzyme** and has **no known catalytic reaction or substrate specificity** in the enzyme/transporter sense. Rather, TOMM5 is best understood as a **structural/regulatory accessory subunit** of a large membrane translocase, contributing to the assembly, stability, and/or mechanistic routing properties of the TOM pore (tucker2019cryoemstructureof pages 1-3, pitt2021abiochemicaland pages 6-9).
+
+### 2) Molecular function of TOMM5 in the TOM complex
+
+#### 2.1 Core biochemical role (inferred from structure + ortholog experiments)
+Across species, Tom5-family proteins are described as **small TOM subunits** that directly associate with the Tom40 β‑barrel and are proposed to support: (i) **TOM complex stability/organization**, (ii) **precursor handling/transfer**, and (iii) **biogenesis/assembly** of TOM components (tucker2019cryoemstructureof pages 1-3, becker2010assemblyofthe pages 1-2, bausewein2020thestructureof pages 5-8).
+
+A key mechanistic idea emphasized in structural reviews is that Tom5 sits at a peripheral region of the TOM dimer and is positioned to participate in routing or recruitment events for particular classes of imported precursors (araiso2022structuraloverviewof pages 1-3). In particular, Araiso & Endo summarize cryo‑EM-derived models in which the **N‑terminal segment of Tom40** traverses the channel and **interacts with Tom5** at the **periphery** of the TOM dimer; this site is discussed as a location where downstream components for **presequence‑lacking precursors** can be recruited (araiso2022structuraloverviewof pages 1-3).
+
+#### 2.2 Role in TOM biogenesis/assembly (strongest direct experimental evidence is fungal/yeast)
+The most direct causal evidence for a Tom5-family protein in TOM assembly comes from yeast: Becker et al. identified a Tom40 assembly intermediate at the SAM complex and concluded that **Tom5 associates with the Tom40 precursor at the SAM complex** in a later stage that promotes Tom40 assembly; Tom5 thereby helps progress Tom40 from early SAM-associated intermediates toward mature TOM complexes (becker2010assemblyofthe pages 1-2). While this is not human TOMM5 per se, it is widely used as the mechanistic basis for inferring a conserved Tom5 contribution to TOM core biogenesis (becker2010assemblyofthe pages 1-2, pitt2021abiochemicaland pages 6-9).
+
+### 3) Subcellular localization and topology (human-specific structural evidence)
+
+#### 3.1 Localization
+TOMM5 is a component of the TOM machinery embedded in the **mitochondrial outer membrane** as part of the detergent-stable TOM **core complex** (pitt2021abiochemicaland pages 6-9, guan2021structuralinsightsinto media bb38bae5).
+
+#### 3.2 Topology and position within the human TOM core
+Human cryo‑EM structures of the TOM core complex resolve Tom5 (TOMM5) as a **single-pass α‑helical** subunit that **surrounds** the Tom40 β‑barrel together with Tom6 and Tom7 (pitt2021abiochemicaland pages 6-9). In the human TOM core complex structure presented by Guan et al., Tom5 is located on the **periphery of each Tom40 barrel** (rather than at the Tom22-bridged central interface), consistent with a peripheral accessory role (guan2021structuralinsightsinto media bb38bae5, guan2021structuralinsightsinto media 07568b50).
+
+### 4) Interaction partners and complex membership
+
+#### 4.1 TOM core membership and direct contacts
+Structural and review evidence places TOMM5 as a β‑barrel-associated TOM core subunit that directly contacts **TOMM40/Tom40**, and resides adjacent to **Tom6, Tom7, and Tom22** in the assembled complex (pitt2021abiochemicaland pages 6-9, pitt2021abiochemicaland pages 3-6). The TOM core is observed in multiple oligomeric states (dimeric/tetrameric/trimeric forms) that all retain Tom5 as part of the assembly (pitt2021abiochemicaland pages 11-12).
+
+#### 4.2 Oligomeric state statistics (structural)
+A review synthesis of cryo‑EM findings reports TOM core oligomers that include:
+* a **dimeric** core containing a dimer of Tom40 with Tom5, Tom6, Tom7, and Tom22;
+* a **tetrameric** arrangement (dimer of dimers) with **two copies each** of Tom6, Tom22, and **Tom5** at the dimer–dimer interface; and
+* a **trimeric** TOM containing three copies of Tom40, Tom5, Tom6, Tom7, Tom22 (pitt2021abiochemicaland pages 11-12).
+
+### 5) Recent developments and latest research (priority 2023–2024)
+
+#### 5.1 2023: TOMM5 as a mitochondrial microprotein in a large translocase
+A 2023 review focused on mitochondrial microproteins explicitly catalogs TOMM5 as a **51‑amino‑acid** TOM component and describes Tom5/TOMM5 (with TOMM6 and TOMM7) as associating with TOMM40 and **regulating stability** of the import channel; the review also contextualizes the TOM complex as an ~**440 kDa** system (kamradt2023mitochondrialmicroproteinscritical pages 1-4). Although the excerpted text is review-level (not a new primary perturbation study), it represents current (2023) consensus framing of TOMM5’s role as a very small structural regulator embedded in a major import machine (kamradt2023mitochondrialmicroproteinscritical pages 1-4).
+
+#### 5.2 2024: Structure/dynamics-focused TOM reviews reinforce TOMM5’s role as a small core subunit
+A 2024 Biochemical Society Transactions review on TOM structure/dynamics lists Tom5 among the holo-complex subunits and emphasizes the structural context of a two‑pore Tom40 architecture revealed by cryo‑EM; it additionally notes that Tom5 shows relatively **low sequence identity** across fungi, consistent with evolutionary flexibility outside small conserved motifs (nussberger2024newinsightsinto pages 2-4). A complementary structure-centric synthesis also frames Tom5 among the “low molecular weight” TOM subunits implicated in assembly/stability and possible precursor handover at the cytosolic face (bausewein2020thestructureof pages 5-8).
+
+### 6) Disease relevance, phenotypes, and real-world implementations
+
+#### 6.1 Human disease genetics: limited TOMM5-specific evidence in retrieved primary literature
+In the retrieved sources, there is **no well-established monogenic human disease** directly attributed to TOMM5 variants, and human TOMM5-specific functional perturbation datasets were not prominent in the accessible full texts (pitt2021abiochemicaland pages 16-17, pitt2021abiochemicaland pages 3-6). Database-level disease-target associations exist (e.g., Open Targets lists several diseases with low overall association scores and evidence largely driven by limited literature and functional genomics screens), but these should be treated as **hypothesis-generating** rather than confirmatory (OpenTargets Search: -TOMM5).
+
+#### 6.2 Strongest organismal phenotype evidence: Tomm5−/− mice
+A dedicated mouse knockout pathology study reported that **Tomm5−/−** mice develop a striking **lung-restricted** phenotype resembling human **cryptogenic organizing pneumonia (COP)**, with patchy intra-alveolar organizing lesions that evolve into fibrogenic buds containing extracellular matrix components and **α‑SMA-positive myofibroblasts**; the authors propose impaired mitochondrial function/import during neonatal transition to air and oxidative stress as plausible contributing mechanisms (vogel2013cryptogenicorganizingpneumonia pages 1-2, vogel2013cryptogenicorganizingpneumonia pages 5-7). This provides important in vivo evidence that Tomm5 can be physiologically important, though it does not by itself establish a direct human TOMM5 disease mechanism (vogel2013cryptogenicorganizingpneumonia pages 5-7).
+
+#### 6.3 Applications and implementations in research/biomedicine
+* **Structure-enabled mechanistic modeling:** Human cryo‑EM structures (and their review syntheses) are actively used to infer how accessory subunits such as Tom5 position around Tom40 and may influence routing and complex dynamics (guan2021structuralinsightsinto media bb38bae5, araiso2022structuraloverviewof pages 1-3).
+* **Mitochondrial targeting tools:** A TOM review notes that human Tom5 has been used as a **mitochondrial-targeting fusion** in a cancer-cell context (e.g., to deliver p53 to mitochondria), illustrating use of TOMM5-derived sequences as experimental targeting elements; however, this is not yet a validated therapeutic approach (pitt2021abiochemicaland pages 16-17).
+
+### 7) Expert synthesis and interpretation (authoritative viewpoints)
+
+1. **Confidence-high statements (human structural context):** TOMM5 is a small α‑helical TOM core subunit that directly contacts Tom40 and is positioned peripherally in human TOM core cryo‑EM reconstructions (guan2021structuralinsightsinto media bb38bae5, pitt2021abiochemicaland pages 6-9).
+2. **Moderate-confidence mechanistic role (cross-species inference):** Tom5-family proteins likely contribute to **TOM assembly/biogenesis and stability**, supported strongly by yeast SAM-associated assembly intermediates and widely extrapolated to metazoans (becker2010assemblyofthe pages 1-2, pitt2021abiochemicaland pages 6-9).
+3. **Open questions emphasized by experts:** Reviews explicitly state that functional knowledge for Tom5/TOMM5 in humans remains limited compared with other subunits; some yeast-specific mechanistic features (Tom40 regions implicated in Tom5 interactions) may not be conserved in human Tom40, implying that the exact human mechanism could differ (pitt2021abiochemicaland pages 16-17).
+
+### 8) Key statistics and data points (from recent/authoritative sources)
+* TOMM5 is described as **~51 aa** in a 2023 mitochondrial microprotein review (kamradt2023mitochondrialmicroproteinscritical pages 1-4).
+* TOM (reviewed) is an ~**440 kDa** complex (kamradt2023mitochondrialmicroproteinscritical pages 1-4).
+* TOM core oligomeric states reported from cryo‑EM include dimeric/tetrameric/trimeric assemblies containing Tom5, with **two copies** of Tom5 at the tetramer interface (review synthesis) (pitt2021abiochemicaland pages 11-12).
+
+### 9) Summary table of evidence
+The following table consolidates high-confidence annotation statements, clearly separating human-structure-based evidence from inferences and remaining gaps.
+
+| Annotation topic | Key points | Best supporting sources |
+|---|---|---|
+| Protein identity | • Human gene/protein verified as **TOMM5 / Tom5**, UniProt **Q8N4H5** • Small **Tom5-family** subunit of the mitochondrial **TOM** (translocase of outer membrane) complex • Reviewed as one of the canonical TOM components in human mitochondria | Pitt & Buchanan, 2021, https://doi.org/10.3390/cells10051164 (pitt2021abiochemicaland pages 1-3, pitt2021abiochemicaland pages 3-6); Lionaki et al., 2023, https://doi.org/10.1002/bies.202200160 |
+| Subcellular localization / topology | • Localized to the **mitochondrial outer membrane** within the TOM core complex • **Single-pass α-helical** membrane protein; one of the small TOM subunits • In human cryo-EM structures, Tom5 lies on the **periphery of each Tom40 barrel**, opposite the Tom22-bridged central interface | Guan et al., 2021, https://doi.org/10.1038/s41421-021-00252-7 (guan2021structuralinsightsinto media bb38bae5, guan2021structuralinsightsinto media 07568b50); Wang et al., 2020, https://doi.org/10.1038/s41421-020-00198-2; Araiso & Endo, 2022, https://doi.org/10.2142/biophysico.bppb-v19.0022 (araiso2022structuraloverviewof pages 1-3) |
+| Molecular function | • Not an enzyme; acts as a **structural/regulatory accessory subunit** of the TOM import channel • Proposed roles include **precursor transfer**, **binding-site formation**, and **assembly/stability** support for TOM • Functional assignment in humans remains partly inferred from structure and fungal homologs | Tucker & Park, 2019, https://doi.org/10.1038/s41594-019-0339-2 (tucker2019cryoemstructureof pages 1-3); Pitt & Buchanan, 2021, https://doi.org/10.3390/cells10051164 (pitt2021abiochemicaland pages 6-9, pitt2021abiochemicaland pages 16-17) |
+| Complex membership / interactions | • Member of the detergent-stable **TOM core** with **Tom40, Tom22, Tom6, Tom7** • Directly contacts **Tom40**; positioned near Tom22/Tom6/Tom7 in dimeric and higher-order assemblies • Human TOM cores resolved as **dimers**, with tetrameric/higher-order states also observed | Pitt & Buchanan, 2021, https://doi.org/10.3390/cells10051164 (pitt2021abiochemicaland pages 3-6, pitt2021abiochemicaland pages 11-12, pitt2021abiochemicaland pages 6-9); Guan et al., 2021, https://doi.org/10.1038/s41421-021-00252-7; Wang et al., 2020, https://doi.org/10.1038/s41421-020-00198-2 |
+| Role in import mechanism | • TOM is the main entry gate for most nuclear-encoded mitochondrial proteins; Tom5 contributes as an **auxiliary subunit** rather than a receptor with a known substrate specificity • Structural review places Tom5 near the **Tom40 N-terminal segment** and a peripheral route implicated in recruiting downstream factors for **presequence-lacking precursors** • Detailed **human-specific mechanistic proof** remains limited | Araiso & Endo, 2022, https://doi.org/10.2142/biophysico.bppb-v19.0022 (araiso2022structuraloverviewof pages 1-3); Pitt & Buchanan, 2021, https://doi.org/10.3390/cells10051164 (pitt2021abiochemicaland pages 16-17) |
+| Role in TOM biogenesis / assembly | • Best direct evidence comes from **yeast/fungal ortholog** studies: Tom5 promotes a later **SAM-associated Tom40 assembly stage** • Supports formation of stable intermediates for integration of newly synthesized TOM components • Human role is widely inferred to involve **assembly and maintenance** of TOM, but dedicated endogenous TOMM5 perturbation data are scarce | Becker et al., 2010, https://doi.org/10.1091/mbc.e10-06-0518 (becker2010assemblyofthe pages 1-2); Pitt & Buchanan, 2021, https://doi.org/10.3390/cells10051164 (pitt2021abiochemicaland pages 6-9, pitt2021abiochemicaland pages 16-17) |
+| Recent 2023–2024 developments | • 2023 review highlights TOMM5 as a **51-aa mitochondrial microprotein** embedded in a large import machine • 2024 reviews emphasize evolutionary conservation of the TOM architecture and new structure/dynamics insights, reinforcing Tom5 as a **small regulatory/core-surrounding subunit** • Recent work refines **complex architecture and dynamics** more than TOMM5-specific biochemistry | Kamradt & Makarewich, 2023, https://doi.org/10.1152/ajpcell.00189.2023; Lionaki et al., 2023, https://doi.org/10.1002/bies.202200160; Nussberger et al., 2024, https://doi.org/10.1042/bst20231236; Özdemir & Dennerlein, 2024, https://doi.org/10.1515/hsz-2024-0043 |
+| Disease / phenotype links | • No well-established **monogenic human TOMM5 disease** is supported by the retrieved primary literature • Broader TOM dysfunction is linked to neurodegeneration, cardiovascular disease, mitophagy defects, and cancer biology, but this is usually driven by other TOM subunits • Database-level disease associations for TOMM5 exist but are **low-confidence / indirect** and should be interpreted cautiously | Heinemeyer et al., 2019, https://doi.org/10.1089/dna.2018.4292; Zhao & Zou, 2021, https://doi.org/10.3389/fcvm.2021.749756; Open Targets (accessed via tool output) (OpenTargets Search: -TOMM5) |
+| Model-organism phenotype evidence | • A mouse knockout report described **cryptogenic organizing pneumonia** in **Tomm5−/−** mice, indicating organism-level importance • This phenotype is informative but does **not yet define the precise molecular lesion** in human cells • Separate TOM-complex small-subunit disease precedent exists for **TOMM7**, underscoring plausibility of TOM small-subunit pathology | Vogel et al., 2013, https://doi.org/10.1177/0300985812450723; Young et al., 2023, https://doi.org/10.1016/j.xhgg.2022.100148 |
+| Knowledge gaps / confidence limits | • Human **endogenous TOMM5 loss-of-function** studies are very limited • No clear human **substrate specificity**, catalytic activity, or direct disease-causing variants established • Many functional claims are extrapolated from **fungal orthologs** and from TOM-complex structural context rather than TOMM5-specific perturbation experiments | Pitt & Buchanan, 2021, https://doi.org/10.3390/cells10051164 (pitt2021abiochemicaland pages 16-17, pitt2021abiochemicaland pages 3-6); Nussberger et al., 2024, https://doi.org/10.1042/bst20231236 |
+
+
+*Table: This table summarizes the strongest currently available evidence for human TOMM5 functional annotation, emphasizing what is directly supported in humans versus what is inferred from TOM-complex structure or fungal ortholog studies. It is useful for distinguishing high-confidence facts from remaining knowledge gaps.*
+
+### 10) Conclusions (functional annotation statement)
+Human **TOMM5 (Q8N4H5)** encodes a **very small**, single-pass α‑helical subunit of the mitochondrial **TOM** protein import machinery. The highest-confidence human evidence is structural: TOMM5 is a peripheral β‑barrel-associated component of the TOM core that directly contacts **TOMM40/Tom40** and sits adjacent to Tom6/Tom7/Tom22 in the assembled pore complex (guan2021structuralinsightsinto media bb38bae5, pitt2021abiochemicaland pages 6-9). Mechanistically, TOMM5 is best annotated as an **accessory structural/regulatory subunit** that supports TOM complex organization and likely assists biogenesis/assembly (strongest causal evidence from yeast) rather than acting as a receptor with defined substrate specificity (becker2010assemblyofthe pages 1-2, pitt2021abiochemicaland pages 16-17). TOMM5-specific human disease genetics remain underdeveloped in the retrieved literature, but a Tomm5 knockout mouse phenotype indicates potential organism-level importance and motivates deeper human functional and genetic studies (vogel2013cryptogenicorganizingpneumonia pages 5-7).
+
+### URLs (most central sources)
+* Guan et al. 2021 (Cell Discovery; human TOM core structures): https://doi.org/10.1038/s41421-021-00252-7 (guan2021structuralinsightsinto media bb38bae5, guan2021structuralinsightsinto media 07568b50)
+* Wang et al. 2020 (Cell Discovery; atomic human TOM core): https://doi.org/10.1038/s41421-020-00198-2
+* Pitt & Buchanan 2021 (Cells; TOM complex interactions/disease context): https://doi.org/10.3390/cells10051164 (pitt2021abiochemicaland pages 6-9, pitt2021abiochemicaland pages 16-17)
+* Kamradt & Makarewich 2023 (AJP-Cell; mitochondrial microproteins): https://doi.org/10.1152/ajpcell.00189.2023 (kamradt2023mitochondrialmicroproteinscritical pages 1-4)
+* Nussberger et al. 2024 (Biochem Soc Trans; TOM structure/dynamics): https://doi.org/10.1042/bst20231236 (nussberger2024newinsightsinto pages 2-4)
+* Araiso & Endo 2022 (Biophysics and Physicobiology; TOM structural overview): https://doi.org/10.2142/biophysico.bppb-v19.0022 (araiso2022structuraloverviewof pages 1-3)
+* Becker et al. 2010 (MBoC; Tom5 in Tom40 assembly, yeast): https://doi.org/10.1091/mbc.e10-06-0518 (becker2010assemblyofthe pages 1-2)
+* Vogel et al. 2013 (Vet Pathol; Tomm5−/− mouse COP-like phenotype): https://doi.org/10.1177/0300985812450723 (vogel2013cryptogenicorganizingpneumonia pages 5-7, vogel2013cryptogenicorganizingpneumonia pages 1-2)
+
+
+References
+
+1. (pitt2021abiochemicaland pages 1-3): Ashley S. Pitt and Susan K. Buchanan. A biochemical and structural understanding of tom complex interactions and implications for human health and disease. Cells, 10:1164, May 2021. URL: https://doi.org/10.3390/cells10051164, doi:10.3390/cells10051164. This article has 46 citations.
+
+2. (pitt2021abiochemicaland pages 6-9): Ashley S. Pitt and Susan K. Buchanan. A biochemical and structural understanding of tom complex interactions and implications for human health and disease. Cells, 10:1164, May 2021. URL: https://doi.org/10.3390/cells10051164, doi:10.3390/cells10051164. This article has 46 citations.
+
+3. (pitt2021abiochemicaland pages 16-17): Ashley S. Pitt and Susan K. Buchanan. A biochemical and structural understanding of tom complex interactions and implications for human health and disease. Cells, 10:1164, May 2021. URL: https://doi.org/10.3390/cells10051164, doi:10.3390/cells10051164. This article has 46 citations.
+
+4. (tucker2019cryoemstructureof pages 1-3): Kyle Tucker and Eunyong Park. Cryo-em structure of the mitochondrial protein-import channel tom complex at near-atomic resolution. Nature Structural & Molecular Biology, 26:1158-1166, Nov 2019. URL: https://doi.org/10.1038/s41594-019-0339-2, doi:10.1038/s41594-019-0339-2. This article has 208 citations and is from a highest quality peer-reviewed journal.
+
+5. (becker2010assemblyofthe pages 1-2): Thomas Becker, Bernard Guiard, Nicolas Thornton, Nicole Zufall, David A. Stroud, Nils Wiedemann, and Nikolaus Pfanner. Assembly of the mitochondrial protein import channel. Molecular Biology of the Cell, 21:3106-3113, Sep 2010. URL: https://doi.org/10.1091/mbc.e10-06-0518, doi:10.1091/mbc.e10-06-0518. This article has 77 citations and is from a domain leading peer-reviewed journal.
+
+6. (bausewein2020thestructureof pages 5-8): Thomas Bausewein, Hammad Naveed, Jie Liang, and Stephan Nussberger. The structure of the tom core complex in the mitochondrial outer membrane. Biological Chemistry, 401:687-697, Apr 2020. URL: https://doi.org/10.1515/hsz-2020-0104, doi:10.1515/hsz-2020-0104. This article has 25 citations and is from a peer-reviewed journal.
+
+7. (araiso2022structuraloverviewof pages 1-3): Yuhei Araiso and Toshiya Endo. Structural overview of the translocase of the mitochondrial outer membrane complex. Biophysics and Physicobiology, 19:n/a, Jun 2022. URL: https://doi.org/10.2142/biophysico.bppb-v19.0022, doi:10.2142/biophysico.bppb-v19.0022. This article has 21 citations.
+
+8. (guan2021structuralinsightsinto media bb38bae5): Zeyuan Guan, Ling Yan, Qiang Wang, Liangbo Qi, Sixing Hong, Zhou Gong, Chuangye Yan, and Ping Yin. Structural insights into assembly of human mitochondrial translocase tom complex. Cell Discovery, Apr 2021. URL: https://doi.org/10.1038/s41421-021-00252-7, doi:10.1038/s41421-021-00252-7. This article has 50 citations and is from a peer-reviewed journal.
+
+9. (guan2021structuralinsightsinto media 07568b50): Zeyuan Guan, Ling Yan, Qiang Wang, Liangbo Qi, Sixing Hong, Zhou Gong, Chuangye Yan, and Ping Yin. Structural insights into assembly of human mitochondrial translocase tom complex. Cell Discovery, Apr 2021. URL: https://doi.org/10.1038/s41421-021-00252-7, doi:10.1038/s41421-021-00252-7. This article has 50 citations and is from a peer-reviewed journal.
+
+10. (pitt2021abiochemicaland pages 3-6): Ashley S. Pitt and Susan K. Buchanan. A biochemical and structural understanding of tom complex interactions and implications for human health and disease. Cells, 10:1164, May 2021. URL: https://doi.org/10.3390/cells10051164, doi:10.3390/cells10051164. This article has 46 citations.
+
+11. (pitt2021abiochemicaland pages 11-12): Ashley S. Pitt and Susan K. Buchanan. A biochemical and structural understanding of tom complex interactions and implications for human health and disease. Cells, 10:1164, May 2021. URL: https://doi.org/10.3390/cells10051164, doi:10.3390/cells10051164. This article has 46 citations.
+
+12. (kamradt2023mitochondrialmicroproteinscritical pages 1-4): Michael L. Kamradt and Catherine A. Makarewich. Mitochondrial microproteins: critical regulators of protein import, energy production, stress response pathways, and programmed cell death. American Journal of Physiology-Cell Physiology, 325:C807-C816, Oct 2023. URL: https://doi.org/10.1152/ajpcell.00189.2023, doi:10.1152/ajpcell.00189.2023. This article has 12 citations.
+
+13. (nussberger2024newinsightsinto pages 2-4): Stephan Nussberger, Robin Ghosh, and Shuo Wang. New insights into the structure and dynamics of the tom complex in mitochondria. Biochemical Society Transactions, 52:911-922, Apr 2024. URL: https://doi.org/10.1042/bst20231236, doi:10.1042/bst20231236. This article has 5 citations and is from a peer-reviewed journal.
+
+14. (OpenTargets Search: -TOMM5): Open Targets Query (-TOMM5, 5 results). Buniello, A. et al. (2025). Open Targets Platform: facilitating therapeutic hypotheses building in drug discovery. Nucleic Acids Research.
+
+15. (vogel2013cryptogenicorganizingpneumonia pages 1-2): P. Vogel, R. W. Read, J. E. Rehg, and G. M. Hansen. Cryptogenic organizing pneumonia in tomm5–/– mice. Veterinary Pathology, 50:65-75, Jan 2013. URL: https://doi.org/10.1177/0300985812450723, doi:10.1177/0300985812450723. This article has 19 citations and is from a domain leading peer-reviewed journal.
+
+16. (vogel2013cryptogenicorganizingpneumonia pages 5-7): P. Vogel, R. W. Read, J. E. Rehg, and G. M. Hansen. Cryptogenic organizing pneumonia in tomm5–/– mice. Veterinary Pathology, 50:65-75, Jan 2013. URL: https://doi.org/10.1177/0300985812450723, doi:10.1177/0300985812450723. This article has 19 citations and is from a domain leading peer-reviewed journal.
+
+## Citations
+
+1. pitt2021abiochemicaland pages 1-3
+2. araiso2022structuraloverviewof pages 1-3
+3. becker2010assemblyofthe pages 1-2
+4. pitt2021abiochemicaland pages 6-9
+5. pitt2021abiochemicaland pages 11-12
+6. kamradt2023mitochondrialmicroproteinscritical pages 1-4
+7. nussberger2024newinsightsinto pages 2-4
+8. bausewein2020thestructureof pages 5-8
+9. vogel2013cryptogenicorganizingpneumonia pages 5-7
+10. pitt2021abiochemicaland pages 16-17
+11. tucker2019cryoemstructureof pages 1-3
+12. pitt2021abiochemicaland pages 3-6
+13. vogel2013cryptogenicorganizingpneumonia pages 1-2
+14. https://doi.org/10.3390/cells10051164
+15. https://doi.org/10.1002/bies.202200160
+16. https://doi.org/10.1038/s41421-021-00252-7
+17. https://doi.org/10.1038/s41421-020-00198-2;
+18. https://doi.org/10.2142/biophysico.bppb-v19.0022
+19. https://doi.org/10.1038/s41594-019-0339-2
+20. https://doi.org/10.1038/s41421-021-00252-7;
+21. https://doi.org/10.1038/s41421-020-00198-2
+22. https://doi.org/10.1091/mbc.e10-06-0518
+23. https://doi.org/10.1152/ajpcell.00189.2023;
+24. https://doi.org/10.1002/bies.202200160;
+25. https://doi.org/10.1042/bst20231236;
+26. https://doi.org/10.1515/hsz-2024-0043
+27. https://doi.org/10.1089/dna.2018.4292;
+28. https://doi.org/10.3389/fcvm.2021.749756;
+29. https://doi.org/10.1177/0300985812450723;
+30. https://doi.org/10.1016/j.xhgg.2022.100148
+31. https://doi.org/10.1042/bst20231236
+32. https://doi.org/10.1152/ajpcell.00189.2023
+33. https://doi.org/10.1177/0300985812450723
+34. https://doi.org/10.3390/cells10051164,
+35. https://doi.org/10.1038/s41594-019-0339-2,
+36. https://doi.org/10.1091/mbc.e10-06-0518,
+37. https://doi.org/10.1515/hsz-2020-0104,
+38. https://doi.org/10.2142/biophysico.bppb-v19.0022,
+39. https://doi.org/10.1038/s41421-021-00252-7,
+40. https://doi.org/10.1152/ajpcell.00189.2023,
+41. https://doi.org/10.1042/bst20231236,
+42. https://doi.org/10.1177/0300985812450723,

--- a/genes/human/TOMM6/TOMM6-ai-review.html
+++ b/genes/human/TOMM6/TOMM6-ai-review.html
@@ -1,0 +1,2588 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>TOMM6 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>TOMM6</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q96B49" target="_blank" class="term-link">
+                        Q96B49
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "TOMM6";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q96B49" data-a="DESCRIPTION: TOMM6 is a small single-pass mitochondrial outer m..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>TOMM6 is a small single-pass mitochondrial outer membrane subunit of the TOM translocase core. It is not an independent transporter or enzyme; instead it helps organize and stabilize the TOMM40/TOMM22-containing import channel, including anchoring/positioning TOMM22 and supporting TOM core assembly and oligomerization.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q96B49" data-a="GO:0005739" data-r="GO_REF:0000033" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> TOMM6 is a mitochondrial protein, but the annotation is less specific than the well-supported mitochondrial outer membrane/TOM complex localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Subsumed by mitochondrial outer membrane and TOM complex annotations.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005741" target="_blank" class="term-link">
+                                    GO:0005741
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial outer membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q96B49" data-a="GO:0005741" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct UniProt-derived localization. Falcon research summarizes TOMM6 as a single-pass outer mitochondrial membrane component of the TOM core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOMM6/TOMM6-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Human TOMM6 is an OMM component of TOM.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005742" target="_blank" class="term-link">
+                                    GO:0005742
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial outer membrane translocase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q96B49" data-a="GO:0005742" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct complex-level annotation. TOMM6 is one of the small Tom subunits of the TOM core with TOMM40, TOMM22, TOMM5, and TOMM7.
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:32296183
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A reference map of the human binary protein interactome.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q96B49" data-a="GO:0005515" data-r="PMID:32296183" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Generic binary-interactome protein binding does not capture TOMM6&#39;s specific role as a structural/regulatory TOM core subunit.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Protein binding is uninformative for TOMM6; the curated function is TOM complex organization at the mitochondrial outer membrane.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000052
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q96B49" data-a="GO:0005739" data-r="GO_REF:0000052" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct but too general. TOMM6 is specifically an outer membrane TOM core subunit.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Subsumed by mitochondrial outer membrane and TOM complex annotations.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005741" target="_blank" class="term-link">
+                                    GO:0005741
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial outer membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18331822" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:18331822
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Identification of Tom5 and Tom6 in the preprotein translocas...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q96B49" data-a="GO:0005741" data-r="PMID:18331822" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Kato and Mihara identified human Tom6 in the outer membrane TOM preprotein translocase complex; this agrees with structural/review evidence summarized by Falcon.
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045040" target="_blank" class="term-link">
+                                    GO:0045040
+                                </a>
+                            </span>
+                            <span class="term-label">protein insertion into mitochondrial outer membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18331822" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:18331822
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Identification of Tom5 and Tom6 in the preprotein translocas...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="Q96B49" data-a="GO:0045040" data-r="PMID:18331822" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> The broad direction of the annotation is related to TOMM6 biology, but TOMM6 is not itself an insertase. Evidence better supports a role in TOM core assembly, stability, and oligomerization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Replace the insertion process with TOM complex assembly/stability, which better matches the small Tom6 subunit role.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070096" target="_blank" class="term-link">
+                                    mitochondrial outer membrane translocase complex assembly
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140596" target="_blank" class="term-link">
+                                    GO:0140596
+                                </a>
+                            </span>
+                            <span class="term-label">TOM complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18331822" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:18331822
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Identification of Tom5 and Tom6 in the preprotein translocas...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q96B49" data-a="GO:0140596" data-r="PMID:18331822" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct specific complex annotation. TOMM6 is a small TOM core subunit positioned against TOMM40 and coupled to TOMM22 in structural models.
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HTP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:34800366
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Quantitative high-confidence human mitochondrial proteome an...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q96B49" data-a="GO:0005739" data-r="PMID:34800366" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput mitochondrial proteomics supports mitochondrial localization, but this is less specific than the mitochondrial outer membrane/TOM complex annotations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Subsumed by mitochondrial outer membrane and TOM complex annotations.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005741" target="_blank" class="term-link">
+                                    GO:0005741
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial outer membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-5205661
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q96B49" data-a="GO:0005741" data-r="Reactome:R-HSA-5205661" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reactome places TOMM6 at the mitochondrial outer membrane in TOM/PINK1 pathway context. This matches the structural TOM core localization.
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>TOMM6 is a structural/regulatory small Tom subunit that stabilizes and organizes the mitochondrial TOM core, supporting TOMM40/TOMM22-dependent mitochondrial protein import and TOM complex assembly.</h3>
+                <span class="vote-buttons" data-g="Q96B49" data-a="FUNCTION: TOMM6 is a structural/regulatory small Tom subunit..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070096" target="_blank" class="term-link">
+                                mitochondrial outer membrane translocase complex assembly
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005741" target="_blank" class="term-link">
+                                mitochondrial outer membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140596" target="_blank" class="term-link">
+                            TOM complex
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/TOMM6/TOMM6-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">In this framework, **TOMM6** is best defined as an **auxiliary structural/regulatory subunit** that supports **assembly, stability, and oligomerization** of the TOM core</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/TOMM6/TOMM6-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">Human TOMM6 is an OMM component of TOM.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/TOMM6/TOMM6-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">TOMM6 is not itself the pore; rather it supports the protein import pathway by maintaining TOM structural integrity and assembly state.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000052.md" target="_blank" class="term-link">
+                            GO_REF:0000052
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on curation of immunofluorescence data</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/18331822" target="_blank" class="term-link">
+                            PMID:18331822
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Identification of Tom5 and Tom6 in the preprotein translocase complex of human mitochondrial outer membrane.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
+                            PMID:32296183
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A reference map of the human binary protein interactome.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link">
+                            PMID:34800366
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Quantitative high-confidence human mitochondrial proteome and its dynamics in cellular context.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-5205661
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Pink1 is recruited from the cytoplasm to the mitochondria</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/TOMM6/TOMM6-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research report for human TOMM6</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Which human TOMM6 surfaces are required for TOMM22 anchoring versus general TOMM40 core stabilization?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q96B49" data-a="Q: Which human TOMM6 surfaces are required for TOMM22..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does endogenous TOMM6 depletion preferentially impair assembly of new TOM complexes or the import activity of pre-existing TOM complexes?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q96B49" data-a="Q: Does endogenous TOMM6 depletion preferentially imp..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Introduce TOMM6 point mutants in residues predicted to contact TOMM40 or TOMM22, then measure TOM complex assembly by blue-native PAGE/cryo-EM and mitochondrial precursor import using endogenous rescue assays.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: TOMM6 promotes TOM core assembly by stabilizing TOMM40-TOMM22 contacts.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: structure-guided mutagenesis and import assay</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q96B49" data-a="EXPERIMENT: Introduce TOMM6 point mutants in residues predicte..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Deep Research Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(TOMM6-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q96B49" data-a="DOC: Deep Research Falcon" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <hr />
+<p>provider: falcon<br />
+model: Edison Scientific Literature<br />
+cached: false<br />
+start_time: '2026-05-11T10:59:40.604165'<br />
+end_time: '2026-05-11T11:11:15.723692'<br />
+duration_seconds: 695.12<br />
+template_file: templates/gene_research_go_focused.md<br />
+template_variables:<br />
+  organism: human<br />
+  gene_id: TOMM6<br />
+  gene_symbol: TOMM6<br />
+  uniprot_accession: Q96B49<br />
+  protein_description: 'RecName: Full=Mitochondrial import receptor subunit TOM6 homolog;<br />
+    AltName: Full=Overexpressed breast tumor protein; AltName: Full=Translocase of<br />
+    outer membrane 6 kDa subunit homolog;'<br />
+  gene_info: Name=TOMM6; Synonyms=OBTP, TOM6;<br />
+  organism_full: Homo sapiens (Human).<br />
+  protein_family: Belongs to the Tom6 family. .<br />
+  protein_domains: TOMM6. (IPR029182); TOM6p (PF15184)<br />
+provider_config:<br />
+  timeout: 600<br />
+  max_retries: 3<br />
+  parameters:<br />
+    allowed_domains: []<br />
+    temperature: 0.1<br />
+citation_count: 30</p>
+<hr />
+<h2 id="question">Question</h2>
+<h1 id="gene-research-for-functional-annotation">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> Q96B49</li>
+<li><strong>Protein Description:</strong> RecName: Full=Mitochondrial import receptor subunit TOM6 homolog; AltName: Full=Overexpressed breast tumor protein; AltName: Full=Translocase of outer membrane 6 kDa subunit homolog;</li>
+<li><strong>Gene Information:</strong> Name=TOMM6; Synonyms=OBTP, TOM6;</li>
+<li><strong>Organism (full):</strong> Homo sapiens (Human).</li>
+<li><strong>Protein Family:</strong> Belongs to the Tom6 family. .</li>
+<li><strong>Key Domains:</strong> TOMM6. (IPR029182); TOM6p (PF15184)</li>
+</ul>
+<h3 id="mandatory-verification-steps">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "TOMM6" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Homo sapiens (Human).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'TOMM6' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>TOMM6</strong> (gene ID: TOMM6, UniProt: Q96B49) in human.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="output">Output</h2>
+<p>Question: You are an expert researcher providing comprehensive, well-cited information.</p>
+<p>Provide detailed information focusing on:<br />
+1. Key concepts and definitions with current understanding<br />
+2. Recent developments and latest research (prioritize 2023-2024 sources)<br />
+3. Current applications and real-world implementations<br />
+4. Expert opinions and analysis from authoritative sources<br />
+5. Relevant statistics and data from recent studies</p>
+<p>Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.<br />
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.</p>
+<h1 id="gene-research-for-functional-annotation_1">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context_1">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot_1">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> Q96B49</li>
+<li><strong>Protein Description:</strong> RecName: Full=Mitochondrial import receptor subunit TOM6 homolog; AltName: Full=Overexpressed breast tumor protein; AltName: Full=Translocase of outer membrane 6 kDa subunit homolog;</li>
+<li><strong>Gene Information:</strong> Name=TOMM6; Synonyms=OBTP, TOM6;</li>
+<li><strong>Organism (full):</strong> Homo sapiens (Human).</li>
+<li><strong>Protein Family:</strong> Belongs to the Tom6 family. .</li>
+<li><strong>Key Domains:</strong> TOMM6. (IPR029182); TOM6p (PF15184)</li>
+</ul>
+<h3 id="mandatory-verification-steps_1">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "TOMM6" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Homo sapiens (Human).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature_1">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'TOMM6' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target_1">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>TOMM6</strong> (gene ID: TOMM6, UniProt: Q96B49) in human.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="research-report-human-tomm6-uniprot-q96b49-functional-annotation">Research report: Human <strong>TOMM6</strong> (UniProt <strong>Q96B49</strong>) — functional annotation</h2>
+<h3 id="0-target-verification-critical-identity-checks">0) Target verification (critical identity checks)</h3>
+<p>The evidence retrieved aligns with the provided UniProt target: human <strong>TOMM6</strong> (Tom6 family), described as a very small TOM complex subunit (“small TOM”/microprotein) and not an enzyme or transporter with an independent catalytic reaction. Multiple sources describe <strong>Tom6/TOMM6</strong> as an <strong>α-helical single-pass outer mitochondrial membrane (OMM) protein</strong> that participates in the <strong>TOM (translocase of the outer membrane)</strong> protein-import machinery together with TOMM40 (pore) and TOMM22 (core receptor/adaptor). (kamradt2023mitochondrialmicroproteinscritical pages 1-4, guan2021structuralinsightsinto pages 1-3, araiso2022structuraloverviewof pages 1-3)</p>
+<h3 id="1-key-concepts-and-definitions-current-understanding">1) Key concepts and definitions (current understanding)</h3>
+<h4 id="11-the-tom-complex-and-small-tom-subunits">1.1 The TOM complex and “small TOM” subunits</h4>
+<p>The <strong>TOM complex</strong> is the canonical entry gate for import of the vast majority of nuclear-encoded mitochondrial proteins across the OMM. Structurally, it is built around the <strong>β-barrel channel Tom40 (TOMM40)</strong> and several single-pass α-helical subunits, including receptor/adaptor subunits (Tom20/Tom22/Tom70) and “small TOM” subunits <strong>Tom5/Tom6/Tom7</strong>. (araiso2022structuraloverviewof pages 1-3)</p>
+<p>In this framework, <strong>TOMM6</strong> is best defined as an <strong>auxiliary structural/regulatory subunit</strong> that supports <strong>assembly, stability, and oligomerization</strong> of the TOM core rather than directly binding and transporting substrates as a stand-alone importer. (bayne2024mitochondrialproteinimport pages 32-36, kamradt2023mitochondrialmicroproteinscritical pages 1-4)</p>
+<h4 id="12-tomm6-molecular-role-definition-of-function">1.2 TOMM6 molecular role (definition of function)</h4>
+<p>Current functional descriptions emphasize two related roles:<br />
+1) <strong>Stabilizing/assembling the TOM core</strong> by binding the outer wall of Tom40. (araiso2022structuraloverviewof pages 3-5, guan2021structuralinsightsinto pages 1-3)<br />
+2) <strong>Helping couple Tom22 to the Tom40 pore</strong>, described in a 2023 review as TOMM6 “anchoring TOMM22 to the TOMM40 pore.” (kamradt2023mitochondrialmicroproteinscritical pages 1-4)</p>
+<p>Thus, TOMM6’s “primary function” is structural/organizational within the TOM complex, supporting efficient mitochondrial precursor translocation via TOMM40. (bayne2024mitochondrialproteinimport pages 32-36, kamradt2023mitochondrialmicroproteinscritical pages 1-4)</p>
+<h3 id="2-recent-developments-and-latest-research-prioritize-20232024">2) Recent developments and latest research (prioritize 2023–2024)</h3>
+<h4 id="21-2023-tomm6-as-a-mitochondrial-microprotein-subunit-with-an-anchoring-role">2.1 2023: TOMM6 as a mitochondrial microprotein subunit with an anchoring role</h4>
+<p>A 2023 review of mitochondrial microproteins summarizes TOMM6 as a <strong>74-aa microprotein</strong> that associates with TOMM40, contributes to TOM channel stability, and has an “additional role” in <strong>anchoring TOMM22</strong> to the TOMM40 pore. The same review states that <strong>siRNA targeting</strong> of the small TOMM proteins (TOMM5/6/7) destabilizes TOM complex proteins, supporting an assembly/stability role. (kamradt2023mitochondrialmicroproteinscritical pages 1-4)</p>
+<p><strong>Publication details:</strong> Kamradt ML, Makarewich CA. <em>Am J Physiol Cell Physiol.</em> Oct 2023. https://doi.org/10.1152/ajpcell.00189.2023 (kamradt2023mitochondrialmicroproteinscritical pages 1-4)</p>
+<h4 id="22-2024-tom-complex-architecture-is-conserved-small-tom-subunits-regulate-stabilityassembly">2.2 2024: TOM complex architecture is conserved; small Tom subunits regulate stability/assembly</h4>
+<p>A 2024 review text focused on mitochondrial protein import and PINK1-mediated quality control describes Tom6 (with Tom5/Tom7) as part of constitutive accessory factors that form helices on the exterior of the TOM complex and regulate <strong>stability, assembly, and oligomerization</strong>. It also summarizes that TOM core architecture is highly conserved between yeast and human, with a dominant dimeric arrangement. (bayne2024mitochondrialproteinimport pages 32-36)</p>
+<p><strong>Publication details:</strong> Bayne AN. <em>Mitochondrial protein import and the role of PINK1 in mitochondrial quality control</em> (2024; journal not resolved in retrieved text). (bayne2024mitochondrialproteinimport pages 32-36)</p>
+<p><em>Note:</em> The most detailed TOMM6 mechanistic advances in our retrieved corpus are from 2021–2022 structural work; 2023–2024 sources mainly consolidate and contextualize TOMM6’s role as a small TOM subunit/microprotein in a stable conserved machine. (kamradt2023mitochondrialmicroproteinscritical pages 1-4, bayne2024mitochondrialproteinimport pages 32-36)</p>
+<h3 id="3-molecular-function-localization-topology-and-pathways">3) Molecular function, localization, topology, and pathways</h3>
+<h4 id="31-subcellular-localization-and-topology">3.1 Subcellular localization and topology</h4>
+<p>Human TOMM6 is an OMM component of TOM. A primary cryo-EM study and structural reviews describe Tom6 as a <strong>single-pass α-helical membrane protein</strong> (single transmembrane segment) positioned on the exterior of the Tom40 β-barrel, consistent with an accessory structural role. (guan2021structuralinsightsinto pages 1-3, araiso2022structuraloverviewof pages 3-5, araiso2022structuraloverviewof pages 1-3)</p>
+<h4 id="32-interaction-partners-and-placement-within-the-tom-core">3.2 Interaction partners and placement within the TOM core</h4>
+<p><strong>Core membership:</strong> The TOM “core complex” is commonly described as TOMM40 plus TOMM22 plus small Tom proteins (Tom5/6/7); receptor subunits Tom20/Tom70 can dissociate in some preparations. A 2021 human TOM cryo-EM structure built <strong>Tom40, Tom22, Tom5, Tom6, and Tom7</strong> (Tom20/Tom70 were not resolved in the core). (guan2021structuralinsightsinto pages 1-3)</p>
+<p><strong>Specific partner interactions inferred/observed:</strong><br />
+- Tom6 contacts the <strong>Tom40 β-barrel</strong>, especially around the <strong>β13–β15</strong> region, primarily via hydrophobic interactions. (araiso2022structuraloverviewof pages 3-5, guan2021structuralinsightsinto pages 3-4)<br />
+- Tom6 has an <strong>inverted L-shape</strong> with a cytosolic helix segment (α1) that can contact <strong>Tom22</strong>, supporting the notion that Tom6 helps incorporate/position Tom22 in the assembled TOM core. (guan2021structuralinsightsinto pages 3-4)<br />
+- A 2023 review explicitly states TOMM6 helps <strong>anchor TOMM22 to TOMM40</strong>. (kamradt2023mitochondrialmicroproteinscritical pages 1-4)</p>
+<h4 id="33-mechanistic-role-in-mitochondrial-protein-import">3.3 Mechanistic role in mitochondrial protein import</h4>
+<p>TOMM6 is not itself the pore; rather it supports the protein import pathway by maintaining TOM structural integrity and assembly state.<br />
+- Reviews describe Tom5/Tom6/Tom7 as exterior helices that regulate TOM complex <strong>stability/assembly/oligomerization</strong>, which is required for high-throughput import across the OMM. (bayne2024mitochondrialproteinimport pages 32-36)<br />
+- Structural reviews describe the TOM dimer as two Tom40 barrels with accessory subunits surrounding them; Tom6 is one of the small Tom proteins bound to Tom40’s outer wall. (araiso2022structuraloverviewof pages 1-3, araiso2022structuraloverviewof pages 3-5)</p>
+<h4 id="34-pathway-connections-mitochondrial-quality-control-mitophagy-context">3.4 Pathway connections: mitochondrial quality control / mitophagy context</h4>
+<p>The retrieved disease/quality-control literature is largely <strong>TOM-complex-level</strong>, not TOMM6-specific.<br />
+- The TOM machinery is integrated into mitophagy signaling: PINK1 forms complexes with TOM components (notably TOMM70/TOMM22/TOMM20/TOMM40), and TOM levels can modulate PINK1–PRKN mediated clearance in some contexts. (heinemeyer2019underappreciatedrolesof pages 9-10, heinemeyer2019underappreciatedrolesof pages 10-11)<br />
+- No retrieved excerpt demonstrated a TOMM6-specific biochemical role in PINK1 docking or Parkin recruitment; TOMM6’s role here is best framed as enabling proper TOM assembly/stability that would be prerequisite for these events. (bayne2024mitochondrialproteinimport pages 32-36, heinemeyer2019underappreciatedrolesof pages 10-11)</p>
+<h3 id="4-high-confidence-structural-data-and-quantitative-details-key-statistics">4) High-confidence structural data and quantitative details (key statistics)</h3>
+<h4 id="41-cryo-em-resolutions-and-assembly-states-human-tom">4.1 Cryo-EM resolutions and assembly states (human TOM)</h4>
+<p>A major primary study solved human TOM assemblies:<br />
+- <strong>Dimeric TOM core:</strong> <strong>3.0 Å</strong> resolution (near-atomic). (guan2021structuralinsightsinto pages 1-3)<br />
+- <strong>Trimeric TOM:</strong> <strong>4.3 Å</strong> after C2 symmetry; <strong>6.3 Å</strong> overall in a C1 map (lower detail, with helical subunits not confidently modeled in that trimer reconstruction). (guan2021structuralinsightsinto pages 3-4, guan2021structuralinsightsinto pages 1-3)</p>
+<p>These values provide quantitative support that Tom6 placement and lipid-mediated contacts are derived from near-atomic structural information in the dimeric core. (guan2021structuralinsightsinto pages 1-3)</p>
+<p><strong>Publication details:</strong> Guan Z et al. <em>Cell Discovery.</em> Apr 2021. https://doi.org/10.1038/s41421-021-00252-7 (guan2021structuralinsightsinto pages 1-3)</p>
+<h4 id="42-lipid-mediated-tom6tom40-bridging-pl3">4.2 Lipid-mediated Tom6–Tom40 bridging (PL3)</h4>
+<p>The 2021 structure reports a phospholipid-like density (<strong>PL3</strong>) bridging Tom6 and Tom40, with residue-level contacts:<br />
+- PL3 contacts <strong>Tom6 R38 and R43</strong><br />
+- PL3 contacts <strong>Tom40 S320, W322, R348</strong><br />
+This supports a mechanism in which specific lipids help stabilize Tom6 association with Tom40 and potentially influence assembly dynamics. (guan2021structuralinsightsinto pages 1-3, guan2021structuralinsightsinto pages 3-4)</p>
+<p>A figure from this work directly depicts the TOM core architecture and the PL3 bridge between Tom6 and Tom40. (guan2021structuralinsightsinto media 976d9995)</p>
+<h3 id="5-regulation-and-real-world-implementations">5) Regulation and real-world implementations</h3>
+<h4 id="51-ubiquitin-system-regulation-of-mitochondrial-import-complex-level-not-tomm6-specific">5.1 Ubiquitin-system regulation of mitochondrial import (complex-level; not TOMM6-specific)</h4>
+<p>A key mechanistic study shows that mitochondrial ubiquitin machinery dynamically regulates TOM-dependent import. The data include several quantitative/proteomics statistics:<br />
+- Upon USP30 inhibitor treatment, mass spectrometry showed altered ubiquitination of <strong>9 proteins at 30 min</strong> and <strong>489 proteins at 2 h</strong>; many changes were recapitulated in USP30 knockout cells. (phu2020dynamicregulationof pages 4-7)<br />
+- Comparing WT vs USP30 KO without inhibitor, <strong>36 of 61</strong> differentially ubiquitinated mitochondrial proteins were increased in KO cells, with <strong>34</strong> of these being intramitochondrial proteins. (phu2020dynamicregulationof pages 3-4)<br />
+- USP30 inhibition increased ubiquitinated TOM20 (Ub-TOM20) with an <strong>EC50 of 2.45 mM</strong> (as reported in the excerpt), and USP30 co-immunoprecipitated with TOM complex subunits TOM20, TOM40, and TOM70 in the retrieved pages. (phu2020dynamicregulationof pages 4-7, phu2020dynamicregulationof pages 3-4)</p>
+<p>Although TOM complex subunits are discussed as regulated targets, the retrieved excerpts do <strong>not</strong> establish TOMM6 as a direct ubiquitination substrate; therefore the safest statement is that TOMM6 is embedded in a TOM complex whose activity and subunit abundances can be influenced by ubiquitin enzymes acting at TOM. (phu2020dynamicregulationof pages 1-3, phu2020dynamicregulationof pages 9-10)</p>
+<p><strong>Publication details:</strong> Phu L et al. <em>Molecular Cell.</em> Mar 2020. https://doi.org/10.1016/j.molcel.2020.02.012 (phu2020dynamicregulationof pages 1-3)</p>
+<h4 id="52-current-applications-implementations">5.2 Current applications / implementations</h4>
+<p>No TOMM6-specific clinical applications, assays, or targeted drugs were identified in the retrieved evidence. Current “real-world” implementation is primarily <strong>structural and mechanistic</strong>:<br />
+- TOMM6 is part of the experimentally reconstituted and structurally resolved human TOM core that underpins mitochondrial protein import studies and informs mechanistic models of import and quality control. (guan2021structuralinsightsinto pages 1-3, guan2021structuralinsightsinto media 976d9995)<br />
+- Import regulation through ubiquitin enzymes (e.g., USP30/MARCH5/MUL1) is actively investigated as a translational entry point for modulating mitochondrial protein homeostasis; TOMM6 relevance is indirect through its contribution to TOM core integrity. (phu2020dynamicregulationof pages 1-3, phu2020dynamicregulationof pages 4-7)</p>
+<h3 id="6-disease-associations-cancer-links-and-the-obtp-alias-strength-of-evidence">6) Disease associations, cancer links, and the “OBTP” alias (strength of evidence)</h3>
+<h4 id="61-evidence-for-tomm6-specific-disease-links-is-limited">6.1 Evidence for TOMM6-specific disease links is limited</h4>
+<p>A 2019 review broadly connects TOM/TIM subunits to neurodegeneration, cardiovascular disease, and cancers, but the detailed mechanistic and genetic evidence in the retrieved pages focuses on other TOM components (especially TOMM40, and also TOMM20/TOMM22/TOMM70). It notes decreased TOMM40 in PD brain and TOM involvement in PINK1–PRKN mitophagy, and it states generally that increased mRNA/protein levels of complex subunits are found in cancers; however, it does <strong>not</strong> provide TOMM6-specific causal evidence in the retrieved excerpts. (heinemeyer2019underappreciatedrolesof pages 10-11, heinemeyer2019underappreciatedrolesof pages 1-2)</p>
+<p><strong>Publication details:</strong> Heinemeyer T et al. <em>DNA Cell Biol.</em> Jan 2019. https://doi.org/10.1089/dna.2018.4292 (heinemeyer2019underappreciatedrolesof pages 1-2)</p>
+<h4 id="62-open-targets-low-evidence-associations-from-functional-screens">6.2 Open Targets: low-evidence associations from functional screens</h4>
+<p>Open Targets lists TOMM6 associations with broad disease categories (e.g., “neurodegenerative disease”) supported by functional screen evidence (e.g., CRISPRi survival screens) and literature linkage (PubMed 34031600 in the Open Targets evidence rows). This should be interpreted as <strong>hypothesis-generating</strong> rather than establishing mechanism or causality for TOMM6 in disease. (OpenTargets Search: -TOMM6)</p>
+<h4 id="63-obtp-overexpressed-breast-tumor-protein-alias">6.3 “OBTP” (overexpressed breast tumor protein) alias</h4>
+<p>The alternative name “OBTP” suggests historical cancer-related naming, but within the retrieved evidence set, there is <strong>no strong primary study</strong> validating TOMM6 as a breast cancer biomarker/driver, and cancer-related statements are mostly general to TOM/TIM complex subunits without TOMM6-specific support. Therefore, the cancer relevance of TOMM6 remains <strong>unresolved/limited</strong> based on the evidence retrieved here. (heinemeyer2019underappreciatedrolesof pages 1-2, heinemeyer2019underappreciatedrolesof pages 12-13)</p>
+<h3 id="7-expert-synthesis-interpretation">7) Expert synthesis / interpretation</h3>
+<p>Across authoritative structural and review sources, TOMM6 emerges as a <strong>microprotein accessory subunit</strong> that helps organize the TOM core complex at the OMM. The most concrete mechanistic insight is structural: Tom6’s placement on Tom40 (β13–β15 region), its cytosolic helix proximity to Tom22, and lipid-mediated bridging (PL3) provide a plausible physical basis for the repeatedly cited “assembly/stability” and “Tom22 anchoring” roles. (guan2021structuralinsightsinto pages 3-4, kamradt2023mitochondrialmicroproteinscritical pages 1-4, guan2021structuralinsightsinto pages 1-3, guan2021structuralinsightsinto media 976d9995)</p>
+<p>However, compared with receptor and pore subunits (TOM20/TOM22/TOM40/TOM70), there is <strong>less direct disease-genetics and regulatory biochemistry</strong> specifically attributed to TOMM6 in the retrieved literature. Current evidence supports TOMM6 as a necessary part of the core machine; disease links are presently stronger at the level of the TOM complex or other subunits. (heinemeyer2019underappreciatedrolesof pages 1-2, phu2020dynamicregulationof pages 1-3)</p>
+<h3 id="8-summary-table-of-evidence">8) Summary table of evidence</h3>
+<p>The following table consolidates the main functional-annotation claims with evidence types and URLs/DOIs.</p>
+<table>
+<thead>
+<tr>
+<th>Category</th>
+<th>Key points</th>
+<th>Evidence type</th>
+<th>Key references with year and DOI/URL</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Identity/domains</td>
+<td>Human TOMM6 corresponds to UniProt Q96B49 and is the Tom6-family mitochondrial import receptor subunit homolog. In the literature summarized here, TOMM6 is consistently treated as a small TOM complex subunit/microprotein of 74 aa rather than an enzyme or transporter with an independent catalytic activity (kamradt2023mitochondrialmicroproteinscritical pages 1-4, araiso2022structuraloverviewof pages 1-3).</td>
+<td>Review, structural review</td>
+<td>Kamradt &amp; Makarewich 2023, https://doi.org/10.1152/ajpcell.00189.2023; Araiso &amp; Endo 2022, https://doi.org/10.2142/biophysico.bppb-v19.0022</td>
+</tr>
+<tr>
+<td>Localization/topology</td>
+<td>TOMM6 is an outer mitochondrial membrane TOM subunit. Structural/review evidence describes it as an α-helical single-pass membrane protein; Guan et al. place Tom6 at the Tom40 barrel with an inverted L-shaped architecture including a membrane helix and a cytosolic α1 segment that can contact Tom22 (guan2021structuralinsightsinto pages 3-4, araiso2022structuraloverviewof pages 3-5, guan2021structuralinsightsinto pages 1-3, araiso2022structuraloverviewof pages 1-3).</td>
+<td>Cryo-EM/MD, structural review</td>
+<td>Guan et al. 2021, https://doi.org/10.1038/s41421-021-00252-7; Araiso &amp; Endo 2022, https://doi.org/10.2142/biophysico.bppb-v19.0022</td>
+</tr>
+<tr>
+<td>Complex membership/interactions</td>
+<td>TOMM6 is one of the three “small TOM” subunits (Tom5/6/7) in the TOM core complex with TOMM40 and TOMM22. It interacts closely with TOMM40 and is reported to help anchor/stimulate assembly of TOMM22 with TOMM40; mammalian TOM core architecture is conserved with yeast (guan2021structuralinsightsinto pages 3-4, bayne2024mitochondrialproteinimport pages 32-36, kamradt2023mitochondrialmicroproteinscritical pages 1-4, akram2025proximitylabelingapproaches pages 19-22).</td>
+<td>Cryo-EM/MD, review</td>
+<td>Guan et al. 2021, https://doi.org/10.1038/s41421-021-00252-7; Kamradt &amp; Makarewich 2023, https://doi.org/10.1152/ajpcell.00189.2023; Bayne 2024 (review text in evidence)</td>
+</tr>
+<tr>
+<td>Mechanistic role in import</td>
+<td>TOMM6 does not itself transport substrate independently; rather, it supports the TOM import channel by stabilizing/assembling the core and thereby enabling efficient passage of mitochondrial precursor proteins through TOMM40. Reviews state TOMM6, TOMM5, and TOMM7 regulate TOM stability, assembly, and oligomerization, and siRNA against the small TOMMs destabilizes TOM complex proteins (bayne2024mitochondrialproteinimport pages 32-36, kamradt2023mitochondrialmicroproteinscritical pages 1-4).</td>
+<td>Review, perturbation summary</td>
+<td>Kamradt &amp; Makarewich 2023, https://doi.org/10.1152/ajpcell.00189.2023; Araiso &amp; Endo 2022, https://doi.org/10.2142/biophysico.bppb-v19.0022</td>
+</tr>
+<tr>
+<td>Structural evidence</td>
+<td>Human TOM cryo-EM structures resolved the dimeric TOM core at 3.0 Å and a trimeric assembly at 4.3 Å; a lower-resolution 6.3 Å C1 trimer map was also reported. Modeled human core subunits include Tom40, Tom22, Tom5, Tom6, and Tom7, while Tom20/Tom70 were not resolved in the core preparation (guan2021structuralinsightsinto pages 3-4, guan2021structuralinsightsinto pages 1-3, guan2021structuralinsightsinto pages 4-5).</td>
+<td>Cryo-EM</td>
+<td>Guan et al. 2021, https://doi.org/10.1038/s41421-021-00252-7</td>
+</tr>
+<tr>
+<td>Structural evidence</td>
+<td>Tom6 is positioned near β13–β15 of Tom40 and contacts Tom40 mainly through hydrophobic interactions. A phospholipid-like density PL3 bridges Tom6 residues R38/R43 to Tom40 residues S320/W322/R348, and MD simulations suggested PL3 increases Tom6 dynamics, supporting a lipid-mediated assembly/stability role (guan2021structuralinsightsinto pages 3-4, guan2021structuralinsightsinto pages 1-3, guan2021structuralinsightsinto media 976d9995).</td>
+<td>Cryo-EM/MD</td>
+<td>Guan et al. 2021, https://doi.org/10.1038/s41421-021-00252-7</td>
+</tr>
+<tr>
+<td>Regulation</td>
+<td>Direct TOMM6-specific ubiquitination/regulatory evidence was not identified in the gathered material. At the complex level, USP30, MARCH5, and MUL1 dynamically regulate TOM-dependent import, and USP30 knockout mice show reduced abundance of TOM complex subunits across tissues; TOM20 is a named ubiquitin-sensitive TOM substrate, but TOMM6-specific modification was not shown in the retrieved excerpts (phu2020dynamicregulationof pages 9-10, phu2020dynamicregulationof pages 1-3, phu2020dynamicregulationof pages 4-7, phu2020dynamicregulationof pages 3-4).</td>
+<td>Proteomics, ubiquitin biology</td>
+<td>Phu et al. 2020, https://doi.org/10.1016/j.molcel.2020.02.012</td>
+</tr>
+<tr>
+<td>Disease/phenotype links</td>
+<td>Direct disease causality for TOMM6 was limited in the gathered literature. Reviews link TOM machinery broadly to neurodegeneration, mitophagy, cardiovascular disease, and cancer, but the strongest specific evidence is for TOMM40/TOMM20/TOMM22/TOMM70 rather than TOMM6; Open Targets shows only low-evidence disease associations for TOMM6 from functional screens, not established Mendelian disease links (heinemeyer2019underappreciatedrolesof pages 9-10, heinemeyer2019underappreciatedrolesof pages 1-2, heinemeyer2019underappreciatedrolesof pages 10-11, OpenTargets Search: -TOMM6).</td>
+<td>Review, genetics/database</td>
+<td>Heinemeyer et al. 2019, https://doi.org/10.1089/dna.2018.4292; Open Targets context (OpenTargets Search: -TOMM6)</td>
+</tr>
+<tr>
+<td>Disease/phenotype links</td>
+<td>The alias “OBTP” reflects older naming (“overexpressed breast tumor protein”), but the gathered evidence did not provide robust primary support that TOMM6 is a validated breast cancer driver or biomarker. Cancer-related statements in the reviewed literature refer generally to increased expression of some TOM/TIM complex subunits, without TOMM6-specific validation in the retrieved excerpts (heinemeyer2019underappreciatedrolesof pages 1-2, heinemeyer2019underappreciatedrolesof pages 12-13).</td>
+<td>Review</td>
+<td>Heinemeyer et al. 2019, https://doi.org/10.1089/dna.2018.4292</td>
+</tr>
+<tr>
+<td>Applications</td>
+<td>Current real-world relevance is mainly mechanistic and translational: TOMM6 helps define human TOM complex architecture used in mitochondrial import research, and TOM-complex regulation is being studied for mitophagy/neurodegeneration therapeutics. No TOMM6-targeted drugs or clinical implementations were identified in the gathered evidence (guan2021structuralinsightsinto pages 1-3, heinemeyer2019underappreciatedrolesof pages 10-11, phu2020dynamicregulationof pages 4-7).</td>
+<td>Structural biology, disease-mechanism research</td>
+<td>Guan et al. 2021, https://doi.org/10.1038/s41421-021-00252-7; Phu et al. 2020, https://doi.org/10.1016/j.molcel.2020.02.012; Heinemeyer et al. 2019, https://doi.org/10.1089/dna.2018.4292</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the evidence-based functional annotation of human TOMM6/Q96B49, including localization, TOM complex role, structural findings, regulation, and disease relevance. It is useful as a compact reference because direct TOMM6-specific literature is limited and much of the strongest evidence comes from TOM complex structural studies.</em></p>
+<h3 id="key-primary-and-review-sources-urls-publication-dates">Key primary and review sources (URLs; publication dates)</h3>
+<ul>
+<li>Guan Z et al. <strong>Apr 2021</strong>. <em>Cell Discovery.</em> “Structural insights into assembly of human mitochondrial translocase TOM complex.” https://doi.org/10.1038/s41421-021-00252-7 (guan2021structuralinsightsinto pages 1-3)</li>
+<li>Araiso Y, Endo T. <strong>Jun 2022</strong>. <em>Biophysics and Physicobiology.</em> “Structural overview of the translocase of the mitochondrial outer membrane complex.” https://doi.org/10.2142/biophysico.bppb-v19.0022 (araiso2022structuraloverviewof pages 1-3)</li>
+<li>Kamradt ML, Makarewich CA. <strong>Oct 2023</strong>. <em>Am J Physiol Cell Physiol.</em> “Mitochondrial microproteins…” https://doi.org/10.1152/ajpcell.00189.2023 (kamradt2023mitochondrialmicroproteinscritical pages 1-4)</li>
+<li>Bayne AN. <strong>2024</strong>. “Mitochondrial protein import and the role of PINK1…” (journal not resolved in retrieved text). (bayne2024mitochondrialproteinimport pages 32-36)</li>
+<li>Phu L et al. <strong>Mar 2020</strong>. <em>Molecular Cell.</em> “Dynamic regulation of mitochondrial import by the ubiquitin system.” https://doi.org/10.1016/j.molcel.2020.02.012 (phu2020dynamicregulationof pages 1-3)</li>
+<li>Heinemeyer T et al. <strong>Jan 2019</strong>. <em>DNA Cell Biol.</em> “Underappreciated roles…” https://doi.org/10.1089/dna.2018.4292 (heinemeyer2019underappreciatedrolesof pages 1-2)</li>
+</ul>
+<p>References</p>
+<ol>
+<li>
+<p>(kamradt2023mitochondrialmicroproteinscritical pages 1-4): Michael L. Kamradt and Catherine A. Makarewich. Mitochondrial microproteins: critical regulators of protein import, energy production, stress response pathways, and programmed cell death. American Journal of Physiology-Cell Physiology, 325:C807-C816, Oct 2023. URL: https://doi.org/10.1152/ajpcell.00189.2023, doi:10.1152/ajpcell.00189.2023. This article has 12 citations.</p>
+</li>
+<li>
+<p>(guan2021structuralinsightsinto pages 1-3): Zeyuan Guan, Ling Yan, Qiang Wang, Liangbo Qi, Sixing Hong, Zhou Gong, Chuangye Yan, and Ping Yin. Structural insights into assembly of human mitochondrial translocase tom complex. Cell Discovery, Apr 2021. URL: https://doi.org/10.1038/s41421-021-00252-7, doi:10.1038/s41421-021-00252-7. This article has 50 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(araiso2022structuraloverviewof pages 1-3): Yuhei Araiso and Toshiya Endo. Structural overview of the translocase of the mitochondrial outer membrane complex. Biophysics and Physicobiology, 19:n/a, Jun 2022. URL: https://doi.org/10.2142/biophysico.bppb-v19.0022, doi:10.2142/biophysico.bppb-v19.0022. This article has 21 citations.</p>
+</li>
+<li>
+<p>(bayne2024mitochondrialproteinimport pages 32-36): AN Bayne. Mitochondrial protein import and the role of pink1 in mitochondrial quality control. Unknown journal, 2024.</p>
+</li>
+<li>
+<p>(araiso2022structuraloverviewof pages 3-5): Yuhei Araiso and Toshiya Endo. Structural overview of the translocase of the mitochondrial outer membrane complex. Biophysics and Physicobiology, 19:n/a, Jun 2022. URL: https://doi.org/10.2142/biophysico.bppb-v19.0022, doi:10.2142/biophysico.bppb-v19.0022. This article has 21 citations.</p>
+</li>
+<li>
+<p>(guan2021structuralinsightsinto pages 3-4): Zeyuan Guan, Ling Yan, Qiang Wang, Liangbo Qi, Sixing Hong, Zhou Gong, Chuangye Yan, and Ping Yin. Structural insights into assembly of human mitochondrial translocase tom complex. Cell Discovery, Apr 2021. URL: https://doi.org/10.1038/s41421-021-00252-7, doi:10.1038/s41421-021-00252-7. This article has 50 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(heinemeyer2019underappreciatedrolesof pages 9-10): Thea Heinemeyer, Monique Stemmet, Soraya Bardien, and Annika Neethling. Underappreciated roles of the translocase of the outer and inner mitochondrial membrane protein complexes in human disease. DNA and cell biology, 38 1:23-40, Jan 2019. URL: https://doi.org/10.1089/dna.2018.4292, doi:10.1089/dna.2018.4292. This article has 43 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(heinemeyer2019underappreciatedrolesof pages 10-11): Thea Heinemeyer, Monique Stemmet, Soraya Bardien, and Annika Neethling. Underappreciated roles of the translocase of the outer and inner mitochondrial membrane protein complexes in human disease. DNA and cell biology, 38 1:23-40, Jan 2019. URL: https://doi.org/10.1089/dna.2018.4292, doi:10.1089/dna.2018.4292. This article has 43 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(guan2021structuralinsightsinto media 976d9995): Zeyuan Guan, Ling Yan, Qiang Wang, Liangbo Qi, Sixing Hong, Zhou Gong, Chuangye Yan, and Ping Yin. Structural insights into assembly of human mitochondrial translocase tom complex. Cell Discovery, Apr 2021. URL: https://doi.org/10.1038/s41421-021-00252-7, doi:10.1038/s41421-021-00252-7. This article has 50 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(phu2020dynamicregulationof pages 4-7): Lilian Phu, Christopher M. Rose, Joy S. Tea, Christopher E. Wall, Erik Verschueren, Tommy K. Cheung, Donald S. Kirkpatrick, and Baris Bingol. Dynamic regulation of mitochondrial import by the ubiquitin system. Molecular cell, 77 5:1107-1123.e10, Mar 2020. URL: https://doi.org/10.1016/j.molcel.2020.02.012, doi:10.1016/j.molcel.2020.02.012. This article has 163 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(phu2020dynamicregulationof pages 3-4): Lilian Phu, Christopher M. Rose, Joy S. Tea, Christopher E. Wall, Erik Verschueren, Tommy K. Cheung, Donald S. Kirkpatrick, and Baris Bingol. Dynamic regulation of mitochondrial import by the ubiquitin system. Molecular cell, 77 5:1107-1123.e10, Mar 2020. URL: https://doi.org/10.1016/j.molcel.2020.02.012, doi:10.1016/j.molcel.2020.02.012. This article has 163 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(phu2020dynamicregulationof pages 1-3): Lilian Phu, Christopher M. Rose, Joy S. Tea, Christopher E. Wall, Erik Verschueren, Tommy K. Cheung, Donald S. Kirkpatrick, and Baris Bingol. Dynamic regulation of mitochondrial import by the ubiquitin system. Molecular cell, 77 5:1107-1123.e10, Mar 2020. URL: https://doi.org/10.1016/j.molcel.2020.02.012, doi:10.1016/j.molcel.2020.02.012. This article has 163 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(phu2020dynamicregulationof pages 9-10): Lilian Phu, Christopher M. Rose, Joy S. Tea, Christopher E. Wall, Erik Verschueren, Tommy K. Cheung, Donald S. Kirkpatrick, and Baris Bingol. Dynamic regulation of mitochondrial import by the ubiquitin system. Molecular cell, 77 5:1107-1123.e10, Mar 2020. URL: https://doi.org/10.1016/j.molcel.2020.02.012, doi:10.1016/j.molcel.2020.02.012. This article has 163 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(heinemeyer2019underappreciatedrolesof pages 1-2): Thea Heinemeyer, Monique Stemmet, Soraya Bardien, and Annika Neethling. Underappreciated roles of the translocase of the outer and inner mitochondrial membrane protein complexes in human disease. DNA and cell biology, 38 1:23-40, Jan 2019. URL: https://doi.org/10.1089/dna.2018.4292, doi:10.1089/dna.2018.4292. This article has 43 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(OpenTargets Search: -TOMM6): Open Targets Query (-TOMM6, 5 results). Buniello, A. et al. (2025). Open Targets Platform: facilitating therapeutic hypotheses building in drug discovery. Nucleic Acids Research.</p>
+</li>
+<li>
+<p>(heinemeyer2019underappreciatedrolesof pages 12-13): Thea Heinemeyer, Monique Stemmet, Soraya Bardien, and Annika Neethling. Underappreciated roles of the translocase of the outer and inner mitochondrial membrane protein complexes in human disease. DNA and cell biology, 38 1:23-40, Jan 2019. URL: https://doi.org/10.1089/dna.2018.4292, doi:10.1089/dna.2018.4292. This article has 43 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(akram2025proximitylabelingapproaches pages 19-22): S Akram. Proximity labeling approaches to mitochondrial import receptors tomm20 and tomm70. Unknown journal, 2025.</p>
+</li>
+<li>
+<p>(guan2021structuralinsightsinto pages 4-5): Zeyuan Guan, Ling Yan, Qiang Wang, Liangbo Qi, Sixing Hong, Zhou Gong, Chuangye Yan, and Ping Yin. Structural insights into assembly of human mitochondrial translocase tom complex. Cell Discovery, Apr 2021. URL: https://doi.org/10.1038/s41421-021-00252-7, doi:10.1038/s41421-021-00252-7. This article has 50 citations and is from a peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>araiso2022structuraloverviewof pages 1-3</li>
+<li>kamradt2023mitochondrialmicroproteinscritical pages 1-4</li>
+<li>bayne2024mitochondrialproteinimport pages 32-36</li>
+<li>guan2021structuralinsightsinto pages 1-3</li>
+<li>guan2021structuralinsightsinto pages 3-4</li>
+<li>phu2020dynamicregulationof pages 4-7</li>
+<li>phu2020dynamicregulationof pages 3-4</li>
+<li>phu2020dynamicregulationof pages 1-3</li>
+<li>heinemeyer2019underappreciatedrolesof pages 1-2</li>
+<li>araiso2022structuraloverviewof pages 3-5</li>
+<li>heinemeyer2019underappreciatedrolesof pages 9-10</li>
+<li>heinemeyer2019underappreciatedrolesof pages 10-11</li>
+<li>phu2020dynamicregulationof pages 9-10</li>
+<li>heinemeyer2019underappreciatedrolesof pages 12-13</li>
+<li>akram2025proximitylabelingapproaches pages 19-22</li>
+<li>guan2021structuralinsightsinto pages 4-5</li>
+<li>https://doi.org/10.1152/ajpcell.00189.2023</li>
+<li>https://doi.org/10.1038/s41421-021-00252-7</li>
+<li>https://doi.org/10.1016/j.molcel.2020.02.012</li>
+<li>https://doi.org/10.1089/dna.2018.4292</li>
+<li>https://doi.org/10.1152/ajpcell.00189.2023;</li>
+<li>https://doi.org/10.2142/biophysico.bppb-v19.0022</li>
+<li>https://doi.org/10.1038/s41421-021-00252-7;</li>
+<li>https://doi.org/10.1089/dna.2018.4292;</li>
+<li>https://doi.org/10.1016/j.molcel.2020.02.012;</li>
+<li>https://doi.org/10.1152/ajpcell.00189.2023,</li>
+<li>https://doi.org/10.1038/s41421-021-00252-7,</li>
+<li>https://doi.org/10.2142/biophysico.bppb-v19.0022,</li>
+<li>https://doi.org/10.1089/dna.2018.4292,</li>
+<li>https://doi.org/10.1016/j.molcel.2020.02.012,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q96B49
+gene_symbol: TOMM6
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: &gt;-
+  TOMM6 is a small single-pass mitochondrial outer membrane subunit of the TOM
+  translocase core. It is not an independent transporter or enzyme; instead it
+  helps organize and stabilize the TOMM40/TOMM22-containing import channel,
+  including anchoring/positioning TOMM22 and supporting TOM core assembly and
+  oligomerization.
+existing_annotations:
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: &gt;-
+      TOMM6 is a mitochondrial protein, but the annotation is less specific than
+      the well-supported mitochondrial outer membrane/TOM complex localization.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Subsumed by mitochondrial outer membrane and TOM complex annotations.
+    additional_reference_ids:
+    - file:human/TOMM6/TOMM6-deep-research-falcon.md
+- term:
+    id: GO:0005741
+    label: mitochondrial outer membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  review:
+    summary: &gt;-
+      Correct UniProt-derived localization. Falcon research summarizes TOMM6 as
+      a single-pass outer mitochondrial membrane component of the TOM core.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM6/TOMM6-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TOMM6/TOMM6-deep-research-falcon.md
+      supporting_text: &#34;Human TOMM6 is an OMM component of TOM.&#34;
+- term:
+    id: GO:0005742
+    label: mitochondrial outer membrane translocase complex
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  review:
+    summary: &gt;-
+      Correct complex-level annotation. TOMM6 is one of the small Tom subunits
+      of the TOM core with TOMM40, TOMM22, TOMM5, and TOMM7.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM6/TOMM6-deep-research-falcon.md
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:32296183
+  review:
+    summary: &gt;-
+      Generic binary-interactome protein binding does not capture TOMM6&#39;s
+      specific role as a structural/regulatory TOM core subunit.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Protein binding is uninformative for TOMM6; the curated function is TOM
+      complex organization at the mitochondrial outer membrane.
+    additional_reference_ids:
+    - file:human/TOMM6/TOMM6-deep-research-falcon.md
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IDA
+  original_reference_id: GO_REF:0000052
+  review:
+    summary: &gt;-
+      Correct but too general. TOMM6 is specifically an outer membrane TOM core
+      subunit.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Subsumed by mitochondrial outer membrane and TOM complex annotations.
+    additional_reference_ids:
+    - file:human/TOMM6/TOMM6-deep-research-falcon.md
+- term:
+    id: GO:0005741
+    label: mitochondrial outer membrane
+  evidence_type: NAS
+  original_reference_id: PMID:18331822
+  review:
+    summary: &gt;-
+      Kato and Mihara identified human Tom6 in the outer membrane TOM
+      preprotein translocase complex; this agrees with structural/review
+      evidence summarized by Falcon.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM6/TOMM6-deep-research-falcon.md
+- term:
+    id: GO:0045040
+    label: protein insertion into mitochondrial outer membrane
+  evidence_type: NAS
+  original_reference_id: PMID:18331822
+  review:
+    summary: &gt;-
+      The broad direction of the annotation is related to TOMM6 biology, but
+      TOMM6 is not itself an insertase. Evidence better supports a role in TOM
+      core assembly, stability, and oligomerization.
+    action: MODIFY
+    reason: &gt;-
+      Replace the insertion process with TOM complex assembly/stability, which
+      better matches the small Tom6 subunit role.
+    proposed_replacement_terms:
+    - id: GO:0070096
+      label: mitochondrial outer membrane translocase complex assembly
+    additional_reference_ids:
+    - file:human/TOMM6/TOMM6-deep-research-falcon.md
+- term:
+    id: GO:0140596
+    label: TOM complex
+  evidence_type: NAS
+  original_reference_id: PMID:18331822
+  review:
+    summary: &gt;-
+      Correct specific complex annotation. TOMM6 is a small TOM core subunit
+      positioned against TOMM40 and coupled to TOMM22 in structural models.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM6/TOMM6-deep-research-falcon.md
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: HTP
+  original_reference_id: PMID:34800366
+  review:
+    summary: &gt;-
+      High-throughput mitochondrial proteomics supports mitochondrial
+      localization, but this is less specific than the mitochondrial outer
+      membrane/TOM complex annotations.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Subsumed by mitochondrial outer membrane and TOM complex annotations.
+    additional_reference_ids:
+    - file:human/TOMM6/TOMM6-deep-research-falcon.md
+- term:
+    id: GO:0005741
+    label: mitochondrial outer membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-5205661
+  review:
+    summary: &gt;-
+      Reactome places TOMM6 at the mitochondrial outer membrane in TOM/PINK1
+      pathway context. This matches the structural TOM core localization.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM6/TOMM6-deep-research-falcon.md
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: GO_REF:0000052
+  title: Gene Ontology annotation based on curation of immunofluorescence data
+  findings: []
+- id: PMID:18331822
+  title: Identification of Tom5 and Tom6 in the preprotein translocase complex of
+    human mitochondrial outer membrane.
+  findings: []
+- id: PMID:32296183
+  title: A reference map of the human binary protein interactome.
+  findings: []
+- id: PMID:34800366
+  title: Quantitative high-confidence human mitochondrial proteome and its dynamics
+    in cellular context.
+  findings: []
+- id: Reactome:R-HSA-5205661
+  title: Pink1 is recruited from the cytoplasm to the mitochondria
+  findings: []
+- id: file:human/TOMM6/TOMM6-deep-research-falcon.md
+  title: Falcon deep research report for human TOMM6
+  findings: []
+core_functions:
+- description: &gt;-
+    TOMM6 is a structural/regulatory small Tom subunit that stabilizes and
+    organizes the mitochondrial TOM core, supporting TOMM40/TOMM22-dependent
+    mitochondrial protein import and TOM complex assembly.
+  supported_by:
+  - reference_id: file:human/TOMM6/TOMM6-deep-research-falcon.md
+    supporting_text: &#34;In this framework, **TOMM6** is best defined as an **auxiliary structural/regulatory subunit** that supports **assembly, stability, and oligomerization** of the TOM core&#34;
+  - reference_id: file:human/TOMM6/TOMM6-deep-research-falcon.md
+    supporting_text: &#34;Human TOMM6 is an OMM component of TOM.&#34;
+  - reference_id: file:human/TOMM6/TOMM6-deep-research-falcon.md
+    supporting_text: &#34;TOMM6 is not itself the pore; rather it supports the protein import pathway by maintaining TOM structural integrity and assembly state.&#34;
+  contributes_to_molecular_function:
+    id: GO:0008320
+    label: protein transmembrane transporter activity
+  directly_involved_in:
+  - id: GO:0070096
+    label: mitochondrial outer membrane translocase complex assembly
+  locations:
+  - id: GO:0005741
+    label: mitochondrial outer membrane
+  in_complex:
+    id: GO:0140596
+    label: TOM complex
+proposed_new_terms: []
+suggested_questions:
+- question: &gt;-
+    Which human TOMM6 surfaces are required for TOMM22 anchoring versus general
+    TOMM40 core stabilization?
+  experts: []
+- question: &gt;-
+    Does endogenous TOMM6 depletion preferentially impair assembly of new TOM
+    complexes or the import activity of pre-existing TOM complexes?
+  experts: []
+suggested_experiments:
+- hypothesis: &gt;-
+    TOMM6 promotes TOM core assembly by stabilizing TOMM40-TOMM22 contacts.
+  description: &gt;-
+    Introduce TOMM6 point mutants in residues predicted to contact TOMM40 or
+    TOMM22, then measure TOM complex assembly by blue-native PAGE/cryo-EM and
+    mitochondrial precursor import using endogenous rescue assays.
+  experiment_type: structure-guided mutagenesis and import assay
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/human/TOMM6/TOMM6-ai-review.yaml
+++ b/genes/human/TOMM6/TOMM6-ai-review.yaml
@@ -1,11 +1,16 @@
 id: Q96B49
 gene_symbol: TOMM6
 product_type: PROTEIN
-status: INITIALIZED
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
-description: 'TODO: Add description for TOMM6'
+description: >-
+  TOMM6 is a small single-pass mitochondrial outer membrane subunit of the TOM
+  translocase core. It is not an independent transporter or enzyme; instead it
+  helps organize and stabilize the TOMM40/TOMM22-containing import channel,
+  including anchoring/positioning TOMM22 and supporting TOM core assembly and
+  oligomerization.
 existing_annotations:
 - term:
     id: GO:0005739
@@ -13,80 +18,138 @@ existing_annotations:
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      TOMM6 is a mitochondrial protein, but the annotation is less specific than
+      the well-supported mitochondrial outer membrane/TOM complex localization.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Subsumed by mitochondrial outer membrane and TOM complex annotations.
+    additional_reference_ids:
+    - file:human/TOMM6/TOMM6-deep-research-falcon.md
 - term:
     id: GO:0005741
     label: mitochondrial outer membrane
   evidence_type: IEA
   original_reference_id: GO_REF:0000044
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Correct UniProt-derived localization. Falcon research summarizes TOMM6 as
+      a single-pass outer mitochondrial membrane component of the TOM core.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM6/TOMM6-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TOMM6/TOMM6-deep-research-falcon.md
+      supporting_text: "Human TOMM6 is an OMM component of TOM."
 - term:
     id: GO:0005742
     label: mitochondrial outer membrane translocase complex
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Correct complex-level annotation. TOMM6 is one of the small Tom subunits
+      of the TOM core with TOMM40, TOMM22, TOMM5, and TOMM7.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM6/TOMM6-deep-research-falcon.md
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:32296183
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Generic binary-interactome protein binding does not capture TOMM6's
+      specific role as a structural/regulatory TOM core subunit.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      Protein binding is uninformative for TOMM6; the curated function is TOM
+      complex organization at the mitochondrial outer membrane.
+    additional_reference_ids:
+    - file:human/TOMM6/TOMM6-deep-research-falcon.md
 - term:
     id: GO:0005739
     label: mitochondrion
   evidence_type: IDA
   original_reference_id: GO_REF:0000052
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Correct but too general. TOMM6 is specifically an outer membrane TOM core
+      subunit.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Subsumed by mitochondrial outer membrane and TOM complex annotations.
+    additional_reference_ids:
+    - file:human/TOMM6/TOMM6-deep-research-falcon.md
 - term:
     id: GO:0005741
     label: mitochondrial outer membrane
   evidence_type: NAS
   original_reference_id: PMID:18331822
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Kato and Mihara identified human Tom6 in the outer membrane TOM
+      preprotein translocase complex; this agrees with structural/review
+      evidence summarized by Falcon.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM6/TOMM6-deep-research-falcon.md
 - term:
     id: GO:0045040
     label: protein insertion into mitochondrial outer membrane
   evidence_type: NAS
   original_reference_id: PMID:18331822
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      The broad direction of the annotation is related to TOMM6 biology, but
+      TOMM6 is not itself an insertase. Evidence better supports a role in TOM
+      core assembly, stability, and oligomerization.
+    action: MODIFY
+    reason: >-
+      Replace the insertion process with TOM complex assembly/stability, which
+      better matches the small Tom6 subunit role.
+    proposed_replacement_terms:
+    - id: GO:0070096
+      label: mitochondrial outer membrane translocase complex assembly
+    additional_reference_ids:
+    - file:human/TOMM6/TOMM6-deep-research-falcon.md
 - term:
     id: GO:0140596
     label: TOM complex
   evidence_type: NAS
   original_reference_id: PMID:18331822
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Correct specific complex annotation. TOMM6 is a small TOM core subunit
+      positioned against TOMM40 and coupled to TOMM22 in structural models.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM6/TOMM6-deep-research-falcon.md
 - term:
     id: GO:0005739
     label: mitochondrion
   evidence_type: HTP
   original_reference_id: PMID:34800366
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      High-throughput mitochondrial proteomics supports mitochondrial
+      localization, but this is less specific than the mitochondrial outer
+      membrane/TOM complex annotations.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Subsumed by mitochondrial outer membrane and TOM complex annotations.
+    additional_reference_ids:
+    - file:human/TOMM6/TOMM6-deep-research-falcon.md
 - term:
     id: GO:0005741
     label: mitochondrial outer membrane
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-5205661
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Reactome places TOMM6 at the mitochondrial outer membrane in TOM/PINK1
+      pathway context. This matches the structural TOM core localization.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM6/TOMM6-deep-research-falcon.md
 references:
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO
@@ -117,3 +180,48 @@ references:
 - id: Reactome:R-HSA-5205661
   title: Pink1 is recruited from the cytoplasm to the mitochondria
   findings: []
+- id: file:human/TOMM6/TOMM6-deep-research-falcon.md
+  title: Falcon deep research report for human TOMM6
+  findings: []
+core_functions:
+- description: >-
+    TOMM6 is a structural/regulatory small Tom subunit that stabilizes and
+    organizes the mitochondrial TOM core, supporting TOMM40/TOMM22-dependent
+    mitochondrial protein import and TOM complex assembly.
+  supported_by:
+  - reference_id: file:human/TOMM6/TOMM6-deep-research-falcon.md
+    supporting_text: "In this framework, **TOMM6** is best defined as an **auxiliary structural/regulatory subunit** that supports **assembly, stability, and oligomerization** of the TOM core"
+  - reference_id: file:human/TOMM6/TOMM6-deep-research-falcon.md
+    supporting_text: "Human TOMM6 is an OMM component of TOM."
+  - reference_id: file:human/TOMM6/TOMM6-deep-research-falcon.md
+    supporting_text: "TOMM6 is not itself the pore; rather it supports the protein import pathway by maintaining TOM structural integrity and assembly state."
+  contributes_to_molecular_function:
+    id: GO:0008320
+    label: protein transmembrane transporter activity
+  directly_involved_in:
+  - id: GO:0070096
+    label: mitochondrial outer membrane translocase complex assembly
+  locations:
+  - id: GO:0005741
+    label: mitochondrial outer membrane
+  in_complex:
+    id: GO:0140596
+    label: TOM complex
+proposed_new_terms: []
+suggested_questions:
+- question: >-
+    Which human TOMM6 surfaces are required for TOMM22 anchoring versus general
+    TOMM40 core stabilization?
+  experts: []
+- question: >-
+    Does endogenous TOMM6 depletion preferentially impair assembly of new TOM
+    complexes or the import activity of pre-existing TOM complexes?
+  experts: []
+suggested_experiments:
+- hypothesis: >-
+    TOMM6 promotes TOM core assembly by stabilizing TOMM40-TOMM22 contacts.
+  description: >-
+    Introduce TOMM6 point mutants in residues predicted to contact TOMM40 or
+    TOMM22, then measure TOM complex assembly by blue-native PAGE/cryo-EM and
+    mitochondrial precursor import using endogenous rescue assays.
+  experiment_type: structure-guided mutagenesis and import assay

--- a/genes/human/TOMM6/TOMM6-deep-research-falcon.md
+++ b/genes/human/TOMM6/TOMM6-deep-research-falcon.md
@@ -1,0 +1,346 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-11T10:59:40.604165'
+end_time: '2026-05-11T11:11:15.723692'
+duration_seconds: 695.12
+template_file: templates/gene_research_go_focused.md
+template_variables:
+  organism: human
+  gene_id: TOMM6
+  gene_symbol: TOMM6
+  uniprot_accession: Q96B49
+  protein_description: 'RecName: Full=Mitochondrial import receptor subunit TOM6 homolog;
+    AltName: Full=Overexpressed breast tumor protein; AltName: Full=Translocase of
+    outer membrane 6 kDa subunit homolog;'
+  gene_info: Name=TOMM6; Synonyms=OBTP, TOM6;
+  organism_full: Homo sapiens (Human).
+  protein_family: Belongs to the Tom6 family. .
+  protein_domains: TOMM6. (IPR029182); TOM6p (PF15184)
+provider_config:
+  timeout: 600
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 30
+---
+
+## Question
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** Q96B49
+- **Protein Description:** RecName: Full=Mitochondrial import receptor subunit TOM6 homolog; AltName: Full=Overexpressed breast tumor protein; AltName: Full=Translocase of outer membrane 6 kDa subunit homolog;
+- **Gene Information:** Name=TOMM6; Synonyms=OBTP, TOM6;
+- **Organism (full):** Homo sapiens (Human).
+- **Protein Family:** Belongs to the Tom6 family. .
+- **Key Domains:** TOMM6. (IPR029182); TOM6p (PF15184)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "TOMM6" matches the protein description above**
+2. **Verify the organism is correct:** Homo sapiens (Human).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'TOMM6' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **TOMM6** (gene ID: TOMM6, UniProt: Q96B49) in human.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** Q96B49
+- **Protein Description:** RecName: Full=Mitochondrial import receptor subunit TOM6 homolog; AltName: Full=Overexpressed breast tumor protein; AltName: Full=Translocase of outer membrane 6 kDa subunit homolog;
+- **Gene Information:** Name=TOMM6; Synonyms=OBTP, TOM6;
+- **Organism (full):** Homo sapiens (Human).
+- **Protein Family:** Belongs to the Tom6 family. .
+- **Key Domains:** TOMM6. (IPR029182); TOM6p (PF15184)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "TOMM6" matches the protein description above**
+2. **Verify the organism is correct:** Homo sapiens (Human).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'TOMM6' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **TOMM6** (gene ID: TOMM6, UniProt: Q96B49) in human.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Research report: Human **TOMM6** (UniProt **Q96B49**) — functional annotation
+
+### 0) Target verification (critical identity checks)
+The evidence retrieved aligns with the provided UniProt target: human **TOMM6** (Tom6 family), described as a very small TOM complex subunit (“small TOM”/microprotein) and not an enzyme or transporter with an independent catalytic reaction. Multiple sources describe **Tom6/TOMM6** as an **α-helical single-pass outer mitochondrial membrane (OMM) protein** that participates in the **TOM (translocase of the outer membrane)** protein-import machinery together with TOMM40 (pore) and TOMM22 (core receptor/adaptor). (kamradt2023mitochondrialmicroproteinscritical pages 1-4, guan2021structuralinsightsinto pages 1-3, araiso2022structuraloverviewof pages 1-3)
+
+### 1) Key concepts and definitions (current understanding)
+
+#### 1.1 The TOM complex and “small TOM” subunits
+The **TOM complex** is the canonical entry gate for import of the vast majority of nuclear-encoded mitochondrial proteins across the OMM. Structurally, it is built around the **β-barrel channel Tom40 (TOMM40)** and several single-pass α-helical subunits, including receptor/adaptor subunits (Tom20/Tom22/Tom70) and “small TOM” subunits **Tom5/Tom6/Tom7**. (araiso2022structuraloverviewof pages 1-3)
+
+In this framework, **TOMM6** is best defined as an **auxiliary structural/regulatory subunit** that supports **assembly, stability, and oligomerization** of the TOM core rather than directly binding and transporting substrates as a stand-alone importer. (bayne2024mitochondrialproteinimport pages 32-36, kamradt2023mitochondrialmicroproteinscritical pages 1-4)
+
+#### 1.2 TOMM6 molecular role (definition of function)
+Current functional descriptions emphasize two related roles:
+1) **Stabilizing/assembling the TOM core** by binding the outer wall of Tom40. (araiso2022structuraloverviewof pages 3-5, guan2021structuralinsightsinto pages 1-3)
+2) **Helping couple Tom22 to the Tom40 pore**, described in a 2023 review as TOMM6 “anchoring TOMM22 to the TOMM40 pore.” (kamradt2023mitochondrialmicroproteinscritical pages 1-4)
+
+Thus, TOMM6’s “primary function” is structural/organizational within the TOM complex, supporting efficient mitochondrial precursor translocation via TOMM40. (bayne2024mitochondrialproteinimport pages 32-36, kamradt2023mitochondrialmicroproteinscritical pages 1-4)
+
+### 2) Recent developments and latest research (prioritize 2023–2024)
+
+#### 2.1 2023: TOMM6 as a mitochondrial microprotein subunit with an anchoring role
+A 2023 review of mitochondrial microproteins summarizes TOMM6 as a **74-aa microprotein** that associates with TOMM40, contributes to TOM channel stability, and has an “additional role” in **anchoring TOMM22** to the TOMM40 pore. The same review states that **siRNA targeting** of the small TOMM proteins (TOMM5/6/7) destabilizes TOM complex proteins, supporting an assembly/stability role. (kamradt2023mitochondrialmicroproteinscritical pages 1-4)
+
+**Publication details:** Kamradt ML, Makarewich CA. *Am J Physiol Cell Physiol.* Oct 2023. https://doi.org/10.1152/ajpcell.00189.2023 (kamradt2023mitochondrialmicroproteinscritical pages 1-4)
+
+#### 2.2 2024: TOM complex architecture is conserved; small Tom subunits regulate stability/assembly
+A 2024 review text focused on mitochondrial protein import and PINK1-mediated quality control describes Tom6 (with Tom5/Tom7) as part of constitutive accessory factors that form helices on the exterior of the TOM complex and regulate **stability, assembly, and oligomerization**. It also summarizes that TOM core architecture is highly conserved between yeast and human, with a dominant dimeric arrangement. (bayne2024mitochondrialproteinimport pages 32-36)
+
+**Publication details:** Bayne AN. *Mitochondrial protein import and the role of PINK1 in mitochondrial quality control* (2024; journal not resolved in retrieved text). (bayne2024mitochondrialproteinimport pages 32-36)
+
+*Note:* The most detailed TOMM6 mechanistic advances in our retrieved corpus are from 2021–2022 structural work; 2023–2024 sources mainly consolidate and contextualize TOMM6’s role as a small TOM subunit/microprotein in a stable conserved machine. (kamradt2023mitochondrialmicroproteinscritical pages 1-4, bayne2024mitochondrialproteinimport pages 32-36)
+
+### 3) Molecular function, localization, topology, and pathways
+
+#### 3.1 Subcellular localization and topology
+Human TOMM6 is an OMM component of TOM. A primary cryo-EM study and structural reviews describe Tom6 as a **single-pass α-helical membrane protein** (single transmembrane segment) positioned on the exterior of the Tom40 β-barrel, consistent with an accessory structural role. (guan2021structuralinsightsinto pages 1-3, araiso2022structuraloverviewof pages 3-5, araiso2022structuraloverviewof pages 1-3)
+
+#### 3.2 Interaction partners and placement within the TOM core
+**Core membership:** The TOM “core complex” is commonly described as TOMM40 plus TOMM22 plus small Tom proteins (Tom5/6/7); receptor subunits Tom20/Tom70 can dissociate in some preparations. A 2021 human TOM cryo-EM structure built **Tom40, Tom22, Tom5, Tom6, and Tom7** (Tom20/Tom70 were not resolved in the core). (guan2021structuralinsightsinto pages 1-3)
+
+**Specific partner interactions inferred/observed:**
+- Tom6 contacts the **Tom40 β-barrel**, especially around the **β13–β15** region, primarily via hydrophobic interactions. (araiso2022structuraloverviewof pages 3-5, guan2021structuralinsightsinto pages 3-4)
+- Tom6 has an **inverted L-shape** with a cytosolic helix segment (α1) that can contact **Tom22**, supporting the notion that Tom6 helps incorporate/position Tom22 in the assembled TOM core. (guan2021structuralinsightsinto pages 3-4)
+- A 2023 review explicitly states TOMM6 helps **anchor TOMM22 to TOMM40**. (kamradt2023mitochondrialmicroproteinscritical pages 1-4)
+
+#### 3.3 Mechanistic role in mitochondrial protein import
+TOMM6 is not itself the pore; rather it supports the protein import pathway by maintaining TOM structural integrity and assembly state.
+- Reviews describe Tom5/Tom6/Tom7 as exterior helices that regulate TOM complex **stability/assembly/oligomerization**, which is required for high-throughput import across the OMM. (bayne2024mitochondrialproteinimport pages 32-36)
+- Structural reviews describe the TOM dimer as two Tom40 barrels with accessory subunits surrounding them; Tom6 is one of the small Tom proteins bound to Tom40’s outer wall. (araiso2022structuraloverviewof pages 1-3, araiso2022structuraloverviewof pages 3-5)
+
+#### 3.4 Pathway connections: mitochondrial quality control / mitophagy context
+The retrieved disease/quality-control literature is largely **TOM-complex-level**, not TOMM6-specific.
+- The TOM machinery is integrated into mitophagy signaling: PINK1 forms complexes with TOM components (notably TOMM70/TOMM22/TOMM20/TOMM40), and TOM levels can modulate PINK1–PRKN mediated clearance in some contexts. (heinemeyer2019underappreciatedrolesof pages 9-10, heinemeyer2019underappreciatedrolesof pages 10-11)
+- No retrieved excerpt demonstrated a TOMM6-specific biochemical role in PINK1 docking or Parkin recruitment; TOMM6’s role here is best framed as enabling proper TOM assembly/stability that would be prerequisite for these events. (bayne2024mitochondrialproteinimport pages 32-36, heinemeyer2019underappreciatedrolesof pages 10-11)
+
+### 4) High-confidence structural data and quantitative details (key statistics)
+
+#### 4.1 Cryo-EM resolutions and assembly states (human TOM)
+A major primary study solved human TOM assemblies:
+- **Dimeric TOM core:** **3.0 Å** resolution (near-atomic). (guan2021structuralinsightsinto pages 1-3)
+- **Trimeric TOM:** **4.3 Å** after C2 symmetry; **6.3 Å** overall in a C1 map (lower detail, with helical subunits not confidently modeled in that trimer reconstruction). (guan2021structuralinsightsinto pages 3-4, guan2021structuralinsightsinto pages 1-3)
+
+These values provide quantitative support that Tom6 placement and lipid-mediated contacts are derived from near-atomic structural information in the dimeric core. (guan2021structuralinsightsinto pages 1-3)
+
+**Publication details:** Guan Z et al. *Cell Discovery.* Apr 2021. https://doi.org/10.1038/s41421-021-00252-7 (guan2021structuralinsightsinto pages 1-3)
+
+#### 4.2 Lipid-mediated Tom6–Tom40 bridging (PL3)
+The 2021 structure reports a phospholipid-like density (**PL3**) bridging Tom6 and Tom40, with residue-level contacts:
+- PL3 contacts **Tom6 R38 and R43**
+- PL3 contacts **Tom40 S320, W322, R348**
+This supports a mechanism in which specific lipids help stabilize Tom6 association with Tom40 and potentially influence assembly dynamics. (guan2021structuralinsightsinto pages 1-3, guan2021structuralinsightsinto pages 3-4)
+
+A figure from this work directly depicts the TOM core architecture and the PL3 bridge between Tom6 and Tom40. (guan2021structuralinsightsinto media 976d9995)
+
+### 5) Regulation and real-world implementations
+
+#### 5.1 Ubiquitin-system regulation of mitochondrial import (complex-level; not TOMM6-specific)
+A key mechanistic study shows that mitochondrial ubiquitin machinery dynamically regulates TOM-dependent import. The data include several quantitative/proteomics statistics:
+- Upon USP30 inhibitor treatment, mass spectrometry showed altered ubiquitination of **9 proteins at 30 min** and **489 proteins at 2 h**; many changes were recapitulated in USP30 knockout cells. (phu2020dynamicregulationof pages 4-7)
+- Comparing WT vs USP30 KO without inhibitor, **36 of 61** differentially ubiquitinated mitochondrial proteins were increased in KO cells, with **34** of these being intramitochondrial proteins. (phu2020dynamicregulationof pages 3-4)
+- USP30 inhibition increased ubiquitinated TOM20 (Ub-TOM20) with an **EC50 of 2.45 mM** (as reported in the excerpt), and USP30 co-immunoprecipitated with TOM complex subunits TOM20, TOM40, and TOM70 in the retrieved pages. (phu2020dynamicregulationof pages 4-7, phu2020dynamicregulationof pages 3-4)
+
+Although TOM complex subunits are discussed as regulated targets, the retrieved excerpts do **not** establish TOMM6 as a direct ubiquitination substrate; therefore the safest statement is that TOMM6 is embedded in a TOM complex whose activity and subunit abundances can be influenced by ubiquitin enzymes acting at TOM. (phu2020dynamicregulationof pages 1-3, phu2020dynamicregulationof pages 9-10)
+
+**Publication details:** Phu L et al. *Molecular Cell.* Mar 2020. https://doi.org/10.1016/j.molcel.2020.02.012 (phu2020dynamicregulationof pages 1-3)
+
+#### 5.2 Current applications / implementations
+No TOMM6-specific clinical applications, assays, or targeted drugs were identified in the retrieved evidence. Current “real-world” implementation is primarily **structural and mechanistic**:
+- TOMM6 is part of the experimentally reconstituted and structurally resolved human TOM core that underpins mitochondrial protein import studies and informs mechanistic models of import and quality control. (guan2021structuralinsightsinto pages 1-3, guan2021structuralinsightsinto media 976d9995)
+- Import regulation through ubiquitin enzymes (e.g., USP30/MARCH5/MUL1) is actively investigated as a translational entry point for modulating mitochondrial protein homeostasis; TOMM6 relevance is indirect through its contribution to TOM core integrity. (phu2020dynamicregulationof pages 1-3, phu2020dynamicregulationof pages 4-7)
+
+### 6) Disease associations, cancer links, and the “OBTP” alias (strength of evidence)
+
+#### 6.1 Evidence for TOMM6-specific disease links is limited
+A 2019 review broadly connects TOM/TIM subunits to neurodegeneration, cardiovascular disease, and cancers, but the detailed mechanistic and genetic evidence in the retrieved pages focuses on other TOM components (especially TOMM40, and also TOMM20/TOMM22/TOMM70). It notes decreased TOMM40 in PD brain and TOM involvement in PINK1–PRKN mitophagy, and it states generally that increased mRNA/protein levels of complex subunits are found in cancers; however, it does **not** provide TOMM6-specific causal evidence in the retrieved excerpts. (heinemeyer2019underappreciatedrolesof pages 10-11, heinemeyer2019underappreciatedrolesof pages 1-2)
+
+**Publication details:** Heinemeyer T et al. *DNA Cell Biol.* Jan 2019. https://doi.org/10.1089/dna.2018.4292 (heinemeyer2019underappreciatedrolesof pages 1-2)
+
+#### 6.2 Open Targets: low-evidence associations from functional screens
+Open Targets lists TOMM6 associations with broad disease categories (e.g., “neurodegenerative disease”) supported by functional screen evidence (e.g., CRISPRi survival screens) and literature linkage (PubMed 34031600 in the Open Targets evidence rows). This should be interpreted as **hypothesis-generating** rather than establishing mechanism or causality for TOMM6 in disease. (OpenTargets Search: -TOMM6)
+
+#### 6.3 “OBTP” (overexpressed breast tumor protein) alias
+The alternative name “OBTP” suggests historical cancer-related naming, but within the retrieved evidence set, there is **no strong primary study** validating TOMM6 as a breast cancer biomarker/driver, and cancer-related statements are mostly general to TOM/TIM complex subunits without TOMM6-specific support. Therefore, the cancer relevance of TOMM6 remains **unresolved/limited** based on the evidence retrieved here. (heinemeyer2019underappreciatedrolesof pages 1-2, heinemeyer2019underappreciatedrolesof pages 12-13)
+
+### 7) Expert synthesis / interpretation
+Across authoritative structural and review sources, TOMM6 emerges as a **microprotein accessory subunit** that helps organize the TOM core complex at the OMM. The most concrete mechanistic insight is structural: Tom6’s placement on Tom40 (β13–β15 region), its cytosolic helix proximity to Tom22, and lipid-mediated bridging (PL3) provide a plausible physical basis for the repeatedly cited “assembly/stability” and “Tom22 anchoring” roles. (guan2021structuralinsightsinto pages 3-4, kamradt2023mitochondrialmicroproteinscritical pages 1-4, guan2021structuralinsightsinto pages 1-3, guan2021structuralinsightsinto media 976d9995)
+
+However, compared with receptor and pore subunits (TOM20/TOM22/TOM40/TOM70), there is **less direct disease-genetics and regulatory biochemistry** specifically attributed to TOMM6 in the retrieved literature. Current evidence supports TOMM6 as a necessary part of the core machine; disease links are presently stronger at the level of the TOM complex or other subunits. (heinemeyer2019underappreciatedrolesof pages 1-2, phu2020dynamicregulationof pages 1-3)
+
+### 8) Summary table of evidence
+The following table consolidates the main functional-annotation claims with evidence types and URLs/DOIs.
+
+| Category | Key points | Evidence type | Key references with year and DOI/URL |
+|---|---|---|---|
+| Identity/domains | Human TOMM6 corresponds to UniProt Q96B49 and is the Tom6-family mitochondrial import receptor subunit homolog. In the literature summarized here, TOMM6 is consistently treated as a small TOM complex subunit/microprotein of 74 aa rather than an enzyme or transporter with an independent catalytic activity (kamradt2023mitochondrialmicroproteinscritical pages 1-4, araiso2022structuraloverviewof pages 1-3). | Review, structural review | Kamradt & Makarewich 2023, https://doi.org/10.1152/ajpcell.00189.2023; Araiso & Endo 2022, https://doi.org/10.2142/biophysico.bppb-v19.0022 |
+| Localization/topology | TOMM6 is an outer mitochondrial membrane TOM subunit. Structural/review evidence describes it as an α-helical single-pass membrane protein; Guan et al. place Tom6 at the Tom40 barrel with an inverted L-shaped architecture including a membrane helix and a cytosolic α1 segment that can contact Tom22 (guan2021structuralinsightsinto pages 3-4, araiso2022structuraloverviewof pages 3-5, guan2021structuralinsightsinto pages 1-3, araiso2022structuraloverviewof pages 1-3). | Cryo-EM/MD, structural review | Guan et al. 2021, https://doi.org/10.1038/s41421-021-00252-7; Araiso & Endo 2022, https://doi.org/10.2142/biophysico.bppb-v19.0022 |
+| Complex membership/interactions | TOMM6 is one of the three “small TOM” subunits (Tom5/6/7) in the TOM core complex with TOMM40 and TOMM22. It interacts closely with TOMM40 and is reported to help anchor/stimulate assembly of TOMM22 with TOMM40; mammalian TOM core architecture is conserved with yeast (guan2021structuralinsightsinto pages 3-4, bayne2024mitochondrialproteinimport pages 32-36, kamradt2023mitochondrialmicroproteinscritical pages 1-4, akram2025proximitylabelingapproaches pages 19-22). | Cryo-EM/MD, review | Guan et al. 2021, https://doi.org/10.1038/s41421-021-00252-7; Kamradt & Makarewich 2023, https://doi.org/10.1152/ajpcell.00189.2023; Bayne 2024 (review text in evidence) |
+| Mechanistic role in import | TOMM6 does not itself transport substrate independently; rather, it supports the TOM import channel by stabilizing/assembling the core and thereby enabling efficient passage of mitochondrial precursor proteins through TOMM40. Reviews state TOMM6, TOMM5, and TOMM7 regulate TOM stability, assembly, and oligomerization, and siRNA against the small TOMMs destabilizes TOM complex proteins (bayne2024mitochondrialproteinimport pages 32-36, kamradt2023mitochondrialmicroproteinscritical pages 1-4). | Review, perturbation summary | Kamradt & Makarewich 2023, https://doi.org/10.1152/ajpcell.00189.2023; Araiso & Endo 2022, https://doi.org/10.2142/biophysico.bppb-v19.0022 |
+| Structural evidence | Human TOM cryo-EM structures resolved the dimeric TOM core at 3.0 Å and a trimeric assembly at 4.3 Å; a lower-resolution 6.3 Å C1 trimer map was also reported. Modeled human core subunits include Tom40, Tom22, Tom5, Tom6, and Tom7, while Tom20/Tom70 were not resolved in the core preparation (guan2021structuralinsightsinto pages 3-4, guan2021structuralinsightsinto pages 1-3, guan2021structuralinsightsinto pages 4-5). | Cryo-EM | Guan et al. 2021, https://doi.org/10.1038/s41421-021-00252-7 |
+| Structural evidence | Tom6 is positioned near β13–β15 of Tom40 and contacts Tom40 mainly through hydrophobic interactions. A phospholipid-like density PL3 bridges Tom6 residues R38/R43 to Tom40 residues S320/W322/R348, and MD simulations suggested PL3 increases Tom6 dynamics, supporting a lipid-mediated assembly/stability role (guan2021structuralinsightsinto pages 3-4, guan2021structuralinsightsinto pages 1-3, guan2021structuralinsightsinto media 976d9995). | Cryo-EM/MD | Guan et al. 2021, https://doi.org/10.1038/s41421-021-00252-7 |
+| Regulation | Direct TOMM6-specific ubiquitination/regulatory evidence was not identified in the gathered material. At the complex level, USP30, MARCH5, and MUL1 dynamically regulate TOM-dependent import, and USP30 knockout mice show reduced abundance of TOM complex subunits across tissues; TOM20 is a named ubiquitin-sensitive TOM substrate, but TOMM6-specific modification was not shown in the retrieved excerpts (phu2020dynamicregulationof pages 9-10, phu2020dynamicregulationof pages 1-3, phu2020dynamicregulationof pages 4-7, phu2020dynamicregulationof pages 3-4). | Proteomics, ubiquitin biology | Phu et al. 2020, https://doi.org/10.1016/j.molcel.2020.02.012 |
+| Disease/phenotype links | Direct disease causality for TOMM6 was limited in the gathered literature. Reviews link TOM machinery broadly to neurodegeneration, mitophagy, cardiovascular disease, and cancer, but the strongest specific evidence is for TOMM40/TOMM20/TOMM22/TOMM70 rather than TOMM6; Open Targets shows only low-evidence disease associations for TOMM6 from functional screens, not established Mendelian disease links (heinemeyer2019underappreciatedrolesof pages 9-10, heinemeyer2019underappreciatedrolesof pages 1-2, heinemeyer2019underappreciatedrolesof pages 10-11, OpenTargets Search: -TOMM6). | Review, genetics/database | Heinemeyer et al. 2019, https://doi.org/10.1089/dna.2018.4292; Open Targets context (OpenTargets Search: -TOMM6) |
+| Disease/phenotype links | The alias “OBTP” reflects older naming (“overexpressed breast tumor protein”), but the gathered evidence did not provide robust primary support that TOMM6 is a validated breast cancer driver or biomarker. Cancer-related statements in the reviewed literature refer generally to increased expression of some TOM/TIM complex subunits, without TOMM6-specific validation in the retrieved excerpts (heinemeyer2019underappreciatedrolesof pages 1-2, heinemeyer2019underappreciatedrolesof pages 12-13). | Review | Heinemeyer et al. 2019, https://doi.org/10.1089/dna.2018.4292 |
+| Applications | Current real-world relevance is mainly mechanistic and translational: TOMM6 helps define human TOM complex architecture used in mitochondrial import research, and TOM-complex regulation is being studied for mitophagy/neurodegeneration therapeutics. No TOMM6-targeted drugs or clinical implementations were identified in the gathered evidence (guan2021structuralinsightsinto pages 1-3, heinemeyer2019underappreciatedrolesof pages 10-11, phu2020dynamicregulationof pages 4-7). | Structural biology, disease-mechanism research | Guan et al. 2021, https://doi.org/10.1038/s41421-021-00252-7; Phu et al. 2020, https://doi.org/10.1016/j.molcel.2020.02.012; Heinemeyer et al. 2019, https://doi.org/10.1089/dna.2018.4292 |
+
+
+*Table: This table summarizes the evidence-based functional annotation of human TOMM6/Q96B49, including localization, TOM complex role, structural findings, regulation, and disease relevance. It is useful as a compact reference because direct TOMM6-specific literature is limited and much of the strongest evidence comes from TOM complex structural studies.*
+
+### Key primary and review sources (URLs; publication dates)
+- Guan Z et al. **Apr 2021**. *Cell Discovery.* “Structural insights into assembly of human mitochondrial translocase TOM complex.” https://doi.org/10.1038/s41421-021-00252-7 (guan2021structuralinsightsinto pages 1-3)
+- Araiso Y, Endo T. **Jun 2022**. *Biophysics and Physicobiology.* “Structural overview of the translocase of the mitochondrial outer membrane complex.” https://doi.org/10.2142/biophysico.bppb-v19.0022 (araiso2022structuraloverviewof pages 1-3)
+- Kamradt ML, Makarewich CA. **Oct 2023**. *Am J Physiol Cell Physiol.* “Mitochondrial microproteins…” https://doi.org/10.1152/ajpcell.00189.2023 (kamradt2023mitochondrialmicroproteinscritical pages 1-4)
+- Bayne AN. **2024**. “Mitochondrial protein import and the role of PINK1…” (journal not resolved in retrieved text). (bayne2024mitochondrialproteinimport pages 32-36)
+- Phu L et al. **Mar 2020**. *Molecular Cell.* “Dynamic regulation of mitochondrial import by the ubiquitin system.” https://doi.org/10.1016/j.molcel.2020.02.012 (phu2020dynamicregulationof pages 1-3)
+- Heinemeyer T et al. **Jan 2019**. *DNA Cell Biol.* “Underappreciated roles…” https://doi.org/10.1089/dna.2018.4292 (heinemeyer2019underappreciatedrolesof pages 1-2)
+
+
+
+References
+
+1. (kamradt2023mitochondrialmicroproteinscritical pages 1-4): Michael L. Kamradt and Catherine A. Makarewich. Mitochondrial microproteins: critical regulators of protein import, energy production, stress response pathways, and programmed cell death. American Journal of Physiology-Cell Physiology, 325:C807-C816, Oct 2023. URL: https://doi.org/10.1152/ajpcell.00189.2023, doi:10.1152/ajpcell.00189.2023. This article has 12 citations.
+
+2. (guan2021structuralinsightsinto pages 1-3): Zeyuan Guan, Ling Yan, Qiang Wang, Liangbo Qi, Sixing Hong, Zhou Gong, Chuangye Yan, and Ping Yin. Structural insights into assembly of human mitochondrial translocase tom complex. Cell Discovery, Apr 2021. URL: https://doi.org/10.1038/s41421-021-00252-7, doi:10.1038/s41421-021-00252-7. This article has 50 citations and is from a peer-reviewed journal.
+
+3. (araiso2022structuraloverviewof pages 1-3): Yuhei Araiso and Toshiya Endo. Structural overview of the translocase of the mitochondrial outer membrane complex. Biophysics and Physicobiology, 19:n/a, Jun 2022. URL: https://doi.org/10.2142/biophysico.bppb-v19.0022, doi:10.2142/biophysico.bppb-v19.0022. This article has 21 citations.
+
+4. (bayne2024mitochondrialproteinimport pages 32-36): AN Bayne. Mitochondrial protein import and the role of pink1 in mitochondrial quality control. Unknown journal, 2024.
+
+5. (araiso2022structuraloverviewof pages 3-5): Yuhei Araiso and Toshiya Endo. Structural overview of the translocase of the mitochondrial outer membrane complex. Biophysics and Physicobiology, 19:n/a, Jun 2022. URL: https://doi.org/10.2142/biophysico.bppb-v19.0022, doi:10.2142/biophysico.bppb-v19.0022. This article has 21 citations.
+
+6. (guan2021structuralinsightsinto pages 3-4): Zeyuan Guan, Ling Yan, Qiang Wang, Liangbo Qi, Sixing Hong, Zhou Gong, Chuangye Yan, and Ping Yin. Structural insights into assembly of human mitochondrial translocase tom complex. Cell Discovery, Apr 2021. URL: https://doi.org/10.1038/s41421-021-00252-7, doi:10.1038/s41421-021-00252-7. This article has 50 citations and is from a peer-reviewed journal.
+
+7. (heinemeyer2019underappreciatedrolesof pages 9-10): Thea Heinemeyer, Monique Stemmet, Soraya Bardien, and Annika Neethling. Underappreciated roles of the translocase of the outer and inner mitochondrial membrane protein complexes in human disease. DNA and cell biology, 38 1:23-40, Jan 2019. URL: https://doi.org/10.1089/dna.2018.4292, doi:10.1089/dna.2018.4292. This article has 43 citations and is from a peer-reviewed journal.
+
+8. (heinemeyer2019underappreciatedrolesof pages 10-11): Thea Heinemeyer, Monique Stemmet, Soraya Bardien, and Annika Neethling. Underappreciated roles of the translocase of the outer and inner mitochondrial membrane protein complexes in human disease. DNA and cell biology, 38 1:23-40, Jan 2019. URL: https://doi.org/10.1089/dna.2018.4292, doi:10.1089/dna.2018.4292. This article has 43 citations and is from a peer-reviewed journal.
+
+9. (guan2021structuralinsightsinto media 976d9995): Zeyuan Guan, Ling Yan, Qiang Wang, Liangbo Qi, Sixing Hong, Zhou Gong, Chuangye Yan, and Ping Yin. Structural insights into assembly of human mitochondrial translocase tom complex. Cell Discovery, Apr 2021. URL: https://doi.org/10.1038/s41421-021-00252-7, doi:10.1038/s41421-021-00252-7. This article has 50 citations and is from a peer-reviewed journal.
+
+10. (phu2020dynamicregulationof pages 4-7): Lilian Phu, Christopher M. Rose, Joy S. Tea, Christopher E. Wall, Erik Verschueren, Tommy K. Cheung, Donald S. Kirkpatrick, and Baris Bingol. Dynamic regulation of mitochondrial import by the ubiquitin system. Molecular cell, 77 5:1107-1123.e10, Mar 2020. URL: https://doi.org/10.1016/j.molcel.2020.02.012, doi:10.1016/j.molcel.2020.02.012. This article has 163 citations and is from a highest quality peer-reviewed journal.
+
+11. (phu2020dynamicregulationof pages 3-4): Lilian Phu, Christopher M. Rose, Joy S. Tea, Christopher E. Wall, Erik Verschueren, Tommy K. Cheung, Donald S. Kirkpatrick, and Baris Bingol. Dynamic regulation of mitochondrial import by the ubiquitin system. Molecular cell, 77 5:1107-1123.e10, Mar 2020. URL: https://doi.org/10.1016/j.molcel.2020.02.012, doi:10.1016/j.molcel.2020.02.012. This article has 163 citations and is from a highest quality peer-reviewed journal.
+
+12. (phu2020dynamicregulationof pages 1-3): Lilian Phu, Christopher M. Rose, Joy S. Tea, Christopher E. Wall, Erik Verschueren, Tommy K. Cheung, Donald S. Kirkpatrick, and Baris Bingol. Dynamic regulation of mitochondrial import by the ubiquitin system. Molecular cell, 77 5:1107-1123.e10, Mar 2020. URL: https://doi.org/10.1016/j.molcel.2020.02.012, doi:10.1016/j.molcel.2020.02.012. This article has 163 citations and is from a highest quality peer-reviewed journal.
+
+13. (phu2020dynamicregulationof pages 9-10): Lilian Phu, Christopher M. Rose, Joy S. Tea, Christopher E. Wall, Erik Verschueren, Tommy K. Cheung, Donald S. Kirkpatrick, and Baris Bingol. Dynamic regulation of mitochondrial import by the ubiquitin system. Molecular cell, 77 5:1107-1123.e10, Mar 2020. URL: https://doi.org/10.1016/j.molcel.2020.02.012, doi:10.1016/j.molcel.2020.02.012. This article has 163 citations and is from a highest quality peer-reviewed journal.
+
+14. (heinemeyer2019underappreciatedrolesof pages 1-2): Thea Heinemeyer, Monique Stemmet, Soraya Bardien, and Annika Neethling. Underappreciated roles of the translocase of the outer and inner mitochondrial membrane protein complexes in human disease. DNA and cell biology, 38 1:23-40, Jan 2019. URL: https://doi.org/10.1089/dna.2018.4292, doi:10.1089/dna.2018.4292. This article has 43 citations and is from a peer-reviewed journal.
+
+15. (OpenTargets Search: -TOMM6): Open Targets Query (-TOMM6, 5 results). Buniello, A. et al. (2025). Open Targets Platform: facilitating therapeutic hypotheses building in drug discovery. Nucleic Acids Research.
+
+16. (heinemeyer2019underappreciatedrolesof pages 12-13): Thea Heinemeyer, Monique Stemmet, Soraya Bardien, and Annika Neethling. Underappreciated roles of the translocase of the outer and inner mitochondrial membrane protein complexes in human disease. DNA and cell biology, 38 1:23-40, Jan 2019. URL: https://doi.org/10.1089/dna.2018.4292, doi:10.1089/dna.2018.4292. This article has 43 citations and is from a peer-reviewed journal.
+
+17. (akram2025proximitylabelingapproaches pages 19-22): S Akram. Proximity labeling approaches to mitochondrial import receptors tomm20 and tomm70. Unknown journal, 2025.
+
+18. (guan2021structuralinsightsinto pages 4-5): Zeyuan Guan, Ling Yan, Qiang Wang, Liangbo Qi, Sixing Hong, Zhou Gong, Chuangye Yan, and Ping Yin. Structural insights into assembly of human mitochondrial translocase tom complex. Cell Discovery, Apr 2021. URL: https://doi.org/10.1038/s41421-021-00252-7, doi:10.1038/s41421-021-00252-7. This article has 50 citations and is from a peer-reviewed journal.
+
+## Citations
+
+1. araiso2022structuraloverviewof pages 1-3
+2. kamradt2023mitochondrialmicroproteinscritical pages 1-4
+3. bayne2024mitochondrialproteinimport pages 32-36
+4. guan2021structuralinsightsinto pages 1-3
+5. guan2021structuralinsightsinto pages 3-4
+6. phu2020dynamicregulationof pages 4-7
+7. phu2020dynamicregulationof pages 3-4
+8. phu2020dynamicregulationof pages 1-3
+9. heinemeyer2019underappreciatedrolesof pages 1-2
+10. araiso2022structuraloverviewof pages 3-5
+11. heinemeyer2019underappreciatedrolesof pages 9-10
+12. heinemeyer2019underappreciatedrolesof pages 10-11
+13. phu2020dynamicregulationof pages 9-10
+14. heinemeyer2019underappreciatedrolesof pages 12-13
+15. akram2025proximitylabelingapproaches pages 19-22
+16. guan2021structuralinsightsinto pages 4-5
+17. https://doi.org/10.1152/ajpcell.00189.2023
+18. https://doi.org/10.1038/s41421-021-00252-7
+19. https://doi.org/10.1016/j.molcel.2020.02.012
+20. https://doi.org/10.1089/dna.2018.4292
+21. https://doi.org/10.1152/ajpcell.00189.2023;
+22. https://doi.org/10.2142/biophysico.bppb-v19.0022
+23. https://doi.org/10.1038/s41421-021-00252-7;
+24. https://doi.org/10.1089/dna.2018.4292;
+25. https://doi.org/10.1016/j.molcel.2020.02.012;
+26. https://doi.org/10.1152/ajpcell.00189.2023,
+27. https://doi.org/10.1038/s41421-021-00252-7,
+28. https://doi.org/10.2142/biophysico.bppb-v19.0022,
+29. https://doi.org/10.1089/dna.2018.4292,
+30. https://doi.org/10.1016/j.molcel.2020.02.012,


### PR DESCRIPTION
## Summary
- Generate Falcon deep research reports for human TOMM6, TOMM5, and MTX1.
- Complete the AI review YAMLs, incorporating Falcon evidence into annotation decisions and core function summaries.
- Render review HTML for all three genes.

## Validation
- `uv run python scripts/validate_deep_research.py genes/human/TOMM6/TOMM6-deep-research-falcon.md genes/human/TOMM5/TOMM5-deep-research-falcon.md genes/human/MTX1/MTX1-deep-research-falcon.md`
- `just validate human TOMM6`
- `just validate human TOMM5`
- `just validate human MTX1`
- `just render human TOMM6`
- `just render human TOMM5`
- `just render human MTX1`
- `git diff --cached --check`