### PR TITLE
Add Falcon deep research reviews for TIMM17A, MTX2, and TOMM7

### DIFF
--- a/genes/human/MTX2/MTX2-ai-review.html
+++ b/genes/human/MTX2/MTX2-ai-review.html
@@ -1,0 +1,3339 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>MTX2 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>MTX2</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/O75431" target="_blank" class="term-link">
+                        O75431
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "MTX2";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="O75431" data-a="DESCRIPTION: MTX2 (metaxin-2) is a non-enzymatic mitochondrial ..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>MTX2 (metaxin-2) is a non-enzymatic mitochondrial outer membrane metaxin-family factor that partners with MTX1 in the mammalian SAM machinery. Its best-supported core role is mitochondrial outer membrane protein biogenesis/organization, especially SAM-mediated integration and assembly of beta-barrel outer membrane proteins, with additional links to MICOS/MIB architecture, mitochondrial transport, apoptosis, and MTX2-associated mandibuloacral dysplasia.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045040" target="_blank" class="term-link">
+                                    GO:0045040
+                                </a>
+                            </span>
+                            <span class="term-label">protein insertion into mitochondrial outer membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O75431" data-a="GO:0045040" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct phylogenetic inference. MTX2 is an MTX1 partner in the SAM machinery supporting integration/assembly of beta-barrel proteins into the mitochondrial outer membrane.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MTX2/MTX2-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The **mitochondrial Sorting and Assembly Machinery (SAM)** is an OMM pathway that supports the **correct integration of β-barrel proteins into the OMM**.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070096" target="_blank" class="term-link">
+                                    GO:0070096
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial outer membrane translocase complex assembly</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O75431" data-a="GO:0070096" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Accepted as a SAM/metaxin assembly function. MTX2 supports the organization and assembly of outer membrane translocase components and beta-barrel proteins.
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001401" target="_blank" class="term-link">
+                                    GO:0001401
+                                </a>
+                            </span>
+                            <span class="term-label">SAM complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O75431" data-a="GO:0001401" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct. MTX2 is a metaxin component of the mammalian SAM machinery with MTX1 and SAMM50.
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001401" target="_blank" class="term-link">
+                                    GO:0001401
+                                </a>
+                            </span>
+                            <span class="term-label">SAM complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O75431" data-a="GO:0001401" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct InterPro-derived annotation. The Falcon synthesis supports MTX2 as a SAM/metaxin factor at the mitochondrial outer membrane.
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O75431" data-a="GO:0005739" data-r="GO_REF:0000044" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct but too general. MTX2 is specifically localized to the mitochondrial outer membrane and SAM machinery.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Subsumed by mitochondrial outer membrane and SAM complex annotations.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005741" target="_blank" class="term-link">
+                                    GO:0005741
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial outer membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O75431" data-a="GO:0005741" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct UniProt-derived localization. MTX2 is an outer mitochondrial membrane metaxin protein facing the cytosolic compartment.
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25416956" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25416956
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A proteome-scale map of the human interactome network.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="O75431" data-a="GO:0005515" data-r="PMID:25416956" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Proteome-scale protein binding is too generic to capture MTX2 function. The supported biology is MTX2 partnership with MTX1 in SAM/metaxin outer membrane protein biogenesis.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Protein binding is uninformative; use SAM complex and assembly terms instead.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:32296183
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A reference map of the human binary protein interactome.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="O75431" data-a="GO:0005515" data-r="PMID:32296183" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Generic binary-interactome protein binding does not represent MTX2&#39;s curated mitochondrial outer membrane/SAM function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Protein binding is uninformative; complex membership captures the supported function.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000052
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O75431" data-a="GO:0005739" data-r="GO_REF:0000052" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct but less specific than the mitochondrial outer membrane/SAM localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Subsumed by mitochondrial outer membrane and SAM complex annotations.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001401" target="_blank" class="term-link">
+                                    GO:0001401
+                                </a>
+                            </span>
+                            <span class="term-label">SAM complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/17510655" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:17510655
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Conserved roles of Sam50 and metaxins in VDAC biogenesis.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O75431" data-a="GO:0001401" data-r="PMID:17510655" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Accepted. Conserved Sam50/metaxin evidence supports MTX2 as part of the SAM machinery for VDAC/beta-barrel biogenesis.
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005741" target="_blank" class="term-link">
+                                    GO:0005741
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial outer membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/31387448" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:31387448
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mitochondria-hubs for regulating cellular biochemistry: emer...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O75431" data-a="GO:0005741" data-r="PMID:31387448" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Accepted. MTX2 is consistently described as a mitochondrial outer membrane metaxin/SAM component.
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045040" target="_blank" class="term-link">
+                                    GO:0045040
+                                </a>
+                            </span>
+                            <span class="term-label">protein insertion into mitochondrial outer membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/31387448" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:31387448
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mitochondria-hubs for regulating cellular biochemistry: emer...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O75431" data-a="GO:0045040" data-r="PMID:31387448" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Accepted as the core SAM/metaxin process: correct integration and assembly of beta-barrel proteins into the mitochondrial outer membrane.
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HTP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:34800366
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Quantitative high-confidence human mitochondrial proteome an...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O75431" data-a="GO:0005739" data-r="PMID:34800366" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput mitochondrial proteome evidence supports mitochondrial localization, but this is less specific than the outer membrane/SAM annotation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Subsumed by mitochondrial outer membrane and SAM complex annotations.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006839" target="_blank" class="term-link">
+                                    GO:0006839
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/32917887" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:32917887
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Loss of MTX2 causes mandibuloacral dysplasia and links mitoc...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="O75431" data-a="GO:0006839" data-r="PMID:32917887" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Valid but broad disease-mechanism annotation. MTX2 loss disrupts mitochondrial function and transport/biogenesis, but the more precise core process is SAM-mediated outer membrane protein insertion and assembly.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Broad process term; retained as a disease-relevant non-core phenotype/process.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001401" target="_blank" class="term-link">
+                                    GO:0001401
+                                </a>
+                            </span>
+                            <span class="term-label">SAM complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26477565" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:26477565
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Evolution and structural organization of the mitochondrial c...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O75431" data-a="GO:0001401" data-r="PMID:26477565" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Accepted. High-throughput complex evidence is consistent with MTX2 in SAM-associated mitochondrial outer membrane assemblies.
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007007" target="_blank" class="term-link">
+                                    GO:0007007
+                                </a>
+                            </span>
+                            <span class="term-label">inner mitochondrial membrane organization</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IC</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26477565" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:26477565
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Evolution and structural organization of the mitochondrial c...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="O75431" data-a="GO:0007007" data-r="PMID:26477565" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Supported as a secondary consequence/context of SAM-MICOS/MIB bridging and mitochondrial architecture effects, but not the primary MTX2 function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> MIB/MICOS-associated architecture is secondary to the core SAM role.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140275" target="_blank" class="term-link">
+                                    GO:0140275
+                                </a>
+                            </span>
+                            <span class="term-label">MIB complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26477565" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:26477565
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Evolution and structural organization of the mitochondrial c...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="O75431" data-a="GO:0140275" data-r="PMID:26477565" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Supported as an additional SAM-MICOS/MIB-associated context. Keep as non-core because the strongest MTX2 function is SAM/metaxin outer membrane protein biogenesis.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> MIB complex association is secondary to the primary SAM/metaxin role.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25997101" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25997101
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    QIL1 is a novel mitochondrial protein required for MICOS com...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O75431" data-a="GO:0005739" data-r="PMID:25997101" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct but too general for MTX2, which localizes to the mitochondrial outer membrane and SAM machinery.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Subsumed by mitochondrial outer membrane and SAM complex annotations.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005741" target="_blank" class="term-link">
+                                    GO:0005741
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial outer membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10381257" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10381257
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Metaxin 1 interacts with metaxin 2, a novel related protein ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O75431" data-a="GO:0005741" data-r="PMID:10381257" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Accepted. MTX2 was identified as an MTX1-interacting protein associated with the mammalian mitochondrial outer membrane.
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006839" target="_blank" class="term-link">
+                                    GO:0006839
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10381257" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10381257
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Metaxin 1 interacts with metaxin 2, a novel related protein ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="O75431" data-a="GO:0006839" data-r="PMID:10381257" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Broad but directionally correct for metaxin biology. The more specific function is outer membrane protein biogenesis/insertion through SAM.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Broad process term; more specific SAM-mediated insertion terms exist.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>MTX2 is a non-enzymatic metaxin/SAM factor at the mitochondrial outer membrane that partners with MTX1 to support SAM-mediated integration and assembly of beta-barrel outer membrane proteins.</h3>
+                <span class="vote-buttons" data-g="O75431" data-a="FUNCTION: MTX2 is a non-enzymatic metaxin/SAM factor at the ..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045040" target="_blank" class="term-link">
+                                protein insertion into mitochondrial outer membrane
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070096" target="_blank" class="term-link">
+                                mitochondrial outer membrane translocase complex assembly
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005741" target="_blank" class="term-link">
+                                mitochondrial outer membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001401" target="_blank" class="term-link">
+                            SAM complex
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/MTX2/MTX2-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">MTX2 is localized to the **outer mitochondrial membrane** and is described as **facing the cytosolic compartment**.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/MTX2/MTX2-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">The **mitochondrial Sorting and Assembly Machinery (SAM)** is an OMM pathway that supports the **correct integration of β-barrel proteins into the OMM**.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/MTX2/MTX2-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">MTX2 **interacts directly with MTX1** and is positioned as part of the **SAM machinery**</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000052.md" target="_blank" class="term-link">
+                            GO_REF:0000052
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on curation of immunofluorescence data</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/10381257" target="_blank" class="term-link">
+                            PMID:10381257
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Metaxin 1 interacts with metaxin 2, a novel related protein associated with the mammalian mitochondrial outer membrane.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/17510655" target="_blank" class="term-link">
+                            PMID:17510655
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Conserved roles of Sam50 and metaxins in VDAC biogenesis.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/25416956" target="_blank" class="term-link">
+                            PMID:25416956
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A proteome-scale map of the human interactome network.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/25997101" target="_blank" class="term-link">
+                            PMID:25997101
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">QIL1 is a novel mitochondrial protein required for MICOS complex stability and cristae morphology.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/26477565" target="_blank" class="term-link">
+                            PMID:26477565
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Evolution and structural organization of the mitochondrial contact site (MICOS) complex and the mitochondrial intermembrane space bridging (MIB) complex.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/31387448" target="_blank" class="term-link">
+                            PMID:31387448
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Mitochondria-hubs for regulating cellular biochemistry: emerging concepts and networks.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
+                            PMID:32296183
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A reference map of the human binary protein interactome.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/32917887" target="_blank" class="term-link">
+                            PMID:32917887
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Loss of MTX2 causes mandibuloacral dysplasia and links mitochondrial dysfunction to altered nuclear morphology.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link">
+                            PMID:34800366
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Quantitative high-confidence human mitochondrial proteome and its dynamics in cellular context.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/MTX2/MTX2-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research report for human MTX2</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Which MTX2-MTX1 interfaces are required for SAM-mediated beta-barrel insertion versus broader SAM-MICOS/MIB architecture?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="O75431" data-a="Q: Which MTX2-MTX1 interfaces are required for SAM-me..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> How do pathogenic MTX2 splice or null variants alter SAM composition, MTX1 stability, and mitochondrial outer membrane protein assembly in patient cells?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="O75431" data-a="Q: How do pathogenic MTX2 splice or null variants alt..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Perform endogenous MTX2 knockout/rescue and patient-variant rescue in human cells, then measure MTX1 stability, SAM complex assembly, VDAC/TOM40 import, mitochondrial network morphology, and apoptosis/respiration phenotypes.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: MTX2 stabilizes MTX1-containing SAM assemblies required for beta-barrel outer membrane protein biogenesis.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: endogenous rescue and mitochondrial import/assembly assay</p>
+
+                </div>
+                <span class="vote-buttons" data-g="O75431" data-a="EXPERIMENT: Perform endogenous MTX2 knockout/rescue and patien..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Deep Research Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(MTX2-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="O75431" data-a="DOC: Deep Research Falcon" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <hr />
+<p>provider: falcon<br />
+model: Edison Scientific Literature<br />
+cached: false<br />
+start_time: '2026-05-11T12:10:32.107823'<br />
+end_time: '2026-05-11T12:20:15.782421'<br />
+duration_seconds: 583.67<br />
+template_file: templates/gene_research_go_focused.md<br />
+template_variables:<br />
+  organism: human<br />
+  gene_id: MTX2<br />
+  gene_symbol: MTX2<br />
+  uniprot_accession: O75431<br />
+  protein_description: 'RecName: Full=Metaxin-2; AltName: Full=Mitochondrial outer<br />
+    membrane import complex protein 2;'<br />
+  gene_info: Name=MTX2;<br />
+  organism_full: Homo sapiens (Human).<br />
+  protein_family: Belongs to the metaxin family. .<br />
+  protein_domains: Glutathione-S-Trfase_C_sf. (IPR036282); Glutathione_S-Trfase. (IPR040079);<br />
+    Metaxin_GST. (IPR033468); Mito_Protein_Transport_Metaxin. (IPR050931); Sam37/metaxin_N.<br />
+    (IPR019564)<br />
+provider_config:<br />
+  timeout: 600<br />
+  max_retries: 3<br />
+  parameters:<br />
+    allowed_domains: []<br />
+    temperature: 0.1<br />
+citation_count: 15</p>
+<hr />
+<h2 id="question">Question</h2>
+<h1 id="gene-research-for-functional-annotation">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> O75431</li>
+<li><strong>Protein Description:</strong> RecName: Full=Metaxin-2; AltName: Full=Mitochondrial outer membrane import complex protein 2;</li>
+<li><strong>Gene Information:</strong> Name=MTX2;</li>
+<li><strong>Organism (full):</strong> Homo sapiens (Human).</li>
+<li><strong>Protein Family:</strong> Belongs to the metaxin family. .</li>
+<li><strong>Key Domains:</strong> Glutathione-S-Trfase_C_sf. (IPR036282); Glutathione_S-Trfase. (IPR040079); Metaxin_GST. (IPR033468); Mito_Protein_Transport_Metaxin. (IPR050931); Sam37/metaxin_N. (IPR019564)</li>
+</ul>
+<h3 id="mandatory-verification-steps">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "MTX2" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Homo sapiens (Human).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'MTX2' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>MTX2</strong> (gene ID: MTX2, UniProt: O75431) in human.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="output">Output</h2>
+<p>Question: You are an expert researcher providing comprehensive, well-cited information.</p>
+<p>Provide detailed information focusing on:<br />
+1. Key concepts and definitions with current understanding<br />
+2. Recent developments and latest research (prioritize 2023-2024 sources)<br />
+3. Current applications and real-world implementations<br />
+4. Expert opinions and analysis from authoritative sources<br />
+5. Relevant statistics and data from recent studies</p>
+<p>Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.<br />
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.</p>
+<h1 id="gene-research-for-functional-annotation_1">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context_1">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot_1">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> O75431</li>
+<li><strong>Protein Description:</strong> RecName: Full=Metaxin-2; AltName: Full=Mitochondrial outer membrane import complex protein 2;</li>
+<li><strong>Gene Information:</strong> Name=MTX2;</li>
+<li><strong>Organism (full):</strong> Homo sapiens (Human).</li>
+<li><strong>Protein Family:</strong> Belongs to the metaxin family. .</li>
+<li><strong>Key Domains:</strong> Glutathione-S-Trfase_C_sf. (IPR036282); Glutathione_S-Trfase. (IPR040079); Metaxin_GST. (IPR033468); Mito_Protein_Transport_Metaxin. (IPR050931); Sam37/metaxin_N. (IPR019564)</li>
+</ul>
+<h3 id="mandatory-verification-steps_1">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "MTX2" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Homo sapiens (Human).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature_1">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'MTX2' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target_1">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>MTX2</strong> (gene ID: MTX2, UniProt: O75431) in human.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="research-report-human-mtx2-metaxin-2-uniprot-o75431functional-annotation-and-biomedical-relevance">Research report: Human <strong>MTX2 / Metaxin-2</strong> (UniProt <strong>O75431</strong>)—functional annotation and biomedical relevance</h2>
+<h3 id="0-target-verification-geneprotein-identity">0) Target verification (gene/protein identity)</h3>
+<p>The target of this report is <strong>human MTX2 (Metaxin-2)</strong>, corresponding to <strong>UniProt O75431</strong>, a <strong>263–amino-acid</strong> mitochondrial protein localized to the <strong>outer mitochondrial membrane (OMM)</strong>; the literature evidence used here explicitly matches this identity and organism context and does not refer to an unrelated “MTX2” symbol from another species. (elouej2020lossofmtx2 pages 1-2)</p>
+<h3 id="1-key-concepts-and-definitions-current-understanding">1) Key concepts and definitions (current understanding)</h3>
+<h4 id="11-metaxin-family-and-gst-like-fold-definition-vs-enzyme-function">1.1 Metaxin family and “GST-like” fold (definition vs. enzyme function)</h4>
+<p>MTX2 is a member of the <strong>metaxin family</strong> and is described in recent clinical genetics literature as having two annotated regions: an N-terminal <strong>Sam37/metaxin_N</strong> domain (reported as <strong>aa 41–162</strong>) and a <strong>glutathione S-transferase (GST)-like</strong> domain. (dogan2023anovelmtx2 pages 5-5, fu2024casereporta pages 2-4)</p>
+<p>Importantly, the “GST-like” designation in MTX2 is best interpreted as a <strong>structural fold similarity</strong>, not evidence that MTX2 catalyzes canonical GST conjugation reactions; the strongest experimental and genetic evidence supports a <strong>non-enzymatic role in mitochondrial outer membrane protein biogenesis/organization</strong> rather than a metabolic enzyme function. (elouej2020lossofmtx2 pages 1-2, elouej2020lossofmtx2 pages 2-4)</p>
+<h4 id="12-sam-sorting-and-assembly-machinery-and-barrel-insertion-definition">1.2 SAM (Sorting and Assembly Machinery) and β-barrel insertion (definition)</h4>
+<p>The <strong>mitochondrial Sorting and Assembly Machinery (SAM)</strong> is an OMM pathway that supports the <strong>correct integration of β-barrel proteins into the OMM</strong>. MTX2 and its partner <strong>Metaxin-1 (MTX1)</strong> are described as components of this machinery in the context of human disease genetics and functional studies. (elouej2020lossofmtx2 pages 1-2)</p>
+<h4 id="13-micossam-mib-bridging-definition">1.3 MICOS–SAM / MIB bridging (definition)</h4>
+<p>The SAM complex is described as a binding partner of <strong>Mic60</strong>, a core component of <strong>MICOS</strong> (mitochondrial contact site and cristae organizing system). These interactions form larger assemblies described as <strong>mitochondrial intermembrane space bridging</strong> complexes implicated in cristae junction organization and mitochondrial architecture. (elouej2020lossofmtx2 pages 1-2)</p>
+<h3 id="2-molecular-function-pathways-and-subcellular-localization">2) Molecular function, pathways, and subcellular localization</h3>
+<h4 id="21-subcellular-localization-and-topology">2.1 Subcellular localization and topology</h4>
+<p>MTX2 is localized to the <strong>outer mitochondrial membrane</strong> and is described as <strong>facing the cytosolic compartment</strong>. It is proposed to associate with the OMM through direct interaction with <strong>MTX1</strong>. (elouej2020lossofmtx2 pages 1-2, talarmingas2024validationofmetaxin2 pages 1-2)</p>
+<h4 id="22-primary-molecular-function-omm-protein-biogenesisassembly-and-mitochondrial-architecture">2.2 Primary molecular function: OMM protein biogenesis/assembly and mitochondrial architecture</h4>
+<p>Multiple converging lines of evidence support MTX2’s primary function as a <strong>mitochondrial outer membrane protein biogenesis/assembly factor</strong>:</p>
+<ul>
+<li><strong>Complex membership and partner interaction:</strong> MTX2 <strong>interacts directly with MTX1</strong> and is positioned as part of the <strong>SAM machinery</strong>, supporting β-barrel protein integration in the OMM. (elouej2020lossofmtx2 pages 1-2)</li>
+<li><strong>Systems/architecture linkage:</strong> SAM is described as interacting with <strong>Mic60/MICOS</strong> in higher-order bridging assemblies, linking MTX2’s SAM role to broader mitochondrial ultrastructure organization. (elouej2020lossofmtx2 pages 1-2)</li>
+</ul>
+<h4 id="23-apoptosis-and-stress-response-linkage-secondary-functional-axis">2.3 Apoptosis and stress response linkage (secondary functional axis)</h4>
+<p>MTX1/MTX2 have also been discussed as contributing to <strong>TNF-α–induced apoptosis</strong> via interaction with the pro-apoptotic protein <strong>Bak</strong>, linking OMM composition to cell-death signaling. (elouej2020lossofmtx2 pages 1-2)</p>
+<p>Consistent with this, patient fibroblasts lacking MTX2 show <strong>resistance to apoptosis induction</strong> (e.g., TNFα/CHX and staurosporine) and reduced caspase-3 activation. (elouej2020lossofmtx2 pages 6-7)</p>
+<h3 id="3-human-genetics-and-disease-association-real-world-relevance">3) Human genetics and disease association (real-world relevance)</h3>
+<h4 id="31-disease-mandibuloacral-dysplasia-associated-with-mtx2-madam">3.1 Disease: Mandibuloacral dysplasia associated with MTX2 (MADaM)</h4>
+<p>A key real-world “implementation” of MTX2 biology is in <strong>clinical genetics</strong>, where biallelic MTX2 loss-of-function variants cause a severe progeroid syndrome.</p>
+<p><strong>Discovery cohort (primary literature):</strong> Elouej et al. (Nature Communications; <strong>published Sep 2020</strong>; URL: https://doi.org/10.1038/s41467-020-18146-9) evaluated <strong>7 patients from 5 consanguineous families</strong> and reported <strong>5 homozygous null MTX2 variants</strong>, establishing <strong>MADaM</strong>. (elouej2020lossofmtx2 pages 1-2)</p>
+<p>Clinical features included growth retardation and multisystem disease (e.g., renal involvement and severe hypertension), with cellular phenotypes implicating mitochondrial dysfunction. (elouej2020lossofmtx2 pages 1-2)</p>
+<p><strong>Variant spectrum expansion (recent):</strong><br />
+* A 2023 clinical report (American Journal of Medical Genetics A; <strong>Oct 2023</strong>; URL: https://doi.org/10.1002/ajmg.a.63010) described a new <strong>splice-site</strong> variant <strong>c.543+1G&gt;T</strong> causing <strong>exon 8 skipping</strong> (cDNA evidence) and noted that previously only five MTX2 pathogenic variants had been reported in the original discovery paper. (dogan2023anovelmtx2 pages 5-5)<br />
+* A 2024 case report (Frontiers in Endocrinology; <strong>published 13 Mar 2024</strong>; URL: https://doi.org/10.3389/fendo.2024.1345067) reported a novel homozygous splice-site mutation <strong>c.378+1G&gt;A</strong> and summarized that <strong>7 molecularly diagnosed MADaM cases</strong> had been reported worldwide prior to their report; they also describe deep sequencing coverage (<strong>99.80%</strong>, <strong>&gt;100×</strong> depth) supporting diagnostic confidence. (fu2024casereporta pages 1-2, fu2024casereporta pages 2-4)</p>
+<h4 id="32-mechanistic-cellular-consequences-of-mtx2-loss-in-human-patient-fibroblasts-quantitative">3.2 Mechanistic cellular consequences of MTX2 loss in human patient fibroblasts (quantitative)</h4>
+<p>Elouej et al. quantified mitochondrial morphology and function changes in MTX2-deficient fibroblasts:</p>
+<p><strong>(a) Secondary depletion of MTX1:</strong> Patient fibroblasts show loss of MTX2 and a <strong>complete secondary depletion of MTX1 protein</strong>, without reduction in MTX1 transcript levels (consistent with MTX1 instability when MTX2 is absent). (elouej2020lossofmtx2 pages 4-5)</p>
+<p><strong>(b) Mitochondrial network fragmentation / fission bias:</strong> Mitochondrial network analysis (MiNA macro) scored <strong>53 (WT), 46 (MADM2), and 51 (MADM3) cells</strong> from <strong>n=5 independent experiments</strong>, showing significant reductions in network features (mitochondrial footprint, individuals, networks, branches per network). DRP1 was significantly increased (e.g., pMADM2 = 0.0015; pMADM3 = 0.042), consistent with increased fission. (elouej2020lossofmtx2 pages 4-5)</p>
+<p><strong>(c) Respiratory chain protein composition:</strong> Multiple respiratory chain subunits were significantly reduced (complex I/III/IV/V) while complex II SDHA was not. (elouej2020lossofmtx2 pages 5-6)</p>
+<p><strong>(d) Mitochondrial respiration:</strong> Respiration analyses showed a significant decrease in respiration dedicated to ATP synthesis (expressed as <strong>R–O/F</strong>) and decreased basal routine respiration (<strong>R/F</strong>) in patient fibroblasts; reported as <strong>n=4 independent experiments</strong> with <strong>p=0.015</strong>. (elouej2020lossofmtx2 pages 5-6, elouej2020lossofmtx2 media 62f590fd)</p>
+<p><strong>(e) Membrane potential:</strong> TMRM FACS showed increased mitochondrial membrane potential in at least one patient line (MADM2; reported p=0.015). (elouej2020lossofmtx2 pages 5-6, elouej2020lossofmtx2 media 1c141a95)</p>
+<p><strong>(f) Apoptosis resistance and mitophagy/autophagy:</strong> In patient fibroblasts, apoptosis induction was significantly blunted with strong p-values (e.g., TNFα/CHX pMADM2 = 4.0×10−5; pMADM3 = 2.1×10−7; staurosporine pMADM2 = 3.7×10−7; pMADM3 = 4.0×10−4). Autophagy markers (LC3B-II/LC3B-I) were increased (e.g., pMADM2 = 0.0002; pMADM3 = 0.026), and mitophagy was described as LC3C-associated rather than Parkin/ubiquitin-mediated. (elouej2020lossofmtx2 pages 6-7)</p>
+<h3 id="4-recent-developments-prioritizing-20232024">4) Recent developments (prioritizing 2023–2024)</h3>
+<h4 id="41-2023-new-splice-site-pathogenic-variant-with-functional-transcript-evidence">4.1 2023: New splice-site pathogenic variant with functional transcript evidence</h4>
+<p>The 2023 splice-site variant report provides transcript-level evidence (exon skipping) strengthening the causal link between MTX2 splicing disruption and MADaM, and independently reiterates MTX2’s SAM/β-barrel insertion role as the mechanistic frame for disease. (dogan2023anovelmtx2 pages 5-5)</p>
+<h4 id="42-2024-expanded-global-clinical-reporting-and-molecular-diagnostics-rigor">4.2 2024: Expanded global clinical reporting and molecular diagnostics rigor</h4>
+<p>The 2024 Frontiers case report contributes (i) a new likely pathogenic splice-site variant (c.378+1G&gt;A), (ii) explicit clinical laboratory abnormalities (e.g., proteinuria, microhematuria, hypercholesterolemia, low IgG) in a pediatric presentation, and (iii) reporting of sequencing QC metrics (coverage/depth), illustrating how MTX2 is now used in real-world diagnostic workflows. (fu2024casereporta pages 2-4, fu2024casereporta pages 1-2)</p>
+<h4 id="43-2024-model-organism-validation-for-mechanism-and-therapeutic-discovery">4.3 2024: Model organism validation for mechanism and therapeutic discovery</h4>
+<p>Talarmin-Gas et al. (Communications Biology; <strong>Oct 2024</strong>; URL: https://doi.org/10.1038/s42003-024-06967-z) further validated <strong>mtx-2–deficient C. elegans</strong> as a MADaM model, using <strong>AFM</strong>, <strong>oxygen consumption rate analyses</strong>, and <strong>transcriptomics</strong>. They reported perturbations in <strong>aging, TOR, and WNT-signaling pathways</strong> and multiple quantitative phenotypes (e.g., body length reduction, pharyngeal pumping differences, and mitochondrial morphometrics). (talarmingas2024validationofmetaxin2 pages 1-2, talarmingas2024validationofmetaxin2 pages 8-10)</p>
+<h4 id="44-2024-expert-synthesis-linking-mtx2-to-kinase-interactomes-and-mitochondrial-homeostasis">4.4 2024: Expert synthesis linking MTX2 to kinase interactomes and mitochondrial homeostasis</h4>
+<p>A 2024 expert review of Nek kinases and mitochondrial homeostasis (Cells; <strong>7 Mar 2024</strong>; URL: https://doi.org/10.3390/cells13060473) summarizes that MTX2 appears among <strong>validated mitochondrial interactors</strong> emerging from Nek kinase interactome work, placing MTX2 in broader frameworks of mitochondrial composition/structure and stress-response networks. (basei2024themitochondrialconnection pages 1-3)</p>
+<h3 id="5-current-applications-and-real-world-implementations">5) Current applications and real-world implementations</h3>
+<ol>
+<li><strong>Molecular diagnosis and variant interpretation in progeroid syndromes:</strong> Reviews emphasize that overlapping phenotypes across premature-ageing syndromes motivate <strong>NGS gene panels</strong> and specialized clinical evaluation; MADaM (MTX2) is included among these syndromes in clinical genetics context. (coppede2021mutationsinvolvedin pages 1-2)</li>
+<li><strong>Functional assays to interpret variants:</strong> Patient fibroblast phenotyping (mitochondrial network quantification, respiration, apoptosis assays) provides a framework for validating candidate MTX2 variants beyond in silico prediction—especially for splice-site variants now being reported (2023–2024). (elouej2020lossofmtx2 pages 6-7, elouej2020lossofmtx2 pages 5-6, dogan2023anovelmtx2 pages 5-5)</li>
+<li><strong>Model-organism platforms for therapy discovery:</strong> The validated <em>C. elegans</em> model is explicitly positioned as enabling mechanistic dissection and scalable testing for therapeutics, leveraging measurable mitochondrial respiration and organismal phenotypes. (talarmingas2024validationofmetaxin2 pages 1-2)</li>
+</ol>
+<h3 id="6-expert-opinion-and-analysis-authoritative-synthesis">6) Expert opinion and analysis (authoritative synthesis)</h3>
+<ul>
+<li><strong>“Functions remain largely unknown” but anchored by SAM context:</strong> The 2020 discovery paper explicitly notes that MTX2’s functions are “largely unknown” while anchoring its best-supported role in <strong>SAM-mediated β-barrel integration</strong> and interactions with MICOS/Mic60. This is a typical pattern for rare-disease gene discovery: genetic causality and robust cell phenotyping precede deep mechanistic dissection. (elouej2020lossofmtx2 pages 1-2)</li>
+<li><strong>Mechanistic plausibility of pleiotropic phenotypes:</strong> The observed clinical syndrome (MADaM) includes nuclear morphological abnormalities, but the authors interpret these as downstream/secondary to mitochondrial dysfunction and altered mitochondrial composition, supporting an emerging view that mitochondrial architecture and signaling can drive “laminopathy-like” phenotypes without primary LMNA defects. (elouej2020lossofmtx2 pages 9-10, elouej2020lossofmtx2 pages 1-2)</li>
+</ul>
+<h3 id="7-key-statistics-and-data-highlights-recent-and-foundational">7) Key statistics and data highlights (recent and foundational)</h3>
+<ul>
+<li><strong>Human cohort size (discovery):</strong> <strong>7 patients</strong>, <strong>5 families</strong>, <strong>5 homozygous null MTX2 variants</strong> (Nature Communications, Sep 2020). (elouej2020lossofmtx2 pages 1-2)</li>
+<li><strong>Mitochondrial network scoring:</strong> <strong>53/46/51 cells (WT/MADM2/MADM3)</strong> across <strong>n=5 experiments</strong>; multiple network metrics significantly decreased. (elouej2020lossofmtx2 pages 4-5)</li>
+<li><strong>Respiration functional deficit:</strong> Reduced ATP synthesis-linked respiration metric (R–O/F) and basal respiration ratios with <strong>n=4</strong>, <strong>p=0.015</strong>, visualized in Figure 3 panels. (elouej2020lossofmtx2 pages 5-6, elouej2020lossofmtx2 media 62f590fd)</li>
+<li><strong>Apoptosis resistance:</strong> Strong significance for reduced death after TNFα/CHX and staurosporine exposure (p-values down to ~10−7). (elouej2020lossofmtx2 pages 6-7)</li>
+<li><strong>2024 diagnostic sequencing QC:</strong> <strong>99.80% coverage</strong> and <strong>&gt;100×</strong> depth in MTX2 region in a clinical exome workflow. (fu2024casereporta pages 2-4)</li>
+</ul>
+<h3 id="evidence-map-summary-table">Evidence map (summary table)</h3>
+<table>
+<thead>
+<tr>
+<th>Category</th>
+<th>Key points</th>
+<th>Best supporting citations</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Identity/domains</td>
+<td>Human <strong>MTX2</strong> encodes <strong>Metaxin-2</strong> (UniProt <strong>O75431</strong>), a <strong>263-aa</strong> protein. Recent case literature describes two annotated regions: <strong>Sam37/metaxin_N domain (aa 41-162)</strong> and a <strong>GST-like / glutathione S-transferase domain</strong>.</td>
+<td>(elouej2020lossofmtx2 pages 1-2, dogan2023anovelmtx2 pages 5-5, fu2024casereporta pages 2-4)</td>
+</tr>
+<tr>
+<td>Localization/topology</td>
+<td>MTX2 is an <strong>outer mitochondrial membrane (OMM)</strong> protein that <strong>faces the cytosol/cytosolic compartment</strong>. It is described as <strong>peripherally associated</strong> with the OMM through interaction with MTX1.</td>
+<td>(elouej2020lossofmtx2 pages 1-2, talarmingas2024validationofmetaxin2 pages 1-2)</td>
+</tr>
+<tr>
+<td>Molecular function</td>
+<td>Best-supported function is as a <strong>non-enzymatic mitochondrial protein biogenesis/assembly factor</strong>, participating in <strong>protein translocation into mitochondria</strong> and the <strong>correct integration of β-barrel proteins into the OMM</strong>. Loss of MTX2 causes <strong>mitochondrial network fragmentation</strong>, <strong>decreased oxidative phosphorylation</strong>, altered apoptosis responses, increased senescence/autophagy, and reduced proliferation in patient fibroblasts.</td>
+<td>(elouej2020lossofmtx2 pages 1-2, elouej2020lossofmtx2 pages 2-4, talarmingas2024validationofmetaxin2 pages 1-2)</td>
+</tr>
+<tr>
+<td>Complex membership/partners</td>
+<td>MTX2 <strong>directly interacts with MTX1</strong>; MTX1/MTX2 are described as part of the <strong>SAM (sorting and assembly machinery)</strong>. The <strong>SAM complex</strong> is a binding partner of <strong>Mic60/MICOS</strong>, contributing to larger <strong>mitochondrial intermembrane space bridging</strong> assemblies; immunoblot analyses also assessed <strong>SAMM50</strong> in the MTX2-deficiency context.</td>
+<td>(elouej2020lossofmtx2 pages 1-2, elouej2020lossofmtx2 pages 2-4, elouej2020lossofmtx2 pages 4-4)</td>
+</tr>
+<tr>
+<td>Pathway/process</td>
+<td>MTX2 functions in <strong>mitochondrial outer membrane protein biogenesis</strong>, especially <strong>β-barrel protein assembly/trafficking</strong>. It is also linked to <strong>TNF-α-induced apoptosis</strong> via metaxin/Bak-related pathways, and functionally connected to <strong>mitochondrial morphology</strong>, <strong>OxPhos</strong>, <strong>autophagy/mitophagy</strong>, and <strong>cristae-associated SAM-MICOS organization</strong>.</td>
+<td>(elouej2020lossofmtx2 pages 1-2, elouej2020lossofmtx2 pages 2-4, talarmingas2024validationofmetaxin2 pages 1-2)</td>
+</tr>
+<tr>
+<td>Disease association</td>
+<td>Biallelic/homozygous loss-of-function MTX2 variants cause <strong>mandibuloacral dysplasia associated with MTX2 (MADaM)</strong>, a severe progeroid syndrome. Elouej et al. reported <strong>7 patients from 5 consanguineous families</strong> with <strong>5 homozygous null mutations</strong>; later reports added new splice variants including <strong>c.543+1G&gt;T</strong> and <strong>c.378+1G&gt;A</strong>.</td>
+<td>(elouej2020lossofmtx2 pages 1-2, dogan2023anovelmtx2 pages 5-5, fu2024casereporta pages 1-2)</td>
+</tr>
+<tr>
+<td>Key quantitative findings</td>
+<td>In patient fibroblasts, mitochondrial network analysis showed significant changes in <strong>footprint, individuals, networks, and branches/network</strong>; <strong>53 WT, 46 MADM2, 51 MADM3 cells</strong> were scored across <strong>n=5</strong> experiments. Respiratory-chain subunits from complexes <strong>I, III, IV, V</strong> were reduced, while <strong>SDHA/complex II</strong> was not; respiration assays showed reduced <strong>ATP synthesis-linked respiration (R-O/F)</strong> and <strong>basal routine respiration (R/F)</strong> (<strong>n=4</strong>, <strong>p=0.015</strong>). TMRM indicated increased mitochondrial membrane potential in MADM2 (<strong>p=0.015</strong>). Apoptosis resistance was significant for <strong>TNFα/CHX</strong> and <strong>staurosporine</strong>; LC3B-II/LC3B-I was increased (<strong>p=0.0002</strong> for MADM2; <strong>p=0.026</strong> for MADM3). In <em>C. elegans</em>, abnormal mitochondrial morphology occurred in <strong>74% (n=68)</strong> of mtx-2 KO animals.</td>
+<td>(elouej2020lossofmtx2 pages 4-5, elouej2020lossofmtx2 pages 5-6, elouej2020lossofmtx2 pages 6-7, elouej2020lossofmtx2 media 62f590fd)</td>
+</tr>
+<tr>
+<td>2023-2024 updates</td>
+<td><strong>2023:</strong> a novel <strong>splice-site</strong> MTX2 variant (<strong>c.543+1G&gt;T</strong>) causing <strong>exon 8 skipping</strong> expanded the pathogenic spectrum. <strong>2024:</strong> first Chinese MADaM case with <strong>c.378+1G&gt;A</strong>; authors noted only <strong>7 molecularly diagnosed MADaM cases worldwide</strong> before that report. <strong>2024 model work</strong> further validated MTX2-deficient <em>C. elegans</em> as a MADaM model, showing reduced mitochondrial respiratory capacity and pathway perturbations in <strong>aging, TOR, and WNT signaling</strong>.</td>
+<td>(dogan2023anovelmtx2 pages 5-5, fu2024casereporta pages 1-2, talarmingas2024validationofmetaxin2 pages 1-2, talarmingas2024validationofmetaxin2 pages 8-10)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the core functional annotation of human MTX2/Metaxin-2 from the provided evidence, including identity, localization, molecular role, complex membership, disease relevance, and recent 2023-2024 updates. It is useful as a compact evidence map for building the full research report.</em></p>
+<h3 id="visual-evidence-from-primary-literature">Visual evidence from primary literature</h3>
+<p>Quantitative mitochondrial respiration and membrane potential changes in MTX2-deficient human fibroblasts are shown in the cropped panels from Elouej et al. Figure 3 (respiration metrics and TMRM FACS). (elouej2020lossofmtx2 media 62f590fd, elouej2020lossofmtx2 media 1c141a95)</p>
+<h3 id="limitations-of-the-current-evidence-set">Limitations of the current evidence set</h3>
+<p>Within the retrieved 2023–2024 corpus available here, the most direct MTX2 updates are primarily <strong>clinical variant reports</strong> and <strong>model-organism validation</strong> rather than new high-resolution structural biology of human SAM-metaxin assemblies; therefore, this report emphasizes disease genetics, functional cell phenotyping, and validated pathway context (SAM–MICOS/MIB) over detailed atomic-level mechanism. (fu2024casereporta pages 1-2, talarmingas2024validationofmetaxin2 pages 1-2, elouej2020lossofmtx2 pages 1-2)</p>
+<p>References</p>
+<ol>
+<li>
+<p>(elouej2020lossofmtx2 pages 1-2): Sahar Elouej, Karim Harhouri, Morgane Le Mao, Genevieve Baujat, Sheela Nampoothiri, Hϋlya Kayserili, Nihal Al Menabawy, Laila Selim, Arianne Llamos Paneque, Christian Kubisch, Davor Lessel, Robert Rubinsztajn, Chayki Charar, Catherine Bartoli, Coraline Airault, Jean-François Deleuze, Agnes Rötig, Peter Bauer, Catarina Pereira, Abigail Loh, Nathalie Escande-Beillard, Antoine Muchir, Lisa Martino, Yosef Gruenbaum, Song-Hua Lee, Philippe Manivet, Guy Lenaers, Bruno Reversade, Nicolas Lévy, and Annachiara De Sandre-Giovannoli. Loss of mtx2 causes mandibuloacral dysplasia and links mitochondrial dysfunction to altered nuclear morphology. Nature Communications, Sep 2020. URL: https://doi.org/10.1038/s41467-020-18146-9, doi:10.1038/s41467-020-18146-9. This article has 79 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(dogan2023anovelmtx2 pages 5-5): Burcu Yeter Doğan, Neslihan Günay, Yasin Ada, and Muhammet Ensar Doğan. A novel mtx2 gene splice site variant resulting in exon skipping, causing the recently described mandibuloacral dysplasia progeroid syndrome. American Journal of Medical Genetics Part A, 191:173-182, Oct 2023. URL: https://doi.org/10.1002/ajmg.a.63010, doi:10.1002/ajmg.a.63010. This article has 14 citations.</p>
+</li>
+<li>
+<p>(fu2024casereporta pages 2-4): Xiaohui Fu, Shuli Chen, Xiao Huang, Qinghua Lu, Yunfei Cui, Weinan Lin, and Qin Yang. Case report: a novel splice-site mutation of mtx2 gene caused mandibuloacral dysplasia progeroid syndrome: the first report from china and literature review. Frontiers in Endocrinology, Mar 2024. URL: https://doi.org/10.3389/fendo.2024.1345067, doi:10.3389/fendo.2024.1345067. This article has 4 citations.</p>
+</li>
+<li>
+<p>(elouej2020lossofmtx2 pages 2-4): Sahar Elouej, Karim Harhouri, Morgane Le Mao, Genevieve Baujat, Sheela Nampoothiri, Hϋlya Kayserili, Nihal Al Menabawy, Laila Selim, Arianne Llamos Paneque, Christian Kubisch, Davor Lessel, Robert Rubinsztajn, Chayki Charar, Catherine Bartoli, Coraline Airault, Jean-François Deleuze, Agnes Rötig, Peter Bauer, Catarina Pereira, Abigail Loh, Nathalie Escande-Beillard, Antoine Muchir, Lisa Martino, Yosef Gruenbaum, Song-Hua Lee, Philippe Manivet, Guy Lenaers, Bruno Reversade, Nicolas Lévy, and Annachiara De Sandre-Giovannoli. Loss of mtx2 causes mandibuloacral dysplasia and links mitochondrial dysfunction to altered nuclear morphology. Nature Communications, Sep 2020. URL: https://doi.org/10.1038/s41467-020-18146-9, doi:10.1038/s41467-020-18146-9. This article has 79 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(talarmingas2024validationofmetaxin2 pages 1-2): Chloé Talarmin-Gas, Georges Smolyakov, Cleo Parisi, Cyril Scandola, Valérie Andrianasolonirina, Cloé Lecoq, Valentine Houtart, Song-Hua Lee, Homa Adle-Biassette, Bénédicte Thiébot, Timothy Ganderton, and Philippe Manivet. Validation of metaxin-2 deficient c. elegans as a model for mandibuloacral dysplasia associated to mtx-2 (madam) syndrome. Communications Biology, Oct 2024. URL: https://doi.org/10.1038/s42003-024-06967-z, doi:10.1038/s42003-024-06967-z. This article has 5 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(elouej2020lossofmtx2 pages 6-7): Sahar Elouej, Karim Harhouri, Morgane Le Mao, Genevieve Baujat, Sheela Nampoothiri, Hϋlya Kayserili, Nihal Al Menabawy, Laila Selim, Arianne Llamos Paneque, Christian Kubisch, Davor Lessel, Robert Rubinsztajn, Chayki Charar, Catherine Bartoli, Coraline Airault, Jean-François Deleuze, Agnes Rötig, Peter Bauer, Catarina Pereira, Abigail Loh, Nathalie Escande-Beillard, Antoine Muchir, Lisa Martino, Yosef Gruenbaum, Song-Hua Lee, Philippe Manivet, Guy Lenaers, Bruno Reversade, Nicolas Lévy, and Annachiara De Sandre-Giovannoli. Loss of mtx2 causes mandibuloacral dysplasia and links mitochondrial dysfunction to altered nuclear morphology. Nature Communications, Sep 2020. URL: https://doi.org/10.1038/s41467-020-18146-9, doi:10.1038/s41467-020-18146-9. This article has 79 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(fu2024casereporta pages 1-2): Xiaohui Fu, Shuli Chen, Xiao Huang, Qinghua Lu, Yunfei Cui, Weinan Lin, and Qin Yang. Case report: a novel splice-site mutation of mtx2 gene caused mandibuloacral dysplasia progeroid syndrome: the first report from china and literature review. Frontiers in Endocrinology, Mar 2024. URL: https://doi.org/10.3389/fendo.2024.1345067, doi:10.3389/fendo.2024.1345067. This article has 4 citations.</p>
+</li>
+<li>
+<p>(elouej2020lossofmtx2 pages 4-5): Sahar Elouej, Karim Harhouri, Morgane Le Mao, Genevieve Baujat, Sheela Nampoothiri, Hϋlya Kayserili, Nihal Al Menabawy, Laila Selim, Arianne Llamos Paneque, Christian Kubisch, Davor Lessel, Robert Rubinsztajn, Chayki Charar, Catherine Bartoli, Coraline Airault, Jean-François Deleuze, Agnes Rötig, Peter Bauer, Catarina Pereira, Abigail Loh, Nathalie Escande-Beillard, Antoine Muchir, Lisa Martino, Yosef Gruenbaum, Song-Hua Lee, Philippe Manivet, Guy Lenaers, Bruno Reversade, Nicolas Lévy, and Annachiara De Sandre-Giovannoli. Loss of mtx2 causes mandibuloacral dysplasia and links mitochondrial dysfunction to altered nuclear morphology. Nature Communications, Sep 2020. URL: https://doi.org/10.1038/s41467-020-18146-9, doi:10.1038/s41467-020-18146-9. This article has 79 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(elouej2020lossofmtx2 pages 5-6): Sahar Elouej, Karim Harhouri, Morgane Le Mao, Genevieve Baujat, Sheela Nampoothiri, Hϋlya Kayserili, Nihal Al Menabawy, Laila Selim, Arianne Llamos Paneque, Christian Kubisch, Davor Lessel, Robert Rubinsztajn, Chayki Charar, Catherine Bartoli, Coraline Airault, Jean-François Deleuze, Agnes Rötig, Peter Bauer, Catarina Pereira, Abigail Loh, Nathalie Escande-Beillard, Antoine Muchir, Lisa Martino, Yosef Gruenbaum, Song-Hua Lee, Philippe Manivet, Guy Lenaers, Bruno Reversade, Nicolas Lévy, and Annachiara De Sandre-Giovannoli. Loss of mtx2 causes mandibuloacral dysplasia and links mitochondrial dysfunction to altered nuclear morphology. Nature Communications, Sep 2020. URL: https://doi.org/10.1038/s41467-020-18146-9, doi:10.1038/s41467-020-18146-9. This article has 79 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(elouej2020lossofmtx2 media 62f590fd): Sahar Elouej, Karim Harhouri, Morgane Le Mao, Genevieve Baujat, Sheela Nampoothiri, Hϋlya Kayserili, Nihal Al Menabawy, Laila Selim, Arianne Llamos Paneque, Christian Kubisch, Davor Lessel, Robert Rubinsztajn, Chayki Charar, Catherine Bartoli, Coraline Airault, Jean-François Deleuze, Agnes Rötig, Peter Bauer, Catarina Pereira, Abigail Loh, Nathalie Escande-Beillard, Antoine Muchir, Lisa Martino, Yosef Gruenbaum, Song-Hua Lee, Philippe Manivet, Guy Lenaers, Bruno Reversade, Nicolas Lévy, and Annachiara De Sandre-Giovannoli. Loss of mtx2 causes mandibuloacral dysplasia and links mitochondrial dysfunction to altered nuclear morphology. Nature Communications, Sep 2020. URL: https://doi.org/10.1038/s41467-020-18146-9, doi:10.1038/s41467-020-18146-9. This article has 79 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(elouej2020lossofmtx2 media 1c141a95): Sahar Elouej, Karim Harhouri, Morgane Le Mao, Genevieve Baujat, Sheela Nampoothiri, Hϋlya Kayserili, Nihal Al Menabawy, Laila Selim, Arianne Llamos Paneque, Christian Kubisch, Davor Lessel, Robert Rubinsztajn, Chayki Charar, Catherine Bartoli, Coraline Airault, Jean-François Deleuze, Agnes Rötig, Peter Bauer, Catarina Pereira, Abigail Loh, Nathalie Escande-Beillard, Antoine Muchir, Lisa Martino, Yosef Gruenbaum, Song-Hua Lee, Philippe Manivet, Guy Lenaers, Bruno Reversade, Nicolas Lévy, and Annachiara De Sandre-Giovannoli. Loss of mtx2 causes mandibuloacral dysplasia and links mitochondrial dysfunction to altered nuclear morphology. Nature Communications, Sep 2020. URL: https://doi.org/10.1038/s41467-020-18146-9, doi:10.1038/s41467-020-18146-9. This article has 79 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(talarmingas2024validationofmetaxin2 pages 8-10): Chloé Talarmin-Gas, Georges Smolyakov, Cleo Parisi, Cyril Scandola, Valérie Andrianasolonirina, Cloé Lecoq, Valentine Houtart, Song-Hua Lee, Homa Adle-Biassette, Bénédicte Thiébot, Timothy Ganderton, and Philippe Manivet. Validation of metaxin-2 deficient c. elegans as a model for mandibuloacral dysplasia associated to mtx-2 (madam) syndrome. Communications Biology, Oct 2024. URL: https://doi.org/10.1038/s42003-024-06967-z, doi:10.1038/s42003-024-06967-z. This article has 5 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(basei2024themitochondrialconnection pages 1-3): Fernanda L. Basei, Ivan Rosa e Silva, Pedro R. Firmino Dias, Camila C. Ferezin, Andressa Peres de Oliveira, Luidy K. Issayama, Livia A. R. Moura, Fernando Riback da Silva, and Jörg Kobarg. The mitochondrial connection: the nek kinases’ new functional axis in mitochondrial homeostasis. Cells, 13:473, Mar 2024. URL: https://doi.org/10.3390/cells13060473, doi:10.3390/cells13060473. This article has 13 citations.</p>
+</li>
+<li>
+<p>(coppede2021mutationsinvolvedin pages 1-2): Fabio Coppede. Mutations involved in premature-ageing syndromes. The Application of Clinical Genetics, 14:279-295, Jun 2021. URL: https://doi.org/10.2147/tacg.s273525, doi:10.2147/tacg.s273525. This article has 39 citations.</p>
+</li>
+<li>
+<p>(elouej2020lossofmtx2 pages 9-10): Sahar Elouej, Karim Harhouri, Morgane Le Mao, Genevieve Baujat, Sheela Nampoothiri, Hϋlya Kayserili, Nihal Al Menabawy, Laila Selim, Arianne Llamos Paneque, Christian Kubisch, Davor Lessel, Robert Rubinsztajn, Chayki Charar, Catherine Bartoli, Coraline Airault, Jean-François Deleuze, Agnes Rötig, Peter Bauer, Catarina Pereira, Abigail Loh, Nathalie Escande-Beillard, Antoine Muchir, Lisa Martino, Yosef Gruenbaum, Song-Hua Lee, Philippe Manivet, Guy Lenaers, Bruno Reversade, Nicolas Lévy, and Annachiara De Sandre-Giovannoli. Loss of mtx2 causes mandibuloacral dysplasia and links mitochondrial dysfunction to altered nuclear morphology. Nature Communications, Sep 2020. URL: https://doi.org/10.1038/s41467-020-18146-9, doi:10.1038/s41467-020-18146-9. This article has 79 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(elouej2020lossofmtx2 pages 4-4): Sahar Elouej, Karim Harhouri, Morgane Le Mao, Genevieve Baujat, Sheela Nampoothiri, Hϋlya Kayserili, Nihal Al Menabawy, Laila Selim, Arianne Llamos Paneque, Christian Kubisch, Davor Lessel, Robert Rubinsztajn, Chayki Charar, Catherine Bartoli, Coraline Airault, Jean-François Deleuze, Agnes Rötig, Peter Bauer, Catarina Pereira, Abigail Loh, Nathalie Escande-Beillard, Antoine Muchir, Lisa Martino, Yosef Gruenbaum, Song-Hua Lee, Philippe Manivet, Guy Lenaers, Bruno Reversade, Nicolas Lévy, and Annachiara De Sandre-Giovannoli. Loss of mtx2 causes mandibuloacral dysplasia and links mitochondrial dysfunction to altered nuclear morphology. Nature Communications, Sep 2020. URL: https://doi.org/10.1038/s41467-020-18146-9, doi:10.1038/s41467-020-18146-9. This article has 79 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>basei2024themitochondrialconnection pages 1-3</li>
+<li>coppede2021mutationsinvolvedin pages 1-2</li>
+<li>fu2024casereporta pages 2-4</li>
+<li>fu2024casereporta pages 1-2</li>
+<li>https://doi.org/10.1038/s41467-020-18146-9</li>
+<li>https://doi.org/10.1002/ajmg.a.63010</li>
+<li>https://doi.org/10.3389/fendo.2024.1345067</li>
+<li>https://doi.org/10.1038/s42003-024-06967-z</li>
+<li>https://doi.org/10.3390/cells13060473</li>
+<li>https://doi.org/10.1038/s41467-020-18146-9,</li>
+<li>https://doi.org/10.1002/ajmg.a.63010,</li>
+<li>https://doi.org/10.3389/fendo.2024.1345067,</li>
+<li>https://doi.org/10.1038/s42003-024-06967-z,</li>
+<li>https://doi.org/10.3390/cells13060473,</li>
+<li>https://doi.org/10.2147/tacg.s273525,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: O75431
+gene_symbol: MTX2
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: &gt;-
+  MTX2 (metaxin-2) is a non-enzymatic mitochondrial outer membrane metaxin-family
+  factor that partners with MTX1 in the mammalian SAM machinery. Its
+  best-supported core role is mitochondrial outer membrane protein
+  biogenesis/organization, especially SAM-mediated integration and assembly of
+  beta-barrel outer membrane proteins, with additional links to MICOS/MIB
+  architecture, mitochondrial transport, apoptosis, and MTX2-associated
+  mandibuloacral dysplasia.
+alternative_products:
+- name: &#39;1&#39;
+  id: O75431-1
+- name: &#39;2&#39;
+  id: O75431-2
+  sequence_note: VSP_054468
+existing_annotations:
+- term:
+    id: GO:0045040
+    label: protein insertion into mitochondrial outer membrane
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: &gt;-
+      Correct phylogenetic inference. MTX2 is an MTX1 partner in the SAM
+      machinery supporting integration/assembly of beta-barrel proteins into the
+      mitochondrial outer membrane.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/MTX2/MTX2-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/MTX2/MTX2-deep-research-falcon.md
+      supporting_text: &#34;The **mitochondrial Sorting and Assembly Machinery (SAM)** is an OMM pathway that supports the **correct integration of β-barrel proteins into the OMM**.&#34;
+- term:
+    id: GO:0070096
+    label: mitochondrial outer membrane translocase complex assembly
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: &gt;-
+      Accepted as a SAM/metaxin assembly function. MTX2 supports the
+      organization and assembly of outer membrane translocase components and
+      beta-barrel proteins.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/MTX2/MTX2-deep-research-falcon.md
+- term:
+    id: GO:0001401
+    label: SAM complex
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: &gt;-
+      Correct. MTX2 is a metaxin component of the mammalian SAM machinery with
+      MTX1 and SAMM50.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/MTX2/MTX2-deep-research-falcon.md
+- term:
+    id: GO:0001401
+    label: SAM complex
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  review:
+    summary: &gt;-
+      Correct InterPro-derived annotation. The Falcon synthesis supports MTX2 as
+      a SAM/metaxin factor at the mitochondrial outer membrane.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/MTX2/MTX2-deep-research-falcon.md
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  review:
+    summary: &gt;-
+      Correct but too general. MTX2 is specifically localized to the
+      mitochondrial outer membrane and SAM machinery.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Subsumed by mitochondrial outer membrane and SAM complex annotations.
+    additional_reference_ids:
+    - file:human/MTX2/MTX2-deep-research-falcon.md
+- term:
+    id: GO:0005741
+    label: mitochondrial outer membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  review:
+    summary: &gt;-
+      Correct UniProt-derived localization. MTX2 is an outer mitochondrial
+      membrane metaxin protein facing the cytosolic compartment.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/MTX2/MTX2-deep-research-falcon.md
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:25416956
+  review:
+    summary: &gt;-
+      Proteome-scale protein binding is too generic to capture MTX2 function.
+      The supported biology is MTX2 partnership with MTX1 in SAM/metaxin outer
+      membrane protein biogenesis.
+    action: REMOVE
+    reason: Protein binding is uninformative; use SAM complex and assembly terms instead.
+    additional_reference_ids:
+    - file:human/MTX2/MTX2-deep-research-falcon.md
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:32296183
+  review:
+    summary: &gt;-
+      Generic binary-interactome protein binding does not represent MTX2&#39;s
+      curated mitochondrial outer membrane/SAM function.
+    action: REMOVE
+    reason: Protein binding is uninformative; complex membership captures the supported function.
+    additional_reference_ids:
+    - file:human/MTX2/MTX2-deep-research-falcon.md
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IDA
+  original_reference_id: GO_REF:0000052
+  review:
+    summary: &gt;-
+      Correct but less specific than the mitochondrial outer membrane/SAM
+      localization.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Subsumed by mitochondrial outer membrane and SAM complex annotations.
+    additional_reference_ids:
+    - file:human/MTX2/MTX2-deep-research-falcon.md
+- term:
+    id: GO:0001401
+    label: SAM complex
+  evidence_type: IPI
+  original_reference_id: PMID:17510655
+  review:
+    summary: &gt;-
+      Accepted. Conserved Sam50/metaxin evidence supports MTX2 as part of the
+      SAM machinery for VDAC/beta-barrel biogenesis.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/MTX2/MTX2-deep-research-falcon.md
+- term:
+    id: GO:0005741
+    label: mitochondrial outer membrane
+  evidence_type: NAS
+  original_reference_id: PMID:31387448
+  review:
+    summary: &gt;-
+      Accepted. MTX2 is consistently described as a mitochondrial outer membrane
+      metaxin/SAM component.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/MTX2/MTX2-deep-research-falcon.md
+- term:
+    id: GO:0045040
+    label: protein insertion into mitochondrial outer membrane
+  evidence_type: NAS
+  original_reference_id: PMID:31387448
+  review:
+    summary: &gt;-
+      Accepted as the core SAM/metaxin process: correct integration and assembly
+      of beta-barrel proteins into the mitochondrial outer membrane.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/MTX2/MTX2-deep-research-falcon.md
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: HTP
+  original_reference_id: PMID:34800366
+  review:
+    summary: &gt;-
+      High-throughput mitochondrial proteome evidence supports mitochondrial
+      localization, but this is less specific than the outer membrane/SAM
+      annotation.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Subsumed by mitochondrial outer membrane and SAM complex annotations.
+    additional_reference_ids:
+    - file:human/MTX2/MTX2-deep-research-falcon.md
+- term:
+    id: GO:0006839
+    label: mitochondrial transport
+  evidence_type: IMP
+  original_reference_id: PMID:32917887
+  review:
+    summary: &gt;-
+      Valid but broad disease-mechanism annotation. MTX2 loss disrupts
+      mitochondrial function and transport/biogenesis, but the more precise
+      core process is SAM-mediated outer membrane protein insertion and assembly.
+    action: KEEP_AS_NON_CORE
+    reason: Broad process term; retained as a disease-relevant non-core phenotype/process.
+    additional_reference_ids:
+    - file:human/MTX2/MTX2-deep-research-falcon.md
+- term:
+    id: GO:0001401
+    label: SAM complex
+  evidence_type: HDA
+  original_reference_id: PMID:26477565
+  review:
+    summary: &gt;-
+      Accepted. High-throughput complex evidence is consistent with MTX2 in
+      SAM-associated mitochondrial outer membrane assemblies.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/MTX2/MTX2-deep-research-falcon.md
+- term:
+    id: GO:0007007
+    label: inner mitochondrial membrane organization
+  evidence_type: IC
+  original_reference_id: PMID:26477565
+  review:
+    summary: &gt;-
+      Supported as a secondary consequence/context of SAM-MICOS/MIB bridging and
+      mitochondrial architecture effects, but not the primary MTX2 function.
+    action: KEEP_AS_NON_CORE
+    reason: MIB/MICOS-associated architecture is secondary to the core SAM role.
+    additional_reference_ids:
+    - file:human/MTX2/MTX2-deep-research-falcon.md
+- term:
+    id: GO:0140275
+    label: MIB complex
+  evidence_type: HDA
+  original_reference_id: PMID:26477565
+  review:
+    summary: &gt;-
+      Supported as an additional SAM-MICOS/MIB-associated context. Keep as
+      non-core because the strongest MTX2 function is SAM/metaxin outer membrane
+      protein biogenesis.
+    action: KEEP_AS_NON_CORE
+    reason: MIB complex association is secondary to the primary SAM/metaxin role.
+    additional_reference_ids:
+    - file:human/MTX2/MTX2-deep-research-falcon.md
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IDA
+  original_reference_id: PMID:25997101
+  review:
+    summary: &gt;-
+      Correct but too general for MTX2, which localizes to the mitochondrial
+      outer membrane and SAM machinery.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Subsumed by mitochondrial outer membrane and SAM complex annotations.
+    additional_reference_ids:
+    - file:human/MTX2/MTX2-deep-research-falcon.md
+- term:
+    id: GO:0005741
+    label: mitochondrial outer membrane
+  evidence_type: TAS
+  original_reference_id: PMID:10381257
+  review:
+    summary: &gt;-
+      Accepted. MTX2 was identified as an MTX1-interacting protein associated
+      with the mammalian mitochondrial outer membrane.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/MTX2/MTX2-deep-research-falcon.md
+- term:
+    id: GO:0006839
+    label: mitochondrial transport
+  evidence_type: TAS
+  original_reference_id: PMID:10381257
+  review:
+    summary: &gt;-
+      Broad but directionally correct for metaxin biology. The more specific
+      function is outer membrane protein biogenesis/insertion through SAM.
+    action: KEEP_AS_NON_CORE
+    reason: Broad process term; more specific SAM-mediated insertion terms exist.
+    additional_reference_ids:
+    - file:human/MTX2/MTX2-deep-research-falcon.md
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: GO_REF:0000052
+  title: Gene Ontology annotation based on curation of immunofluorescence data
+  findings: []
+- id: PMID:10381257
+  title: Metaxin 1 interacts with metaxin 2, a novel related protein associated with
+    the mammalian mitochondrial outer membrane.
+  findings: []
+- id: PMID:17510655
+  title: Conserved roles of Sam50 and metaxins in VDAC biogenesis.
+  findings: []
+- id: PMID:25416956
+  title: A proteome-scale map of the human interactome network.
+  findings: []
+- id: PMID:25997101
+  title: QIL1 is a novel mitochondrial protein required for MICOS complex stability
+    and cristae morphology.
+  findings: []
+- id: PMID:26477565
+  title: Evolution and structural organization of the mitochondrial contact site (MICOS)
+    complex and the mitochondrial intermembrane space bridging (MIB) complex.
+  findings: []
+- id: PMID:31387448
+  title: &#39;Mitochondria-hubs for regulating cellular biochemistry: emerging concepts
+    and networks.&#39;
+  findings: []
+- id: PMID:32296183
+  title: A reference map of the human binary protein interactome.
+  findings: []
+- id: PMID:32917887
+  title: Loss of MTX2 causes mandibuloacral dysplasia and links mitochondrial dysfunction
+    to altered nuclear morphology.
+  findings: []
+- id: PMID:34800366
+  title: Quantitative high-confidence human mitochondrial proteome and its dynamics
+    in cellular context.
+  findings: []
+- id: file:human/MTX2/MTX2-deep-research-falcon.md
+  title: Falcon deep research report for human MTX2
+  findings: []
+core_functions:
+- description: &gt;-
+    MTX2 is a non-enzymatic metaxin/SAM factor at the mitochondrial outer
+    membrane that partners with MTX1 to support SAM-mediated integration and
+    assembly of beta-barrel outer membrane proteins.
+  supported_by:
+  - reference_id: file:human/MTX2/MTX2-deep-research-falcon.md
+    supporting_text: &#34;MTX2 is localized to the **outer mitochondrial membrane** and is described as **facing the cytosolic compartment**.&#34;
+  - reference_id: file:human/MTX2/MTX2-deep-research-falcon.md
+    supporting_text: &#34;The **mitochondrial Sorting and Assembly Machinery (SAM)** is an OMM pathway that supports the **correct integration of β-barrel proteins into the OMM**.&#34;
+  - reference_id: file:human/MTX2/MTX2-deep-research-falcon.md
+    supporting_text: &#34;MTX2 **interacts directly with MTX1** and is positioned as part of the **SAM machinery**&#34;
+  directly_involved_in:
+  - id: GO:0045040
+    label: protein insertion into mitochondrial outer membrane
+  - id: GO:0070096
+    label: mitochondrial outer membrane translocase complex assembly
+  locations:
+  - id: GO:0005741
+    label: mitochondrial outer membrane
+  in_complex:
+    id: GO:0001401
+    label: SAM complex
+proposed_new_terms: []
+suggested_questions:
+- question: &gt;-
+    Which MTX2-MTX1 interfaces are required for SAM-mediated beta-barrel
+    insertion versus broader SAM-MICOS/MIB architecture?
+  experts: []
+- question: &gt;-
+    How do pathogenic MTX2 splice or null variants alter SAM composition,
+    MTX1 stability, and mitochondrial outer membrane protein assembly in patient
+    cells?
+  experts: []
+suggested_experiments:
+- hypothesis: &gt;-
+    MTX2 stabilizes MTX1-containing SAM assemblies required for beta-barrel outer
+    membrane protein biogenesis.
+  description: &gt;-
+    Perform endogenous MTX2 knockout/rescue and patient-variant rescue in human
+    cells, then measure MTX1 stability, SAM complex assembly, VDAC/TOM40 import,
+    mitochondrial network morphology, and apoptosis/respiration phenotypes.
+  experiment_type: endogenous rescue and mitochondrial import/assembly assay
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/human/MTX2/MTX2-ai-review.yaml
+++ b/genes/human/MTX2/MTX2-ai-review.yaml
@@ -1,11 +1,18 @@
 id: O75431
 gene_symbol: MTX2
 product_type: PROTEIN
-status: INITIALIZED
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
-description: 'TODO: Add description for MTX2'
+description: >-
+  MTX2 (metaxin-2) is a non-enzymatic mitochondrial outer membrane metaxin-family
+  factor that partners with MTX1 in the mammalian SAM machinery. Its
+  best-supported core role is mitochondrial outer membrane protein
+  biogenesis/organization, especially SAM-mediated integration and assembly of
+  beta-barrel outer membrane proteins, with additional links to MICOS/MIB
+  architecture, mitochondrial transport, apoptosis, and MTX2-associated
+  mandibuloacral dysplasia.
 alternative_products:
 - name: '1'
   id: O75431-1
@@ -19,160 +26,259 @@ existing_annotations:
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Correct phylogenetic inference. MTX2 is an MTX1 partner in the SAM
+      machinery supporting integration/assembly of beta-barrel proteins into the
+      mitochondrial outer membrane.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/MTX2/MTX2-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/MTX2/MTX2-deep-research-falcon.md
+      supporting_text: "The **mitochondrial Sorting and Assembly Machinery (SAM)** is an OMM pathway that supports the **correct integration of β-barrel proteins into the OMM**."
 - term:
     id: GO:0070096
     label: mitochondrial outer membrane translocase complex assembly
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Accepted as a SAM/metaxin assembly function. MTX2 supports the
+      organization and assembly of outer membrane translocase components and
+      beta-barrel proteins.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/MTX2/MTX2-deep-research-falcon.md
 - term:
     id: GO:0001401
     label: SAM complex
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Correct. MTX2 is a metaxin component of the mammalian SAM machinery with
+      MTX1 and SAMM50.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/MTX2/MTX2-deep-research-falcon.md
 - term:
     id: GO:0001401
     label: SAM complex
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Correct InterPro-derived annotation. The Falcon synthesis supports MTX2 as
+      a SAM/metaxin factor at the mitochondrial outer membrane.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/MTX2/MTX2-deep-research-falcon.md
 - term:
     id: GO:0005739
     label: mitochondrion
   evidence_type: IEA
   original_reference_id: GO_REF:0000044
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Correct but too general. MTX2 is specifically localized to the
+      mitochondrial outer membrane and SAM machinery.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Subsumed by mitochondrial outer membrane and SAM complex annotations.
+    additional_reference_ids:
+    - file:human/MTX2/MTX2-deep-research-falcon.md
 - term:
     id: GO:0005741
     label: mitochondrial outer membrane
   evidence_type: IEA
   original_reference_id: GO_REF:0000044
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Correct UniProt-derived localization. MTX2 is an outer mitochondrial
+      membrane metaxin protein facing the cytosolic compartment.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/MTX2/MTX2-deep-research-falcon.md
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:25416956
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Proteome-scale protein binding is too generic to capture MTX2 function.
+      The supported biology is MTX2 partnership with MTX1 in SAM/metaxin outer
+      membrane protein biogenesis.
+    action: REMOVE
+    reason: Protein binding is uninformative; use SAM complex and assembly terms instead.
+    additional_reference_ids:
+    - file:human/MTX2/MTX2-deep-research-falcon.md
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:32296183
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Generic binary-interactome protein binding does not represent MTX2's
+      curated mitochondrial outer membrane/SAM function.
+    action: REMOVE
+    reason: Protein binding is uninformative; complex membership captures the supported function.
+    additional_reference_ids:
+    - file:human/MTX2/MTX2-deep-research-falcon.md
 - term:
     id: GO:0005739
     label: mitochondrion
   evidence_type: IDA
   original_reference_id: GO_REF:0000052
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Correct but less specific than the mitochondrial outer membrane/SAM
+      localization.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Subsumed by mitochondrial outer membrane and SAM complex annotations.
+    additional_reference_ids:
+    - file:human/MTX2/MTX2-deep-research-falcon.md
 - term:
     id: GO:0001401
     label: SAM complex
   evidence_type: IPI
   original_reference_id: PMID:17510655
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Accepted. Conserved Sam50/metaxin evidence supports MTX2 as part of the
+      SAM machinery for VDAC/beta-barrel biogenesis.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/MTX2/MTX2-deep-research-falcon.md
 - term:
     id: GO:0005741
     label: mitochondrial outer membrane
   evidence_type: NAS
   original_reference_id: PMID:31387448
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Accepted. MTX2 is consistently described as a mitochondrial outer membrane
+      metaxin/SAM component.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/MTX2/MTX2-deep-research-falcon.md
 - term:
     id: GO:0045040
     label: protein insertion into mitochondrial outer membrane
   evidence_type: NAS
   original_reference_id: PMID:31387448
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Accepted as the core SAM/metaxin process: correct integration and assembly
+      of beta-barrel proteins into the mitochondrial outer membrane.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/MTX2/MTX2-deep-research-falcon.md
 - term:
     id: GO:0005739
     label: mitochondrion
   evidence_type: HTP
   original_reference_id: PMID:34800366
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      High-throughput mitochondrial proteome evidence supports mitochondrial
+      localization, but this is less specific than the outer membrane/SAM
+      annotation.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Subsumed by mitochondrial outer membrane and SAM complex annotations.
+    additional_reference_ids:
+    - file:human/MTX2/MTX2-deep-research-falcon.md
 - term:
     id: GO:0006839
     label: mitochondrial transport
   evidence_type: IMP
   original_reference_id: PMID:32917887
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Valid but broad disease-mechanism annotation. MTX2 loss disrupts
+      mitochondrial function and transport/biogenesis, but the more precise
+      core process is SAM-mediated outer membrane protein insertion and assembly.
+    action: KEEP_AS_NON_CORE
+    reason: Broad process term; retained as a disease-relevant non-core phenotype/process.
+    additional_reference_ids:
+    - file:human/MTX2/MTX2-deep-research-falcon.md
 - term:
     id: GO:0001401
     label: SAM complex
   evidence_type: HDA
   original_reference_id: PMID:26477565
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Accepted. High-throughput complex evidence is consistent with MTX2 in
+      SAM-associated mitochondrial outer membrane assemblies.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/MTX2/MTX2-deep-research-falcon.md
 - term:
     id: GO:0007007
     label: inner mitochondrial membrane organization
   evidence_type: IC
   original_reference_id: PMID:26477565
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Supported as a secondary consequence/context of SAM-MICOS/MIB bridging and
+      mitochondrial architecture effects, but not the primary MTX2 function.
+    action: KEEP_AS_NON_CORE
+    reason: MIB/MICOS-associated architecture is secondary to the core SAM role.
+    additional_reference_ids:
+    - file:human/MTX2/MTX2-deep-research-falcon.md
 - term:
     id: GO:0140275
     label: MIB complex
   evidence_type: HDA
   original_reference_id: PMID:26477565
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Supported as an additional SAM-MICOS/MIB-associated context. Keep as
+      non-core because the strongest MTX2 function is SAM/metaxin outer membrane
+      protein biogenesis.
+    action: KEEP_AS_NON_CORE
+    reason: MIB complex association is secondary to the primary SAM/metaxin role.
+    additional_reference_ids:
+    - file:human/MTX2/MTX2-deep-research-falcon.md
 - term:
     id: GO:0005739
     label: mitochondrion
   evidence_type: IDA
   original_reference_id: PMID:25997101
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Correct but too general for MTX2, which localizes to the mitochondrial
+      outer membrane and SAM machinery.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Subsumed by mitochondrial outer membrane and SAM complex annotations.
+    additional_reference_ids:
+    - file:human/MTX2/MTX2-deep-research-falcon.md
 - term:
     id: GO:0005741
     label: mitochondrial outer membrane
   evidence_type: TAS
   original_reference_id: PMID:10381257
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Accepted. MTX2 was identified as an MTX1-interacting protein associated
+      with the mammalian mitochondrial outer membrane.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/MTX2/MTX2-deep-research-falcon.md
 - term:
     id: GO:0006839
     label: mitochondrial transport
   evidence_type: TAS
   original_reference_id: PMID:10381257
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Broad but directionally correct for metaxin biology. The more specific
+      function is outer membrane protein biogenesis/insertion through SAM.
+    action: KEEP_AS_NON_CORE
+    reason: Broad process term; more specific SAM-mediated insertion terms exist.
+    additional_reference_ids:
+    - file:human/MTX2/MTX2-deep-research-falcon.md
 references:
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO
@@ -222,3 +328,49 @@ references:
   title: Quantitative high-confidence human mitochondrial proteome and its dynamics
     in cellular context.
   findings: []
+- id: file:human/MTX2/MTX2-deep-research-falcon.md
+  title: Falcon deep research report for human MTX2
+  findings: []
+core_functions:
+- description: >-
+    MTX2 is a non-enzymatic metaxin/SAM factor at the mitochondrial outer
+    membrane that partners with MTX1 to support SAM-mediated integration and
+    assembly of beta-barrel outer membrane proteins.
+  supported_by:
+  - reference_id: file:human/MTX2/MTX2-deep-research-falcon.md
+    supporting_text: "MTX2 is localized to the **outer mitochondrial membrane** and is described as **facing the cytosolic compartment**."
+  - reference_id: file:human/MTX2/MTX2-deep-research-falcon.md
+    supporting_text: "The **mitochondrial Sorting and Assembly Machinery (SAM)** is an OMM pathway that supports the **correct integration of β-barrel proteins into the OMM**."
+  - reference_id: file:human/MTX2/MTX2-deep-research-falcon.md
+    supporting_text: "MTX2 **interacts directly with MTX1** and is positioned as part of the **SAM machinery**"
+  directly_involved_in:
+  - id: GO:0045040
+    label: protein insertion into mitochondrial outer membrane
+  - id: GO:0070096
+    label: mitochondrial outer membrane translocase complex assembly
+  locations:
+  - id: GO:0005741
+    label: mitochondrial outer membrane
+  in_complex:
+    id: GO:0001401
+    label: SAM complex
+proposed_new_terms: []
+suggested_questions:
+- question: >-
+    Which MTX2-MTX1 interfaces are required for SAM-mediated beta-barrel
+    insertion versus broader SAM-MICOS/MIB architecture?
+  experts: []
+- question: >-
+    How do pathogenic MTX2 splice or null variants alter SAM composition,
+    MTX1 stability, and mitochondrial outer membrane protein assembly in patient
+    cells?
+  experts: []
+suggested_experiments:
+- hypothesis: >-
+    MTX2 stabilizes MTX1-containing SAM assemblies required for beta-barrel outer
+    membrane protein biogenesis.
+  description: >-
+    Perform endogenous MTX2 knockout/rescue and patient-variant rescue in human
+    cells, then measure MTX1 stability, SAM complex assembly, VDAC/TOM40 import,
+    mitochondrial network morphology, and apoptosis/respiration phenotypes.
+  experiment_type: endogenous rescue and mitochondrial import/assembly assay

--- a/genes/human/MTX2/MTX2-deep-research-falcon.md
+++ b/genes/human/MTX2/MTX2-deep-research-falcon.md
@@ -1,0 +1,305 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-11T12:10:32.107823'
+end_time: '2026-05-11T12:20:15.782421'
+duration_seconds: 583.67
+template_file: templates/gene_research_go_focused.md
+template_variables:
+  organism: human
+  gene_id: MTX2
+  gene_symbol: MTX2
+  uniprot_accession: O75431
+  protein_description: 'RecName: Full=Metaxin-2; AltName: Full=Mitochondrial outer
+    membrane import complex protein 2;'
+  gene_info: Name=MTX2;
+  organism_full: Homo sapiens (Human).
+  protein_family: Belongs to the metaxin family. .
+  protein_domains: Glutathione-S-Trfase_C_sf. (IPR036282); Glutathione_S-Trfase. (IPR040079);
+    Metaxin_GST. (IPR033468); Mito_Protein_Transport_Metaxin. (IPR050931); Sam37/metaxin_N.
+    (IPR019564)
+provider_config:
+  timeout: 600
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 15
+---
+
+## Question
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** O75431
+- **Protein Description:** RecName: Full=Metaxin-2; AltName: Full=Mitochondrial outer membrane import complex protein 2;
+- **Gene Information:** Name=MTX2;
+- **Organism (full):** Homo sapiens (Human).
+- **Protein Family:** Belongs to the metaxin family. .
+- **Key Domains:** Glutathione-S-Trfase_C_sf. (IPR036282); Glutathione_S-Trfase. (IPR040079); Metaxin_GST. (IPR033468); Mito_Protein_Transport_Metaxin. (IPR050931); Sam37/metaxin_N. (IPR019564)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "MTX2" matches the protein description above**
+2. **Verify the organism is correct:** Homo sapiens (Human).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'MTX2' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **MTX2** (gene ID: MTX2, UniProt: O75431) in human.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** O75431
+- **Protein Description:** RecName: Full=Metaxin-2; AltName: Full=Mitochondrial outer membrane import complex protein 2;
+- **Gene Information:** Name=MTX2;
+- **Organism (full):** Homo sapiens (Human).
+- **Protein Family:** Belongs to the metaxin family. .
+- **Key Domains:** Glutathione-S-Trfase_C_sf. (IPR036282); Glutathione_S-Trfase. (IPR040079); Metaxin_GST. (IPR033468); Mito_Protein_Transport_Metaxin. (IPR050931); Sam37/metaxin_N. (IPR019564)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "MTX2" matches the protein description above**
+2. **Verify the organism is correct:** Homo sapiens (Human).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'MTX2' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **MTX2** (gene ID: MTX2, UniProt: O75431) in human.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Research report: Human **MTX2 / Metaxin-2** (UniProt **O75431**)—functional annotation and biomedical relevance
+
+### 0) Target verification (gene/protein identity)
+The target of this report is **human MTX2 (Metaxin-2)**, corresponding to **UniProt O75431**, a **263–amino-acid** mitochondrial protein localized to the **outer mitochondrial membrane (OMM)**; the literature evidence used here explicitly matches this identity and organism context and does not refer to an unrelated “MTX2” symbol from another species. (elouej2020lossofmtx2 pages 1-2)
+
+### 1) Key concepts and definitions (current understanding)
+
+#### 1.1 Metaxin family and “GST-like” fold (definition vs. enzyme function)
+MTX2 is a member of the **metaxin family** and is described in recent clinical genetics literature as having two annotated regions: an N-terminal **Sam37/metaxin_N** domain (reported as **aa 41–162**) and a **glutathione S-transferase (GST)-like** domain. (dogan2023anovelmtx2 pages 5-5, fu2024casereporta pages 2-4)
+
+Importantly, the “GST-like” designation in MTX2 is best interpreted as a **structural fold similarity**, not evidence that MTX2 catalyzes canonical GST conjugation reactions; the strongest experimental and genetic evidence supports a **non-enzymatic role in mitochondrial outer membrane protein biogenesis/organization** rather than a metabolic enzyme function. (elouej2020lossofmtx2 pages 1-2, elouej2020lossofmtx2 pages 2-4)
+
+#### 1.2 SAM (Sorting and Assembly Machinery) and β-barrel insertion (definition)
+The **mitochondrial Sorting and Assembly Machinery (SAM)** is an OMM pathway that supports the **correct integration of β-barrel proteins into the OMM**. MTX2 and its partner **Metaxin-1 (MTX1)** are described as components of this machinery in the context of human disease genetics and functional studies. (elouej2020lossofmtx2 pages 1-2)
+
+#### 1.3 MICOS–SAM / MIB bridging (definition)
+The SAM complex is described as a binding partner of **Mic60**, a core component of **MICOS** (mitochondrial contact site and cristae organizing system). These interactions form larger assemblies described as **mitochondrial intermembrane space bridging** complexes implicated in cristae junction organization and mitochondrial architecture. (elouej2020lossofmtx2 pages 1-2)
+
+### 2) Molecular function, pathways, and subcellular localization
+
+#### 2.1 Subcellular localization and topology
+MTX2 is localized to the **outer mitochondrial membrane** and is described as **facing the cytosolic compartment**. It is proposed to associate with the OMM through direct interaction with **MTX1**. (elouej2020lossofmtx2 pages 1-2, talarmingas2024validationofmetaxin2 pages 1-2)
+
+#### 2.2 Primary molecular function: OMM protein biogenesis/assembly and mitochondrial architecture
+Multiple converging lines of evidence support MTX2’s primary function as a **mitochondrial outer membrane protein biogenesis/assembly factor**:
+
+* **Complex membership and partner interaction:** MTX2 **interacts directly with MTX1** and is positioned as part of the **SAM machinery**, supporting β-barrel protein integration in the OMM. (elouej2020lossofmtx2 pages 1-2)
+* **Systems/architecture linkage:** SAM is described as interacting with **Mic60/MICOS** in higher-order bridging assemblies, linking MTX2’s SAM role to broader mitochondrial ultrastructure organization. (elouej2020lossofmtx2 pages 1-2)
+
+#### 2.3 Apoptosis and stress response linkage (secondary functional axis)
+MTX1/MTX2 have also been discussed as contributing to **TNF-α–induced apoptosis** via interaction with the pro-apoptotic protein **Bak**, linking OMM composition to cell-death signaling. (elouej2020lossofmtx2 pages 1-2)
+
+Consistent with this, patient fibroblasts lacking MTX2 show **resistance to apoptosis induction** (e.g., TNFα/CHX and staurosporine) and reduced caspase-3 activation. (elouej2020lossofmtx2 pages 6-7)
+
+### 3) Human genetics and disease association (real-world relevance)
+
+#### 3.1 Disease: Mandibuloacral dysplasia associated with MTX2 (MADaM)
+A key real-world “implementation” of MTX2 biology is in **clinical genetics**, where biallelic MTX2 loss-of-function variants cause a severe progeroid syndrome.
+
+**Discovery cohort (primary literature):** Elouej et al. (Nature Communications; **published Sep 2020**; URL: https://doi.org/10.1038/s41467-020-18146-9) evaluated **7 patients from 5 consanguineous families** and reported **5 homozygous null MTX2 variants**, establishing **MADaM**. (elouej2020lossofmtx2 pages 1-2)
+
+Clinical features included growth retardation and multisystem disease (e.g., renal involvement and severe hypertension), with cellular phenotypes implicating mitochondrial dysfunction. (elouej2020lossofmtx2 pages 1-2)
+
+**Variant spectrum expansion (recent):**
+* A 2023 clinical report (American Journal of Medical Genetics A; **Oct 2023**; URL: https://doi.org/10.1002/ajmg.a.63010) described a new **splice-site** variant **c.543+1G>T** causing **exon 8 skipping** (cDNA evidence) and noted that previously only five MTX2 pathogenic variants had been reported in the original discovery paper. (dogan2023anovelmtx2 pages 5-5)
+* A 2024 case report (Frontiers in Endocrinology; **published 13 Mar 2024**; URL: https://doi.org/10.3389/fendo.2024.1345067) reported a novel homozygous splice-site mutation **c.378+1G>A** and summarized that **7 molecularly diagnosed MADaM cases** had been reported worldwide prior to their report; they also describe deep sequencing coverage (**99.80%**, **>100×** depth) supporting diagnostic confidence. (fu2024casereporta pages 1-2, fu2024casereporta pages 2-4)
+
+#### 3.2 Mechanistic cellular consequences of MTX2 loss in human patient fibroblasts (quantitative)
+Elouej et al. quantified mitochondrial morphology and function changes in MTX2-deficient fibroblasts:
+
+**(a) Secondary depletion of MTX1:** Patient fibroblasts show loss of MTX2 and a **complete secondary depletion of MTX1 protein**, without reduction in MTX1 transcript levels (consistent with MTX1 instability when MTX2 is absent). (elouej2020lossofmtx2 pages 4-5)
+
+**(b) Mitochondrial network fragmentation / fission bias:** Mitochondrial network analysis (MiNA macro) scored **53 (WT), 46 (MADM2), and 51 (MADM3) cells** from **n=5 independent experiments**, showing significant reductions in network features (mitochondrial footprint, individuals, networks, branches per network). DRP1 was significantly increased (e.g., pMADM2 = 0.0015; pMADM3 = 0.042), consistent with increased fission. (elouej2020lossofmtx2 pages 4-5)
+
+**(c) Respiratory chain protein composition:** Multiple respiratory chain subunits were significantly reduced (complex I/III/IV/V) while complex II SDHA was not. (elouej2020lossofmtx2 pages 5-6)
+
+**(d) Mitochondrial respiration:** Respiration analyses showed a significant decrease in respiration dedicated to ATP synthesis (expressed as **R–O/F**) and decreased basal routine respiration (**R/F**) in patient fibroblasts; reported as **n=4 independent experiments** with **p=0.015**. (elouej2020lossofmtx2 pages 5-6, elouej2020lossofmtx2 media 62f590fd)
+
+**(e) Membrane potential:** TMRM FACS showed increased mitochondrial membrane potential in at least one patient line (MADM2; reported p=0.015). (elouej2020lossofmtx2 pages 5-6, elouej2020lossofmtx2 media 1c141a95)
+
+**(f) Apoptosis resistance and mitophagy/autophagy:** In patient fibroblasts, apoptosis induction was significantly blunted with strong p-values (e.g., TNFα/CHX pMADM2 = 4.0×10−5; pMADM3 = 2.1×10−7; staurosporine pMADM2 = 3.7×10−7; pMADM3 = 4.0×10−4). Autophagy markers (LC3B-II/LC3B-I) were increased (e.g., pMADM2 = 0.0002; pMADM3 = 0.026), and mitophagy was described as LC3C-associated rather than Parkin/ubiquitin-mediated. (elouej2020lossofmtx2 pages 6-7)
+
+### 4) Recent developments (prioritizing 2023–2024)
+
+#### 4.1 2023: New splice-site pathogenic variant with functional transcript evidence
+The 2023 splice-site variant report provides transcript-level evidence (exon skipping) strengthening the causal link between MTX2 splicing disruption and MADaM, and independently reiterates MTX2’s SAM/β-barrel insertion role as the mechanistic frame for disease. (dogan2023anovelmtx2 pages 5-5)
+
+#### 4.2 2024: Expanded global clinical reporting and molecular diagnostics rigor
+The 2024 Frontiers case report contributes (i) a new likely pathogenic splice-site variant (c.378+1G>A), (ii) explicit clinical laboratory abnormalities (e.g., proteinuria, microhematuria, hypercholesterolemia, low IgG) in a pediatric presentation, and (iii) reporting of sequencing QC metrics (coverage/depth), illustrating how MTX2 is now used in real-world diagnostic workflows. (fu2024casereporta pages 2-4, fu2024casereporta pages 1-2)
+
+#### 4.3 2024: Model organism validation for mechanism and therapeutic discovery
+Talarmin-Gas et al. (Communications Biology; **Oct 2024**; URL: https://doi.org/10.1038/s42003-024-06967-z) further validated **mtx-2–deficient C. elegans** as a MADaM model, using **AFM**, **oxygen consumption rate analyses**, and **transcriptomics**. They reported perturbations in **aging, TOR, and WNT-signaling pathways** and multiple quantitative phenotypes (e.g., body length reduction, pharyngeal pumping differences, and mitochondrial morphometrics). (talarmingas2024validationofmetaxin2 pages 1-2, talarmingas2024validationofmetaxin2 pages 8-10)
+
+#### 4.4 2024: Expert synthesis linking MTX2 to kinase interactomes and mitochondrial homeostasis
+A 2024 expert review of Nek kinases and mitochondrial homeostasis (Cells; **7 Mar 2024**; URL: https://doi.org/10.3390/cells13060473) summarizes that MTX2 appears among **validated mitochondrial interactors** emerging from Nek kinase interactome work, placing MTX2 in broader frameworks of mitochondrial composition/structure and stress-response networks. (basei2024themitochondrialconnection pages 1-3)
+
+### 5) Current applications and real-world implementations
+
+1. **Molecular diagnosis and variant interpretation in progeroid syndromes:** Reviews emphasize that overlapping phenotypes across premature-ageing syndromes motivate **NGS gene panels** and specialized clinical evaluation; MADaM (MTX2) is included among these syndromes in clinical genetics context. (coppede2021mutationsinvolvedin pages 1-2)
+2. **Functional assays to interpret variants:** Patient fibroblast phenotyping (mitochondrial network quantification, respiration, apoptosis assays) provides a framework for validating candidate MTX2 variants beyond in silico prediction—especially for splice-site variants now being reported (2023–2024). (elouej2020lossofmtx2 pages 6-7, elouej2020lossofmtx2 pages 5-6, dogan2023anovelmtx2 pages 5-5)
+3. **Model-organism platforms for therapy discovery:** The validated *C. elegans* model is explicitly positioned as enabling mechanistic dissection and scalable testing for therapeutics, leveraging measurable mitochondrial respiration and organismal phenotypes. (talarmingas2024validationofmetaxin2 pages 1-2)
+
+### 6) Expert opinion and analysis (authoritative synthesis)
+
+* **“Functions remain largely unknown” but anchored by SAM context:** The 2020 discovery paper explicitly notes that MTX2’s functions are “largely unknown” while anchoring its best-supported role in **SAM-mediated β-barrel integration** and interactions with MICOS/Mic60. This is a typical pattern for rare-disease gene discovery: genetic causality and robust cell phenotyping precede deep mechanistic dissection. (elouej2020lossofmtx2 pages 1-2)
+* **Mechanistic plausibility of pleiotropic phenotypes:** The observed clinical syndrome (MADaM) includes nuclear morphological abnormalities, but the authors interpret these as downstream/secondary to mitochondrial dysfunction and altered mitochondrial composition, supporting an emerging view that mitochondrial architecture and signaling can drive “laminopathy-like” phenotypes without primary LMNA defects. (elouej2020lossofmtx2 pages 9-10, elouej2020lossofmtx2 pages 1-2)
+
+### 7) Key statistics and data highlights (recent and foundational)
+
+* **Human cohort size (discovery):** **7 patients**, **5 families**, **5 homozygous null MTX2 variants** (Nature Communications, Sep 2020). (elouej2020lossofmtx2 pages 1-2)
+* **Mitochondrial network scoring:** **53/46/51 cells (WT/MADM2/MADM3)** across **n=5 experiments**; multiple network metrics significantly decreased. (elouej2020lossofmtx2 pages 4-5)
+* **Respiration functional deficit:** Reduced ATP synthesis-linked respiration metric (R–O/F) and basal respiration ratios with **n=4**, **p=0.015**, visualized in Figure 3 panels. (elouej2020lossofmtx2 pages 5-6, elouej2020lossofmtx2 media 62f590fd)
+* **Apoptosis resistance:** Strong significance for reduced death after TNFα/CHX and staurosporine exposure (p-values down to ~10−7). (elouej2020lossofmtx2 pages 6-7)
+* **2024 diagnostic sequencing QC:** **99.80% coverage** and **>100×** depth in MTX2 region in a clinical exome workflow. (fu2024casereporta pages 2-4)
+
+### Evidence map (summary table)
+| Category | Key points | Best supporting citations |
+|---|---|---|
+| Identity/domains | Human **MTX2** encodes **Metaxin-2** (UniProt **O75431**), a **263-aa** protein. Recent case literature describes two annotated regions: **Sam37/metaxin_N domain (aa 41-162)** and a **GST-like / glutathione S-transferase domain**. | (elouej2020lossofmtx2 pages 1-2, dogan2023anovelmtx2 pages 5-5, fu2024casereporta pages 2-4) |
+| Localization/topology | MTX2 is an **outer mitochondrial membrane (OMM)** protein that **faces the cytosol/cytosolic compartment**. It is described as **peripherally associated** with the OMM through interaction with MTX1. | (elouej2020lossofmtx2 pages 1-2, talarmingas2024validationofmetaxin2 pages 1-2) |
+| Molecular function | Best-supported function is as a **non-enzymatic mitochondrial protein biogenesis/assembly factor**, participating in **protein translocation into mitochondria** and the **correct integration of β-barrel proteins into the OMM**. Loss of MTX2 causes **mitochondrial network fragmentation**, **decreased oxidative phosphorylation**, altered apoptosis responses, increased senescence/autophagy, and reduced proliferation in patient fibroblasts. | (elouej2020lossofmtx2 pages 1-2, elouej2020lossofmtx2 pages 2-4, talarmingas2024validationofmetaxin2 pages 1-2) |
+| Complex membership/partners | MTX2 **directly interacts with MTX1**; MTX1/MTX2 are described as part of the **SAM (sorting and assembly machinery)**. The **SAM complex** is a binding partner of **Mic60/MICOS**, contributing to larger **mitochondrial intermembrane space bridging** assemblies; immunoblot analyses also assessed **SAMM50** in the MTX2-deficiency context. | (elouej2020lossofmtx2 pages 1-2, elouej2020lossofmtx2 pages 2-4, elouej2020lossofmtx2 pages 4-4) |
+| Pathway/process | MTX2 functions in **mitochondrial outer membrane protein biogenesis**, especially **β-barrel protein assembly/trafficking**. It is also linked to **TNF-α-induced apoptosis** via metaxin/Bak-related pathways, and functionally connected to **mitochondrial morphology**, **OxPhos**, **autophagy/mitophagy**, and **cristae-associated SAM-MICOS organization**. | (elouej2020lossofmtx2 pages 1-2, elouej2020lossofmtx2 pages 2-4, talarmingas2024validationofmetaxin2 pages 1-2) |
+| Disease association | Biallelic/homozygous loss-of-function MTX2 variants cause **mandibuloacral dysplasia associated with MTX2 (MADaM)**, a severe progeroid syndrome. Elouej et al. reported **7 patients from 5 consanguineous families** with **5 homozygous null mutations**; later reports added new splice variants including **c.543+1G>T** and **c.378+1G>A**. | (elouej2020lossofmtx2 pages 1-2, dogan2023anovelmtx2 pages 5-5, fu2024casereporta pages 1-2) |
+| Key quantitative findings | In patient fibroblasts, mitochondrial network analysis showed significant changes in **footprint, individuals, networks, and branches/network**; **53 WT, 46 MADM2, 51 MADM3 cells** were scored across **n=5** experiments. Respiratory-chain subunits from complexes **I, III, IV, V** were reduced, while **SDHA/complex II** was not; respiration assays showed reduced **ATP synthesis-linked respiration (R-O/F)** and **basal routine respiration (R/F)** (**n=4**, **p=0.015**). TMRM indicated increased mitochondrial membrane potential in MADM2 (**p=0.015**). Apoptosis resistance was significant for **TNFα/CHX** and **staurosporine**; LC3B-II/LC3B-I was increased (**p=0.0002** for MADM2; **p=0.026** for MADM3). In *C. elegans*, abnormal mitochondrial morphology occurred in **74% (n=68)** of mtx-2 KO animals. | (elouej2020lossofmtx2 pages 4-5, elouej2020lossofmtx2 pages 5-6, elouej2020lossofmtx2 pages 6-7, elouej2020lossofmtx2 media 62f590fd) |
+| 2023-2024 updates | **2023:** a novel **splice-site** MTX2 variant (**c.543+1G>T**) causing **exon 8 skipping** expanded the pathogenic spectrum. **2024:** first Chinese MADaM case with **c.378+1G>A**; authors noted only **7 molecularly diagnosed MADaM cases worldwide** before that report. **2024 model work** further validated MTX2-deficient *C. elegans* as a MADaM model, showing reduced mitochondrial respiratory capacity and pathway perturbations in **aging, TOR, and WNT signaling**. | (dogan2023anovelmtx2 pages 5-5, fu2024casereporta pages 1-2, talarmingas2024validationofmetaxin2 pages 1-2, talarmingas2024validationofmetaxin2 pages 8-10) |
+
+
+*Table: This table summarizes the core functional annotation of human MTX2/Metaxin-2 from the provided evidence, including identity, localization, molecular role, complex membership, disease relevance, and recent 2023-2024 updates. It is useful as a compact evidence map for building the full research report.*
+
+### Visual evidence from primary literature
+Quantitative mitochondrial respiration and membrane potential changes in MTX2-deficient human fibroblasts are shown in the cropped panels from Elouej et al. Figure 3 (respiration metrics and TMRM FACS). (elouej2020lossofmtx2 media 62f590fd, elouej2020lossofmtx2 media 1c141a95)
+
+### Limitations of the current evidence set
+Within the retrieved 2023–2024 corpus available here, the most direct MTX2 updates are primarily **clinical variant reports** and **model-organism validation** rather than new high-resolution structural biology of human SAM-metaxin assemblies; therefore, this report emphasizes disease genetics, functional cell phenotyping, and validated pathway context (SAM–MICOS/MIB) over detailed atomic-level mechanism. (fu2024casereporta pages 1-2, talarmingas2024validationofmetaxin2 pages 1-2, elouej2020lossofmtx2 pages 1-2)
+
+References
+
+1. (elouej2020lossofmtx2 pages 1-2): Sahar Elouej, Karim Harhouri, Morgane Le Mao, Genevieve Baujat, Sheela Nampoothiri, Hϋlya Kayserili, Nihal Al Menabawy, Laila Selim, Arianne Llamos Paneque, Christian Kubisch, Davor Lessel, Robert Rubinsztajn, Chayki Charar, Catherine Bartoli, Coraline Airault, Jean-François Deleuze, Agnes Rötig, Peter Bauer, Catarina Pereira, Abigail Loh, Nathalie Escande-Beillard, Antoine Muchir, Lisa Martino, Yosef Gruenbaum, Song-Hua Lee, Philippe Manivet, Guy Lenaers, Bruno Reversade, Nicolas Lévy, and Annachiara De Sandre-Giovannoli. Loss of mtx2 causes mandibuloacral dysplasia and links mitochondrial dysfunction to altered nuclear morphology. Nature Communications, Sep 2020. URL: https://doi.org/10.1038/s41467-020-18146-9, doi:10.1038/s41467-020-18146-9. This article has 79 citations and is from a highest quality peer-reviewed journal.
+
+2. (dogan2023anovelmtx2 pages 5-5): Burcu Yeter Doğan, Neslihan Günay, Yasin Ada, and Muhammet Ensar Doğan. A novel mtx2 gene splice site variant resulting in exon skipping, causing the recently described mandibuloacral dysplasia progeroid syndrome. American Journal of Medical Genetics Part A, 191:173-182, Oct 2023. URL: https://doi.org/10.1002/ajmg.a.63010, doi:10.1002/ajmg.a.63010. This article has 14 citations.
+
+3. (fu2024casereporta pages 2-4): Xiaohui Fu, Shuli Chen, Xiao Huang, Qinghua Lu, Yunfei Cui, Weinan Lin, and Qin Yang. Case report: a novel splice-site mutation of mtx2 gene caused mandibuloacral dysplasia progeroid syndrome: the first report from china and literature review. Frontiers in Endocrinology, Mar 2024. URL: https://doi.org/10.3389/fendo.2024.1345067, doi:10.3389/fendo.2024.1345067. This article has 4 citations.
+
+4. (elouej2020lossofmtx2 pages 2-4): Sahar Elouej, Karim Harhouri, Morgane Le Mao, Genevieve Baujat, Sheela Nampoothiri, Hϋlya Kayserili, Nihal Al Menabawy, Laila Selim, Arianne Llamos Paneque, Christian Kubisch, Davor Lessel, Robert Rubinsztajn, Chayki Charar, Catherine Bartoli, Coraline Airault, Jean-François Deleuze, Agnes Rötig, Peter Bauer, Catarina Pereira, Abigail Loh, Nathalie Escande-Beillard, Antoine Muchir, Lisa Martino, Yosef Gruenbaum, Song-Hua Lee, Philippe Manivet, Guy Lenaers, Bruno Reversade, Nicolas Lévy, and Annachiara De Sandre-Giovannoli. Loss of mtx2 causes mandibuloacral dysplasia and links mitochondrial dysfunction to altered nuclear morphology. Nature Communications, Sep 2020. URL: https://doi.org/10.1038/s41467-020-18146-9, doi:10.1038/s41467-020-18146-9. This article has 79 citations and is from a highest quality peer-reviewed journal.
+
+5. (talarmingas2024validationofmetaxin2 pages 1-2): Chloé Talarmin-Gas, Georges Smolyakov, Cleo Parisi, Cyril Scandola, Valérie Andrianasolonirina, Cloé Lecoq, Valentine Houtart, Song-Hua Lee, Homa Adle-Biassette, Bénédicte Thiébot, Timothy Ganderton, and Philippe Manivet. Validation of metaxin-2 deficient c. elegans as a model for mandibuloacral dysplasia associated to mtx-2 (madam) syndrome. Communications Biology, Oct 2024. URL: https://doi.org/10.1038/s42003-024-06967-z, doi:10.1038/s42003-024-06967-z. This article has 5 citations and is from a peer-reviewed journal.
+
+6. (elouej2020lossofmtx2 pages 6-7): Sahar Elouej, Karim Harhouri, Morgane Le Mao, Genevieve Baujat, Sheela Nampoothiri, Hϋlya Kayserili, Nihal Al Menabawy, Laila Selim, Arianne Llamos Paneque, Christian Kubisch, Davor Lessel, Robert Rubinsztajn, Chayki Charar, Catherine Bartoli, Coraline Airault, Jean-François Deleuze, Agnes Rötig, Peter Bauer, Catarina Pereira, Abigail Loh, Nathalie Escande-Beillard, Antoine Muchir, Lisa Martino, Yosef Gruenbaum, Song-Hua Lee, Philippe Manivet, Guy Lenaers, Bruno Reversade, Nicolas Lévy, and Annachiara De Sandre-Giovannoli. Loss of mtx2 causes mandibuloacral dysplasia and links mitochondrial dysfunction to altered nuclear morphology. Nature Communications, Sep 2020. URL: https://doi.org/10.1038/s41467-020-18146-9, doi:10.1038/s41467-020-18146-9. This article has 79 citations and is from a highest quality peer-reviewed journal.
+
+7. (fu2024casereporta pages 1-2): Xiaohui Fu, Shuli Chen, Xiao Huang, Qinghua Lu, Yunfei Cui, Weinan Lin, and Qin Yang. Case report: a novel splice-site mutation of mtx2 gene caused mandibuloacral dysplasia progeroid syndrome: the first report from china and literature review. Frontiers in Endocrinology, Mar 2024. URL: https://doi.org/10.3389/fendo.2024.1345067, doi:10.3389/fendo.2024.1345067. This article has 4 citations.
+
+8. (elouej2020lossofmtx2 pages 4-5): Sahar Elouej, Karim Harhouri, Morgane Le Mao, Genevieve Baujat, Sheela Nampoothiri, Hϋlya Kayserili, Nihal Al Menabawy, Laila Selim, Arianne Llamos Paneque, Christian Kubisch, Davor Lessel, Robert Rubinsztajn, Chayki Charar, Catherine Bartoli, Coraline Airault, Jean-François Deleuze, Agnes Rötig, Peter Bauer, Catarina Pereira, Abigail Loh, Nathalie Escande-Beillard, Antoine Muchir, Lisa Martino, Yosef Gruenbaum, Song-Hua Lee, Philippe Manivet, Guy Lenaers, Bruno Reversade, Nicolas Lévy, and Annachiara De Sandre-Giovannoli. Loss of mtx2 causes mandibuloacral dysplasia and links mitochondrial dysfunction to altered nuclear morphology. Nature Communications, Sep 2020. URL: https://doi.org/10.1038/s41467-020-18146-9, doi:10.1038/s41467-020-18146-9. This article has 79 citations and is from a highest quality peer-reviewed journal.
+
+9. (elouej2020lossofmtx2 pages 5-6): Sahar Elouej, Karim Harhouri, Morgane Le Mao, Genevieve Baujat, Sheela Nampoothiri, Hϋlya Kayserili, Nihal Al Menabawy, Laila Selim, Arianne Llamos Paneque, Christian Kubisch, Davor Lessel, Robert Rubinsztajn, Chayki Charar, Catherine Bartoli, Coraline Airault, Jean-François Deleuze, Agnes Rötig, Peter Bauer, Catarina Pereira, Abigail Loh, Nathalie Escande-Beillard, Antoine Muchir, Lisa Martino, Yosef Gruenbaum, Song-Hua Lee, Philippe Manivet, Guy Lenaers, Bruno Reversade, Nicolas Lévy, and Annachiara De Sandre-Giovannoli. Loss of mtx2 causes mandibuloacral dysplasia and links mitochondrial dysfunction to altered nuclear morphology. Nature Communications, Sep 2020. URL: https://doi.org/10.1038/s41467-020-18146-9, doi:10.1038/s41467-020-18146-9. This article has 79 citations and is from a highest quality peer-reviewed journal.
+
+10. (elouej2020lossofmtx2 media 62f590fd): Sahar Elouej, Karim Harhouri, Morgane Le Mao, Genevieve Baujat, Sheela Nampoothiri, Hϋlya Kayserili, Nihal Al Menabawy, Laila Selim, Arianne Llamos Paneque, Christian Kubisch, Davor Lessel, Robert Rubinsztajn, Chayki Charar, Catherine Bartoli, Coraline Airault, Jean-François Deleuze, Agnes Rötig, Peter Bauer, Catarina Pereira, Abigail Loh, Nathalie Escande-Beillard, Antoine Muchir, Lisa Martino, Yosef Gruenbaum, Song-Hua Lee, Philippe Manivet, Guy Lenaers, Bruno Reversade, Nicolas Lévy, and Annachiara De Sandre-Giovannoli. Loss of mtx2 causes mandibuloacral dysplasia and links mitochondrial dysfunction to altered nuclear morphology. Nature Communications, Sep 2020. URL: https://doi.org/10.1038/s41467-020-18146-9, doi:10.1038/s41467-020-18146-9. This article has 79 citations and is from a highest quality peer-reviewed journal.
+
+11. (elouej2020lossofmtx2 media 1c141a95): Sahar Elouej, Karim Harhouri, Morgane Le Mao, Genevieve Baujat, Sheela Nampoothiri, Hϋlya Kayserili, Nihal Al Menabawy, Laila Selim, Arianne Llamos Paneque, Christian Kubisch, Davor Lessel, Robert Rubinsztajn, Chayki Charar, Catherine Bartoli, Coraline Airault, Jean-François Deleuze, Agnes Rötig, Peter Bauer, Catarina Pereira, Abigail Loh, Nathalie Escande-Beillard, Antoine Muchir, Lisa Martino, Yosef Gruenbaum, Song-Hua Lee, Philippe Manivet, Guy Lenaers, Bruno Reversade, Nicolas Lévy, and Annachiara De Sandre-Giovannoli. Loss of mtx2 causes mandibuloacral dysplasia and links mitochondrial dysfunction to altered nuclear morphology. Nature Communications, Sep 2020. URL: https://doi.org/10.1038/s41467-020-18146-9, doi:10.1038/s41467-020-18146-9. This article has 79 citations and is from a highest quality peer-reviewed journal.
+
+12. (talarmingas2024validationofmetaxin2 pages 8-10): Chloé Talarmin-Gas, Georges Smolyakov, Cleo Parisi, Cyril Scandola, Valérie Andrianasolonirina, Cloé Lecoq, Valentine Houtart, Song-Hua Lee, Homa Adle-Biassette, Bénédicte Thiébot, Timothy Ganderton, and Philippe Manivet. Validation of metaxin-2 deficient c. elegans as a model for mandibuloacral dysplasia associated to mtx-2 (madam) syndrome. Communications Biology, Oct 2024. URL: https://doi.org/10.1038/s42003-024-06967-z, doi:10.1038/s42003-024-06967-z. This article has 5 citations and is from a peer-reviewed journal.
+
+13. (basei2024themitochondrialconnection pages 1-3): Fernanda L. Basei, Ivan Rosa e Silva, Pedro R. Firmino Dias, Camila C. Ferezin, Andressa Peres de Oliveira, Luidy K. Issayama, Livia A. R. Moura, Fernando Riback da Silva, and Jörg Kobarg. The mitochondrial connection: the nek kinases’ new functional axis in mitochondrial homeostasis. Cells, 13:473, Mar 2024. URL: https://doi.org/10.3390/cells13060473, doi:10.3390/cells13060473. This article has 13 citations.
+
+14. (coppede2021mutationsinvolvedin pages 1-2): Fabio Coppede. Mutations involved in premature-ageing syndromes. The Application of Clinical Genetics, 14:279-295, Jun 2021. URL: https://doi.org/10.2147/tacg.s273525, doi:10.2147/tacg.s273525. This article has 39 citations.
+
+15. (elouej2020lossofmtx2 pages 9-10): Sahar Elouej, Karim Harhouri, Morgane Le Mao, Genevieve Baujat, Sheela Nampoothiri, Hϋlya Kayserili, Nihal Al Menabawy, Laila Selim, Arianne Llamos Paneque, Christian Kubisch, Davor Lessel, Robert Rubinsztajn, Chayki Charar, Catherine Bartoli, Coraline Airault, Jean-François Deleuze, Agnes Rötig, Peter Bauer, Catarina Pereira, Abigail Loh, Nathalie Escande-Beillard, Antoine Muchir, Lisa Martino, Yosef Gruenbaum, Song-Hua Lee, Philippe Manivet, Guy Lenaers, Bruno Reversade, Nicolas Lévy, and Annachiara De Sandre-Giovannoli. Loss of mtx2 causes mandibuloacral dysplasia and links mitochondrial dysfunction to altered nuclear morphology. Nature Communications, Sep 2020. URL: https://doi.org/10.1038/s41467-020-18146-9, doi:10.1038/s41467-020-18146-9. This article has 79 citations and is from a highest quality peer-reviewed journal.
+
+16. (elouej2020lossofmtx2 pages 4-4): Sahar Elouej, Karim Harhouri, Morgane Le Mao, Genevieve Baujat, Sheela Nampoothiri, Hϋlya Kayserili, Nihal Al Menabawy, Laila Selim, Arianne Llamos Paneque, Christian Kubisch, Davor Lessel, Robert Rubinsztajn, Chayki Charar, Catherine Bartoli, Coraline Airault, Jean-François Deleuze, Agnes Rötig, Peter Bauer, Catarina Pereira, Abigail Loh, Nathalie Escande-Beillard, Antoine Muchir, Lisa Martino, Yosef Gruenbaum, Song-Hua Lee, Philippe Manivet, Guy Lenaers, Bruno Reversade, Nicolas Lévy, and Annachiara De Sandre-Giovannoli. Loss of mtx2 causes mandibuloacral dysplasia and links mitochondrial dysfunction to altered nuclear morphology. Nature Communications, Sep 2020. URL: https://doi.org/10.1038/s41467-020-18146-9, doi:10.1038/s41467-020-18146-9. This article has 79 citations and is from a highest quality peer-reviewed journal.
+
+## Citations
+
+1. basei2024themitochondrialconnection pages 1-3
+2. coppede2021mutationsinvolvedin pages 1-2
+3. fu2024casereporta pages 2-4
+4. fu2024casereporta pages 1-2
+5. https://doi.org/10.1038/s41467-020-18146-9
+6. https://doi.org/10.1002/ajmg.a.63010
+7. https://doi.org/10.3389/fendo.2024.1345067
+8. https://doi.org/10.1038/s42003-024-06967-z
+9. https://doi.org/10.3390/cells13060473
+10. https://doi.org/10.1038/s41467-020-18146-9,
+11. https://doi.org/10.1002/ajmg.a.63010,
+12. https://doi.org/10.3389/fendo.2024.1345067,
+13. https://doi.org/10.1038/s42003-024-06967-z,
+14. https://doi.org/10.3390/cells13060473,
+15. https://doi.org/10.2147/tacg.s273525,

--- a/genes/human/TIMM17A/TIMM17A-ai-review.html
+++ b/genes/human/TIMM17A/TIMM17A-ai-review.html
@@ -1,0 +1,2976 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>TIMM17A - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>TIMM17A</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q99595" target="_blank" class="term-link">
+                        Q99595
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "TIMM17A";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q99595" data-a="DESCRIPTION: TIMM17A is an integral mitochondrial inner membran..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>TIMM17A is an integral mitochondrial inner membrane subunit of the human TIM23 presequence translocase. It contributes to the TIM23 protein-conducting channel/cavity for import of presequence-containing mitochondrial precursors, especially matrix-destined proteins, and participates in TIM23 complex organization and regulated remodeling of mitochondrial protein import.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008320" target="_blank" class="term-link">
+                                    GO:0008320
+                                </a>
+                            </span>
+                            <span class="term-label">protein transmembrane transporter activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q99595" data-a="GO:0008320" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct as a contributes_to molecular-function annotation. TIMM17A is a TIM23 core subunit that contributes to the protein-conducting import channel/cavity rather than acting as a standalone transporter.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM17A/TIMM17A-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">TIMM17A is an **integral mitochondrial inner membrane** component of the **TIM23 core**</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030150" target="_blank" class="term-link">
+                                    GO:0030150
+                                </a>
+                            </span>
+                            <span class="term-label">protein import into mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q99595" data-a="GO:0030150" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct core biological process. TIM23 imports presequence-containing precursors into the matrix, and TIMM17A contributes to the TIM23 translocation path.
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005744" target="_blank" class="term-link">
+                                    GO:0005744
+                                </a>
+                            </span>
+                            <span class="term-label">TIM23 mitochondrial import inner membrane translocase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q99595" data-a="GO:0005744" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct complex annotation. TIMM17A is a core subunit of a human TIM23 variant with TIMM23 and ROMO1.
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005743" target="_blank" class="term-link">
+                                    GO:0005743
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial inner membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q99595" data-a="GO:0005743" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct UniProt-derived localization. TIMM17A is an integral mitochondrial inner membrane protein with conserved Tim17-family transmembrane topology.
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005744" target="_blank" class="term-link">
+                                    GO:0005744
+                                </a>
+                            </span>
+                            <span class="term-label">TIM23 mitochondrial import inner membrane translocase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q99595" data-a="GO:0005744" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct InterPro-derived annotation. TIMM17A belongs to the Tim17/Tim23 family and is part of the TIM23 inner membrane translocase.
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008320" target="_blank" class="term-link">
+                                    GO:0008320
+                                </a>
+                            </span>
+                            <span class="term-label">protein transmembrane transporter activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q99595" data-a="GO:0008320" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct when interpreted as a TIM23 subunit contribution to the protein-conducting channel/cavity.
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030150" target="_blank" class="term-link">
+                                    GO:0030150
+                                </a>
+                            </span>
+                            <span class="term-label">protein import into mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q99595" data-a="GO:0030150" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct InterPro-derived process annotation for the TIM23 presequence pathway. TIMM17A contributes to import of matrix-destined precursors.
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005743" target="_blank" class="term-link">
+                                    GO:0005743
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial inner membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10339406" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10339406
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Genetic and structural characterization of the human mitocho...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q99595" data-a="GO:0005743" data-r="PMID:10339406" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct. The foundational human TIM23 study places Tim17-A in the mitochondrial inner membrane translocase.
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005744" target="_blank" class="term-link">
+                                    GO:0005744
+                                </a>
+                            </span>
+                            <span class="term-label">TIM23 mitochondrial import inner membrane translocase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10339406" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10339406
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Genetic and structural characterization of the human mitocho...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q99595" data-a="GO:0005744" data-r="PMID:10339406" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct. TIMM17A is a human TIM23 core component and is consistently described in recent TIM23 architecture studies.
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006886" target="_blank" class="term-link">
+                                    GO:0006886
+                                </a>
+                            </span>
+                            <span class="term-label">intracellular protein transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10339406" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10339406
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Genetic and structural characterization of the human mitocho...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="Q99595" data-a="GO:0006886" data-r="PMID:10339406" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> The annotation captures protein transport but is too broad. The specific TIMM17A process is mitochondrial matrix import through TIM23.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Replace broad intracellular protein transport with mitochondrial matrix import.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030150" target="_blank" class="term-link">
+                                    protein import into mitochondrial matrix
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030150" target="_blank" class="term-link">
+                                    GO:0030150
+                                </a>
+                            </span>
+                            <span class="term-label">protein import into mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10339406" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10339406
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Genetic and structural characterization of the human mitocho...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q99595" data-a="GO:0030150" data-r="PMID:10339406" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct. TIMM17A is a TIM23 translocase subunit involved in matrix import of presequence-containing precursors.
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000052
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q99595" data-a="GO:0005739" data-r="GO_REF:0000052" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct but too general. TIMM17A is specifically localized to the mitochondrial inner membrane and TIM23 complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Subsumed by mitochondrial inner membrane and TIM23 complex annotations.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HTP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:34800366
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Quantitative high-confidence human mitochondrial proteome an...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q99595" data-a="GO:0005739" data-r="PMID:34800366" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput mitochondrial proteome evidence supports mitochondrial localization, but the term is less specific than the inner membrane/TIM23 localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Subsumed by mitochondrial inner membrane and TIM23 complex annotations.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005744" target="_blank" class="term-link">
+                                    GO:0005744
+                                </a>
+                            </span>
+                            <span class="term-label">TIM23 mitochondrial import inner membrane translocase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/30598479" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:30598479
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    ROMO1 is a constituent of the human presequence translocase ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q99595" data-a="GO:0005744" data-r="PMID:30598479" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Accepted. ROMO1/TIM23 complex studies recovered TIM17A in authentic human TIM23 assemblies.
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005743" target="_blank" class="term-link">
+                                    GO:0005743
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial inner membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20053669" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:20053669
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Role of Magmas in protein transport and human mitochondria b...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q99595" data-a="GO:0005743" data-r="PMID:20053669" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct localization for TIMM17A as an integral TIM23 inner membrane subunit.
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005743" target="_blank" class="term-link">
+                                    GO:0005743
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial inner membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10339406" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10339406
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Genetic and structural characterization of the human mitocho...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q99595" data-a="GO:0005743" data-r="PMID:10339406" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct localization from the foundational human TIM23 characterization.
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005744" target="_blank" class="term-link">
+                                    GO:0005744
+                                </a>
+                            </span>
+                            <span class="term-label">TIM23 mitochondrial import inner membrane translocase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10339406" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10339406
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Genetic and structural characterization of the human mitocho...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q99595" data-a="GO:0005744" data-r="PMID:10339406" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct complex annotation from the foundational human TIM23 characterization and supported by recent TIM23 architecture literature.
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>TIMM17A contributes to the TIM23 presequence translocase channel/cavity at the mitochondrial inner membrane, supporting import of presequence-containing nuclear-encoded precursors into the matrix and sorting through TIM23.</h3>
+                <span class="vote-buttons" data-g="Q99595" data-a="FUNCTION: TIMM17A contributes to the TIM23 presequence trans..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030150" target="_blank" class="term-link">
+                                protein import into mitochondrial matrix
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005743" target="_blank" class="term-link">
+                                mitochondrial inner membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005744" target="_blank" class="term-link">
+                            TIM23 mitochondrial import inner membrane translocase complex
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/TIMM17A/TIMM17A-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">TIMM17A is an **integral mitochondrial inner membrane** component of the **TIM23 core**</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/TIMM17A/TIMM17A-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">TIM23 imports **presequence‑containing precursors** destined to the **matrix** and many destined to the **inner membrane**</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/TIMM17A/TIMM17A-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">TIMM17A acts at the **inner membrane** as part of the translocation pore/cavity</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000052.md" target="_blank" class="term-link">
+                            GO_REF:0000052
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on curation of immunofluorescence data</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/10339406" target="_blank" class="term-link">
+                            PMID:10339406
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Genetic and structural characterization of the human mitochondrial inner membrane translocase.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/20053669" target="_blank" class="term-link">
+                            PMID:20053669
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Role of Magmas in protein transport and human mitochondria biogenesis.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/30598479" target="_blank" class="term-link">
+                            PMID:30598479
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">ROMO1 is a constituent of the human presequence translocase required for YME1L protease import.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link">
+                            PMID:34800366
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Quantitative high-confidence human mitochondrial proteome and its dynamics in cellular context.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/TIMM17A/TIMM17A-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research report for human TIMM17A</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Which TIMM17A-specific surfaces distinguish translocase-A regulation from TIMM17B-containing housekeeping TIM23 complexes?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q99595" data-a="Q: Which TIMM17A-specific surfaces distinguish transl..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> How does YME1L-dependent TIMM17A turnover remodel the substrate spectrum of human TIM23 under hypoxia or nutrient stress?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q99595" data-a="Q: How does YME1L-dependent TIMM17A turnover remodel ..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Use endogenous TIMM17A knockout/rescue with TIMM17A/TIMM17B swap and structure-guided mutants, then assay TIM23 complex composition, matrix precursor import, YME1L-dependent turnover, and stress-dependent proteome remodeling.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: TIMM17A-specific structural features tune TIM23 matrix import and stress remodeling independently of core TIM23 assembly.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: endogenous rescue and mitochondrial import assay</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q99595" data-a="EXPERIMENT: Use endogenous TIMM17A knockout/rescue with TIMM17..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Deep Research Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(TIMM17A-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q99595" data-a="DOC: Deep Research Falcon" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <hr />
+<p>provider: falcon<br />
+model: Edison Scientific Literature<br />
+cached: false<br />
+start_time: '2026-05-11T12:10:32.086996'<br />
+end_time: '2026-05-11T12:29:26.503316'<br />
+duration_seconds: 1134.42<br />
+template_file: templates/gene_research_go_focused.md<br />
+template_variables:<br />
+  organism: human<br />
+  gene_id: TIMM17A<br />
+  gene_symbol: TIMM17A<br />
+  uniprot_accession: Q99595<br />
+  protein_description: 'RecName: Full=Mitochondrial import inner membrane translocase<br />
+    subunit Tim17-A; AltName: Full=Inner membrane preprotein translocase Tim17a;'<br />
+  gene_info: Name=TIMM17A; Synonyms=MIMT17, TIM17, TIM17A, TIMM17;<br />
+  organism_full: Homo sapiens (Human).<br />
+  protein_family: Belongs to the Tim17/Tim22/Tim23 family. .<br />
+  protein_domains: Tim17. (IPR005678); Tim17 (PF02466)<br />
+provider_config:<br />
+  timeout: 600<br />
+  max_retries: 3<br />
+  parameters:<br />
+    allowed_domains: []<br />
+    temperature: 0.1<br />
+citation_count: 16</p>
+<hr />
+<h2 id="question">Question</h2>
+<h1 id="gene-research-for-functional-annotation">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> Q99595</li>
+<li><strong>Protein Description:</strong> RecName: Full=Mitochondrial import inner membrane translocase subunit Tim17-A; AltName: Full=Inner membrane preprotein translocase Tim17a;</li>
+<li><strong>Gene Information:</strong> Name=TIMM17A; Synonyms=MIMT17, TIM17, TIM17A, TIMM17;</li>
+<li><strong>Organism (full):</strong> Homo sapiens (Human).</li>
+<li><strong>Protein Family:</strong> Belongs to the Tim17/Tim22/Tim23 family. .</li>
+<li><strong>Key Domains:</strong> Tim17. (IPR005678); Tim17 (PF02466)</li>
+</ul>
+<h3 id="mandatory-verification-steps">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "TIMM17A" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Homo sapiens (Human).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'TIMM17A' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>TIMM17A</strong> (gene ID: TIMM17A, UniProt: Q99595) in human.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="output">Output</h2>
+<p>Question: You are an expert researcher providing comprehensive, well-cited information.</p>
+<p>Provide detailed information focusing on:<br />
+1. Key concepts and definitions with current understanding<br />
+2. Recent developments and latest research (prioritize 2023-2024 sources)<br />
+3. Current applications and real-world implementations<br />
+4. Expert opinions and analysis from authoritative sources<br />
+5. Relevant statistics and data from recent studies</p>
+<p>Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.<br />
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.</p>
+<h1 id="gene-research-for-functional-annotation_1">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context_1">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot_1">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> Q99595</li>
+<li><strong>Protein Description:</strong> RecName: Full=Mitochondrial import inner membrane translocase subunit Tim17-A; AltName: Full=Inner membrane preprotein translocase Tim17a;</li>
+<li><strong>Gene Information:</strong> Name=TIMM17A; Synonyms=MIMT17, TIM17, TIM17A, TIMM17;</li>
+<li><strong>Organism (full):</strong> Homo sapiens (Human).</li>
+<li><strong>Protein Family:</strong> Belongs to the Tim17/Tim22/Tim23 family. .</li>
+<li><strong>Key Domains:</strong> Tim17. (IPR005678); Tim17 (PF02466)</li>
+</ul>
+<h3 id="mandatory-verification-steps_1">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "TIMM17A" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Homo sapiens (Human).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature_1">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'TIMM17A' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target_1">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>TIMM17A</strong> (gene ID: TIMM17A, UniProt: Q99595) in human.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="comprehensive-research-report-human-timm17a-uniprot-q99595functional-annotation-and-current-understanding">Comprehensive research report: Human <strong>TIMM17A</strong> (UniProt <strong>Q99595</strong>)—functional annotation and current understanding</h2>
+<h3 id="0-target-verification-and-nomenclature">0) Target verification and nomenclature</h3>
+<p>The literature summarized here is explicitly matched to the UniProt entry <strong>Q99595</strong>, annotated as <strong>mitochondrial import inner membrane translocase subunit Tim17-A</strong>, encoded by the human gene <strong>TIMM17A</strong> (Tim17a). A 2024 peer‑reviewed study on the human core TIM23 complex explicitly identifies <strong>TIMM17A as UniProt Q99595</strong> and places it in the Tim17/Tim22/Tim23 family (pfam Tim17; IPR005678) (maruszczak2024structurepredictionanalysis pages 2-3). Human TIMM17A is distinct from the paralog <strong>TIMM17B</strong>, which forms an alternative TIM23 core variant and shares ~<strong>76%</strong> sequence identity (maruszczak2024structurepredictionanalysis pages 3-5).</p>
+<h3 id="1-key-concepts-and-definitions-current-understanding">1) Key concepts and definitions (current understanding)</h3>
+<h4 id="11-the-tim23-presequence-pathway">1.1 The TIM23 “presequence” pathway</h4>
+<p>Most mitochondrial proteins are nuclear‑encoded and must be imported post‑translationally. The <strong>TIM23 complex</strong> (translocase of the inner membrane 23) is the central inner‑membrane translocase for <strong>presequence‑containing</strong> precursor proteins. A 2024 TIM23 disease‑focused mini‑review estimates that TIM23 mediates import of <strong>~60% of the mitochondrial proteome</strong>, including the majority of matrix proteins and many inner‑membrane proteins, plus a subset of intermembrane space (IMS) proteins (jain2024hotspotsfordiseasecausing pages 2-4).</p>
+<h4 id="12-tim23-functional-modes-motor-vs-sorting">1.2 TIM23 functional modes: motor vs sorting</h4>
+<p>TIM23 is described as operating in at least two coupled modes:<br />
+* <strong>TIM23MOTOR</strong>: association of the TIM23 core with the <strong>PAM</strong> (presequence translocase‑associated motor) to drive <strong>matrix import</strong> (ATP‑dependent mtHsp70 pulling plus inner‑membrane potential). (jain2024hotspotsfordiseasecausing pages 2-4, chaudhuri2020tim17updatesa pages 6-8)<br />
+* <strong>TIM23SORT</strong>: association with factors such as <strong>Tim21</strong> and <strong>Mgr2</strong> (yeast) to favor <strong>lateral insertion/sorting</strong> of some inner‑membrane proteins and certain IMS sorting events. (jain2024hotspotsfordiseasecausing pages 2-4, chaudhuri2020tim17updatesa pages 6-8)</p>
+<p>Human complexes are discussed in analogous terms, with TIMM17 paralogs contributing to different assemblies (jain2024hotspotsfordiseasecausing pages 2-4).</p>
+<h4 id="13-what-timm17a-is-molecular-role">1.3 What TIMM17A is (molecular role)</h4>
+<p>TIMM17A is an <strong>integral mitochondrial inner membrane</strong> component of the <strong>TIM23 core</strong> (maruszczak2024structurepredictionanalysis pages 2-3, chaudhuri2020tim17updatesa pages 6-8). Tim17 family reviews describe a conserved <strong>four‑transmembrane helix topology</strong>, classically with both N‑ and C‑termini in the <strong>IMS</strong> (chaudhuri2020tim17updatesa pages 8-10). TIMM17A does not catalyze an enzymatic reaction; rather, it contributes to the <strong>protein‑conducting import channel/cavity</strong> and/or its regulation within TIM23 (maruszczak2024structurepredictionanalysis pages 2-3, sim2023structuralbasisof pages 1-4).</p>
+<h3 id="2-timm17a-complex-membership-interaction-partners-and-localization">2) TIMM17A complex membership, interaction partners, and localization</h3>
+<h4 id="21-core-complex-membership-and-paralog-specialization-timm17a-vs-timm17b">2.1 Core complex membership and paralog specialization (TIMM17A vs TIMM17B)</h4>
+<p>Humans have <strong>two Tim17 orthologs</strong>, TIMM17A and TIMM17B, which form <strong>two pools/variants</strong> of the TIM23 core complex in combination with TIMM23 (maruszczak2024structurepredictionanalysis pages 2-3, maruszczak2024structurepredictionanalysis pages 1-2). The variants are predicted to be <strong>highly similar structurally</strong> (maruszczak2024structurepredictionanalysis pages 3-5, maruszczak2024structurepredictionanalysis pages 9-11).</p>
+<p>A 2024 Genes mini‑review further describes human TIM23 “motor” assemblies in which <strong>TIMM17A defines translocase A</strong> together with <strong>DNAJC15</strong>, while TIMM17B isoforms pair with <strong>DNAJC19</strong> to define other assemblies (translocases B1/B2) (jain2024hotspotsfordiseasecausing pages 2-4). In review literature, translocase‑B is described as constitutive/essential for normal function, while translocase‑A (TIMM17A‑linked) is dispensable under normal conditions but important for <strong>oncogenic proliferation contexts</strong> (chaudhuri2020tim17updatesa pages 6-8).</p>
+<h4 id="22-romo1-as-a-human-tim23-constituent-quantitative-evidence">2.2 ROMO1 as a human TIM23 constituent (quantitative evidence)</h4>
+<p>A key human‑cell biochemical study defined <strong>ROMO1</strong> as a constituent of the human presequence translocase and recovered <strong>TIM17A</strong> in TIM23/TIM21/TIM50 purifications by SILAC‑MS, placing TIMM17A within authentic human TIM23 complexes (richter2019romo1isa pages 1-2).</p>
+<p>Importantly, the same work provides quantitative complex‑association measurements: approximately <strong>25%</strong> of mitochondrial ROMO1 co‑isolated with <strong>TIM23‑FLAG</strong>, and ~<strong>50%</strong> of ROMO1 co‑isolated with <strong>TIM21‑FLAG</strong> (richter2019romo1isa pages 2-4). These results support ROMO1 as a stable, though dynamic, component of TIM23 assemblies that include TIM17A/B, TIM50, TIM44, and TIM21 (richter2019romo1isa pages 2-4).</p>
+<h3 id="3-mechanistic-function-what-timm17a-does-in-preprotein-import">3) Mechanistic function: what TIMM17A does in preprotein import</h3>
+<h4 id="31-revised-channel-model-tim17-cavity-as-central-translocation-route">3.1 Revised channel model: Tim17 cavity as central translocation route</h4>
+<p>A major conceptual shift in 2023–2024 TIM23 biology is the growing structural/biochemical evidence that <strong>Tim17</strong>, rather than Tim23, provides much of the <strong>polypeptide translocation path</strong>.</p>
+<p>A 2023 cryo‑EM study of the TIM23 complex (in yeast) reports that Tim17 and Tim23 form a stable <strong>1:1 heterodimer</strong> in an idle state and identifies a <strong>laterally open cavity in Tim17</strong>, with Mgr2 positioned at this lateral opening; the authors propose enclosure of the Tim17 cavity provides a plausible route for polypeptide translocation (sim2023structuralbasisof pages 1-4). The same source argues against interpreting Tim23 as the sole/primary aqueous channel because prior electrophysiology often relied on refolded Tim23 preparations and lacks gold‑standard native‑membrane patch clamp validation (sim2023structuralbasisof pages 1-4).</p>
+<p>Human‑focused modeling reinforces this reinterpretation: a 2024 structure‑prediction analysis emphasizes that recent structural and biochemical work places Tim17 as having a primary role in translocation, forming a cavity large enough to accommodate translocating proteins (maruszczak2024structurepredictionanalysis pages 1-2).</p>
+<h4 id="32-timm17a-structural-features-relevant-to-substrate-handling">3.2 TIMM17A structural features relevant to substrate handling</h4>
+<p>The 2024 human TIM23 architecture analysis attributes conserved features to TIMM17A that are relevant to presequence import: an <strong>IMS‑exposed acidic patch</strong> that could attract positively charged presequences, a <strong>hydrophobic cavity lining</strong> conducive to polypeptide passage, and an <strong>intramolecular disulfide bond</strong> described as essential for function (maruszczak2024structurepredictionanalysis pages 2-3). These features are consistent with a role in guiding positively charged presequences into a membrane‑embedded import cavity (maruszczak2024structurepredictionanalysis pages 2-3).</p>
+<h4 id="33-substrate-classes-what-is-imported-and-where-timm17a-acts">3.3 Substrate classes (what is imported) and where TIMM17A acts</h4>
+<p>TIM23 imports <strong>presequence‑containing precursors</strong> destined to the <strong>matrix</strong> and many destined to the <strong>inner membrane</strong>, with some IMS sorting, representing a large fraction of mitochondrial proteins (~60% as above) (jain2024hotspotsfordiseasecausing pages 2-4). TIMM17A acts at the <strong>inner membrane</strong> as part of the translocation pore/cavity and as a platform for mode switching between motor‑driven matrix import and lateral sorting modes, through interactions with accessory factors (jain2024hotspotsfordiseasecausing pages 2-4, sim2023structuralbasisof pages 1-4).</p>
+<h3 id="4-regulation-of-timm17a-abundance-and-activity-stress-proteolysis-and-signaling">4) Regulation of TIMM17A abundance and activity (stress, proteolysis, and signaling)</h3>
+<h4 id="41-yme1ldependent-proteolytic-control-of-timm17a">4.1 YME1L‑dependent proteolytic control of TIMM17A</h4>
+<p>Multiple sources support <strong>protease‑mediated regulation</strong> of TIMM17A, particularly via the i‑AAA protease <strong>YME1L</strong>.</p>
+<p>A high‑impact 2019 Nature study demonstrates that cellular stresses that inhibit mTORC1 (including nutrient limitation and hypoxia) can induce acute, <strong>YME1L‑dependent proteolysis</strong> of TIMM17A among a set of substrates, linking mitochondrial membrane lipid composition and nutrient signaling to regulated degradation of inner‑membrane proteins (macvicar2019lipidsignallingdrives pages 3-4). The authors also reconstituted TIMM17A proteolysis in liposomes as an ATP‑dependent YME1L activity (with an inactive catalytic mutant control), supporting a direct proteolytic mechanism (macvicar2019lipidsignallingdrives pages 3-4). The study provides quantitative experimental context including immunoblot quantification for TIMM17A under hypoxia with <strong>n=3</strong> independent experiments and points to public proteomics/transcriptomics datasets (PRIDE: <strong>PXD011750</strong>, <strong>PXD014405</strong>; GEO: <strong>GSE133753</strong>) for deeper quantitative evaluation (macvicar2019lipidsignallingdrives pages 10-14).</p>
+<p>A 2024 Biochemical Society Transactions mini‑review synthesizes these findings, stating that Tim17A is a <strong>stress‑induced degradation substrate of YME1L</strong> in human cells, and that TIMM17A and TIMM23 are down‑regulated under hypoxia in WT but not Yme1l−/− contexts (kan2024roleofyme1 pages 3-4).</p>
+<h4 id="42-coupling-of-import-and-proteostasis-via-romo1yme1l-feedback">4.2 Coupling of import and proteostasis via ROMO1–YME1L feedback</h4>
+<p>ROMO1 was identified as a TIM23 constituent required for efficient import of the YME1L protease itself; ROMO1 is also short‑lived and accumulates in YME1L knockout cells, indicating YME1L‑dependent ROMO1 turnover (richter2019romo1isa pages 9-11). This creates a plausible <strong>feedback loop</strong> in which import machinery composition affects import of quality‑control proteases, and proteases in turn remodel the import machinery (richter2019romo1isa pages 9-11, kan2024roleofyme1 pages 3-4). TIM17A is listed among known YME1L substrates, reinforcing the link between import channel composition and proteolytic remodeling (richter2019romo1isa pages 2-4).</p>
+<h4 id="43-protein-import-machinery-as-a-stresssignaling-hub-2023-perspective">4.3 Protein import machinery as a stress‑signaling hub (2023 perspective)</h4>
+<p>A 2023 review frames mitochondrial protein import as a <strong>signaling hub</strong>, where import impairment triggers proteostatic and metabolic responses beyond mitochondria (maruszczak2024structurepredictionanalysis pages 1-2). Within that context, TIMM17A is specifically mentioned as an import component subject to stress‑linked remodeling (including cleavage/turnover of TIMM17A as part of adaptive responses) (maruszczak2024structurepredictionanalysis pages 2-3).</p>
+<h3 id="5-recent-developments-prioritize-20232024">5) Recent developments (prioritize 2023–2024)</h3>
+<h4 id="51-2023-cryoem-structure-revises-the-tim23-channel-assumption">5.1 2023: Cryo‑EM structure revises the “Tim23 channel” assumption</h4>
+<p>The 2023 Nature cryo‑EM work is widely treated as a mechanistic inflection point, presenting a Tim17‑centered cavity model and explicitly questioning whether prior Tim23‑only channel models reflect the native state (sim2023structuralbasisof pages 1-4).</p>
+<h4 id="52-2024-human-tim23-core-architecture-modeling-timm17a-vs-timm17b-comparison">5.2 2024: Human TIM23 core architecture modeling, TIMM17A vs TIMM17B comparison</h4>
+<p>A 2024 FEBS Open Bio study provides a human‑focused structural interpretation: TIMM17A (UniProt Q99595) and TIMM17B form two predicted human TIM23 core variants with TIMM23 and ROMO1 and show high structural conservation relative to yeast TIM23 (maruszczak2024structurepredictionanalysis pages 2-3, maruszczak2024structurepredictionanalysis pages 3-5). It also compiles functional distinctions discussed in the literature, including the idea that TIMM17B may be more “housekeeping” whereas TIMM17A may contribute to regulated remodeling and stress/cancer contexts (maruszczak2024structurepredictionanalysis pages 3-5).</p>
+<h4 id="53-2024-disease-mutation-landscape-review-of-tim23-complex">5.3 2024: Disease mutation landscape review of TIM23 complex</h4>
+<p>A 2024 Genes mini‑review synthesizes pathogenic‑variant hotspots across TIM23 components and places TIMM17A within the landscape of TIM23 motor/sorting assemblies, emphasizing that Tim17 can act as the channel for TIM23 motor activity and summarizing evidence linking high TIMM17A expression with adverse outcomes in breast cancer (jain2024hotspotsfordiseasecausing pages 2-4, jain2024hotspotsfordiseasecausing pages 11-12).</p>
+<h3 id="6-current-applications-and-realworld-implementations">6) Current applications and real‑world implementations</h3>
+<h4 id="61-variant-interpretation-and-mitochondrial-disease-mechanisms">6.1 Variant interpretation and mitochondrial disease mechanisms</h4>
+<p>Although TIMM17A itself is not emphasized as a dominant monogenic disease hotspot in the TIM23 complex compared with other components (e.g., Tim50/PAM factors discussed elsewhere), TIM23 dysfunction is a clinically important mechanism in mitochondrial disease, and mechanistic mapping of TIM23 substrate classes (matrix vs lateral insertion) can directly inform phenotypic interpretation (jain2024hotspotsfordiseasecausing pages 2-4). Human TIM23 biology is also increasingly approached using proteomics to map downstream consequences of reduced import and altered translocase composition (macvicar2019lipidsignallingdrives pages 10-14).</p>
+<h4 id="62-cancer-biology-and-biomarker-hypotheses">6.2 Cancer biology and biomarker hypotheses</h4>
+<p>Review sources cite clinical associations that <strong>high TIMM17A expression</strong> is linked with <strong>adverse pathological/clinical outcomes</strong> and aggressiveness in human breast cancer (jain2024hotspotsfordiseasecausing pages 11-12). Separately, translocase‑A (TIMM17A‑linked) is described as dispensable for normal mitochondrial function but required for <strong>oncogenic proliferation</strong> in review literature, suggesting a potential vulnerability axis in cancer metabolism/biogenesis (chaudhuri2020tim17updatesa pages 6-8).</p>
+<h4 id="63-experimental-and-systems-applications">6.3 Experimental and systems applications</h4>
+<p>The 2019 YME1L study explicitly provides public quantitative datasets (PRIDE proteomics and GEO transcriptomics) that can be mined to evaluate TIMM17A abundance and remodeling across hypoxia/nutrient conditions, enabling reproducible integrative functional annotation (macvicar2019lipidsignallingdrives pages 10-14).</p>
+<h3 id="7-expert-opinions-and-analysis-authoritative-interpretations">7) Expert opinions and analysis (authoritative interpretations)</h3>
+<p>A consistent theme across recent expert syntheses is that TIM23 is not a static pore but a <strong>dynamic translocation system</strong> whose <strong>core architecture is conserved</strong> yet whose functional specificity can be tuned by paralog choice (TIMM17A vs TIMM17B) and accessory subunits (ROMO1/TIM21/PAM). The 2024 human structure‑prediction study explicitly frames an open problem: TIMM17A‑ and TIMM17B‑containing cores are nearly identical structurally, so differences likely arise from <strong>regulatory factors</strong> and context‑specific remodeling rather than gross architectural differences (maruszczak2024structurepredictionanalysis pages 9-11). The 2023 cryo‑EM work similarly emphasizes unresolved mechanistic gaps (e.g., initial presequence engagement with the Tim17 cavity and dynamics during translocation) despite clearer structural grounding (sim2023structuralbasisof pages 1-4).</p>
+<h3 id="8-key-statistics-and-quantitative-data-from-recentprimary-evidence">8) Key statistics and quantitative data (from recent/primary evidence)</h3>
+<ul>
+<li>TIM23 is reported to import <strong>~60% of the mitochondrial proteome</strong> (matrix + many inner‑membrane proteins; some IMS proteins) (jain2024hotspotsfordiseasecausing pages 2-4).</li>
+<li>In human‑cell purifications, ROMO1 co‑isolates at approximately <strong>25% with TIM23‑FLAG</strong> and <strong>~50% with TIM21‑FLAG</strong>, consistent with ROMO1 as a TIM23 constituent interacting with TIM21 and the TIM23 core that includes TIM17A/B (richter2019romo1isa pages 2-4, richter2019romo1isa media 2e38f9b5).</li>
+<li>Hypoxia/HIF1α and nutrient signaling regulate YME1L‑dependent remodeling including TIMM17A abundance; quantitative immunoblotting context includes <strong>n=3</strong> independent experiments and linked public omics datasets for reanalysis (macvicar2019lipidsignallingdrives pages 10-14).</li>
+</ul>
+<h3 id="9-visual-evidence-human-tim23-composition-and-romo1-association">9) Visual evidence (human TIM23 composition and ROMO1 association)</h3>
+<p>Richter et al. provide a schematic of the human TIM23 presequence translocase including TIM17A/B and ROMO1 and quantitative ROMO1 co‑purification with TIM23 and TIM21 (richter2019romo1isa media 2e38f9b5).</p>
+<h3 id="10-summary-functional-annotation-concise">10) Summary functional annotation (concise)</h3>
+<p><strong>TIMM17A (UniProt Q99595)</strong> encodes an integral <strong>mitochondrial inner membrane</strong> protein of the <strong>TIM23 presequence translocase</strong>. It participates in import of nuclear‑encoded, <strong>presequence‑containing precursor proteins</strong> into the <strong>mitochondrial matrix</strong> and for <strong>inner‑membrane insertion</strong>, acting as a core translocation component (channel/cavity) within TIM23 motor assemblies and coordinating with accessory factors (TIM21/ROMO1/PAM) that tune sorting versus matrix import. Its abundance is <strong>stress‑regulated</strong>, notably via <strong>YME1L‑dependent proteolysis</strong> in response to nutrient/hypoxia signaling, providing a mechanism to remodel mitochondrial biogenesis/import capacity. (maruszczak2024structurepredictionanalysis pages 2-3, jain2024hotspotsfordiseasecausing pages 2-4, sim2023structuralbasisof pages 1-4, macvicar2019lipidsignallingdrives pages 3-4)</p>
+<hr />
+<h3 id="embedded-evidence-table">Embedded evidence table</h3>
+<table>
+<thead>
+<tr>
+<th>Aspect</th>
+<th>Key points</th>
+<th>Best recent source(s) with year/URL/DOI</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Identity</td>
+<td>Human <strong>TIMM17A</strong> encodes mitochondrial import inner membrane translocase subunit <strong>Tim17-A</strong>; UniProt <strong>Q99595</strong>. It is one of two human Tim17 paralogs (<strong>TIMM17A</strong>, <strong>TIMM17B</strong>) in the <strong>Tim17/Tim22/Tim23 family</strong> and a core subunit of the <strong>TIM23 presequence translocase</strong>. TIMM17A and TIMM17B share ~<strong>76%</strong> sequence identity. (maruszczak2024structurepredictionanalysis pages 2-3, maruszczak2024structurepredictionanalysis pages 3-5)</td>
+<td>Maruszczak et al., <strong>2024</strong>, FEBS Open Bio, https://doi.org/10.1002/2211-5463.13840, DOI: 10.1002/2211-5463.13840</td>
+</tr>
+<tr>
+<td>Subcellular localization / topology</td>
+<td>TIMM17A is a <strong>mitochondrial inner membrane</strong> protein. Tim17-family proteins show a conserved <strong>4-transmembrane-helix topology</strong> with both <strong>N- and C-termini in the intermembrane space</strong>; TIMM17A is tightly anchored in the inner membrane as part of the import channel machinery. (chaudhuri2020tim17updatesa pages 8-10, chaudhuri2020tim17updatesa pages 6-8)</td>
+<td>Chaudhuri et al., <strong>2020</strong>, Biomolecules, https://doi.org/10.3390/biom10121643, DOI: 10.3390/biom10121643</td>
+</tr>
+<tr>
+<td>Complex membership</td>
+<td>TIMM17A forms one of the two human <strong>core TIM23</strong> variants with <strong>TIMM23</strong> and <strong>ROMO1</strong>; the human core also associates with <strong>TIM44</strong>, <strong>TIM50</strong>, <strong>TIM21</strong>, and mtHsp70-linked motor components. Human TIM23 assemblies can be described as <strong>translocase-A</strong> (TIMM17A-containing; linked with <strong>DNAJC15</strong>) versus <strong>translocase-B</strong> (TIMM17B-containing; linked with <strong>DNAJC19</strong> isoforms). (maruszczak2024structurepredictionanalysis pages 2-3, jain2024hotspotsfordiseasecausing pages 2-4, richter2019romo1isa pages 1-2, richter2019romo1isa pages 2-4, richter2019romo1isa media 2e38f9b5)</td>
+<td>Maruszczak et al., <strong>2024</strong>, FEBS Open Bio, https://doi.org/10.1002/2211-5463.13840, DOI: 10.1002/2211-5463.13840; Jain et al., <strong>2024</strong>, Genes, https://doi.org/10.3390/genes15121534, DOI: 10.3390/genes15121534; Richter et al., <strong>2019</strong>, J Cell Biol, https://doi.org/10.1083/jcb.201806093, DOI: 10.1083/jcb.201806093</td>
+</tr>
+<tr>
+<td>Key interaction partners</td>
+<td>Best-supported partners include <strong>TIMM23</strong> (stable Tim17–Tim23 core), <strong>ROMO1</strong> (human Mgr2-like subunit), <strong>TIM50</strong>, <strong>TIM21</strong>, <strong>TIM44</strong>, and <strong>HSP70/PAM-related factors</strong> in the import motor. Quantitatively, ~<strong>25%</strong> of mitochondrial ROMO1 co-isolated with <strong>TIM23-FLAG</strong>, and ~<strong>50%</strong> co-isolated with <strong>TIM21-FLAG</strong> in human-cell purifications, supporting ROMO1’s association with the human TIM23 machinery. (maruszczak2024structurepredictionanalysis pages 1-2, richter2019romo1isa pages 2-4, richter2019romo1isa media 2e38f9b5)</td>
+<td>Richter et al., <strong>2019</strong>, J Cell Biol, https://doi.org/10.1083/jcb.201806093, DOI: 10.1083/jcb.201806093; Maruszczak et al., <strong>2024</strong>, FEBS Open Bio, https://doi.org/10.1002/2211-5463.13840, DOI: 10.1002/2211-5463.13840</td>
+</tr>
+<tr>
+<td>Mechanistic role</td>
+<td>Current model places <strong>Tim17/TIMM17A</strong> at the center of the translocation path: recent structural work argues Tim17 forms a <strong>laterally open cavity/channel</strong> large enough to accommodate translocating polypeptides, while Tim23 is more constrained and likely has a more regulatory/architectural role. Conserved TIMM17A features include an <strong>IMS acidic patch</strong> that can attract positively charged <strong>presequences</strong>, a <strong>hydrophobic cavity lining</strong>, and an <strong>intramolecular disulfide bond</strong> important for function. (maruszczak2024structurepredictionanalysis pages 2-3, maruszczak2024structurepredictionanalysis pages 1-2, sim2023structuralbasisof pages 1-4)</td>
+<td>Sim et al., <strong>2023</strong>, Nature, https://doi.org/10.1038/s41586-023-06239-6, DOI: 10.1038/s41586-023-06239-6; Maruszczak et al., <strong>2024</strong>, FEBS Open Bio, https://doi.org/10.1002/2211-5463.13840, DOI: 10.1002/2211-5463.13840</td>
+</tr>
+<tr>
+<td>Functional distinction vs TIMM17B</td>
+<td>TIMM17A- and TIMM17B-containing human TIM23 complexes are predicted to be <strong>structurally very similar</strong>, but functional specialization is reported: <strong>TIMM17B</strong> is often described as the more <strong>housekeeping/canonical</strong> import variant, whereas <strong>TIMM17A</strong> has a more <strong>specialized/regulatory</strong> role and is linked to <strong>translocase-A</strong> and oncogenic proliferation contexts. (maruszczak2024structurepredictionanalysis pages 3-5, chaudhuri2020tim17updatesa pages 8-10, chaudhuri2020tim17updatesa pages 6-8)</td>
+<td>Maruszczak et al., <strong>2024</strong>, FEBS Open Bio, https://doi.org/10.1002/2211-5463.13840, DOI: 10.1002/2211-5463.13840; Chaudhuri et al., <strong>2020</strong>, Biomolecules, https://doi.org/10.3390/biom10121643, DOI: 10.3390/biom10121643</td>
+</tr>
+<tr>
+<td>Regulation / proteolysis</td>
+<td>TIMM17A is regulated by mitochondrial quality-control proteases. It is reported as a <strong>YME1L substrate</strong>, and stress-adaptive remodeling of import can include <strong>selective turnover of TIMM17A</strong> to reduce mitochondrial import and alter metabolic state. In ROMO1 studies, <strong>ROMO1</strong> itself is also short-lived and <strong>YME1L-regulated</strong>, linking TIMM17A-containing TIM23 assemblies to proteostatic control. (maruszczak2024structurepredictionanalysis pages 2-3, richter2019romo1isa pages 1-2, richter2019romo1isa pages 9-11, richter2019romo1isa pages 2-4)</td>
+<td>Richter et al., <strong>2019</strong>, J Cell Biol, https://doi.org/10.1083/jcb.201806093, DOI: 10.1083/jcb.201806093; Maruszczak et al., <strong>2024</strong>, FEBS Open Bio, https://doi.org/10.1002/2211-5463.13840, DOI: 10.1002/2211-5463.13840</td>
+</tr>
+<tr>
+<td>Disease / cancer associations</td>
+<td>No recurrent monogenic <strong>TIMM17A</strong> disease hotspot is established in current TIM23 disease reviews, but <strong>high TIMM17A expression</strong> has been associated with <strong>adverse outcomes and aggressiveness in breast cancer</strong>. Broader TIM23-complex dysfunction is clinically important in mitochondrial disease, and TIMM17A-containing translocase-A has been described as required for <strong>oncogenic cell proliferation</strong> in review literature. (jain2024hotspotsfordiseasecausing pages 2-4, jain2024hotspotsfordiseasecausing pages 11-12, chaudhuri2020tim17updatesa pages 6-8)</td>
+<td>Jain et al., <strong>2024</strong>, Genes, https://doi.org/10.3390/genes15121534, DOI: 10.3390/genes15121534; Chaudhuri et al., <strong>2020</strong>, Biomolecules, https://doi.org/10.3390/biom10121643, DOI: 10.3390/biom10121643</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the verified identity, localization, complex membership, mechanism, regulation, and disease relevance of human TIMM17A. It highlights the most useful recent sources for interpreting TIMM17A as a core TIM23 presequence-translocase subunit.</em></p>
+<p>References</p>
+<ol>
+<li>
+<p>(maruszczak2024structurepredictionanalysis pages 2-3): Klaudia K. Maruszczak, Piotr Draczkowski, Artur Wnorowski, and Agnieszka Chacinska. Structure prediction analysis of human core tim23 complex reveals conservation of the protein translocation mechanism. FEBS Open Bio, 14:1656-1667, Jun 2024. URL: https://doi.org/10.1002/2211-5463.13840, doi:10.1002/2211-5463.13840. This article has 13 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(maruszczak2024structurepredictionanalysis pages 3-5): Klaudia K. Maruszczak, Piotr Draczkowski, Artur Wnorowski, and Agnieszka Chacinska. Structure prediction analysis of human core tim23 complex reveals conservation of the protein translocation mechanism. FEBS Open Bio, 14:1656-1667, Jun 2024. URL: https://doi.org/10.1002/2211-5463.13840, doi:10.1002/2211-5463.13840. This article has 13 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(jain2024hotspotsfordiseasecausing pages 2-4): Sahil Jain, Eyal Paz, and Abdussalam Azem. Hotspots for disease-causing mutations in the mitochondrial tim23 import complex. Genes, 15:1534, Nov 2024. URL: https://doi.org/10.3390/genes15121534, doi:10.3390/genes15121534. This article has 1 citations.</p>
+</li>
+<li>
+<p>(chaudhuri2020tim17updatesa pages 6-8): Minu Chaudhuri, Chauncey Darden, Fidel Soto Gonzalez, Ujjal K. Singha, Linda Quinones, and Anuj Tripathi. Tim17 updates: a comprehensive review of an ancient mitochondrial protein translocator. Biomolecules, 10:1643, Dec 2020. URL: https://doi.org/10.3390/biom10121643, doi:10.3390/biom10121643. This article has 24 citations.</p>
+</li>
+<li>
+<p>(chaudhuri2020tim17updatesa pages 8-10): Minu Chaudhuri, Chauncey Darden, Fidel Soto Gonzalez, Ujjal K. Singha, Linda Quinones, and Anuj Tripathi. Tim17 updates: a comprehensive review of an ancient mitochondrial protein translocator. Biomolecules, 10:1643, Dec 2020. URL: https://doi.org/10.3390/biom10121643, doi:10.3390/biom10121643. This article has 24 citations.</p>
+</li>
+<li>
+<p>(sim2023structuralbasisof pages 1-4): Sue Im Sim, Yuanyuan Chen, Diane L. Lynch, James C. Gumbart, and Eunyong Park. Structural basis of mitochondrial protein import by the tim23 complex. Nature, 621:620-626, Jun 2023. URL: https://doi.org/10.1038/s41586-023-06239-6, doi:10.1038/s41586-023-06239-6. This article has 105 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(maruszczak2024structurepredictionanalysis pages 1-2): Klaudia K. Maruszczak, Piotr Draczkowski, Artur Wnorowski, and Agnieszka Chacinska. Structure prediction analysis of human core tim23 complex reveals conservation of the protein translocation mechanism. FEBS Open Bio, 14:1656-1667, Jun 2024. URL: https://doi.org/10.1002/2211-5463.13840, doi:10.1002/2211-5463.13840. This article has 13 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(maruszczak2024structurepredictionanalysis pages 9-11): Klaudia K. Maruszczak, Piotr Draczkowski, Artur Wnorowski, and Agnieszka Chacinska. Structure prediction analysis of human core tim23 complex reveals conservation of the protein translocation mechanism. FEBS Open Bio, 14:1656-1667, Jun 2024. URL: https://doi.org/10.1002/2211-5463.13840, doi:10.1002/2211-5463.13840. This article has 13 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(richter2019romo1isa pages 1-2): Frank Richter, Sven Dennerlein, Miroslav Nikolov, Daniel C. Jans, Nataliia Naumenko, Abhishek Aich, Thomas MacVicar, Andreas Linden, Stefan Jakobs, Henning Urlaub, Thomas Langer, and Peter Rehling. Romo1 is a constituent of the human presequence translocase required for yme1l protease import. The Journal of Cell Biology, 218:598-614, Dec 2019. URL: https://doi.org/10.1083/jcb.201806093, doi:10.1083/jcb.201806093. This article has 74 citations.</p>
+</li>
+<li>
+<p>(richter2019romo1isa pages 2-4): Frank Richter, Sven Dennerlein, Miroslav Nikolov, Daniel C. Jans, Nataliia Naumenko, Abhishek Aich, Thomas MacVicar, Andreas Linden, Stefan Jakobs, Henning Urlaub, Thomas Langer, and Peter Rehling. Romo1 is a constituent of the human presequence translocase required for yme1l protease import. The Journal of Cell Biology, 218:598-614, Dec 2019. URL: https://doi.org/10.1083/jcb.201806093, doi:10.1083/jcb.201806093. This article has 74 citations.</p>
+</li>
+<li>
+<p>(macvicar2019lipidsignallingdrives pages 3-4): Thomas MacVicar, Yohsuke Ohba, Hendrik Nolte, Fiona Carola Mayer, Takashi Tatsuta, Hans-Georg Sprenger, Barbara Lindner, Yue Zhao, Jiahui Li, Christiane Bruns, Marcus Krüger, Markus Habich, Jan Riemer, Robin Schwarzer, Manolis Pasparakis, Sinika Henschke, Jens C. Brüning, Nicola Zamboni, and Thomas Langer. Lipid signalling drives proteolytic rewiring of mitochondria by yme1l. Nature, 575:361-365, Nov 2019. URL: https://doi.org/10.1038/s41586-019-1738-6, doi:10.1038/s41586-019-1738-6. This article has 207 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(macvicar2019lipidsignallingdrives pages 10-14): Thomas MacVicar, Yohsuke Ohba, Hendrik Nolte, Fiona Carola Mayer, Takashi Tatsuta, Hans-Georg Sprenger, Barbara Lindner, Yue Zhao, Jiahui Li, Christiane Bruns, Marcus Krüger, Markus Habich, Jan Riemer, Robin Schwarzer, Manolis Pasparakis, Sinika Henschke, Jens C. Brüning, Nicola Zamboni, and Thomas Langer. Lipid signalling drives proteolytic rewiring of mitochondria by yme1l. Nature, 575:361-365, Nov 2019. URL: https://doi.org/10.1038/s41586-019-1738-6, doi:10.1038/s41586-019-1738-6. This article has 207 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(kan2024roleofyme1 pages 3-4): Kwan Ting Kan, Joel Wilcock, and Hui Lu. Role of yme1 in mitochondrial protein homeostasis: from regulation of protein import, oxphos function to lipid synthesis and mitochondrial dynamics. Biochemical Society Transactions, 52:1539-1548, Jun 2024. URL: https://doi.org/10.1042/bst20240450, doi:10.1042/bst20240450. This article has 9 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(richter2019romo1isa pages 9-11): Frank Richter, Sven Dennerlein, Miroslav Nikolov, Daniel C. Jans, Nataliia Naumenko, Abhishek Aich, Thomas MacVicar, Andreas Linden, Stefan Jakobs, Henning Urlaub, Thomas Langer, and Peter Rehling. Romo1 is a constituent of the human presequence translocase required for yme1l protease import. The Journal of Cell Biology, 218:598-614, Dec 2019. URL: https://doi.org/10.1083/jcb.201806093, doi:10.1083/jcb.201806093. This article has 74 citations.</p>
+</li>
+<li>
+<p>(jain2024hotspotsfordiseasecausing pages 11-12): Sahil Jain, Eyal Paz, and Abdussalam Azem. Hotspots for disease-causing mutations in the mitochondrial tim23 import complex. Genes, 15:1534, Nov 2024. URL: https://doi.org/10.3390/genes15121534, doi:10.3390/genes15121534. This article has 1 citations.</p>
+</li>
+<li>
+<p>(richter2019romo1isa media 2e38f9b5): Frank Richter, Sven Dennerlein, Miroslav Nikolov, Daniel C. Jans, Nataliia Naumenko, Abhishek Aich, Thomas MacVicar, Andreas Linden, Stefan Jakobs, Henning Urlaub, Thomas Langer, and Peter Rehling. Romo1 is a constituent of the human presequence translocase required for yme1l protease import. The Journal of Cell Biology, 218:598-614, Dec 2019. URL: https://doi.org/10.1083/jcb.201806093, doi:10.1083/jcb.201806093. This article has 74 citations.</p>
+</li>
+</ol>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>maruszczak2024structurepredictionanalysis pages 2-3</li>
+<li>maruszczak2024structurepredictionanalysis pages 3-5</li>
+<li>jain2024hotspotsfordiseasecausing pages 2-4</li>
+<li>sim2023structuralbasisof pages 1-4</li>
+<li>maruszczak2024structurepredictionanalysis pages 1-2</li>
+<li>macvicar2019lipidsignallingdrives pages 3-4</li>
+<li>macvicar2019lipidsignallingdrives pages 10-14</li>
+<li>jain2024hotspotsfordiseasecausing pages 11-12</li>
+<li>maruszczak2024structurepredictionanalysis pages 9-11</li>
+<li>https://doi.org/10.1002/2211-5463.13840,</li>
+<li>https://doi.org/10.3390/biom10121643,</li>
+<li>https://doi.org/10.3390/genes15121534,</li>
+<li>https://doi.org/10.1083/jcb.201806093,</li>
+<li>https://doi.org/10.1038/s41586-023-06239-6,</li>
+<li>https://doi.org/10.1038/s41586-019-1738-6,</li>
+<li>https://doi.org/10.1042/bst20240450,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q99595
+gene_symbol: TIMM17A
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: &gt;-
+  TIMM17A is an integral mitochondrial inner membrane subunit of the human TIM23
+  presequence translocase. It contributes to the TIM23 protein-conducting
+  channel/cavity for import of presequence-containing mitochondrial precursors,
+  especially matrix-destined proteins, and participates in TIM23 complex
+  organization and regulated remodeling of mitochondrial protein import.
+existing_annotations:
+- term:
+    id: GO:0008320
+    label: protein transmembrane transporter activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: contributes_to
+  review:
+    summary: &gt;-
+      Correct as a contributes_to molecular-function annotation. TIMM17A is a
+      TIM23 core subunit that contributes to the protein-conducting import
+      channel/cavity rather than acting as a standalone transporter.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TIMM17A/TIMM17A-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TIMM17A/TIMM17A-deep-research-falcon.md
+      supporting_text: &#34;TIMM17A is an **integral mitochondrial inner membrane** component of the **TIM23 core**&#34;
+- term:
+    id: GO:0030150
+    label: protein import into mitochondrial matrix
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: &gt;-
+      Correct core biological process. TIM23 imports presequence-containing
+      precursors into the matrix, and TIMM17A contributes to the TIM23
+      translocation path.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TIMM17A/TIMM17A-deep-research-falcon.md
+- term:
+    id: GO:0005744
+    label: TIM23 mitochondrial import inner membrane translocase complex
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: &gt;-
+      Correct complex annotation. TIMM17A is a core subunit of a human TIM23
+      variant with TIMM23 and ROMO1.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TIMM17A/TIMM17A-deep-research-falcon.md
+- term:
+    id: GO:0005743
+    label: mitochondrial inner membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  review:
+    summary: &gt;-
+      Correct UniProt-derived localization. TIMM17A is an integral mitochondrial
+      inner membrane protein with conserved Tim17-family transmembrane topology.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TIMM17A/TIMM17A-deep-research-falcon.md
+- term:
+    id: GO:0005744
+    label: TIM23 mitochondrial import inner membrane translocase complex
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  review:
+    summary: &gt;-
+      Correct InterPro-derived annotation. TIMM17A belongs to the Tim17/Tim23
+      family and is part of the TIM23 inner membrane translocase.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TIMM17A/TIMM17A-deep-research-falcon.md
+- term:
+    id: GO:0008320
+    label: protein transmembrane transporter activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  review:
+    summary: &gt;-
+      Correct when interpreted as a TIM23 subunit contribution to the
+      protein-conducting channel/cavity.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TIMM17A/TIMM17A-deep-research-falcon.md
+- term:
+    id: GO:0030150
+    label: protein import into mitochondrial matrix
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  review:
+    summary: &gt;-
+      Correct InterPro-derived process annotation for the TIM23 presequence
+      pathway. TIMM17A contributes to import of matrix-destined precursors.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TIMM17A/TIMM17A-deep-research-falcon.md
+- term:
+    id: GO:0005743
+    label: mitochondrial inner membrane
+  evidence_type: NAS
+  original_reference_id: PMID:10339406
+  review:
+    summary: &gt;-
+      Correct. The foundational human TIM23 study places Tim17-A in the
+      mitochondrial inner membrane translocase.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TIMM17A/TIMM17A-deep-research-falcon.md
+- term:
+    id: GO:0005744
+    label: TIM23 mitochondrial import inner membrane translocase complex
+  evidence_type: NAS
+  original_reference_id: PMID:10339406
+  review:
+    summary: &gt;-
+      Correct. TIMM17A is a human TIM23 core component and is consistently
+      described in recent TIM23 architecture studies.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TIMM17A/TIMM17A-deep-research-falcon.md
+- term:
+    id: GO:0006886
+    label: intracellular protein transport
+  evidence_type: NAS
+  original_reference_id: PMID:10339406
+  review:
+    summary: &gt;-
+      The annotation captures protein transport but is too broad. The specific
+      TIMM17A process is mitochondrial matrix import through TIM23.
+    action: MODIFY
+    reason: Replace broad intracellular protein transport with mitochondrial matrix import.
+    proposed_replacement_terms:
+    - id: GO:0030150
+      label: protein import into mitochondrial matrix
+    additional_reference_ids:
+    - file:human/TIMM17A/TIMM17A-deep-research-falcon.md
+- term:
+    id: GO:0030150
+    label: protein import into mitochondrial matrix
+  evidence_type: TAS
+  original_reference_id: PMID:10339406
+  review:
+    summary: &gt;-
+      Correct. TIMM17A is a TIM23 translocase subunit involved in matrix import
+      of presequence-containing precursors.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TIMM17A/TIMM17A-deep-research-falcon.md
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IDA
+  original_reference_id: GO_REF:0000052
+  review:
+    summary: &gt;-
+      Correct but too general. TIMM17A is specifically localized to the
+      mitochondrial inner membrane and TIM23 complex.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Subsumed by mitochondrial inner membrane and TIM23 complex annotations.
+    additional_reference_ids:
+    - file:human/TIMM17A/TIMM17A-deep-research-falcon.md
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: HTP
+  original_reference_id: PMID:34800366
+  review:
+    summary: &gt;-
+      High-throughput mitochondrial proteome evidence supports mitochondrial
+      localization, but the term is less specific than the inner membrane/TIM23
+      localization.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Subsumed by mitochondrial inner membrane and TIM23 complex annotations.
+    additional_reference_ids:
+    - file:human/TIMM17A/TIMM17A-deep-research-falcon.md
+- term:
+    id: GO:0005744
+    label: TIM23 mitochondrial import inner membrane translocase complex
+  evidence_type: IDA
+  original_reference_id: PMID:30598479
+  review:
+    summary: &gt;-
+      Accepted. ROMO1/TIM23 complex studies recovered TIM17A in authentic human
+      TIM23 assemblies.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TIMM17A/TIMM17A-deep-research-falcon.md
+- term:
+    id: GO:0005743
+    label: mitochondrial inner membrane
+  evidence_type: IDA
+  original_reference_id: PMID:20053669
+  review:
+    summary: &gt;-
+      Correct localization for TIMM17A as an integral TIM23 inner membrane
+      subunit.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TIMM17A/TIMM17A-deep-research-falcon.md
+- term:
+    id: GO:0005743
+    label: mitochondrial inner membrane
+  evidence_type: IDA
+  original_reference_id: PMID:10339406
+  review:
+    summary: &gt;-
+      Correct localization from the foundational human TIM23 characterization.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TIMM17A/TIMM17A-deep-research-falcon.md
+- term:
+    id: GO:0005744
+    label: TIM23 mitochondrial import inner membrane translocase complex
+  evidence_type: IDA
+  original_reference_id: PMID:10339406
+  review:
+    summary: &gt;-
+      Correct complex annotation from the foundational human TIM23
+      characterization and supported by recent TIM23 architecture literature.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TIMM17A/TIMM17A-deep-research-falcon.md
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: GO_REF:0000052
+  title: Gene Ontology annotation based on curation of immunofluorescence data
+  findings: []
+- id: PMID:10339406
+  title: Genetic and structural characterization of the human mitochondrial inner
+    membrane translocase.
+  findings: []
+- id: PMID:20053669
+  title: Role of Magmas in protein transport and human mitochondria biogenesis.
+  findings: []
+- id: PMID:30598479
+  title: ROMO1 is a constituent of the human presequence translocase required for
+    YME1L protease import.
+  findings: []
+- id: PMID:34800366
+  title: Quantitative high-confidence human mitochondrial proteome and its dynamics
+    in cellular context.
+  findings: []
+- id: file:human/TIMM17A/TIMM17A-deep-research-falcon.md
+  title: Falcon deep research report for human TIMM17A
+  findings: []
+core_functions:
+- description: &gt;-
+    TIMM17A contributes to the TIM23 presequence translocase channel/cavity at
+    the mitochondrial inner membrane, supporting import of presequence-containing
+    nuclear-encoded precursors into the matrix and sorting through TIM23.
+  supported_by:
+  - reference_id: file:human/TIMM17A/TIMM17A-deep-research-falcon.md
+    supporting_text: &#34;TIMM17A is an **integral mitochondrial inner membrane** component of the **TIM23 core**&#34;
+  - reference_id: file:human/TIMM17A/TIMM17A-deep-research-falcon.md
+    supporting_text: &#34;TIM23 imports **presequence‑containing precursors** destined to the **matrix** and many destined to the **inner membrane**&#34;
+  - reference_id: file:human/TIMM17A/TIMM17A-deep-research-falcon.md
+    supporting_text: &#34;TIMM17A acts at the **inner membrane** as part of the translocation pore/cavity&#34;
+  contributes_to_molecular_function:
+    id: GO:0008320
+    label: protein transmembrane transporter activity
+  directly_involved_in:
+  - id: GO:0030150
+    label: protein import into mitochondrial matrix
+  locations:
+  - id: GO:0005743
+    label: mitochondrial inner membrane
+  in_complex:
+    id: GO:0005744
+    label: TIM23 mitochondrial import inner membrane translocase complex
+proposed_new_terms: []
+suggested_questions:
+- question: &gt;-
+    Which TIMM17A-specific surfaces distinguish translocase-A regulation from
+    TIMM17B-containing housekeeping TIM23 complexes?
+  experts: []
+- question: &gt;-
+    How does YME1L-dependent TIMM17A turnover remodel the substrate spectrum of
+    human TIM23 under hypoxia or nutrient stress?
+  experts: []
+suggested_experiments:
+- hypothesis: &gt;-
+    TIMM17A-specific structural features tune TIM23 matrix import and stress
+    remodeling independently of core TIM23 assembly.
+  description: &gt;-
+    Use endogenous TIMM17A knockout/rescue with TIMM17A/TIMM17B swap and
+    structure-guided mutants, then assay TIM23 complex composition, matrix
+    precursor import, YME1L-dependent turnover, and stress-dependent proteome
+    remodeling.
+  experiment_type: endogenous rescue and mitochondrial import assay
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/human/TIMM17A/TIMM17A-ai-review.yaml
+++ b/genes/human/TIMM17A/TIMM17A-ai-review.yaml
@@ -1,11 +1,16 @@
 id: Q99595
 gene_symbol: TIMM17A
 product_type: PROTEIN
-status: INITIALIZED
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
-description: 'TODO: Add description for TIMM17A'
+description: >-
+  TIMM17A is an integral mitochondrial inner membrane subunit of the human TIM23
+  presequence translocase. It contributes to the TIM23 protein-conducting
+  channel/cavity for import of presequence-containing mitochondrial precursors,
+  especially matrix-destined proteins, and participates in TIM23 complex
+  organization and regulated remodeling of mitochondrial protein import.
 existing_annotations:
 - term:
     id: GO:0008320
@@ -14,136 +19,215 @@ existing_annotations:
   original_reference_id: GO_REF:0000033
   qualifier: contributes_to
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Correct as a contributes_to molecular-function annotation. TIMM17A is a
+      TIM23 core subunit that contributes to the protein-conducting import
+      channel/cavity rather than acting as a standalone transporter.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TIMM17A/TIMM17A-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TIMM17A/TIMM17A-deep-research-falcon.md
+      supporting_text: "TIMM17A is an **integral mitochondrial inner membrane** component of the **TIM23 core**"
 - term:
     id: GO:0030150
     label: protein import into mitochondrial matrix
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Correct core biological process. TIM23 imports presequence-containing
+      precursors into the matrix, and TIMM17A contributes to the TIM23
+      translocation path.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TIMM17A/TIMM17A-deep-research-falcon.md
 - term:
     id: GO:0005744
     label: TIM23 mitochondrial import inner membrane translocase complex
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Correct complex annotation. TIMM17A is a core subunit of a human TIM23
+      variant with TIMM23 and ROMO1.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TIMM17A/TIMM17A-deep-research-falcon.md
 - term:
     id: GO:0005743
     label: mitochondrial inner membrane
   evidence_type: IEA
   original_reference_id: GO_REF:0000044
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Correct UniProt-derived localization. TIMM17A is an integral mitochondrial
+      inner membrane protein with conserved Tim17-family transmembrane topology.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TIMM17A/TIMM17A-deep-research-falcon.md
 - term:
     id: GO:0005744
     label: TIM23 mitochondrial import inner membrane translocase complex
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Correct InterPro-derived annotation. TIMM17A belongs to the Tim17/Tim23
+      family and is part of the TIM23 inner membrane translocase.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TIMM17A/TIMM17A-deep-research-falcon.md
 - term:
     id: GO:0008320
     label: protein transmembrane transporter activity
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Correct when interpreted as a TIM23 subunit contribution to the
+      protein-conducting channel/cavity.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TIMM17A/TIMM17A-deep-research-falcon.md
 - term:
     id: GO:0030150
     label: protein import into mitochondrial matrix
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Correct InterPro-derived process annotation for the TIM23 presequence
+      pathway. TIMM17A contributes to import of matrix-destined precursors.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TIMM17A/TIMM17A-deep-research-falcon.md
 - term:
     id: GO:0005743
     label: mitochondrial inner membrane
   evidence_type: NAS
   original_reference_id: PMID:10339406
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Correct. The foundational human TIM23 study places Tim17-A in the
+      mitochondrial inner membrane translocase.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TIMM17A/TIMM17A-deep-research-falcon.md
 - term:
     id: GO:0005744
     label: TIM23 mitochondrial import inner membrane translocase complex
   evidence_type: NAS
   original_reference_id: PMID:10339406
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Correct. TIMM17A is a human TIM23 core component and is consistently
+      described in recent TIM23 architecture studies.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TIMM17A/TIMM17A-deep-research-falcon.md
 - term:
     id: GO:0006886
     label: intracellular protein transport
   evidence_type: NAS
   original_reference_id: PMID:10339406
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      The annotation captures protein transport but is too broad. The specific
+      TIMM17A process is mitochondrial matrix import through TIM23.
+    action: MODIFY
+    reason: Replace broad intracellular protein transport with mitochondrial matrix import.
+    proposed_replacement_terms:
+    - id: GO:0030150
+      label: protein import into mitochondrial matrix
+    additional_reference_ids:
+    - file:human/TIMM17A/TIMM17A-deep-research-falcon.md
 - term:
     id: GO:0030150
     label: protein import into mitochondrial matrix
   evidence_type: TAS
   original_reference_id: PMID:10339406
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Correct. TIMM17A is a TIM23 translocase subunit involved in matrix import
+      of presequence-containing precursors.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TIMM17A/TIMM17A-deep-research-falcon.md
 - term:
     id: GO:0005739
     label: mitochondrion
   evidence_type: IDA
   original_reference_id: GO_REF:0000052
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Correct but too general. TIMM17A is specifically localized to the
+      mitochondrial inner membrane and TIM23 complex.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Subsumed by mitochondrial inner membrane and TIM23 complex annotations.
+    additional_reference_ids:
+    - file:human/TIMM17A/TIMM17A-deep-research-falcon.md
 - term:
     id: GO:0005739
     label: mitochondrion
   evidence_type: HTP
   original_reference_id: PMID:34800366
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      High-throughput mitochondrial proteome evidence supports mitochondrial
+      localization, but the term is less specific than the inner membrane/TIM23
+      localization.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Subsumed by mitochondrial inner membrane and TIM23 complex annotations.
+    additional_reference_ids:
+    - file:human/TIMM17A/TIMM17A-deep-research-falcon.md
 - term:
     id: GO:0005744
     label: TIM23 mitochondrial import inner membrane translocase complex
   evidence_type: IDA
   original_reference_id: PMID:30598479
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Accepted. ROMO1/TIM23 complex studies recovered TIM17A in authentic human
+      TIM23 assemblies.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TIMM17A/TIMM17A-deep-research-falcon.md
 - term:
     id: GO:0005743
     label: mitochondrial inner membrane
   evidence_type: IDA
   original_reference_id: PMID:20053669
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Correct localization for TIMM17A as an integral TIM23 inner membrane
+      subunit.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TIMM17A/TIMM17A-deep-research-falcon.md
 - term:
     id: GO:0005743
     label: mitochondrial inner membrane
   evidence_type: IDA
   original_reference_id: PMID:10339406
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Correct localization from the foundational human TIM23 characterization.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TIMM17A/TIMM17A-deep-research-falcon.md
 - term:
     id: GO:0005744
     label: TIM23 mitochondrial import inner membrane translocase complex
   evidence_type: IDA
   original_reference_id: PMID:10339406
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Correct complex annotation from the foundational human TIM23
+      characterization and supported by recent TIM23 architecture literature.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TIMM17A/TIMM17A-deep-research-falcon.md
 references:
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO
@@ -175,3 +259,50 @@ references:
   title: Quantitative high-confidence human mitochondrial proteome and its dynamics
     in cellular context.
   findings: []
+- id: file:human/TIMM17A/TIMM17A-deep-research-falcon.md
+  title: Falcon deep research report for human TIMM17A
+  findings: []
+core_functions:
+- description: >-
+    TIMM17A contributes to the TIM23 presequence translocase channel/cavity at
+    the mitochondrial inner membrane, supporting import of presequence-containing
+    nuclear-encoded precursors into the matrix and sorting through TIM23.
+  supported_by:
+  - reference_id: file:human/TIMM17A/TIMM17A-deep-research-falcon.md
+    supporting_text: "TIMM17A is an **integral mitochondrial inner membrane** component of the **TIM23 core**"
+  - reference_id: file:human/TIMM17A/TIMM17A-deep-research-falcon.md
+    supporting_text: "TIM23 imports **presequence‑containing precursors** destined to the **matrix** and many destined to the **inner membrane**"
+  - reference_id: file:human/TIMM17A/TIMM17A-deep-research-falcon.md
+    supporting_text: "TIMM17A acts at the **inner membrane** as part of the translocation pore/cavity"
+  contributes_to_molecular_function:
+    id: GO:0008320
+    label: protein transmembrane transporter activity
+  directly_involved_in:
+  - id: GO:0030150
+    label: protein import into mitochondrial matrix
+  locations:
+  - id: GO:0005743
+    label: mitochondrial inner membrane
+  in_complex:
+    id: GO:0005744
+    label: TIM23 mitochondrial import inner membrane translocase complex
+proposed_new_terms: []
+suggested_questions:
+- question: >-
+    Which TIMM17A-specific surfaces distinguish translocase-A regulation from
+    TIMM17B-containing housekeeping TIM23 complexes?
+  experts: []
+- question: >-
+    How does YME1L-dependent TIMM17A turnover remodel the substrate spectrum of
+    human TIM23 under hypoxia or nutrient stress?
+  experts: []
+suggested_experiments:
+- hypothesis: >-
+    TIMM17A-specific structural features tune TIM23 matrix import and stress
+    remodeling independently of core TIM23 assembly.
+  description: >-
+    Use endogenous TIMM17A knockout/rescue with TIMM17A/TIMM17B swap and
+    structure-guided mutants, then assay TIM23 complex composition, matrix
+    precursor import, YME1L-dependent turnover, and stress-dependent proteome
+    remodeling.
+  experiment_type: endogenous rescue and mitochondrial import assay

--- a/genes/human/TIMM17A/TIMM17A-deep-research-falcon.md
+++ b/genes/human/TIMM17A/TIMM17A-deep-research-falcon.md
@@ -1,0 +1,297 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-11T12:10:32.086996'
+end_time: '2026-05-11T12:29:26.503316'
+duration_seconds: 1134.42
+template_file: templates/gene_research_go_focused.md
+template_variables:
+  organism: human
+  gene_id: TIMM17A
+  gene_symbol: TIMM17A
+  uniprot_accession: Q99595
+  protein_description: 'RecName: Full=Mitochondrial import inner membrane translocase
+    subunit Tim17-A; AltName: Full=Inner membrane preprotein translocase Tim17a;'
+  gene_info: Name=TIMM17A; Synonyms=MIMT17, TIM17, TIM17A, TIMM17;
+  organism_full: Homo sapiens (Human).
+  protein_family: Belongs to the Tim17/Tim22/Tim23 family. .
+  protein_domains: Tim17. (IPR005678); Tim17 (PF02466)
+provider_config:
+  timeout: 600
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 16
+---
+
+## Question
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** Q99595
+- **Protein Description:** RecName: Full=Mitochondrial import inner membrane translocase subunit Tim17-A; AltName: Full=Inner membrane preprotein translocase Tim17a;
+- **Gene Information:** Name=TIMM17A; Synonyms=MIMT17, TIM17, TIM17A, TIMM17;
+- **Organism (full):** Homo sapiens (Human).
+- **Protein Family:** Belongs to the Tim17/Tim22/Tim23 family. .
+- **Key Domains:** Tim17. (IPR005678); Tim17 (PF02466)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "TIMM17A" matches the protein description above**
+2. **Verify the organism is correct:** Homo sapiens (Human).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'TIMM17A' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **TIMM17A** (gene ID: TIMM17A, UniProt: Q99595) in human.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** Q99595
+- **Protein Description:** RecName: Full=Mitochondrial import inner membrane translocase subunit Tim17-A; AltName: Full=Inner membrane preprotein translocase Tim17a;
+- **Gene Information:** Name=TIMM17A; Synonyms=MIMT17, TIM17, TIM17A, TIMM17;
+- **Organism (full):** Homo sapiens (Human).
+- **Protein Family:** Belongs to the Tim17/Tim22/Tim23 family. .
+- **Key Domains:** Tim17. (IPR005678); Tim17 (PF02466)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "TIMM17A" matches the protein description above**
+2. **Verify the organism is correct:** Homo sapiens (Human).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'TIMM17A' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **TIMM17A** (gene ID: TIMM17A, UniProt: Q99595) in human.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Comprehensive research report: Human **TIMM17A** (UniProt **Q99595**)—functional annotation and current understanding
+
+### 0) Target verification and nomenclature
+The literature summarized here is explicitly matched to the UniProt entry **Q99595**, annotated as **mitochondrial import inner membrane translocase subunit Tim17-A**, encoded by the human gene **TIMM17A** (Tim17a). A 2024 peer‑reviewed study on the human core TIM23 complex explicitly identifies **TIMM17A as UniProt Q99595** and places it in the Tim17/Tim22/Tim23 family (pfam Tim17; IPR005678) (maruszczak2024structurepredictionanalysis pages 2-3). Human TIMM17A is distinct from the paralog **TIMM17B**, which forms an alternative TIM23 core variant and shares ~**76%** sequence identity (maruszczak2024structurepredictionanalysis pages 3-5).
+
+### 1) Key concepts and definitions (current understanding)
+#### 1.1 The TIM23 “presequence” pathway
+Most mitochondrial proteins are nuclear‑encoded and must be imported post‑translationally. The **TIM23 complex** (translocase of the inner membrane 23) is the central inner‑membrane translocase for **presequence‑containing** precursor proteins. A 2024 TIM23 disease‑focused mini‑review estimates that TIM23 mediates import of **~60% of the mitochondrial proteome**, including the majority of matrix proteins and many inner‑membrane proteins, plus a subset of intermembrane space (IMS) proteins (jain2024hotspotsfordiseasecausing pages 2-4).
+
+#### 1.2 TIM23 functional modes: motor vs sorting
+TIM23 is described as operating in at least two coupled modes:
+* **TIM23MOTOR**: association of the TIM23 core with the **PAM** (presequence translocase‑associated motor) to drive **matrix import** (ATP‑dependent mtHsp70 pulling plus inner‑membrane potential). (jain2024hotspotsfordiseasecausing pages 2-4, chaudhuri2020tim17updatesa pages 6-8)
+* **TIM23SORT**: association with factors such as **Tim21** and **Mgr2** (yeast) to favor **lateral insertion/sorting** of some inner‑membrane proteins and certain IMS sorting events. (jain2024hotspotsfordiseasecausing pages 2-4, chaudhuri2020tim17updatesa pages 6-8)
+
+Human complexes are discussed in analogous terms, with TIMM17 paralogs contributing to different assemblies (jain2024hotspotsfordiseasecausing pages 2-4).
+
+#### 1.3 What TIMM17A is (molecular role)
+TIMM17A is an **integral mitochondrial inner membrane** component of the **TIM23 core** (maruszczak2024structurepredictionanalysis pages 2-3, chaudhuri2020tim17updatesa pages 6-8). Tim17 family reviews describe a conserved **four‑transmembrane helix topology**, classically with both N‑ and C‑termini in the **IMS** (chaudhuri2020tim17updatesa pages 8-10). TIMM17A does not catalyze an enzymatic reaction; rather, it contributes to the **protein‑conducting import channel/cavity** and/or its regulation within TIM23 (maruszczak2024structurepredictionanalysis pages 2-3, sim2023structuralbasisof pages 1-4).
+
+### 2) TIMM17A complex membership, interaction partners, and localization
+#### 2.1 Core complex membership and paralog specialization (TIMM17A vs TIMM17B)
+Humans have **two Tim17 orthologs**, TIMM17A and TIMM17B, which form **two pools/variants** of the TIM23 core complex in combination with TIMM23 (maruszczak2024structurepredictionanalysis pages 2-3, maruszczak2024structurepredictionanalysis pages 1-2). The variants are predicted to be **highly similar structurally** (maruszczak2024structurepredictionanalysis pages 3-5, maruszczak2024structurepredictionanalysis pages 9-11).
+
+A 2024 Genes mini‑review further describes human TIM23 “motor” assemblies in which **TIMM17A defines translocase A** together with **DNAJC15**, while TIMM17B isoforms pair with **DNAJC19** to define other assemblies (translocases B1/B2) (jain2024hotspotsfordiseasecausing pages 2-4). In review literature, translocase‑B is described as constitutive/essential for normal function, while translocase‑A (TIMM17A‑linked) is dispensable under normal conditions but important for **oncogenic proliferation contexts** (chaudhuri2020tim17updatesa pages 6-8).
+
+#### 2.2 ROMO1 as a human TIM23 constituent (quantitative evidence)
+A key human‑cell biochemical study defined **ROMO1** as a constituent of the human presequence translocase and recovered **TIM17A** in TIM23/TIM21/TIM50 purifications by SILAC‑MS, placing TIMM17A within authentic human TIM23 complexes (richter2019romo1isa pages 1-2).
+
+Importantly, the same work provides quantitative complex‑association measurements: approximately **25%** of mitochondrial ROMO1 co‑isolated with **TIM23‑FLAG**, and ~**50%** of ROMO1 co‑isolated with **TIM21‑FLAG** (richter2019romo1isa pages 2-4). These results support ROMO1 as a stable, though dynamic, component of TIM23 assemblies that include TIM17A/B, TIM50, TIM44, and TIM21 (richter2019romo1isa pages 2-4).
+
+### 3) Mechanistic function: what TIMM17A does in preprotein import
+#### 3.1 Revised channel model: Tim17 cavity as central translocation route
+A major conceptual shift in 2023–2024 TIM23 biology is the growing structural/biochemical evidence that **Tim17**, rather than Tim23, provides much of the **polypeptide translocation path**.
+
+A 2023 cryo‑EM study of the TIM23 complex (in yeast) reports that Tim17 and Tim23 form a stable **1:1 heterodimer** in an idle state and identifies a **laterally open cavity in Tim17**, with Mgr2 positioned at this lateral opening; the authors propose enclosure of the Tim17 cavity provides a plausible route for polypeptide translocation (sim2023structuralbasisof pages 1-4). The same source argues against interpreting Tim23 as the sole/primary aqueous channel because prior electrophysiology often relied on refolded Tim23 preparations and lacks gold‑standard native‑membrane patch clamp validation (sim2023structuralbasisof pages 1-4).
+
+Human‑focused modeling reinforces this reinterpretation: a 2024 structure‑prediction analysis emphasizes that recent structural and biochemical work places Tim17 as having a primary role in translocation, forming a cavity large enough to accommodate translocating proteins (maruszczak2024structurepredictionanalysis pages 1-2).
+
+#### 3.2 TIMM17A structural features relevant to substrate handling
+The 2024 human TIM23 architecture analysis attributes conserved features to TIMM17A that are relevant to presequence import: an **IMS‑exposed acidic patch** that could attract positively charged presequences, a **hydrophobic cavity lining** conducive to polypeptide passage, and an **intramolecular disulfide bond** described as essential for function (maruszczak2024structurepredictionanalysis pages 2-3). These features are consistent with a role in guiding positively charged presequences into a membrane‑embedded import cavity (maruszczak2024structurepredictionanalysis pages 2-3).
+
+#### 3.3 Substrate classes (what is imported) and where TIMM17A acts
+TIM23 imports **presequence‑containing precursors** destined to the **matrix** and many destined to the **inner membrane**, with some IMS sorting, representing a large fraction of mitochondrial proteins (~60% as above) (jain2024hotspotsfordiseasecausing pages 2-4). TIMM17A acts at the **inner membrane** as part of the translocation pore/cavity and as a platform for mode switching between motor‑driven matrix import and lateral sorting modes, through interactions with accessory factors (jain2024hotspotsfordiseasecausing pages 2-4, sim2023structuralbasisof pages 1-4).
+
+### 4) Regulation of TIMM17A abundance and activity (stress, proteolysis, and signaling)
+#### 4.1 YME1L‑dependent proteolytic control of TIMM17A
+Multiple sources support **protease‑mediated regulation** of TIMM17A, particularly via the i‑AAA protease **YME1L**.
+
+A high‑impact 2019 Nature study demonstrates that cellular stresses that inhibit mTORC1 (including nutrient limitation and hypoxia) can induce acute, **YME1L‑dependent proteolysis** of TIMM17A among a set of substrates, linking mitochondrial membrane lipid composition and nutrient signaling to regulated degradation of inner‑membrane proteins (macvicar2019lipidsignallingdrives pages 3-4). The authors also reconstituted TIMM17A proteolysis in liposomes as an ATP‑dependent YME1L activity (with an inactive catalytic mutant control), supporting a direct proteolytic mechanism (macvicar2019lipidsignallingdrives pages 3-4). The study provides quantitative experimental context including immunoblot quantification for TIMM17A under hypoxia with **n=3** independent experiments and points to public proteomics/transcriptomics datasets (PRIDE: **PXD011750**, **PXD014405**; GEO: **GSE133753**) for deeper quantitative evaluation (macvicar2019lipidsignallingdrives pages 10-14).
+
+A 2024 Biochemical Society Transactions mini‑review synthesizes these findings, stating that Tim17A is a **stress‑induced degradation substrate of YME1L** in human cells, and that TIMM17A and TIMM23 are down‑regulated under hypoxia in WT but not Yme1l−/− contexts (kan2024roleofyme1 pages 3-4).
+
+#### 4.2 Coupling of import and proteostasis via ROMO1–YME1L feedback
+ROMO1 was identified as a TIM23 constituent required for efficient import of the YME1L protease itself; ROMO1 is also short‑lived and accumulates in YME1L knockout cells, indicating YME1L‑dependent ROMO1 turnover (richter2019romo1isa pages 9-11). This creates a plausible **feedback loop** in which import machinery composition affects import of quality‑control proteases, and proteases in turn remodel the import machinery (richter2019romo1isa pages 9-11, kan2024roleofyme1 pages 3-4). TIM17A is listed among known YME1L substrates, reinforcing the link between import channel composition and proteolytic remodeling (richter2019romo1isa pages 2-4).
+
+#### 4.3 Protein import machinery as a stress‑signaling hub (2023 perspective)
+A 2023 review frames mitochondrial protein import as a **signaling hub**, where import impairment triggers proteostatic and metabolic responses beyond mitochondria (maruszczak2024structurepredictionanalysis pages 1-2). Within that context, TIMM17A is specifically mentioned as an import component subject to stress‑linked remodeling (including cleavage/turnover of TIMM17A as part of adaptive responses) (maruszczak2024structurepredictionanalysis pages 2-3).
+
+### 5) Recent developments (prioritize 2023–2024)
+#### 5.1 2023: Cryo‑EM structure revises the “Tim23 channel” assumption
+The 2023 Nature cryo‑EM work is widely treated as a mechanistic inflection point, presenting a Tim17‑centered cavity model and explicitly questioning whether prior Tim23‑only channel models reflect the native state (sim2023structuralbasisof pages 1-4).
+
+#### 5.2 2024: Human TIM23 core architecture modeling, TIMM17A vs TIMM17B comparison
+A 2024 FEBS Open Bio study provides a human‑focused structural interpretation: TIMM17A (UniProt Q99595) and TIMM17B form two predicted human TIM23 core variants with TIMM23 and ROMO1 and show high structural conservation relative to yeast TIM23 (maruszczak2024structurepredictionanalysis pages 2-3, maruszczak2024structurepredictionanalysis pages 3-5). It also compiles functional distinctions discussed in the literature, including the idea that TIMM17B may be more “housekeeping” whereas TIMM17A may contribute to regulated remodeling and stress/cancer contexts (maruszczak2024structurepredictionanalysis pages 3-5).
+
+#### 5.3 2024: Disease mutation landscape review of TIM23 complex
+A 2024 Genes mini‑review synthesizes pathogenic‑variant hotspots across TIM23 components and places TIMM17A within the landscape of TIM23 motor/sorting assemblies, emphasizing that Tim17 can act as the channel for TIM23 motor activity and summarizing evidence linking high TIMM17A expression with adverse outcomes in breast cancer (jain2024hotspotsfordiseasecausing pages 2-4, jain2024hotspotsfordiseasecausing pages 11-12).
+
+### 6) Current applications and real‑world implementations
+#### 6.1 Variant interpretation and mitochondrial disease mechanisms
+Although TIMM17A itself is not emphasized as a dominant monogenic disease hotspot in the TIM23 complex compared with other components (e.g., Tim50/PAM factors discussed elsewhere), TIM23 dysfunction is a clinically important mechanism in mitochondrial disease, and mechanistic mapping of TIM23 substrate classes (matrix vs lateral insertion) can directly inform phenotypic interpretation (jain2024hotspotsfordiseasecausing pages 2-4). Human TIM23 biology is also increasingly approached using proteomics to map downstream consequences of reduced import and altered translocase composition (macvicar2019lipidsignallingdrives pages 10-14).
+
+#### 6.2 Cancer biology and biomarker hypotheses
+Review sources cite clinical associations that **high TIMM17A expression** is linked with **adverse pathological/clinical outcomes** and aggressiveness in human breast cancer (jain2024hotspotsfordiseasecausing pages 11-12). Separately, translocase‑A (TIMM17A‑linked) is described as dispensable for normal mitochondrial function but required for **oncogenic proliferation** in review literature, suggesting a potential vulnerability axis in cancer metabolism/biogenesis (chaudhuri2020tim17updatesa pages 6-8).
+
+#### 6.3 Experimental and systems applications
+The 2019 YME1L study explicitly provides public quantitative datasets (PRIDE proteomics and GEO transcriptomics) that can be mined to evaluate TIMM17A abundance and remodeling across hypoxia/nutrient conditions, enabling reproducible integrative functional annotation (macvicar2019lipidsignallingdrives pages 10-14).
+
+### 7) Expert opinions and analysis (authoritative interpretations)
+A consistent theme across recent expert syntheses is that TIM23 is not a static pore but a **dynamic translocation system** whose **core architecture is conserved** yet whose functional specificity can be tuned by paralog choice (TIMM17A vs TIMM17B) and accessory subunits (ROMO1/TIM21/PAM). The 2024 human structure‑prediction study explicitly frames an open problem: TIMM17A‑ and TIMM17B‑containing cores are nearly identical structurally, so differences likely arise from **regulatory factors** and context‑specific remodeling rather than gross architectural differences (maruszczak2024structurepredictionanalysis pages 9-11). The 2023 cryo‑EM work similarly emphasizes unresolved mechanistic gaps (e.g., initial presequence engagement with the Tim17 cavity and dynamics during translocation) despite clearer structural grounding (sim2023structuralbasisof pages 1-4).
+
+### 8) Key statistics and quantitative data (from recent/primary evidence)
+* TIM23 is reported to import **~60% of the mitochondrial proteome** (matrix + many inner‑membrane proteins; some IMS proteins) (jain2024hotspotsfordiseasecausing pages 2-4).
+* In human‑cell purifications, ROMO1 co‑isolates at approximately **25% with TIM23‑FLAG** and **~50% with TIM21‑FLAG**, consistent with ROMO1 as a TIM23 constituent interacting with TIM21 and the TIM23 core that includes TIM17A/B (richter2019romo1isa pages 2-4, richter2019romo1isa media 2e38f9b5).
+* Hypoxia/HIF1α and nutrient signaling regulate YME1L‑dependent remodeling including TIMM17A abundance; quantitative immunoblotting context includes **n=3** independent experiments and linked public omics datasets for reanalysis (macvicar2019lipidsignallingdrives pages 10-14).
+
+### 9) Visual evidence (human TIM23 composition and ROMO1 association)
+Richter et al. provide a schematic of the human TIM23 presequence translocase including TIM17A/B and ROMO1 and quantitative ROMO1 co‑purification with TIM23 and TIM21 (richter2019romo1isa media 2e38f9b5).
+
+### 10) Summary functional annotation (concise)
+**TIMM17A (UniProt Q99595)** encodes an integral **mitochondrial inner membrane** protein of the **TIM23 presequence translocase**. It participates in import of nuclear‑encoded, **presequence‑containing precursor proteins** into the **mitochondrial matrix** and for **inner‑membrane insertion**, acting as a core translocation component (channel/cavity) within TIM23 motor assemblies and coordinating with accessory factors (TIM21/ROMO1/PAM) that tune sorting versus matrix import. Its abundance is **stress‑regulated**, notably via **YME1L‑dependent proteolysis** in response to nutrient/hypoxia signaling, providing a mechanism to remodel mitochondrial biogenesis/import capacity. (maruszczak2024structurepredictionanalysis pages 2-3, jain2024hotspotsfordiseasecausing pages 2-4, sim2023structuralbasisof pages 1-4, macvicar2019lipidsignallingdrives pages 3-4)
+
+---
+
+### Embedded evidence table
+| Aspect | Key points | Best recent source(s) with year/URL/DOI |
+|---|---|---|
+| Identity | Human **TIMM17A** encodes mitochondrial import inner membrane translocase subunit **Tim17-A**; UniProt **Q99595**. It is one of two human Tim17 paralogs (**TIMM17A**, **TIMM17B**) in the **Tim17/Tim22/Tim23 family** and a core subunit of the **TIM23 presequence translocase**. TIMM17A and TIMM17B share ~**76%** sequence identity. (maruszczak2024structurepredictionanalysis pages 2-3, maruszczak2024structurepredictionanalysis pages 3-5) | Maruszczak et al., **2024**, FEBS Open Bio, https://doi.org/10.1002/2211-5463.13840, DOI: 10.1002/2211-5463.13840 |
+| Subcellular localization / topology | TIMM17A is a **mitochondrial inner membrane** protein. Tim17-family proteins show a conserved **4-transmembrane-helix topology** with both **N- and C-termini in the intermembrane space**; TIMM17A is tightly anchored in the inner membrane as part of the import channel machinery. (chaudhuri2020tim17updatesa pages 8-10, chaudhuri2020tim17updatesa pages 6-8) | Chaudhuri et al., **2020**, Biomolecules, https://doi.org/10.3390/biom10121643, DOI: 10.3390/biom10121643 |
+| Complex membership | TIMM17A forms one of the two human **core TIM23** variants with **TIMM23** and **ROMO1**; the human core also associates with **TIM44**, **TIM50**, **TIM21**, and mtHsp70-linked motor components. Human TIM23 assemblies can be described as **translocase-A** (TIMM17A-containing; linked with **DNAJC15**) versus **translocase-B** (TIMM17B-containing; linked with **DNAJC19** isoforms). (maruszczak2024structurepredictionanalysis pages 2-3, jain2024hotspotsfordiseasecausing pages 2-4, richter2019romo1isa pages 1-2, richter2019romo1isa pages 2-4, richter2019romo1isa media 2e38f9b5) | Maruszczak et al., **2024**, FEBS Open Bio, https://doi.org/10.1002/2211-5463.13840, DOI: 10.1002/2211-5463.13840; Jain et al., **2024**, Genes, https://doi.org/10.3390/genes15121534, DOI: 10.3390/genes15121534; Richter et al., **2019**, J Cell Biol, https://doi.org/10.1083/jcb.201806093, DOI: 10.1083/jcb.201806093 |
+| Key interaction partners | Best-supported partners include **TIMM23** (stable Tim17–Tim23 core), **ROMO1** (human Mgr2-like subunit), **TIM50**, **TIM21**, **TIM44**, and **HSP70/PAM-related factors** in the import motor. Quantitatively, ~**25%** of mitochondrial ROMO1 co-isolated with **TIM23-FLAG**, and ~**50%** co-isolated with **TIM21-FLAG** in human-cell purifications, supporting ROMO1’s association with the human TIM23 machinery. (maruszczak2024structurepredictionanalysis pages 1-2, richter2019romo1isa pages 2-4, richter2019romo1isa media 2e38f9b5) | Richter et al., **2019**, J Cell Biol, https://doi.org/10.1083/jcb.201806093, DOI: 10.1083/jcb.201806093; Maruszczak et al., **2024**, FEBS Open Bio, https://doi.org/10.1002/2211-5463.13840, DOI: 10.1002/2211-5463.13840 |
+| Mechanistic role | Current model places **Tim17/TIMM17A** at the center of the translocation path: recent structural work argues Tim17 forms a **laterally open cavity/channel** large enough to accommodate translocating polypeptides, while Tim23 is more constrained and likely has a more regulatory/architectural role. Conserved TIMM17A features include an **IMS acidic patch** that can attract positively charged **presequences**, a **hydrophobic cavity lining**, and an **intramolecular disulfide bond** important for function. (maruszczak2024structurepredictionanalysis pages 2-3, maruszczak2024structurepredictionanalysis pages 1-2, sim2023structuralbasisof pages 1-4) | Sim et al., **2023**, Nature, https://doi.org/10.1038/s41586-023-06239-6, DOI: 10.1038/s41586-023-06239-6; Maruszczak et al., **2024**, FEBS Open Bio, https://doi.org/10.1002/2211-5463.13840, DOI: 10.1002/2211-5463.13840 |
+| Functional distinction vs TIMM17B | TIMM17A- and TIMM17B-containing human TIM23 complexes are predicted to be **structurally very similar**, but functional specialization is reported: **TIMM17B** is often described as the more **housekeeping/canonical** import variant, whereas **TIMM17A** has a more **specialized/regulatory** role and is linked to **translocase-A** and oncogenic proliferation contexts. (maruszczak2024structurepredictionanalysis pages 3-5, chaudhuri2020tim17updatesa pages 8-10, chaudhuri2020tim17updatesa pages 6-8) | Maruszczak et al., **2024**, FEBS Open Bio, https://doi.org/10.1002/2211-5463.13840, DOI: 10.1002/2211-5463.13840; Chaudhuri et al., **2020**, Biomolecules, https://doi.org/10.3390/biom10121643, DOI: 10.3390/biom10121643 |
+| Regulation / proteolysis | TIMM17A is regulated by mitochondrial quality-control proteases. It is reported as a **YME1L substrate**, and stress-adaptive remodeling of import can include **selective turnover of TIMM17A** to reduce mitochondrial import and alter metabolic state. In ROMO1 studies, **ROMO1** itself is also short-lived and **YME1L-regulated**, linking TIMM17A-containing TIM23 assemblies to proteostatic control. (maruszczak2024structurepredictionanalysis pages 2-3, richter2019romo1isa pages 1-2, richter2019romo1isa pages 9-11, richter2019romo1isa pages 2-4) | Richter et al., **2019**, J Cell Biol, https://doi.org/10.1083/jcb.201806093, DOI: 10.1083/jcb.201806093; Maruszczak et al., **2024**, FEBS Open Bio, https://doi.org/10.1002/2211-5463.13840, DOI: 10.1002/2211-5463.13840 |
+| Disease / cancer associations | No recurrent monogenic **TIMM17A** disease hotspot is established in current TIM23 disease reviews, but **high TIMM17A expression** has been associated with **adverse outcomes and aggressiveness in breast cancer**. Broader TIM23-complex dysfunction is clinically important in mitochondrial disease, and TIMM17A-containing translocase-A has been described as required for **oncogenic cell proliferation** in review literature. (jain2024hotspotsfordiseasecausing pages 2-4, jain2024hotspotsfordiseasecausing pages 11-12, chaudhuri2020tim17updatesa pages 6-8) | Jain et al., **2024**, Genes, https://doi.org/10.3390/genes15121534, DOI: 10.3390/genes15121534; Chaudhuri et al., **2020**, Biomolecules, https://doi.org/10.3390/biom10121643, DOI: 10.3390/biom10121643 |
+
+
+*Table: This table summarizes the verified identity, localization, complex membership, mechanism, regulation, and disease relevance of human TIMM17A. It highlights the most useful recent sources for interpreting TIMM17A as a core TIM23 presequence-translocase subunit.*
+
+References
+
+1. (maruszczak2024structurepredictionanalysis pages 2-3): Klaudia K. Maruszczak, Piotr Draczkowski, Artur Wnorowski, and Agnieszka Chacinska. Structure prediction analysis of human core tim23 complex reveals conservation of the protein translocation mechanism. FEBS Open Bio, 14:1656-1667, Jun 2024. URL: https://doi.org/10.1002/2211-5463.13840, doi:10.1002/2211-5463.13840. This article has 13 citations and is from a peer-reviewed journal.
+
+2. (maruszczak2024structurepredictionanalysis pages 3-5): Klaudia K. Maruszczak, Piotr Draczkowski, Artur Wnorowski, and Agnieszka Chacinska. Structure prediction analysis of human core tim23 complex reveals conservation of the protein translocation mechanism. FEBS Open Bio, 14:1656-1667, Jun 2024. URL: https://doi.org/10.1002/2211-5463.13840, doi:10.1002/2211-5463.13840. This article has 13 citations and is from a peer-reviewed journal.
+
+3. (jain2024hotspotsfordiseasecausing pages 2-4): Sahil Jain, Eyal Paz, and Abdussalam Azem. Hotspots for disease-causing mutations in the mitochondrial tim23 import complex. Genes, 15:1534, Nov 2024. URL: https://doi.org/10.3390/genes15121534, doi:10.3390/genes15121534. This article has 1 citations.
+
+4. (chaudhuri2020tim17updatesa pages 6-8): Minu Chaudhuri, Chauncey Darden, Fidel Soto Gonzalez, Ujjal K. Singha, Linda Quinones, and Anuj Tripathi. Tim17 updates: a comprehensive review of an ancient mitochondrial protein translocator. Biomolecules, 10:1643, Dec 2020. URL: https://doi.org/10.3390/biom10121643, doi:10.3390/biom10121643. This article has 24 citations.
+
+5. (chaudhuri2020tim17updatesa pages 8-10): Minu Chaudhuri, Chauncey Darden, Fidel Soto Gonzalez, Ujjal K. Singha, Linda Quinones, and Anuj Tripathi. Tim17 updates: a comprehensive review of an ancient mitochondrial protein translocator. Biomolecules, 10:1643, Dec 2020. URL: https://doi.org/10.3390/biom10121643, doi:10.3390/biom10121643. This article has 24 citations.
+
+6. (sim2023structuralbasisof pages 1-4): Sue Im Sim, Yuanyuan Chen, Diane L. Lynch, James C. Gumbart, and Eunyong Park. Structural basis of mitochondrial protein import by the tim23 complex. Nature, 621:620-626, Jun 2023. URL: https://doi.org/10.1038/s41586-023-06239-6, doi:10.1038/s41586-023-06239-6. This article has 105 citations and is from a highest quality peer-reviewed journal.
+
+7. (maruszczak2024structurepredictionanalysis pages 1-2): Klaudia K. Maruszczak, Piotr Draczkowski, Artur Wnorowski, and Agnieszka Chacinska. Structure prediction analysis of human core tim23 complex reveals conservation of the protein translocation mechanism. FEBS Open Bio, 14:1656-1667, Jun 2024. URL: https://doi.org/10.1002/2211-5463.13840, doi:10.1002/2211-5463.13840. This article has 13 citations and is from a peer-reviewed journal.
+
+8. (maruszczak2024structurepredictionanalysis pages 9-11): Klaudia K. Maruszczak, Piotr Draczkowski, Artur Wnorowski, and Agnieszka Chacinska. Structure prediction analysis of human core tim23 complex reveals conservation of the protein translocation mechanism. FEBS Open Bio, 14:1656-1667, Jun 2024. URL: https://doi.org/10.1002/2211-5463.13840, doi:10.1002/2211-5463.13840. This article has 13 citations and is from a peer-reviewed journal.
+
+9. (richter2019romo1isa pages 1-2): Frank Richter, Sven Dennerlein, Miroslav Nikolov, Daniel C. Jans, Nataliia Naumenko, Abhishek Aich, Thomas MacVicar, Andreas Linden, Stefan Jakobs, Henning Urlaub, Thomas Langer, and Peter Rehling. Romo1 is a constituent of the human presequence translocase required for yme1l protease import. The Journal of Cell Biology, 218:598-614, Dec 2019. URL: https://doi.org/10.1083/jcb.201806093, doi:10.1083/jcb.201806093. This article has 74 citations.
+
+10. (richter2019romo1isa pages 2-4): Frank Richter, Sven Dennerlein, Miroslav Nikolov, Daniel C. Jans, Nataliia Naumenko, Abhishek Aich, Thomas MacVicar, Andreas Linden, Stefan Jakobs, Henning Urlaub, Thomas Langer, and Peter Rehling. Romo1 is a constituent of the human presequence translocase required for yme1l protease import. The Journal of Cell Biology, 218:598-614, Dec 2019. URL: https://doi.org/10.1083/jcb.201806093, doi:10.1083/jcb.201806093. This article has 74 citations.
+
+11. (macvicar2019lipidsignallingdrives pages 3-4): Thomas MacVicar, Yohsuke Ohba, Hendrik Nolte, Fiona Carola Mayer, Takashi Tatsuta, Hans-Georg Sprenger, Barbara Lindner, Yue Zhao, Jiahui Li, Christiane Bruns, Marcus Krüger, Markus Habich, Jan Riemer, Robin Schwarzer, Manolis Pasparakis, Sinika Henschke, Jens C. Brüning, Nicola Zamboni, and Thomas Langer. Lipid signalling drives proteolytic rewiring of mitochondria by yme1l. Nature, 575:361-365, Nov 2019. URL: https://doi.org/10.1038/s41586-019-1738-6, doi:10.1038/s41586-019-1738-6. This article has 207 citations and is from a highest quality peer-reviewed journal.
+
+12. (macvicar2019lipidsignallingdrives pages 10-14): Thomas MacVicar, Yohsuke Ohba, Hendrik Nolte, Fiona Carola Mayer, Takashi Tatsuta, Hans-Georg Sprenger, Barbara Lindner, Yue Zhao, Jiahui Li, Christiane Bruns, Marcus Krüger, Markus Habich, Jan Riemer, Robin Schwarzer, Manolis Pasparakis, Sinika Henschke, Jens C. Brüning, Nicola Zamboni, and Thomas Langer. Lipid signalling drives proteolytic rewiring of mitochondria by yme1l. Nature, 575:361-365, Nov 2019. URL: https://doi.org/10.1038/s41586-019-1738-6, doi:10.1038/s41586-019-1738-6. This article has 207 citations and is from a highest quality peer-reviewed journal.
+
+13. (kan2024roleofyme1 pages 3-4): Kwan Ting Kan, Joel Wilcock, and Hui Lu. Role of yme1 in mitochondrial protein homeostasis: from regulation of protein import, oxphos function to lipid synthesis and mitochondrial dynamics. Biochemical Society Transactions, 52:1539-1548, Jun 2024. URL: https://doi.org/10.1042/bst20240450, doi:10.1042/bst20240450. This article has 9 citations and is from a peer-reviewed journal.
+
+14. (richter2019romo1isa pages 9-11): Frank Richter, Sven Dennerlein, Miroslav Nikolov, Daniel C. Jans, Nataliia Naumenko, Abhishek Aich, Thomas MacVicar, Andreas Linden, Stefan Jakobs, Henning Urlaub, Thomas Langer, and Peter Rehling. Romo1 is a constituent of the human presequence translocase required for yme1l protease import. The Journal of Cell Biology, 218:598-614, Dec 2019. URL: https://doi.org/10.1083/jcb.201806093, doi:10.1083/jcb.201806093. This article has 74 citations.
+
+15. (jain2024hotspotsfordiseasecausing pages 11-12): Sahil Jain, Eyal Paz, and Abdussalam Azem. Hotspots for disease-causing mutations in the mitochondrial tim23 import complex. Genes, 15:1534, Nov 2024. URL: https://doi.org/10.3390/genes15121534, doi:10.3390/genes15121534. This article has 1 citations.
+
+16. (richter2019romo1isa media 2e38f9b5): Frank Richter, Sven Dennerlein, Miroslav Nikolov, Daniel C. Jans, Nataliia Naumenko, Abhishek Aich, Thomas MacVicar, Andreas Linden, Stefan Jakobs, Henning Urlaub, Thomas Langer, and Peter Rehling. Romo1 is a constituent of the human presequence translocase required for yme1l protease import. The Journal of Cell Biology, 218:598-614, Dec 2019. URL: https://doi.org/10.1083/jcb.201806093, doi:10.1083/jcb.201806093. This article has 74 citations.
+
+## Citations
+
+1. maruszczak2024structurepredictionanalysis pages 2-3
+2. maruszczak2024structurepredictionanalysis pages 3-5
+3. jain2024hotspotsfordiseasecausing pages 2-4
+4. sim2023structuralbasisof pages 1-4
+5. maruszczak2024structurepredictionanalysis pages 1-2
+6. macvicar2019lipidsignallingdrives pages 3-4
+7. macvicar2019lipidsignallingdrives pages 10-14
+8. jain2024hotspotsfordiseasecausing pages 11-12
+9. maruszczak2024structurepredictionanalysis pages 9-11
+10. https://doi.org/10.1002/2211-5463.13840,
+11. https://doi.org/10.3390/biom10121643,
+12. https://doi.org/10.3390/genes15121534,
+13. https://doi.org/10.1083/jcb.201806093,
+14. https://doi.org/10.1038/s41586-023-06239-6,
+15. https://doi.org/10.1038/s41586-019-1738-6,
+16. https://doi.org/10.1042/bst20240450,

--- a/genes/human/TOMM7/TOMM7-ai-review.html
+++ b/genes/human/TOMM7/TOMM7-ai-review.html
@@ -1,0 +1,3505 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>TOMM7 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>TOMM7</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q9P0U1" target="_blank" class="term-link">
+                        Q9P0U1
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "TOMM7";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q9P0U1" data-a="DESCRIPTION: TOMM7 is a small single-pass mitochondrial outer m..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>TOMM7 is a small single-pass mitochondrial outer membrane TOM complex subunit. It is not the TOM pore or a standalone transporter; instead it regulates TOM core assembly, stability, and oligomeric organization, and it has a supported mitochondrial quality-control role in PINK1 stabilization/activation and PINK1-Parkin mitophagy signaling after mitochondrial depolarization.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005742" target="_blank" class="term-link">
+                                    GO:0005742
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial outer membrane translocase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9P0U1" data-a="GO:0005742" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct phylogenetic inference. TOMM7 is a conserved small TOM subunit in the mitochondrial outer membrane translocase complex.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOMM7/TOMM7-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">TOMM7 is an **outer mitochondrial membrane** subunit of the TOM machinery.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005741" target="_blank" class="term-link">
+                                    GO:0005741
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial outer membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9P0U1" data-a="GO:0005741" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct UniProt-derived localization. TOMM7 is a single-pass outer mitochondrial membrane TOM subunit.
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005742" target="_blank" class="term-link">
+                                    GO:0005742
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial outer membrane translocase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9P0U1" data-a="GO:0005742" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct InterPro-derived annotation. TOMM7 is a Tom7-family small TOM complex subunit.
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030150" target="_blank" class="term-link">
+                                    GO:0030150
+                                </a>
+                            </span>
+                            <span class="term-label">protein import into mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9P0U1" data-a="GO:0030150" data-r="GO_REF:0000002" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct as a broad TOM pathway consequence but not TOMM7&#39;s most specific role. TOMM7 regulates TOM complex assembly/stability and supports import indirectly through the TOM complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Matrix import is one route through TOM; TOMM7&#39;s core role is TOM complex regulation.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12198123" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12198123
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Insertion and assembly of human tom7 into the preprotein tra...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9P0U1" data-a="GO:0005515" data-r="PMID:12198123" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Protein binding is too generic. The relevant result is TOMM7 insertion and assembly into the TOM complex, captured by TOM complex and assembly terms.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Protein binding is uninformative for TOMM7 function.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/30021884" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:30021884
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Histone Interaction Landscapes Visualized by Crosslinking Ma...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9P0U1" data-a="GO:0005515" data-r="PMID:30021884" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Histone crosslinking protein binding is not part of the curated TOMM7 mitochondrial outer membrane/TOM function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Protein binding is uninformative and likely unrelated to TOMM7 core function.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/35271311" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:35271311
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    OpenCell: Endogenous tagging for the cartography of human ce...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9P0U1" data-a="GO:0005515" data-r="PMID:35271311" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Generic OpenCell protein binding does not capture TOMM7&#39;s function as a regulatory/structural TOM complex subunit.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Protein binding is uninformative; complex and process annotations are more appropriate.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030150" target="_blank" class="term-link">
+                                    GO:0030150
+                                </a>
+                            </span>
+                            <span class="term-label">protein import into mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15644312" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15644312
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dissection of the mitochondrial import and assembly pathway ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9P0U1" data-a="GO:0030150" data-r="PMID:15644312" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Broad but valid for the TOM import pathway. TOMM7 contributes indirectly through TOM complex organization rather than acting as the matrix-import motor or pore.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Matrix import is a TOM pathway outcome but not TOMM7&#39;s most specific function.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005741" target="_blank" class="term-link">
+                                    GO:0005741
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial outer membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18331822" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:18331822
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Identification of Tom5 and Tom6 in the preprotein translocas...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9P0U1" data-a="GO:0005741" data-r="PMID:18331822" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct localization. TOMM7 is a small outer mitochondrial membrane subunit of the TOM machinery.
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045040" target="_blank" class="term-link">
+                                    GO:0045040
+                                </a>
+                            </span>
+                            <span class="term-label">protein insertion into mitochondrial outer membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18331822" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:18331822
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Identification of Tom5 and Tom6 in the preprotein translocas...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="Q9P0U1" data-a="GO:0045040" data-r="PMID:18331822" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> The broad TOM biology is related, but TOMM7 is not an independent insertase. The specific supported role is TOM complex assembly/stability and oligomeric-state regulation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Replace outer membrane insertion with TOM complex assembly/stability.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070096" target="_blank" class="term-link">
+                                    mitochondrial outer membrane translocase complex assembly
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140596" target="_blank" class="term-link">
+                                    GO:0140596
+                                </a>
+                            </span>
+                            <span class="term-label">TOM complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18331822" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:18331822
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Identification of Tom5 and Tom6 in the preprotein translocas...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9P0U1" data-a="GO:0140596" data-r="PMID:18331822" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct and specific. TOMM7 is a TOM core/holo complex subunit adjacent to TOM40/TOM22 and the other small Tom proteins.
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HTP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:34800366
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Quantitative high-confidence human mitochondrial proteome an...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9P0U1" data-a="GO:0005739" data-r="PMID:34800366" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct but too general. TOMM7 is specifically a mitochondrial outer membrane TOM complex subunit.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Subsumed by mitochondrial outer membrane and TOM complex annotations.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005742" target="_blank" class="term-link">
+                                    GO:0005742
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial outer membrane translocase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/24270810" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:24270810
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    High-content genome-wide RNAi screens identify regulators of...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9P0U1" data-a="GO:0005742" data-r="PMID:24270810" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Accepted. The TOMM7/PINK1-Parkin evidence is consistent with TOMM7 acting at the TOM complex.
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031647" target="_blank" class="term-link">
+                                    GO:0031647
+                                </a>
+                            </span>
+                            <span class="term-label">regulation of protein stability</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/24270810" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:24270810
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    High-content genome-wide RNAi screens identify regulators of...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9P0U1" data-a="GO:0031647" data-r="PMID:24270810" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Accepted for the PINK1 context. TOMM7 is required for efficient PINK1 stabilization/activation at the TOM complex after mitochondrial depolarization.
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1903749" target="_blank" class="term-link">
+                                    GO:1903749
+                                </a>
+                            </span>
+                            <span class="term-label">positive regulation of protein localization to mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/24270810" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:24270810
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    High-content genome-wide RNAi screens identify regulators of...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9P0U1" data-a="GO:1903749" data-r="PMID:24270810" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Accepted as a PINK1-related annotation. TOMM7 supports PINK1 accumulation at damaged mitochondria/TOM after depolarization.
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1905091" target="_blank" class="term-link">
+                                    GO:1905091
+                                </a>
+                            </span>
+                            <span class="term-label">positive regulation of type 2 mitophagy</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/24270810" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:24270810
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    High-content genome-wide RNAi screens identify regulators of...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9P0U1" data-a="GO:1905091" data-r="PMID:24270810" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Accepted. TOMM7 enables PINK1 stabilization/activation at TOM and downstream Parkin recruitment, supporting PINK1-Parkin mitophagy signaling.
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005741" target="_blank" class="term-link">
+                                    GO:0005741
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial outer membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-5205661
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9P0U1" data-a="GO:0005741" data-r="Reactome:R-HSA-5205661" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Accepted. Reactome places TOMM7 at the mitochondrial outer membrane in TOM/PINK1 pathway context.
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12198123" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12198123
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Insertion and assembly of human tom7 into the preprotein tra...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9P0U1" data-a="GO:0005739" data-r="PMID:12198123" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct but too general. TOMM7 is specifically an outer membrane TOM complex subunit.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Subsumed by mitochondrial outer membrane and TOM complex annotations.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005742" target="_blank" class="term-link">
+                                    GO:0005742
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial outer membrane translocase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12198123" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12198123
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Insertion and assembly of human tom7 into the preprotein tra...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9P0U1" data-a="GO:0005742" data-r="PMID:12198123" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Accepted. PMID:12198123 directly addresses insertion and assembly of human TOM7 into the TOM complex.
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008320" target="_blank" class="term-link">
+                                    GO:0008320
+                                </a>
+                            </span>
+                            <span class="term-label">protein transmembrane transporter activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15644312" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15644312
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dissection of the mitochondrial import and assembly pathway ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9P0U1" data-a="GO:0008320" data-r="PMID:15644312" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> TOMM7 is not the TOM protein-conducting pore. Its role is regulatory and structural within the TOM complex rather than direct transporter activity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> TOMM7 regulates TOM complex assembly/stability but does not independently enable protein transmembrane transporter activity.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>TOMM7 is a regulatory/structural small TOM subunit that modulates TOM complex assembly, stability, and oligomeric organization at the mitochondrial outer membrane.</h3>
+                <span class="vote-buttons" data-g="Q9P0U1" data-a="FUNCTION: TOMM7 is a regulatory/structural small TOM subunit..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070096" target="_blank" class="term-link">
+                                mitochondrial outer membrane translocase complex assembly
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005741" target="_blank" class="term-link">
+                                mitochondrial outer membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140596" target="_blank" class="term-link">
+                            TOM complex
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/TOMM7/TOMM7-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">Functionally, TOMM7 is best classified as a **non-enzymatic regulatory/structural subunit**</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/TOMM7/TOMM7-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">TOMM7 is an **outer mitochondrial membrane** subunit of the TOM machinery.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>TOMM7 links the TOM complex to mitochondrial quality control by enabling PINK1 stabilization/activation at TOM and downstream PINK1-Parkin mitophagy signaling after mitochondrial damage.</h3>
+                <span class="vote-buttons" data-g="Q9P0U1" data-a="FUNCTION: TOMM7 links the TOM complex to mitochondrial quali..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1905091" target="_blank" class="term-link">
+                                positive regulation of type 2 mitophagy
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031647" target="_blank" class="term-link">
+                                regulation of protein stability
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1903749" target="_blank" class="term-link">
+                                positive regulation of protein localization to mitochondrion
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005741" target="_blank" class="term-link">
+                                mitochondrial outer membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140596" target="_blank" class="term-link">
+                            TOM complex
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/TOMM7/TOMM7-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">TOMM7 is also **required for efficient PINK1 stabilization/activation at the TOM complex**</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/12198123" target="_blank" class="term-link">
+                            PMID:12198123
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Insertion and assembly of human tom7 into the preprotein translocase complex of the outer mitochondrial membrane.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/15644312" target="_blank" class="term-link">
+                            PMID:15644312
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Dissection of the mitochondrial import and assembly pathway for human Tom40.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/18331822" target="_blank" class="term-link">
+                            PMID:18331822
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Identification of Tom5 and Tom6 in the preprotein translocase complex of human mitochondrial outer membrane.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/24270810" target="_blank" class="term-link">
+                            PMID:24270810
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">High-content genome-wide RNAi screens identify regulators of parkin upstream of mitophagy.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/30021884" target="_blank" class="term-link">
+                            PMID:30021884
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Histone Interaction Landscapes Visualized by Crosslinking Mass Spectrometry in Intact Cell Nuclei.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link">
+                            PMID:34800366
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Quantitative high-confidence human mitochondrial proteome and its dynamics in cellular context.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/35271311" target="_blank" class="term-link">
+                            PMID:35271311
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">OpenCell: Endogenous tagging for the cartography of human cellular organization.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-5205661
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Pink1 is recruited from the cytoplasm to the mitochondria</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/TOMM7/TOMM7-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research report for human TOMM7</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Which TOMM7 structural features separately control TOM oligomeric stability and PINK1 arrest/activation at the TOM complex?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q9P0U1" data-a="Q: Which TOMM7 structural features separately control..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Why do different TOMM7 disease alleles produce selective developmental, metabolic, or cerebrovascular phenotypes despite retention of mitochondrial localization?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q9P0U1" data-a="Q: Why do different TOMM7 disease alleles produce sel..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Compare endogenous TOMM7 knockout/rescue with p.W25R and p.P29L alleles for TOM complex assembly, TOMM40/TOMM22 interaction, import of representative mitochondrial precursors, PINK1 stabilization, Parkin recruitment, and endothelial/iPSC metabolic phenotypes.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: TOMM7 disease variants selectively weaken TOMM7-TOMM40/TOMM22 interactions, altering TOM assembly and PINK1 signaling without uniformly abolishing import.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: endogenous rescue, TOM assembly assay, and mitophagy assay</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q9P0U1" data-a="EXPERIMENT: Compare endogenous TOMM7 knockout/rescue with p.W2..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Deep Research Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(TOMM7-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q9P0U1" data-a="DOC: Deep Research Falcon" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <hr />
+<p>provider: falcon<br />
+model: Edison Scientific Literature<br />
+cached: false<br />
+start_time: '2026-05-11T12:20:35.144001'<br />
+end_time: '2026-05-11T12:29:42.246057'<br />
+duration_seconds: 547.1<br />
+template_file: templates/gene_research_go_focused.md<br />
+template_variables:<br />
+  organism: human<br />
+  gene_id: TOMM7<br />
+  gene_symbol: TOMM7<br />
+  uniprot_accession: Q9P0U1<br />
+  protein_description: 'RecName: Full=Mitochondrial import receptor subunit TOM7 homolog;<br />
+    AltName: Full=Translocase of outer membrane 7 kDa subunit homolog;'<br />
+  gene_info: Name=TOMM7; Synonyms=TOM7, TOMM07; ORFNames=AD-014;<br />
+  organism_full: Homo sapiens (Human).<br />
+  protein_family: Belongs to the Tom7 family. .<br />
+  protein_domains: Tom7. (IPR012621); Tom7 (PF08038)<br />
+provider_config:<br />
+  timeout: 600<br />
+  max_retries: 3<br />
+  parameters:<br />
+    allowed_domains: []<br />
+    temperature: 0.1<br />
+citation_count: 36</p>
+<hr />
+<h2 id="question">Question</h2>
+<h1 id="gene-research-for-functional-annotation">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> Q9P0U1</li>
+<li><strong>Protein Description:</strong> RecName: Full=Mitochondrial import receptor subunit TOM7 homolog; AltName: Full=Translocase of outer membrane 7 kDa subunit homolog;</li>
+<li><strong>Gene Information:</strong> Name=TOMM7; Synonyms=TOM7, TOMM07; ORFNames=AD-014;</li>
+<li><strong>Organism (full):</strong> Homo sapiens (Human).</li>
+<li><strong>Protein Family:</strong> Belongs to the Tom7 family. .</li>
+<li><strong>Key Domains:</strong> Tom7. (IPR012621); Tom7 (PF08038)</li>
+</ul>
+<h3 id="mandatory-verification-steps">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "TOMM7" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Homo sapiens (Human).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'TOMM7' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>TOMM7</strong> (gene ID: TOMM7, UniProt: Q9P0U1) in human.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="output">Output</h2>
+<p>Question: You are an expert researcher providing comprehensive, well-cited information.</p>
+<p>Provide detailed information focusing on:<br />
+1. Key concepts and definitions with current understanding<br />
+2. Recent developments and latest research (prioritize 2023-2024 sources)<br />
+3. Current applications and real-world implementations<br />
+4. Expert opinions and analysis from authoritative sources<br />
+5. Relevant statistics and data from recent studies</p>
+<p>Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.<br />
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.</p>
+<h1 id="gene-research-for-functional-annotation_1">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context_1">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot_1">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> Q9P0U1</li>
+<li><strong>Protein Description:</strong> RecName: Full=Mitochondrial import receptor subunit TOM7 homolog; AltName: Full=Translocase of outer membrane 7 kDa subunit homolog;</li>
+<li><strong>Gene Information:</strong> Name=TOMM7; Synonyms=TOM7, TOMM07; ORFNames=AD-014;</li>
+<li><strong>Organism (full):</strong> Homo sapiens (Human).</li>
+<li><strong>Protein Family:</strong> Belongs to the Tom7 family. .</li>
+<li><strong>Key Domains:</strong> Tom7. (IPR012621); Tom7 (PF08038)</li>
+</ul>
+<h3 id="mandatory-verification-steps_1">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "TOMM7" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Homo sapiens (Human).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature_1">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'TOMM7' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target_1">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>TOMM7</strong> (gene ID: TOMM7, UniProt: Q9P0U1) in human.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="research-report-human-tomm7-uniprot-q9p0u1-functional-annotation-mechanisms-and-recent-findings">Research report: Human <strong>TOMM7</strong> (UniProt <strong>Q9P0U1</strong>) — functional annotation, mechanisms, and recent findings</h2>
+<h3 id="0-target-identity-verification-mandatory">0) Target identity verification (mandatory)</h3>
+<p>The UniProt accession <strong>Q9P0U1</strong> corresponds to <strong>Homo sapiens TOMM7</strong> (synonyms: TOM7, TOMM07), annotated as <strong>“mitochondrial import receptor subunit TOM7 homolog”</strong>, a small Tom7-family component of the <strong>translocase of the outer mitochondrial membrane (TOM) complex</strong>. The retrieved human structural, mechanistic, and genetics literature consistently uses <strong>TOMM7/Tom7</strong> to describe this <strong>TOM complex subunit</strong> and does not indicate an alternative gene/protein identity under this symbol in humans (pitt2021abiochemicaland pages 16-17, raimi2024mechanismofhuman pages 1-2, young2023ahypomorphicvariant pages 1-2).</p>
+<h3 id="1-key-concepts-and-definitions-current-understanding">1) Key concepts and definitions (current understanding)</h3>
+<h4 id="11-the-tom-complex-and-tomm7s-functional-class">1.1 The TOM complex and TOMM7’s functional class</h4>
+<p>The <strong>TOM complex</strong> is the major entry gate for nuclear-encoded mitochondrial precursor proteins, consisting of the pore-forming <strong>TOM40</strong> plus receptor and accessory subunits. In humans, one commonly described composition includes <strong>seven subunits: TOM5, TOM6, TOM7, TOM20, TOM22, TOM40, TOM70</strong> (raimi2024mechanismofhuman pages 1-2, su2024structureofthe pages 1-3). In human cryo-EM structures, <strong>TOMM7</strong> is a <strong>small, single-pass α-helical subunit</strong> that associates peripherally with the TOM40 β-barrel and is part of the <strong>TOM core complex</strong> (wang2020atomicstructureof pages 1-2, pitt2021abiochemicaland pages 6-9).</p>
+<p>Functionally, TOMM7 is best classified as a <strong>non-enzymatic regulatory/structural subunit</strong>: it does not form the transport pore itself but instead <strong>modulates TOM complex assembly, stability, and higher-order organization</strong>, and it contributes to mitochondrial quality-control signaling (pitt2021abiochemicaland pages 6-9, su2024structureofthe pages 1-3).</p>
+<h4 id="12-localization-and-topology">1.2 Localization and topology</h4>
+<p>TOMM7 is an <strong>outer mitochondrial membrane</strong> subunit of the TOM machinery. Topology evidence summarized in a structural/biochemical review indicates that TOMM7’s <strong>C-terminus faces the intermembrane space (IMS)</strong>: fusing GFP to the IMS-facing C-terminus abolishes correct mitochondrial targeting, consistent with an IMS-exposed C-terminal region (pitt2021abiochemicaland pages 16-17).</p>
+<h4 id="13-structural-features-relevant-to-mechanism">1.3 Structural features relevant to mechanism</h4>
+<p>Recent structural syntheses emphasize that human Tom7 has an <strong>IMS-directed extended/elongated C-terminal segment/loop</strong> (nussberger2024newinsightsinto pages 2-4). Cryo-EM-based reviews also describe an <strong>extended IMS segment</strong> in human Tom7 containing a <strong>negatively charged patch</strong> (pitt2021abiochemicaland pages 11-12). In addition, Tom7’s transmembrane helix shows a <strong>kink/bend</strong>, positioning it near Tom22/Tom40 interfaces and supporting a role in organizing TOM subunit architecture and oligomeric state (pitt2021abiochemicaland pages 6-9).</p>
+<h3 id="2-tomm7-primary-functions-and-supported-mechanisms">2) TOMM7 primary functions and supported mechanisms</h3>
+<h4 id="21-regulator-of-tom-complex-assembly-stability-and-oligomeric-state">2.1 Regulator of TOM complex assembly, stability, and oligomeric state</h4>
+<p>Human TOM structures show Tom7 as one of the small subunits surrounding TOM40 in the TOM core, consistent with a stabilizing/organizing role within the complex (wang2020atomicstructureof pages 1-2, pitt2021abiochemicaland pages 6-9). Functional interpretations from cryo-EM and biochemical literature support that Tom7 <strong>modulates assembly dynamics</strong> and can function antagonistically to Tom6: Tom6 promotes TOM formation/stability, whereas Tom7 <strong>delays assembly and/or reduces stability</strong> (wang2020atomicstructureof pages 1-2, su2024structureofthe pages 1-3). A 2024 cryo-EM study of the human TOM holo complex (capturing intact Tom20) explicitly states that <strong>Tom6 stabilizes TOM via interaction with Tom22</strong>, while <strong>Tom7 reduces complex stability</strong> (su2024structureofthe pages 1-3).</p>
+<p>Together, these data support annotating TOMM7 as a <strong>regulatory subunit influencing TOM stability and higher-order organization</strong> rather than as a canonical receptor (TOM20/TOM70) or the pore (TOM40) (su2024structureofthe pages 1-3, raimi2024mechanismofhuman pages 1-2).</p>
+<h4 id="22-role-in-pink1-import-arrest-and-pink1parkin-mitophagy-signaling">2.2 Role in PINK1 import arrest and PINK1/Parkin mitophagy signaling</h4>
+<p>A major mechanistic role of TOMM7 in mammalian cells is its requirement for <strong>PINK1 stabilization/activation at the TOM complex</strong> on damaged mitochondria.</p>
+<ul>
+<li>
+<p><strong>Genetic/functional evidence (cell biology):</strong> Tom7 was identified as essential for <strong>PINK1 accumulation on the outer mitochondrial membrane (OMM)</strong> after loss of mitochondrial membrane potential; without Tom7, PINK1 is imported into depolarized mitochondria and then <strong>cleaved by OMA1</strong> rather than accumulating for Parkin activation (sekine2019reciprocalrolesof pages 1-3). This supports a model in which TOMM7 promotes or enables <strong>import arrest</strong> of PINK1 at TOM under depolarization conditions.</p>
+</li>
+<li>
+<p><strong>Mechanistic reconstitution (2024):</strong> In a reconstituted system, co-expression of <strong>human PINK1</strong> together with <strong>all seven TOM subunits</strong> is sufficient for PINK1 activation. The study demonstrates an <strong>essential role for TOM40 and its structurally associated TOM7 and TOM22</strong> in PINK1 activation, while TOM20 and TOM70 are required for optimal activation (raimi2024mechanismofhuman pages 1-2). This work also provides a quantitative biochemical signature: under depolarization, full-length PINK1 appears in a distinct <strong>~700-kDa TOM-associated complex</strong>, compared with native TOM at <strong>~500 kDa</strong> by BN-PAGE (raimi2024mechanismofhuman pages 1-2).</p>
+</li>
+<li>
+<p><strong>Downstream effect on Parkin:</strong> A structural/biochemical review summarizes evidence that human Tom7 is critical for <strong>Parkin recruitment/OMM accumulation</strong> and PINK1 accumulation after depolarization, and notes that defects in Tom7-deficient cells can be rescued by <strong>OMA1 knockdown</strong> in some contexts, indicating functional interplay between TOMM7-dependent PINK1 stabilization and proteolytic regulation by OMA1 (pitt2021abiochemicaland pages 16-17, pitt2021abiochemicaland pages 17-19).</p>
+</li>
+</ul>
+<p>Collectively, the most defensible functional annotation is that TOMM7 is a TOM-core accessory subunit that <strong>links outer-membrane protein import machinery to mitochondrial quality control</strong> by enabling <strong>PINK1 retention/activation at TOM</strong> during stress, thereby promoting <strong>PINK1–Parkin mitophagy</strong> signaling (sekine2019reciprocalrolesof pages 1-3, raimi2024mechanismofhuman pages 1-2).</p>
+<h3 id="3-recent-developments-and-latest-research-prioritizing-20232024">3) Recent developments and latest research (prioritizing 2023–2024)</h3>
+<h4 id="31-2024-structural-insights-into-tomm7-topology-and-dynamics">3.1 2024 structural insights into TOMM7 topology and dynamics</h4>
+<p>A 2024 structural review highlights Tom7’s <strong>elongated IMS-oriented C-terminus/loop</strong>, proposing that this element may help shape the <strong>IMS-side exit pathway</strong> of the TOM pore region in human complexes (nussberger2024newinsightsinto pages 2-4). In parallel, 2024 cryo-EM work capturing the TOM holo complex (including intact Tom20) reinforces Tom7’s presence as a small subunit surrounding Tom40 and frames Tom7 as a <strong>destabilizing counterbalance</strong> to Tom6 stabilization (su2024structureofthe pages 1-3). These studies are important because they shift TOMM7 annotation from a generic “small TOM subunit” to a <strong>structurally distinctive, IMS-featured modulator</strong> of TOM architecture (nussberger2024newinsightsinto pages 2-4, pitt2021abiochemicaland pages 11-12).</p>
+<h4 id="32-2024-mechanistic-clarification-of-tom-subunit-requirements-for-pink1-activation">3.2 2024 mechanistic clarification of TOM subunit requirements for PINK1 activation</h4>
+<p>The 2024 Science Advances reconstitution study is a key advance because it disentangles TOM subunit contributions: TOM7 (with TOM40 and TOM22) is <strong>essential</strong>, whereas receptor subunits TOM20/TOM70 are <strong>required for optimal</strong> activation, and the work explicitly frames these insights as enabling development of <strong>small-molecule PINK1 activators</strong> as a Parkinson’s disease therapeutic strategy (raimi2024mechanismofhuman pages 1-2).</p>
+<h4 id="33-20232024-human-genetics-tomm7-as-a-mendelian-disease-gene">3.3 2023–2024 human genetics: TOMM7 as a Mendelian disease gene</h4>
+<p>Two recent clinical genetics reports provide strong real-world evidence that TOMM7 dysfunction causes multisystem developmental disease:</p>
+<ul>
+<li>
+<p><strong>2023 (Jan): p.Trp25Arg (W25R) hypomorphic allele.</strong> A homozygous missense variant <strong>c.73T&gt;C (p.Trp25Arg)</strong> causes syndromic short stature and developmental delay with skeletal dysplasia, hypotonia, microvesicular liver steatosis, and ocular findings; mouse modeling supports the allele as <strong>hypomorphic</strong> and associates TOMM7 perturbation with bioenergetic uncoupling-like phenotypes (young2023ahypomorphicvariant pages 1-2). URL: https://doi.org/10.1016/j.xhgg.2022.100148 (Jan 2023) (young2023ahypomorphicvariant pages 1-2).</p>
+</li>
+<li>
+<p><strong>2024 (Dec): recurrent p.Pro29Leu (P29L) expands phenotype to moyamoya.</strong> A recurrent homozygous <strong>p.Pro29Leu (p.P29L; c.86C&gt;T)</strong> was found in <strong>9 patients from 7 unrelated families</strong> with microcephaly, short stature/postnatal growth failure, developmental delay, facial dysmorphism, atrophic macular scarring, and <strong>moyamoya disease in 5/9</strong> (li2024homozygousvariantin pages 2-3). This association reached genome-wide significance (<strong>P = 2.5072 × 10−23</strong>) in the authors’ analysis, and the paper reports a TOMM7 frequency across gnomAD ancestry groups of <strong>0.0251%</strong> (li2024homozygousvariantin pages 14-16). URL: https://doi.org/10.1016/j.ebiom.2024.105476 (Dec 2024) (li2024homozygousvariantin pages 2-3, li2024homozygousvariantin pages 14-16).</p>
+</li>
+</ul>
+<p>These findings support including TOMM7 in diagnostic gene panels for syndromic growth failure/microcephaly and potentially for pediatric cerebrovascular syndromes with mitochondrial features (li2024homozygousvariantin pages 2-3, young2023ahypomorphicvariant pages 1-2).</p>
+<h3 id="4-pathways-interactions-and-cellular-contexts">4) Pathways, interactions, and cellular contexts</h3>
+<h4 id="41-core-pathway-mitochondrial-protein-import-via-tom">4.1 Core pathway: mitochondrial protein import via TOM</h4>
+<p>TOMM7 participates in mitochondrial protein import indirectly by regulating the integrity and assembly state of the TOM complex, which is required for the import of most nuclear-encoded mitochondrial proteins (raimi2024mechanismofhuman pages 1-2, su2024structureofthe pages 1-3). Thus, TOMM7 is best placed in pathways annotated as <strong>mitochondrial protein targeting/import</strong> and <strong>mitochondrial outer membrane translocation</strong>.</p>
+<h4 id="42-mitochondrial-quality-control-pink1parkin-pathway">4.2 Mitochondrial quality control: PINK1–Parkin pathway</h4>
+<p>When mitochondria lose membrane potential, PINK1 is stabilized at the TOM complex and triggers Parkin recruitment/activation to initiate mitophagy. TOMM7 is a key determinant of this switch: loss of Tom7 prevents PINK1 arrest at the OMM and leads to OMA1-dependent cleavage, thereby reducing PINK1’s ability to activate Parkin on damaged mitochondria (sekine2019reciprocalrolesof pages 1-3). Reconstitution work places TOMM7 among the essential TOM components for PINK1 activation (raimi2024mechanismofhuman pages 1-2).</p>
+<h3 id="5-quantitative-data-and-key-statistics-from-recent-studies">5) Quantitative data and key statistics from recent studies</h3>
+<ul>
+<li>
+<p><strong>BN-PAGE complex sizes (2024 mechanistic study):</strong> full-length PINK1 stabilizes in a TOM-associated complex at <strong>~700 kDa</strong>, distinct from native TOM at <strong>~500 kDa</strong> (raimi2024mechanismofhuman pages 1-2).</p>
+</li>
+<li>
+<p><strong>Population/statistical genetics (2024):</strong> p.P29L cohort of <strong>9 patients / 7 families</strong>; <strong>moyamoya in 5/9</strong>; association significance <strong>P = 2.5072 × 10−23</strong>; reported gnomAD presence <strong>0.0251%</strong> across ancestry groups (li2024homozygousvariantin pages 2-3, li2024homozygousvariantin pages 14-16).</p>
+</li>
+<li>
+<p><strong>Mitochondrial proteomics/flux (2022, still highly relevant to 2024 genetics):</strong> in TOMM7 p.P29L patient fibroblasts, mitochondrial proteomics detected <strong>587 proteins</strong>, with <strong>91 differentially expressed</strong> (P&lt;0.05), and patient fibroblasts showed <strong>elevated basal and maximal OCR</strong> (garg2022autosomalrecessiveprogeroid pages 2-3). Variant functional assays show reduced TOMM7 interaction with TOMM40 and TOMM22 (garg2022autosomalrecessiveprogeroid pages 3-5).</p>
+</li>
+</ul>
+<p>These numbers support the interpretation that TOMM7 variants can shift mitochondrial import/proteome balance and bioenergetics without necessarily collapsing mitochondrial respiration globally (garg2022autosomalrecessiveprogeroid pages 2-3, garg2022autosomalrecessiveprogeroid pages 3-5).</p>
+<h3 id="6-current-applications-and-real-world-implementations">6) Current applications and real-world implementations</h3>
+<ol>
+<li>
+<p><strong>Clinical genetics / diagnostics (2023–2024 implementation):</strong> TOMM7 has clear relevance as a Mendelian disease gene for syndromic growth and neurodevelopmental phenotypes, and (in 2024) a distinct syndrome including <strong>moyamoya</strong>. These data motivate TOMM7 inclusion in diagnostic pipelines for <strong>microcephaly + growth failure + developmental delay</strong>, particularly when accompanied by ophthalmologic findings and/or cerebrovascular disease (li2024homozygousvariantin pages 2-3, young2023ahypomorphicvariant pages 1-2).</p>
+</li>
+<li>
+<p><strong>Therapeutic strategy development (mitophagy modulation):</strong> mechanistic reconstitution of PINK1 activation at TOM explicitly frames the work as enabling <strong>small-molecule activators of PINK1</strong> as a therapeutic approach for Parkinson’s disease, and identifies TOM7/TOM22/TOM40 as essential components to consider in such strategies (raimi2024mechanismofhuman pages 1-2). Complementarily, earlier mechanistic work suggests that modulating <strong>OMA1</strong> can rescue Parkin recruitment for some PINK1 dysfunction contexts, highlighting the TOMM7–OMA1 axis as a conceptual intervention point (sekine2019reciprocalrolesof pages 1-3, pitt2021abiochemicaland pages 17-19).</p>
+</li>
+</ol>
+<h3 id="7-expert-synthesis-and-interpretation-authoritative-sources">7) Expert synthesis and interpretation (authoritative sources)</h3>
+<p>Structural/biochemical reviews emphasize that the TOM complex is not only a constitutive import machine but also a hub connecting import, mitochondrial homeostasis, and disease processes. Within that framework, TOMM7 is increasingly viewed as a <strong>regulatory element</strong> whose IMS-facing structural features and impact on complex stability can influence both import and quality-control signaling (nussberger2024newinsightsinto pages 2-4, su2024structureofthe pages 1-3). In Parkinson’s-related mechanisms, primary and reconstitution studies converge on TOMM7 as a component required for appropriate PINK1 behavior at the import gate during mitochondrial damage, which helps explain why TOM machinery components are repeatedly implicated in mitophagy regulation and disease-relevant stress responses (sekine2019reciprocalrolesof pages 1-3, raimi2024mechanismofhuman pages 1-2).</p>
+<h3 id="8-consolidated-evidence-table">8) Consolidated evidence table</h3>
+<table>
+<thead>
+<tr>
+<th>Topic</th>
+<th>Key findings</th>
+<th>Evidence type</th>
+<th>Publication (first author, year, journal)</th>
+<th>Publication date (month/year if available)</th>
+<th>URL</th>
+<th>Notes for functional annotation</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Identity/localization/topology</td>
+<td>TOMM7 matches UniProt Q9P0U1: a small human TOM complex subunit in the Tom7 family. It is part of the TOM core/holo complex with TOM40, TOM22, TOM5, TOM6, and receptors TOM20/TOM70. Topology data support a single-pass outer-membrane helix with the C-terminus facing the intermembrane space (IMS); GFP fusion to the C-terminus disrupts targeting, consistent with an IMS-exposed tail. (pitt2021abiochemicaland pages 16-17, raimi2024mechanismofhuman pages 1-2, pitt2021abiochemicaland pages 3-6)</td>
+<td>Cryo-EM, cell biology, review</td>
+<td>Pitt, 2021, <em>Cells</em>; Raimi, 2024, <em>Science Advances</em></td>
+<td>05/2021; 06/2024</td>
+<td>https://doi.org/10.3390/cells10051164 ; https://doi.org/10.1126/sciadv.adn7191</td>
+<td>Annotate as a non-enzymatic regulatory/structural TOM subunit of the mitochondrial outer membrane, not a transporter channel itself.</td>
+</tr>
+<tr>
+<td>Structural features</td>
+<td>Human Tom7 has a kinked transmembrane helix and an elongated C-terminal/loop segment projecting toward the IMS; this IMS-directed segment is described as extended and includes a negatively charged patch. Tom7 lies peripherally adjacent to the Tom40 β-barrel and near Tom22/Tom5, helping shape the TOM core architecture. (nussberger2024newinsightsinto pages 2-4, pitt2021abiochemicaland pages 6-9, pitt2021abiochemicaland pages 11-12)</td>
+<td>Cryo-EM, structural review</td>
+<td>Nussberger, 2024, <em>Biochemical Society Transactions</em>; Pitt, 2021, <em>Cells</em></td>
+<td>04/2024; 05/2021</td>
+<td>https://doi.org/10.1042/bst20231236 ; https://doi.org/10.3390/cells10051164</td>
+<td>Useful for annotation of topology and likely IMS-side regulatory interactions during precursor exit/complex organization.</td>
+</tr>
+<tr>
+<td>TOM assembly &amp; stability</td>
+<td>Tom7 is a small α-helical TOM subunit that surrounds Tom40 and participates in assembly/stability dynamics. Human and comparative studies support an antagonistic relationship with Tom6: Tom6 stabilizes TOM, whereas Tom7 can reduce stability/delay assembly; loss of Tom7 increases tetramer formation and increases hTom40 import/biogenesis in some systems. (wang2020atomicstructureof pages 1-2, pitt2021abiochemicaland pages 6-9, su2024structureofthe pages 1-3)</td>
+<td>Cryo-EM, biochemical genetics, review</td>
+<td>Wang, 2020, <em>Cell Discovery</em>; Pitt, 2021, <em>Cells</em>; Su, 2024, <em>PNAS Nexus</em></td>
+<td>09/2020; 05/2021; 06/2024</td>
+<td>https://doi.org/10.1038/s41421-020-00198-2 ; https://doi.org/10.3390/cells10051164 ; https://doi.org/10.1093/pnasnexus/pgae269</td>
+<td>Best described as a regulator of TOM complex biogenesis/oligomeric state rather than a core receptor or pore-forming unit.</td>
+</tr>
+<tr>
+<td>PINK1/Parkin mitophagy</td>
+<td>TOMM7 is required for efficient PINK1 stabilization/activation at damaged mitochondria and for downstream Parkin recruitment. In TOMM7-deficient cells, PINK1 fails to accumulate after depolarization; Tom7 loss allows PINK1 import/OMA1 cleavage instead of OMM arrest. OMA1 knockdown can rescue defects in some contexts. Reconstituted human TOM studies show TOM40, TOM22, and TOM7 are essential for PINK1 activation, while TOM20/TOM70 optimize activation. BN-PAGE detects full-length PINK1 in a ~700-kDa TOM-associated complex versus native TOM at ~500-kDa. (pitt2021abiochemicaland pages 16-17, raimi2024mechanismofhuman pages 1-2, sekine2019reciprocalrolesof pages 1-3, pitt2021abiochemicaland pages 17-19)</td>
+<td>Cell biology, reconstitution, BN-PAGE</td>
+<td>Sekine, 2019, <em>Molecular Cell</em>; Raimi, 2024, <em>Science Advances</em>; Pitt, 2021, <em>Cells</em></td>
+<td>03/2019; 06/2024; 05/2021</td>
+<td>https://doi.org/10.1016/j.molcel.2019.01.002 ; https://doi.org/10.1126/sciadv.adn7191 ; https://doi.org/10.3390/cells10051164</td>
+<td>Functional annotation should mention a role in mitochondrial quality control/mitophagy via PINK1 import arrest and activation at TOM.</td>
+</tr>
+<tr>
+<td>Human disease genetics</td>
+<td>Hypomorphic TOMM7 p.Trp25Arg (c.73T&gt;C; p.W25R) causes syndromic short stature/developmental delay with skeletal dysplasia, hypotonia, liver steatosis, and ocular findings; proband homozygous, parents heterozygous. Prior structural interpretation places Trp25 near Arg24, predicted to affect TOMM40 interaction. (young2023ahypomorphicvariant pages 1-2)</td>
+<td>Human genetics, mouse modeling, bioenergetics</td>
+<td>Young, 2023, <em>Human Genetics and Genomics Advances</em></td>
+<td>01/2023</td>
+<td>https://doi.org/10.1016/j.xhgg.2022.100148</td>
+<td>Supports disease relevance of partial TOMM7 loss of function and TOM complex dysregulation in growth/development.</td>
+</tr>
+<tr>
+<td>Human disease genetics</td>
+<td>TOMM7 p.Pro29Leu (c.86C&gt;T; p.P29L) was first linked to autosomal recessive progeroid syndrome/Garg-Mishra phenotype in a single family: severe dwarfism, mandibular hypoplasia, hyperopia/micro-ophthalmia, partial lipodystrophy. The variant is rare in gnomAD (MAF 0.000048 in East Asians in one report) and affects a fully conserved residue in the kinked helix contacting TOMM40. (garg2022autosomalrecessiveprogeroid pages 1-2, garg2022autosomalrecessiveprogeroid pages 2-3, garg2022autosomalrecessiveprogeroid pages 3-5)</td>
+<td>Human genetics, structural interpretation, proteomics</td>
+<td>Garg, 2022, <em>Journal of Clinical Investigation</em></td>
+<td>12/2022</td>
+<td>https://doi.org/10.1172/jci156864</td>
+<td>Strong evidence that altered TOMM7-TOM interactions can produce a multisystem developmental/progeroid disorder.</td>
+</tr>
+<tr>
+<td>Human disease genetics</td>
+<td>A 2024 study expanded p.Pro29Leu to a recurrent disease allele: homozygous TOMM7 p.P29L in 9 patients from 7 unrelated families, with postnatal growth failure/short stature, microcephaly, facial dysmorphism, developmental delay, atrophic macular scarring, and moyamoya disease in 5/9 patients. Association reached genome-wide significance (P = 2.5072 × 10^-23). The variant frequency quoted across gnomAD ancestry groups was 0.0251%, and the paper notes enrichment in the Taiwanese population. (li2024homozygousvariantin pages 2-3, li2024homozygousvariantin pages 1-2, li2024homozygousvariantin pages 14-16)</td>
+<td>Human genetics, population analysis, iPSC/endothelial biology</td>
+<td>Li, 2024, <em>eBioMedicine</em></td>
+<td>12/2024</td>
+<td>https://doi.org/10.1016/j.ebiom.2024.105476</td>
+<td>Expands annotation to include cerebrovascular disease susceptibility and metabolic reprogramming phenotypes.</td>
+</tr>
+<tr>
+<td>Quantitative data/stats</td>
+<td>In TOMM7 p.P29L patient fibroblasts, mitochondrial proteomics detected 587 proteins, with 91 differentially expressed proteins (P&lt;0.05); GSEA showed enrichment of ATP-production/proton-transport proteins and reduction of phospholipid metabolic proteins. Patient fibroblasts showed elevated basal and maximal OCR. (garg2022autosomalrecessiveprogeroid pages 2-3, garg2022autosomalrecessiveprogeroid pages 3-5)</td>
+<td>Proteomics, extracellular flux</td>
+<td>Garg, 2022, <em>Journal of Clinical Investigation</em></td>
+<td>12/2022</td>
+<td>https://doi.org/10.1172/jci156864</td>
+<td>Quantitative support that TOMM7 perturbs select mitochondrial proteome/import balance rather than abolishing respiration globally.</td>
+</tr>
+<tr>
+<td>Quantitative data/stats</td>
+<td>p.W25R and Tomm7 deficiency produce a paradoxical bioenergetic phenotype: increased oxygen consumption despite bioenergetic deficiency, interpreted as uncoupling between oxidation and ATP synthesis rather than overt TCA/ETC failure. In 2024 endothelial/iPSC models with p.P29L, respiration was slightly decreased while glycolytic ATP production increased significantly, with elevated hexokinase 2 and enhanced glycolysis. (young2023ahypomorphicvariant pages 1-2, li2024homozygousvariantin pages 1-2)</td>
+<td>Mouse/cell physiology, iPSC metabolism</td>
+<td>Young, 2023, <em>HGGA</em>; Li, 2024, <em>eBioMedicine</em></td>
+<td>01/2023; 12/2024</td>
+<td>https://doi.org/10.1016/j.xhgg.2022.100148 ; https://doi.org/10.1016/j.ebiom.2024.105476</td>
+<td>Suggests TOMM7 loss/hypomorphism alters mitochondrial import-linked metabolic setpoints and can trigger glycolytic compensation.</td>
+</tr>
+<tr>
+<td>Human disease genetics / mechanism</td>
+<td>TOMM7 p.P29L retains mitochondrial localization but shows reduced interaction with TOMM40 and TOMM22, consistent with impaired integration into or regulation of the TOM complex. In contrast, Parkin-dependent mitophagy appeared largely intact in patient fibroblasts in the JCI study, indicating that not all TOMM7 disease alleles phenocopy complete TOMM7 loss for mitophagy. (garg2022autosomalrecessiveprogeroid pages 2-3, garg2022autosomalrecessiveprogeroid pages 5-6, garg2022autosomalrecessiveprogeroid pages 3-5)</td>
+<td>Co-IP, localization, mitophagy assay</td>
+<td>Garg, 2022, <em>Journal of Clinical Investigation</em></td>
+<td>12/2022</td>
+<td>https://doi.org/10.1172/jci156864</td>
+<td>Important nuance: disease mechanism may involve selective defects in TOM assembly/import specificity rather than total mitophagy failure.</td>
+</tr>
+<tr>
+<td>Functional systems biology</td>
+<td>In vascular/endothelial contexts, TOMM7 modulates mitochondrial Rac1/redox signaling and cerebrovascular network formation; Tomm7 loss in zebrafish and mice causes cerebrovascular abnormalities. The 2024 human p.P29L study connects this biology to moyamoya disease and endothelial tube-formation defects in edited iPSC-derived endothelial cells. (li2024homozygousvariantin pages 2-3, li2024homozygousvariantin pages 1-2)</td>
+<td>Animal models, endothelial cell biology, iPSC</td>
+<td>Li, 2024, <em>eBioMedicine</em></td>
+<td>12/2024</td>
+<td>https://doi.org/10.1016/j.ebiom.2024.105476</td>
+<td>Real-world relevance includes developmental vascular pathology, not only mitochondrial import biochemistry.</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes identity, structural biology, mitochondrial import function, mitophagy roles, and disease genetics for human TOMM7 (UniProt Q9P0U1). It consolidates recent and foundational evidence, including variant-specific clinical findings and key quantitative results useful for functional annotation.</em></p>
+<h3 id="9-summary-functional-annotation-actionable">9) Summary functional annotation (actionable)</h3>
+<p><strong>TOMM7 (Tom7)</strong> is a small, single-pass <strong>outer mitochondrial membrane</strong> TOM complex subunit with an <strong>IMS-facing extended C-terminal/loop segment</strong> and a kinked transmembrane helix (nussberger2024newinsightsinto pages 2-4, pitt2021abiochemicaland pages 11-12). Its primary role is to <strong>regulate TOM complex assembly/oligomeric state and stability</strong>, acting in opposition to Tom6 in stability control, and to support the TOM complex’s function as a signaling node in mitochondrial quality control (su2024structureofthe pages 1-3, pitt2021abiochemicaland pages 6-9). TOMM7 is also <strong>required for efficient PINK1 stabilization/activation at the TOM complex</strong> under mitochondrial depolarization, thereby enabling <strong>Parkin recruitment and PINK1–Parkin mitophagy</strong> (sekine2019reciprocalrolesof pages 1-3, raimi2024mechanismofhuman pages 1-2). Human biallelic missense variants (notably <strong>p.W25R</strong> and <strong>p.P29L</strong>) cause syndromic developmental disease, and recurrent <strong>p.P29L</strong> is associated with a microcephalic osteodysplastic dwarfism syndrome frequently complicated by <strong>moyamoya disease</strong> (young2023ahypomorphicvariant pages 1-2, li2024homozygousvariantin pages 2-3).</p>
+<p>References</p>
+<ol>
+<li>
+<p>(pitt2021abiochemicaland pages 16-17): Ashley S. Pitt and Susan K. Buchanan. A biochemical and structural understanding of tom complex interactions and implications for human health and disease. Cells, 10:1164, May 2021. URL: https://doi.org/10.3390/cells10051164, doi:10.3390/cells10051164. This article has 46 citations.</p>
+</li>
+<li>
+<p>(raimi2024mechanismofhuman pages 1-2): Olawale G. Raimi, Hina Ojha, Kenneth Ehses, Verena Dederer, Sven M. Lange, Cristian Polo Rivera, Tom D. Deegan, Yinchen Chen, Melanie Wightman, Rachel Toth, Karim P. M. Labib, Sebastian Mathea, Neil Ranson, Rubén Fernández-Busnadiego, and Miratul M. K. Muqit. Mechanism of human pink1 activation at the tom complex in a reconstituted system. Science Advances, Jun 2024. URL: https://doi.org/10.1126/sciadv.adn7191, doi:10.1126/sciadv.adn7191. This article has 40 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(young2023ahypomorphicvariant pages 1-2): Cameron Young, Dominyka Batkovskyte, Miyuki Kitamura, Maria Shvedova, Yutaro Mihara, Jun Akiba, Wen Zhou, Anna Hammarsjö, Gen Nishimura, Shuichi Yatsuga, Giedre Grigelioniene, and Tatsuya Kobayashi. A hypomorphic variant in the translocase of the outer mitochondrial membrane complex subunit tomm7 causes short stature and developmental delay. Human Genetics and Genomics Advances, 4:100148, Jan 2023. URL: https://doi.org/10.1016/j.xhgg.2022.100148, doi:10.1016/j.xhgg.2022.100148. This article has 23 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(su2024structureofthe pages 1-3): Jiayue Su, Xuyang Tian, Ziyi Wang, Jiawen Yang, Shan Sun, and Sen-Fang Sui. Structure of the intact tom20 receptor in the human translocase of the outer membrane complex. PNAS Nexus, Jun 2024. URL: https://doi.org/10.1093/pnasnexus/pgae269, doi:10.1093/pnasnexus/pgae269. This article has 12 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(wang2020atomicstructureof pages 1-2): Wenhe Wang, Xudong Chen, Laixing Zhang, Jingbo Yi, Qingxi Ma, Jian Yin, Wei Zhuo, Jinke Gu, and Maojun Yang. Atomic structure of human tom core complex. Cell Discovery, Sep 2020. URL: https://doi.org/10.1038/s41421-020-00198-2, doi:10.1038/s41421-020-00198-2. This article has 151 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(pitt2021abiochemicaland pages 6-9): Ashley S. Pitt and Susan K. Buchanan. A biochemical and structural understanding of tom complex interactions and implications for human health and disease. Cells, 10:1164, May 2021. URL: https://doi.org/10.3390/cells10051164, doi:10.3390/cells10051164. This article has 46 citations.</p>
+</li>
+<li>
+<p>(nussberger2024newinsightsinto pages 2-4): Stephan Nussberger, Robin Ghosh, and Shuo Wang. New insights into the structure and dynamics of the tom complex in mitochondria. Biochemical Society Transactions, 52:911-922, Apr 2024. URL: https://doi.org/10.1042/bst20231236, doi:10.1042/bst20231236. This article has 5 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(pitt2021abiochemicaland pages 11-12): Ashley S. Pitt and Susan K. Buchanan. A biochemical and structural understanding of tom complex interactions and implications for human health and disease. Cells, 10:1164, May 2021. URL: https://doi.org/10.3390/cells10051164, doi:10.3390/cells10051164. This article has 46 citations.</p>
+</li>
+<li>
+<p>(sekine2019reciprocalrolesof pages 1-3): Shiori Sekine, Chunxin Wang, Dionisia P. Sideris, Eric Bunker, Zhe Zhang, and Richard J. Youle. Reciprocal roles of tom7 and oma1 during mitochondrial import and activation of pink1. Molecular cell, 73 5:1028-1043.e5, Mar 2019. URL: https://doi.org/10.1016/j.molcel.2019.01.002, doi:10.1016/j.molcel.2019.01.002. This article has 189 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(pitt2021abiochemicaland pages 17-19): Ashley S. Pitt and Susan K. Buchanan. A biochemical and structural understanding of tom complex interactions and implications for human health and disease. Cells, 10:1164, May 2021. URL: https://doi.org/10.3390/cells10051164, doi:10.3390/cells10051164. This article has 46 citations.</p>
+</li>
+<li>
+<p>(li2024homozygousvariantin pages 2-3): Chia-Yi Li, Li-Wen Chen, Meng-Che Tsai, Yen-Yin Chou, Pei-Xuan Lin, Yu-Ming Chang, Wuh-Liang Hwu, Yin-Hsiu Chien, Ju-Li Lin, Hui-An Chen, Ni-Chung Lee, Pen-Hua Su, Tzung-Chien Hsieh, Hannah Klinkhammer, Yi-Chieh Wang, Yi-Ting Huang, Peter M. Krawitz, Sheng-Hsiang Lin, Lynn L.H. Huang, Po-Min Chiang, Min-Hsiu Shih, and Peng-Chieh Chen. Homozygous variant in translocase of outer mitochondrial membrane 7 leads to metabolic reprogramming and microcephalic osteodysplastic dwarfism with moyamoya disease. eBioMedicine, 110:105476, Dec 2024. URL: https://doi.org/10.1016/j.ebiom.2024.105476, doi:10.1016/j.ebiom.2024.105476. This article has 7 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(li2024homozygousvariantin pages 14-16): Chia-Yi Li, Li-Wen Chen, Meng-Che Tsai, Yen-Yin Chou, Pei-Xuan Lin, Yu-Ming Chang, Wuh-Liang Hwu, Yin-Hsiu Chien, Ju-Li Lin, Hui-An Chen, Ni-Chung Lee, Pen-Hua Su, Tzung-Chien Hsieh, Hannah Klinkhammer, Yi-Chieh Wang, Yi-Ting Huang, Peter M. Krawitz, Sheng-Hsiang Lin, Lynn L.H. Huang, Po-Min Chiang, Min-Hsiu Shih, and Peng-Chieh Chen. Homozygous variant in translocase of outer mitochondrial membrane 7 leads to metabolic reprogramming and microcephalic osteodysplastic dwarfism with moyamoya disease. eBioMedicine, 110:105476, Dec 2024. URL: https://doi.org/10.1016/j.ebiom.2024.105476, doi:10.1016/j.ebiom.2024.105476. This article has 7 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(garg2022autosomalrecessiveprogeroid pages 2-3): Abhimanyu Garg, Wee-Teik Keng, Zhenkang Chen, Adwait Amod Sathe, Chao Xing, Pavithira Devi Kailasam, Yanqiu Shao, Nicholas P. Lesner, Claire B. Llamas, Anil K. Agarwal, and Prashant Mishra. Autosomal recessive progeroid syndrome due to homozygosity for a tomm7 variant. Journal of Clinical Investigation, Dec 2022. URL: https://doi.org/10.1172/jci156864, doi:10.1172/jci156864. This article has 33 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(garg2022autosomalrecessiveprogeroid pages 3-5): Abhimanyu Garg, Wee-Teik Keng, Zhenkang Chen, Adwait Amod Sathe, Chao Xing, Pavithira Devi Kailasam, Yanqiu Shao, Nicholas P. Lesner, Claire B. Llamas, Anil K. Agarwal, and Prashant Mishra. Autosomal recessive progeroid syndrome due to homozygosity for a tomm7 variant. Journal of Clinical Investigation, Dec 2022. URL: https://doi.org/10.1172/jci156864, doi:10.1172/jci156864. This article has 33 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(pitt2021abiochemicaland pages 3-6): Ashley S. Pitt and Susan K. Buchanan. A biochemical and structural understanding of tom complex interactions and implications for human health and disease. Cells, 10:1164, May 2021. URL: https://doi.org/10.3390/cells10051164, doi:10.3390/cells10051164. This article has 46 citations.</p>
+</li>
+<li>
+<p>(garg2022autosomalrecessiveprogeroid pages 1-2): Abhimanyu Garg, Wee-Teik Keng, Zhenkang Chen, Adwait Amod Sathe, Chao Xing, Pavithira Devi Kailasam, Yanqiu Shao, Nicholas P. Lesner, Claire B. Llamas, Anil K. Agarwal, and Prashant Mishra. Autosomal recessive progeroid syndrome due to homozygosity for a tomm7 variant. Journal of Clinical Investigation, Dec 2022. URL: https://doi.org/10.1172/jci156864, doi:10.1172/jci156864. This article has 33 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(li2024homozygousvariantin pages 1-2): Chia-Yi Li, Li-Wen Chen, Meng-Che Tsai, Yen-Yin Chou, Pei-Xuan Lin, Yu-Ming Chang, Wuh-Liang Hwu, Yin-Hsiu Chien, Ju-Li Lin, Hui-An Chen, Ni-Chung Lee, Pen-Hua Su, Tzung-Chien Hsieh, Hannah Klinkhammer, Yi-Chieh Wang, Yi-Ting Huang, Peter M. Krawitz, Sheng-Hsiang Lin, Lynn L.H. Huang, Po-Min Chiang, Min-Hsiu Shih, and Peng-Chieh Chen. Homozygous variant in translocase of outer mitochondrial membrane 7 leads to metabolic reprogramming and microcephalic osteodysplastic dwarfism with moyamoya disease. eBioMedicine, 110:105476, Dec 2024. URL: https://doi.org/10.1016/j.ebiom.2024.105476, doi:10.1016/j.ebiom.2024.105476. This article has 7 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(garg2022autosomalrecessiveprogeroid pages 5-6): Abhimanyu Garg, Wee-Teik Keng, Zhenkang Chen, Adwait Amod Sathe, Chao Xing, Pavithira Devi Kailasam, Yanqiu Shao, Nicholas P. Lesner, Claire B. Llamas, Anil K. Agarwal, and Prashant Mishra. Autosomal recessive progeroid syndrome due to homozygosity for a tomm7 variant. Journal of Clinical Investigation, Dec 2022. URL: https://doi.org/10.1172/jci156864, doi:10.1172/jci156864. This article has 33 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>pitt2021abiochemicaland pages 16-17</li>
+<li>nussberger2024newinsightsinto pages 2-4</li>
+<li>pitt2021abiochemicaland pages 11-12</li>
+<li>pitt2021abiochemicaland pages 6-9</li>
+<li>su2024structureofthe pages 1-3</li>
+<li>sekine2019reciprocalrolesof pages 1-3</li>
+<li>raimi2024mechanismofhuman pages 1-2</li>
+<li>young2023ahypomorphicvariant pages 1-2</li>
+<li>li2024homozygousvariantin pages 2-3</li>
+<li>li2024homozygousvariantin pages 14-16</li>
+<li>garg2022autosomalrecessiveprogeroid pages 2-3</li>
+<li>garg2022autosomalrecessiveprogeroid pages 3-5</li>
+<li>wang2020atomicstructureof pages 1-2</li>
+<li>pitt2021abiochemicaland pages 17-19</li>
+<li>pitt2021abiochemicaland pages 3-6</li>
+<li>garg2022autosomalrecessiveprogeroid pages 1-2</li>
+<li>li2024homozygousvariantin pages 1-2</li>
+<li>garg2022autosomalrecessiveprogeroid pages 5-6</li>
+<li>https://doi.org/10.1016/j.xhgg.2022.100148</li>
+<li>https://doi.org/10.1016/j.ebiom.2024.105476</li>
+<li>https://doi.org/10.3390/cells10051164</li>
+<li>https://doi.org/10.1126/sciadv.adn7191</li>
+<li>https://doi.org/10.1042/bst20231236</li>
+<li>https://doi.org/10.1038/s41421-020-00198-2</li>
+<li>https://doi.org/10.1093/pnasnexus/pgae269</li>
+<li>https://doi.org/10.1016/j.molcel.2019.01.002</li>
+<li>https://doi.org/10.1172/jci156864</li>
+<li>https://doi.org/10.3390/cells10051164,</li>
+<li>https://doi.org/10.1126/sciadv.adn7191,</li>
+<li>https://doi.org/10.1016/j.xhgg.2022.100148,</li>
+<li>https://doi.org/10.1093/pnasnexus/pgae269,</li>
+<li>https://doi.org/10.1038/s41421-020-00198-2,</li>
+<li>https://doi.org/10.1042/bst20231236,</li>
+<li>https://doi.org/10.1016/j.molcel.2019.01.002,</li>
+<li>https://doi.org/10.1016/j.ebiom.2024.105476,</li>
+<li>https://doi.org/10.1172/jci156864,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q9P0U1
+gene_symbol: TOMM7
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: &gt;-
+  TOMM7 is a small single-pass mitochondrial outer membrane TOM complex subunit.
+  It is not the TOM pore or a standalone transporter; instead it regulates TOM
+  core assembly, stability, and oligomeric organization, and it has a supported
+  mitochondrial quality-control role in PINK1 stabilization/activation and
+  PINK1-Parkin mitophagy signaling after mitochondrial depolarization.
+existing_annotations:
+- term:
+    id: GO:0005742
+    label: mitochondrial outer membrane translocase complex
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: &gt;-
+      Correct phylogenetic inference. TOMM7 is a conserved small TOM subunit in
+      the mitochondrial outer membrane translocase complex.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM7/TOMM7-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TOMM7/TOMM7-deep-research-falcon.md
+      supporting_text: &#34;TOMM7 is an **outer mitochondrial membrane** subunit of the TOM machinery.&#34;
+- term:
+    id: GO:0005741
+    label: mitochondrial outer membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  review:
+    summary: &gt;-
+      Correct UniProt-derived localization. TOMM7 is a single-pass outer
+      mitochondrial membrane TOM subunit.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM7/TOMM7-deep-research-falcon.md
+- term:
+    id: GO:0005742
+    label: mitochondrial outer membrane translocase complex
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  review:
+    summary: &gt;-
+      Correct InterPro-derived annotation. TOMM7 is a Tom7-family small TOM
+      complex subunit.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM7/TOMM7-deep-research-falcon.md
+- term:
+    id: GO:0030150
+    label: protein import into mitochondrial matrix
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  review:
+    summary: &gt;-
+      Correct as a broad TOM pathway consequence but not TOMM7&#39;s most specific
+      role. TOMM7 regulates TOM complex assembly/stability and supports import
+      indirectly through the TOM complex.
+    action: KEEP_AS_NON_CORE
+    reason: Matrix import is one route through TOM; TOMM7&#39;s core role is TOM complex regulation.
+    additional_reference_ids:
+    - file:human/TOMM7/TOMM7-deep-research-falcon.md
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:12198123
+  review:
+    summary: &gt;-
+      Protein binding is too generic. The relevant result is TOMM7 insertion and
+      assembly into the TOM complex, captured by TOM complex and assembly terms.
+    action: REMOVE
+    reason: Protein binding is uninformative for TOMM7 function.
+    additional_reference_ids:
+    - file:human/TOMM7/TOMM7-deep-research-falcon.md
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:30021884
+  review:
+    summary: &gt;-
+      Histone crosslinking protein binding is not part of the curated TOMM7
+      mitochondrial outer membrane/TOM function.
+    action: REMOVE
+    reason: Protein binding is uninformative and likely unrelated to TOMM7 core function.
+    additional_reference_ids:
+    - file:human/TOMM7/TOMM7-deep-research-falcon.md
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:35271311
+  review:
+    summary: &gt;-
+      Generic OpenCell protein binding does not capture TOMM7&#39;s function as a
+      regulatory/structural TOM complex subunit.
+    action: REMOVE
+    reason: Protein binding is uninformative; complex and process annotations are more appropriate.
+    additional_reference_ids:
+    - file:human/TOMM7/TOMM7-deep-research-falcon.md
+- term:
+    id: GO:0030150
+    label: protein import into mitochondrial matrix
+  evidence_type: TAS
+  original_reference_id: PMID:15644312
+  review:
+    summary: &gt;-
+      Broad but valid for the TOM import pathway. TOMM7 contributes indirectly
+      through TOM complex organization rather than acting as the matrix-import
+      motor or pore.
+    action: KEEP_AS_NON_CORE
+    reason: Matrix import is a TOM pathway outcome but not TOMM7&#39;s most specific function.
+    additional_reference_ids:
+    - file:human/TOMM7/TOMM7-deep-research-falcon.md
+- term:
+    id: GO:0005741
+    label: mitochondrial outer membrane
+  evidence_type: NAS
+  original_reference_id: PMID:18331822
+  review:
+    summary: &gt;-
+      Correct localization. TOMM7 is a small outer mitochondrial membrane subunit
+      of the TOM machinery.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM7/TOMM7-deep-research-falcon.md
+- term:
+    id: GO:0045040
+    label: protein insertion into mitochondrial outer membrane
+  evidence_type: NAS
+  original_reference_id: PMID:18331822
+  review:
+    summary: &gt;-
+      The broad TOM biology is related, but TOMM7 is not an independent insertase.
+      The specific supported role is TOM complex assembly/stability and
+      oligomeric-state regulation.
+    action: MODIFY
+    reason: Replace outer membrane insertion with TOM complex assembly/stability.
+    proposed_replacement_terms:
+    - id: GO:0070096
+      label: mitochondrial outer membrane translocase complex assembly
+    additional_reference_ids:
+    - file:human/TOMM7/TOMM7-deep-research-falcon.md
+- term:
+    id: GO:0140596
+    label: TOM complex
+  evidence_type: NAS
+  original_reference_id: PMID:18331822
+  review:
+    summary: &gt;-
+      Correct and specific. TOMM7 is a TOM core/holo complex subunit adjacent to
+      TOM40/TOM22 and the other small Tom proteins.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM7/TOMM7-deep-research-falcon.md
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: HTP
+  original_reference_id: PMID:34800366
+  review:
+    summary: &gt;-
+      Correct but too general. TOMM7 is specifically a mitochondrial outer
+      membrane TOM complex subunit.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Subsumed by mitochondrial outer membrane and TOM complex annotations.
+    additional_reference_ids:
+    - file:human/TOMM7/TOMM7-deep-research-falcon.md
+- term:
+    id: GO:0005742
+    label: mitochondrial outer membrane translocase complex
+  evidence_type: TAS
+  original_reference_id: PMID:24270810
+  review:
+    summary: &gt;-
+      Accepted. The TOMM7/PINK1-Parkin evidence is consistent with TOMM7 acting
+      at the TOM complex.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM7/TOMM7-deep-research-falcon.md
+- term:
+    id: GO:0031647
+    label: regulation of protein stability
+  evidence_type: IMP
+  original_reference_id: PMID:24270810
+  review:
+    summary: &gt;-
+      Accepted for the PINK1 context. TOMM7 is required for efficient PINK1
+      stabilization/activation at the TOM complex after mitochondrial
+      depolarization.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM7/TOMM7-deep-research-falcon.md
+- term:
+    id: GO:1903749
+    label: positive regulation of protein localization to mitochondrion
+  evidence_type: IMP
+  original_reference_id: PMID:24270810
+  review:
+    summary: &gt;-
+      Accepted as a PINK1-related annotation. TOMM7 supports PINK1 accumulation
+      at damaged mitochondria/TOM after depolarization.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM7/TOMM7-deep-research-falcon.md
+- term:
+    id: GO:1905091
+    label: positive regulation of type 2 mitophagy
+  evidence_type: IMP
+  original_reference_id: PMID:24270810
+  review:
+    summary: &gt;-
+      Accepted. TOMM7 enables PINK1 stabilization/activation at TOM and
+      downstream Parkin recruitment, supporting PINK1-Parkin mitophagy signaling.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM7/TOMM7-deep-research-falcon.md
+- term:
+    id: GO:0005741
+    label: mitochondrial outer membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-5205661
+  review:
+    summary: &gt;-
+      Accepted. Reactome places TOMM7 at the mitochondrial outer membrane in
+      TOM/PINK1 pathway context.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM7/TOMM7-deep-research-falcon.md
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IDA
+  original_reference_id: PMID:12198123
+  review:
+    summary: &gt;-
+      Correct but too general. TOMM7 is specifically an outer membrane TOM
+      complex subunit.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Subsumed by mitochondrial outer membrane and TOM complex annotations.
+    additional_reference_ids:
+    - file:human/TOMM7/TOMM7-deep-research-falcon.md
+- term:
+    id: GO:0005742
+    label: mitochondrial outer membrane translocase complex
+  evidence_type: IDA
+  original_reference_id: PMID:12198123
+  review:
+    summary: &gt;-
+      Accepted. PMID:12198123 directly addresses insertion and assembly of human
+      TOM7 into the TOM complex.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM7/TOMM7-deep-research-falcon.md
+- term:
+    id: GO:0008320
+    label: protein transmembrane transporter activity
+  evidence_type: TAS
+  original_reference_id: PMID:15644312
+  review:
+    summary: &gt;-
+      TOMM7 is not the TOM protein-conducting pore. Its role is regulatory and
+      structural within the TOM complex rather than direct transporter activity.
+    action: REMOVE
+    reason: &gt;-
+      TOMM7 regulates TOM complex assembly/stability but does not independently
+      enable protein transmembrane transporter activity.
+    additional_reference_ids:
+    - file:human/TOMM7/TOMM7-deep-research-falcon.md
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: PMID:12198123
+  title: Insertion and assembly of human tom7 into the preprotein translocase complex
+    of the outer mitochondrial membrane.
+  findings: []
+- id: PMID:15644312
+  title: Dissection of the mitochondrial import and assembly pathway for human Tom40.
+  findings: []
+- id: PMID:18331822
+  title: Identification of Tom5 and Tom6 in the preprotein translocase complex of
+    human mitochondrial outer membrane.
+  findings: []
+- id: PMID:24270810
+  title: High-content genome-wide RNAi screens identify regulators of parkin upstream
+    of mitophagy.
+  findings: []
+- id: PMID:30021884
+  title: Histone Interaction Landscapes Visualized by Crosslinking Mass Spectrometry
+    in Intact Cell Nuclei.
+  findings: []
+- id: PMID:34800366
+  title: Quantitative high-confidence human mitochondrial proteome and its dynamics
+    in cellular context.
+  findings: []
+- id: PMID:35271311
+  title: &#39;OpenCell: Endogenous tagging for the cartography of human cellular organization.&#39;
+  findings: []
+- id: Reactome:R-HSA-5205661
+  title: Pink1 is recruited from the cytoplasm to the mitochondria
+  findings: []
+- id: file:human/TOMM7/TOMM7-deep-research-falcon.md
+  title: Falcon deep research report for human TOMM7
+  findings: []
+core_functions:
+- description: &gt;-
+    TOMM7 is a regulatory/structural small TOM subunit that modulates TOM complex
+    assembly, stability, and oligomeric organization at the mitochondrial outer
+    membrane.
+  supported_by:
+  - reference_id: file:human/TOMM7/TOMM7-deep-research-falcon.md
+    supporting_text: &#34;Functionally, TOMM7 is best classified as a **non-enzymatic regulatory/structural subunit**&#34;
+  - reference_id: file:human/TOMM7/TOMM7-deep-research-falcon.md
+    supporting_text: &#34;TOMM7 is an **outer mitochondrial membrane** subunit of the TOM machinery.&#34;
+  directly_involved_in:
+  - id: GO:0070096
+    label: mitochondrial outer membrane translocase complex assembly
+  locations:
+  - id: GO:0005741
+    label: mitochondrial outer membrane
+  in_complex:
+    id: GO:0140596
+    label: TOM complex
+- description: &gt;-
+    TOMM7 links the TOM complex to mitochondrial quality control by enabling
+    PINK1 stabilization/activation at TOM and downstream PINK1-Parkin mitophagy
+    signaling after mitochondrial damage.
+  supported_by:
+  - reference_id: file:human/TOMM7/TOMM7-deep-research-falcon.md
+    supporting_text: &#34;TOMM7 is also **required for efficient PINK1 stabilization/activation at the TOM complex**&#34;
+  directly_involved_in:
+  - id: GO:1905091
+    label: positive regulation of type 2 mitophagy
+  - id: GO:0031647
+    label: regulation of protein stability
+  - id: GO:1903749
+    label: positive regulation of protein localization to mitochondrion
+  locations:
+  - id: GO:0005741
+    label: mitochondrial outer membrane
+  in_complex:
+    id: GO:0140596
+    label: TOM complex
+proposed_new_terms: []
+suggested_questions:
+- question: &gt;-
+    Which TOMM7 structural features separately control TOM oligomeric stability
+    and PINK1 arrest/activation at the TOM complex?
+  experts: []
+- question: &gt;-
+    Why do different TOMM7 disease alleles produce selective developmental,
+    metabolic, or cerebrovascular phenotypes despite retention of mitochondrial
+    localization?
+  experts: []
+suggested_experiments:
+- hypothesis: &gt;-
+    TOMM7 disease variants selectively weaken TOMM7-TOMM40/TOMM22 interactions,
+    altering TOM assembly and PINK1 signaling without uniformly abolishing import.
+  description: &gt;-
+    Compare endogenous TOMM7 knockout/rescue with p.W25R and p.P29L alleles for
+    TOM complex assembly, TOMM40/TOMM22 interaction, import of representative
+    mitochondrial precursors, PINK1 stabilization, Parkin recruitment, and
+    endothelial/iPSC metabolic phenotypes.
+  experiment_type: endogenous rescue, TOM assembly assay, and mitophagy assay
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/human/TOMM7/TOMM7-ai-review.yaml
+++ b/genes/human/TOMM7/TOMM7-ai-review.yaml
@@ -1,11 +1,16 @@
 id: Q9P0U1
 gene_symbol: TOMM7
 product_type: PROTEIN
-status: INITIALIZED
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
-description: 'TODO: Add description for TOMM7'
+description: >-
+  TOMM7 is a small single-pass mitochondrial outer membrane TOM complex subunit.
+  It is not the TOM pore or a standalone transporter; instead it regulates TOM
+  core assembly, stability, and oligomeric organization, and it has a supported
+  mitochondrial quality-control role in PINK1 stabilization/activation and
+  PINK1-Parkin mitophagy signaling after mitochondrial depolarization.
 existing_annotations:
 - term:
     id: GO:0005742
@@ -13,160 +18,261 @@ existing_annotations:
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Correct phylogenetic inference. TOMM7 is a conserved small TOM subunit in
+      the mitochondrial outer membrane translocase complex.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM7/TOMM7-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TOMM7/TOMM7-deep-research-falcon.md
+      supporting_text: "TOMM7 is an **outer mitochondrial membrane** subunit of the TOM machinery."
 - term:
     id: GO:0005741
     label: mitochondrial outer membrane
   evidence_type: IEA
   original_reference_id: GO_REF:0000044
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Correct UniProt-derived localization. TOMM7 is a single-pass outer
+      mitochondrial membrane TOM subunit.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM7/TOMM7-deep-research-falcon.md
 - term:
     id: GO:0005742
     label: mitochondrial outer membrane translocase complex
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Correct InterPro-derived annotation. TOMM7 is a Tom7-family small TOM
+      complex subunit.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM7/TOMM7-deep-research-falcon.md
 - term:
     id: GO:0030150
     label: protein import into mitochondrial matrix
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Correct as a broad TOM pathway consequence but not TOMM7's most specific
+      role. TOMM7 regulates TOM complex assembly/stability and supports import
+      indirectly through the TOM complex.
+    action: KEEP_AS_NON_CORE
+    reason: Matrix import is one route through TOM; TOMM7's core role is TOM complex regulation.
+    additional_reference_ids:
+    - file:human/TOMM7/TOMM7-deep-research-falcon.md
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:12198123
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Protein binding is too generic. The relevant result is TOMM7 insertion and
+      assembly into the TOM complex, captured by TOM complex and assembly terms.
+    action: REMOVE
+    reason: Protein binding is uninformative for TOMM7 function.
+    additional_reference_ids:
+    - file:human/TOMM7/TOMM7-deep-research-falcon.md
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:30021884
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Histone crosslinking protein binding is not part of the curated TOMM7
+      mitochondrial outer membrane/TOM function.
+    action: REMOVE
+    reason: Protein binding is uninformative and likely unrelated to TOMM7 core function.
+    additional_reference_ids:
+    - file:human/TOMM7/TOMM7-deep-research-falcon.md
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:35271311
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Generic OpenCell protein binding does not capture TOMM7's function as a
+      regulatory/structural TOM complex subunit.
+    action: REMOVE
+    reason: Protein binding is uninformative; complex and process annotations are more appropriate.
+    additional_reference_ids:
+    - file:human/TOMM7/TOMM7-deep-research-falcon.md
 - term:
     id: GO:0030150
     label: protein import into mitochondrial matrix
   evidence_type: TAS
   original_reference_id: PMID:15644312
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Broad but valid for the TOM import pathway. TOMM7 contributes indirectly
+      through TOM complex organization rather than acting as the matrix-import
+      motor or pore.
+    action: KEEP_AS_NON_CORE
+    reason: Matrix import is a TOM pathway outcome but not TOMM7's most specific function.
+    additional_reference_ids:
+    - file:human/TOMM7/TOMM7-deep-research-falcon.md
 - term:
     id: GO:0005741
     label: mitochondrial outer membrane
   evidence_type: NAS
   original_reference_id: PMID:18331822
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Correct localization. TOMM7 is a small outer mitochondrial membrane subunit
+      of the TOM machinery.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM7/TOMM7-deep-research-falcon.md
 - term:
     id: GO:0045040
     label: protein insertion into mitochondrial outer membrane
   evidence_type: NAS
   original_reference_id: PMID:18331822
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      The broad TOM biology is related, but TOMM7 is not an independent insertase.
+      The specific supported role is TOM complex assembly/stability and
+      oligomeric-state regulation.
+    action: MODIFY
+    reason: Replace outer membrane insertion with TOM complex assembly/stability.
+    proposed_replacement_terms:
+    - id: GO:0070096
+      label: mitochondrial outer membrane translocase complex assembly
+    additional_reference_ids:
+    - file:human/TOMM7/TOMM7-deep-research-falcon.md
 - term:
     id: GO:0140596
     label: TOM complex
   evidence_type: NAS
   original_reference_id: PMID:18331822
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Correct and specific. TOMM7 is a TOM core/holo complex subunit adjacent to
+      TOM40/TOM22 and the other small Tom proteins.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM7/TOMM7-deep-research-falcon.md
 - term:
     id: GO:0005739
     label: mitochondrion
   evidence_type: HTP
   original_reference_id: PMID:34800366
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Correct but too general. TOMM7 is specifically a mitochondrial outer
+      membrane TOM complex subunit.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Subsumed by mitochondrial outer membrane and TOM complex annotations.
+    additional_reference_ids:
+    - file:human/TOMM7/TOMM7-deep-research-falcon.md
 - term:
     id: GO:0005742
     label: mitochondrial outer membrane translocase complex
   evidence_type: TAS
   original_reference_id: PMID:24270810
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Accepted. The TOMM7/PINK1-Parkin evidence is consistent with TOMM7 acting
+      at the TOM complex.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM7/TOMM7-deep-research-falcon.md
 - term:
     id: GO:0031647
     label: regulation of protein stability
   evidence_type: IMP
   original_reference_id: PMID:24270810
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Accepted for the PINK1 context. TOMM7 is required for efficient PINK1
+      stabilization/activation at the TOM complex after mitochondrial
+      depolarization.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM7/TOMM7-deep-research-falcon.md
 - term:
     id: GO:1903749
     label: positive regulation of protein localization to mitochondrion
   evidence_type: IMP
   original_reference_id: PMID:24270810
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Accepted as a PINK1-related annotation. TOMM7 supports PINK1 accumulation
+      at damaged mitochondria/TOM after depolarization.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM7/TOMM7-deep-research-falcon.md
 - term:
     id: GO:1905091
     label: positive regulation of type 2 mitophagy
   evidence_type: IMP
   original_reference_id: PMID:24270810
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Accepted. TOMM7 enables PINK1 stabilization/activation at TOM and
+      downstream Parkin recruitment, supporting PINK1-Parkin mitophagy signaling.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM7/TOMM7-deep-research-falcon.md
 - term:
     id: GO:0005741
     label: mitochondrial outer membrane
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-5205661
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Accepted. Reactome places TOMM7 at the mitochondrial outer membrane in
+      TOM/PINK1 pathway context.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM7/TOMM7-deep-research-falcon.md
 - term:
     id: GO:0005739
     label: mitochondrion
   evidence_type: IDA
   original_reference_id: PMID:12198123
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Correct but too general. TOMM7 is specifically an outer membrane TOM
+      complex subunit.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Subsumed by mitochondrial outer membrane and TOM complex annotations.
+    additional_reference_ids:
+    - file:human/TOMM7/TOMM7-deep-research-falcon.md
 - term:
     id: GO:0005742
     label: mitochondrial outer membrane translocase complex
   evidence_type: IDA
   original_reference_id: PMID:12198123
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      Accepted. PMID:12198123 directly addresses insertion and assembly of human
+      TOM7 into the TOM complex.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM7/TOMM7-deep-research-falcon.md
 - term:
     id: GO:0008320
     label: protein transmembrane transporter activity
   evidence_type: TAS
   original_reference_id: PMID:15644312
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      TOMM7 is not the TOM protein-conducting pore. Its role is regulatory and
+      structural within the TOM complex rather than direct transporter activity.
+    action: REMOVE
+    reason: >-
+      TOMM7 regulates TOM complex assembly/stability but does not independently
+      enable protein transmembrane transporter activity.
+    additional_reference_ids:
+    - file:human/TOMM7/TOMM7-deep-research-falcon.md
 references:
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO
@@ -209,3 +315,66 @@ references:
 - id: Reactome:R-HSA-5205661
   title: Pink1 is recruited from the cytoplasm to the mitochondria
   findings: []
+- id: file:human/TOMM7/TOMM7-deep-research-falcon.md
+  title: Falcon deep research report for human TOMM7
+  findings: []
+core_functions:
+- description: >-
+    TOMM7 is a regulatory/structural small TOM subunit that modulates TOM complex
+    assembly, stability, and oligomeric organization at the mitochondrial outer
+    membrane.
+  supported_by:
+  - reference_id: file:human/TOMM7/TOMM7-deep-research-falcon.md
+    supporting_text: "Functionally, TOMM7 is best classified as a **non-enzymatic regulatory/structural subunit**"
+  - reference_id: file:human/TOMM7/TOMM7-deep-research-falcon.md
+    supporting_text: "TOMM7 is an **outer mitochondrial membrane** subunit of the TOM machinery."
+  directly_involved_in:
+  - id: GO:0070096
+    label: mitochondrial outer membrane translocase complex assembly
+  locations:
+  - id: GO:0005741
+    label: mitochondrial outer membrane
+  in_complex:
+    id: GO:0140596
+    label: TOM complex
+- description: >-
+    TOMM7 links the TOM complex to mitochondrial quality control by enabling
+    PINK1 stabilization/activation at TOM and downstream PINK1-Parkin mitophagy
+    signaling after mitochondrial damage.
+  supported_by:
+  - reference_id: file:human/TOMM7/TOMM7-deep-research-falcon.md
+    supporting_text: "TOMM7 is also **required for efficient PINK1 stabilization/activation at the TOM complex**"
+  directly_involved_in:
+  - id: GO:1905091
+    label: positive regulation of type 2 mitophagy
+  - id: GO:0031647
+    label: regulation of protein stability
+  - id: GO:1903749
+    label: positive regulation of protein localization to mitochondrion
+  locations:
+  - id: GO:0005741
+    label: mitochondrial outer membrane
+  in_complex:
+    id: GO:0140596
+    label: TOM complex
+proposed_new_terms: []
+suggested_questions:
+- question: >-
+    Which TOMM7 structural features separately control TOM oligomeric stability
+    and PINK1 arrest/activation at the TOM complex?
+  experts: []
+- question: >-
+    Why do different TOMM7 disease alleles produce selective developmental,
+    metabolic, or cerebrovascular phenotypes despite retention of mitochondrial
+    localization?
+  experts: []
+suggested_experiments:
+- hypothesis: >-
+    TOMM7 disease variants selectively weaken TOMM7-TOMM40/TOMM22 interactions,
+    altering TOM assembly and PINK1 signaling without uniformly abolishing import.
+  description: >-
+    Compare endogenous TOMM7 knockout/rescue with p.W25R and p.P29L alleles for
+    TOM complex assembly, TOMM40/TOMM22 interaction, import of representative
+    mitochondrial precursors, PINK1 stabilization, Parkin recruitment, and
+    endothelial/iPSC metabolic phenotypes.
+  experiment_type: endogenous rescue, TOM assembly assay, and mitophagy assay

--- a/genes/human/TOMM7/TOMM7-deep-research-falcon.md
+++ b/genes/human/TOMM7/TOMM7-deep-research-falcon.md
@@ -1,0 +1,314 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-11T12:20:35.144001'
+end_time: '2026-05-11T12:29:42.246057'
+duration_seconds: 547.1
+template_file: templates/gene_research_go_focused.md
+template_variables:
+  organism: human
+  gene_id: TOMM7
+  gene_symbol: TOMM7
+  uniprot_accession: Q9P0U1
+  protein_description: 'RecName: Full=Mitochondrial import receptor subunit TOM7 homolog;
+    AltName: Full=Translocase of outer membrane 7 kDa subunit homolog;'
+  gene_info: Name=TOMM7; Synonyms=TOM7, TOMM07; ORFNames=AD-014;
+  organism_full: Homo sapiens (Human).
+  protein_family: Belongs to the Tom7 family. .
+  protein_domains: Tom7. (IPR012621); Tom7 (PF08038)
+provider_config:
+  timeout: 600
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 36
+---
+
+## Question
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** Q9P0U1
+- **Protein Description:** RecName: Full=Mitochondrial import receptor subunit TOM7 homolog; AltName: Full=Translocase of outer membrane 7 kDa subunit homolog;
+- **Gene Information:** Name=TOMM7; Synonyms=TOM7, TOMM07; ORFNames=AD-014;
+- **Organism (full):** Homo sapiens (Human).
+- **Protein Family:** Belongs to the Tom7 family. .
+- **Key Domains:** Tom7. (IPR012621); Tom7 (PF08038)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "TOMM7" matches the protein description above**
+2. **Verify the organism is correct:** Homo sapiens (Human).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'TOMM7' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **TOMM7** (gene ID: TOMM7, UniProt: Q9P0U1) in human.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** Q9P0U1
+- **Protein Description:** RecName: Full=Mitochondrial import receptor subunit TOM7 homolog; AltName: Full=Translocase of outer membrane 7 kDa subunit homolog;
+- **Gene Information:** Name=TOMM7; Synonyms=TOM7, TOMM07; ORFNames=AD-014;
+- **Organism (full):** Homo sapiens (Human).
+- **Protein Family:** Belongs to the Tom7 family. .
+- **Key Domains:** Tom7. (IPR012621); Tom7 (PF08038)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "TOMM7" matches the protein description above**
+2. **Verify the organism is correct:** Homo sapiens (Human).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'TOMM7' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **TOMM7** (gene ID: TOMM7, UniProt: Q9P0U1) in human.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Research report: Human **TOMM7** (UniProt **Q9P0U1**) — functional annotation, mechanisms, and recent findings
+
+### 0) Target identity verification (mandatory)
+The UniProt accession **Q9P0U1** corresponds to **Homo sapiens TOMM7** (synonyms: TOM7, TOMM07), annotated as **“mitochondrial import receptor subunit TOM7 homolog”**, a small Tom7-family component of the **translocase of the outer mitochondrial membrane (TOM) complex**. The retrieved human structural, mechanistic, and genetics literature consistently uses **TOMM7/Tom7** to describe this **TOM complex subunit** and does not indicate an alternative gene/protein identity under this symbol in humans (pitt2021abiochemicaland pages 16-17, raimi2024mechanismofhuman pages 1-2, young2023ahypomorphicvariant pages 1-2).
+
+### 1) Key concepts and definitions (current understanding)
+
+#### 1.1 The TOM complex and TOMM7’s functional class
+The **TOM complex** is the major entry gate for nuclear-encoded mitochondrial precursor proteins, consisting of the pore-forming **TOM40** plus receptor and accessory subunits. In humans, one commonly described composition includes **seven subunits: TOM5, TOM6, TOM7, TOM20, TOM22, TOM40, TOM70** (raimi2024mechanismofhuman pages 1-2, su2024structureofthe pages 1-3). In human cryo-EM structures, **TOMM7** is a **small, single-pass α-helical subunit** that associates peripherally with the TOM40 β-barrel and is part of the **TOM core complex** (wang2020atomicstructureof pages 1-2, pitt2021abiochemicaland pages 6-9).
+
+Functionally, TOMM7 is best classified as a **non-enzymatic regulatory/structural subunit**: it does not form the transport pore itself but instead **modulates TOM complex assembly, stability, and higher-order organization**, and it contributes to mitochondrial quality-control signaling (pitt2021abiochemicaland pages 6-9, su2024structureofthe pages 1-3).
+
+#### 1.2 Localization and topology
+TOMM7 is an **outer mitochondrial membrane** subunit of the TOM machinery. Topology evidence summarized in a structural/biochemical review indicates that TOMM7’s **C-terminus faces the intermembrane space (IMS)**: fusing GFP to the IMS-facing C-terminus abolishes correct mitochondrial targeting, consistent with an IMS-exposed C-terminal region (pitt2021abiochemicaland pages 16-17).
+
+#### 1.3 Structural features relevant to mechanism
+Recent structural syntheses emphasize that human Tom7 has an **IMS-directed extended/elongated C-terminal segment/loop** (nussberger2024newinsightsinto pages 2-4). Cryo-EM-based reviews also describe an **extended IMS segment** in human Tom7 containing a **negatively charged patch** (pitt2021abiochemicaland pages 11-12). In addition, Tom7’s transmembrane helix shows a **kink/bend**, positioning it near Tom22/Tom40 interfaces and supporting a role in organizing TOM subunit architecture and oligomeric state (pitt2021abiochemicaland pages 6-9).
+
+### 2) TOMM7 primary functions and supported mechanisms
+
+#### 2.1 Regulator of TOM complex assembly, stability, and oligomeric state
+Human TOM structures show Tom7 as one of the small subunits surrounding TOM40 in the TOM core, consistent with a stabilizing/organizing role within the complex (wang2020atomicstructureof pages 1-2, pitt2021abiochemicaland pages 6-9). Functional interpretations from cryo-EM and biochemical literature support that Tom7 **modulates assembly dynamics** and can function antagonistically to Tom6: Tom6 promotes TOM formation/stability, whereas Tom7 **delays assembly and/or reduces stability** (wang2020atomicstructureof pages 1-2, su2024structureofthe pages 1-3). A 2024 cryo-EM study of the human TOM holo complex (capturing intact Tom20) explicitly states that **Tom6 stabilizes TOM via interaction with Tom22**, while **Tom7 reduces complex stability** (su2024structureofthe pages 1-3).
+
+Together, these data support annotating TOMM7 as a **regulatory subunit influencing TOM stability and higher-order organization** rather than as a canonical receptor (TOM20/TOM70) or the pore (TOM40) (su2024structureofthe pages 1-3, raimi2024mechanismofhuman pages 1-2).
+
+#### 2.2 Role in PINK1 import arrest and PINK1/Parkin mitophagy signaling
+A major mechanistic role of TOMM7 in mammalian cells is its requirement for **PINK1 stabilization/activation at the TOM complex** on damaged mitochondria.
+
+* **Genetic/functional evidence (cell biology):** Tom7 was identified as essential for **PINK1 accumulation on the outer mitochondrial membrane (OMM)** after loss of mitochondrial membrane potential; without Tom7, PINK1 is imported into depolarized mitochondria and then **cleaved by OMA1** rather than accumulating for Parkin activation (sekine2019reciprocalrolesof pages 1-3). This supports a model in which TOMM7 promotes or enables **import arrest** of PINK1 at TOM under depolarization conditions.
+
+* **Mechanistic reconstitution (2024):** In a reconstituted system, co-expression of **human PINK1** together with **all seven TOM subunits** is sufficient for PINK1 activation. The study demonstrates an **essential role for TOM40 and its structurally associated TOM7 and TOM22** in PINK1 activation, while TOM20 and TOM70 are required for optimal activation (raimi2024mechanismofhuman pages 1-2). This work also provides a quantitative biochemical signature: under depolarization, full-length PINK1 appears in a distinct **~700-kDa TOM-associated complex**, compared with native TOM at **~500 kDa** by BN-PAGE (raimi2024mechanismofhuman pages 1-2).
+
+* **Downstream effect on Parkin:** A structural/biochemical review summarizes evidence that human Tom7 is critical for **Parkin recruitment/OMM accumulation** and PINK1 accumulation after depolarization, and notes that defects in Tom7-deficient cells can be rescued by **OMA1 knockdown** in some contexts, indicating functional interplay between TOMM7-dependent PINK1 stabilization and proteolytic regulation by OMA1 (pitt2021abiochemicaland pages 16-17, pitt2021abiochemicaland pages 17-19).
+
+Collectively, the most defensible functional annotation is that TOMM7 is a TOM-core accessory subunit that **links outer-membrane protein import machinery to mitochondrial quality control** by enabling **PINK1 retention/activation at TOM** during stress, thereby promoting **PINK1–Parkin mitophagy** signaling (sekine2019reciprocalrolesof pages 1-3, raimi2024mechanismofhuman pages 1-2).
+
+### 3) Recent developments and latest research (prioritizing 2023–2024)
+
+#### 3.1 2024 structural insights into TOMM7 topology and dynamics
+A 2024 structural review highlights Tom7’s **elongated IMS-oriented C-terminus/loop**, proposing that this element may help shape the **IMS-side exit pathway** of the TOM pore region in human complexes (nussberger2024newinsightsinto pages 2-4). In parallel, 2024 cryo-EM work capturing the TOM holo complex (including intact Tom20) reinforces Tom7’s presence as a small subunit surrounding Tom40 and frames Tom7 as a **destabilizing counterbalance** to Tom6 stabilization (su2024structureofthe pages 1-3). These studies are important because they shift TOMM7 annotation from a generic “small TOM subunit” to a **structurally distinctive, IMS-featured modulator** of TOM architecture (nussberger2024newinsightsinto pages 2-4, pitt2021abiochemicaland pages 11-12).
+
+#### 3.2 2024 mechanistic clarification of TOM subunit requirements for PINK1 activation
+The 2024 Science Advances reconstitution study is a key advance because it disentangles TOM subunit contributions: TOM7 (with TOM40 and TOM22) is **essential**, whereas receptor subunits TOM20/TOM70 are **required for optimal** activation, and the work explicitly frames these insights as enabling development of **small-molecule PINK1 activators** as a Parkinson’s disease therapeutic strategy (raimi2024mechanismofhuman pages 1-2).
+
+#### 3.3 2023–2024 human genetics: TOMM7 as a Mendelian disease gene
+Two recent clinical genetics reports provide strong real-world evidence that TOMM7 dysfunction causes multisystem developmental disease:
+
+* **2023 (Jan): p.Trp25Arg (W25R) hypomorphic allele.** A homozygous missense variant **c.73T>C (p.Trp25Arg)** causes syndromic short stature and developmental delay with skeletal dysplasia, hypotonia, microvesicular liver steatosis, and ocular findings; mouse modeling supports the allele as **hypomorphic** and associates TOMM7 perturbation with bioenergetic uncoupling-like phenotypes (young2023ahypomorphicvariant pages 1-2). URL: https://doi.org/10.1016/j.xhgg.2022.100148 (Jan 2023) (young2023ahypomorphicvariant pages 1-2).
+
+* **2024 (Dec): recurrent p.Pro29Leu (P29L) expands phenotype to moyamoya.** A recurrent homozygous **p.Pro29Leu (p.P29L; c.86C>T)** was found in **9 patients from 7 unrelated families** with microcephaly, short stature/postnatal growth failure, developmental delay, facial dysmorphism, atrophic macular scarring, and **moyamoya disease in 5/9** (li2024homozygousvariantin pages 2-3). This association reached genome-wide significance (**P = 2.5072 × 10−23**) in the authors’ analysis, and the paper reports a TOMM7 frequency across gnomAD ancestry groups of **0.0251%** (li2024homozygousvariantin pages 14-16). URL: https://doi.org/10.1016/j.ebiom.2024.105476 (Dec 2024) (li2024homozygousvariantin pages 2-3, li2024homozygousvariantin pages 14-16).
+
+These findings support including TOMM7 in diagnostic gene panels for syndromic growth failure/microcephaly and potentially for pediatric cerebrovascular syndromes with mitochondrial features (li2024homozygousvariantin pages 2-3, young2023ahypomorphicvariant pages 1-2).
+
+### 4) Pathways, interactions, and cellular contexts
+
+#### 4.1 Core pathway: mitochondrial protein import via TOM
+TOMM7 participates in mitochondrial protein import indirectly by regulating the integrity and assembly state of the TOM complex, which is required for the import of most nuclear-encoded mitochondrial proteins (raimi2024mechanismofhuman pages 1-2, su2024structureofthe pages 1-3). Thus, TOMM7 is best placed in pathways annotated as **mitochondrial protein targeting/import** and **mitochondrial outer membrane translocation**.
+
+#### 4.2 Mitochondrial quality control: PINK1–Parkin pathway
+When mitochondria lose membrane potential, PINK1 is stabilized at the TOM complex and triggers Parkin recruitment/activation to initiate mitophagy. TOMM7 is a key determinant of this switch: loss of Tom7 prevents PINK1 arrest at the OMM and leads to OMA1-dependent cleavage, thereby reducing PINK1’s ability to activate Parkin on damaged mitochondria (sekine2019reciprocalrolesof pages 1-3). Reconstitution work places TOMM7 among the essential TOM components for PINK1 activation (raimi2024mechanismofhuman pages 1-2).
+
+### 5) Quantitative data and key statistics from recent studies
+
+* **BN-PAGE complex sizes (2024 mechanistic study):** full-length PINK1 stabilizes in a TOM-associated complex at **~700 kDa**, distinct from native TOM at **~500 kDa** (raimi2024mechanismofhuman pages 1-2).
+
+* **Population/statistical genetics (2024):** p.P29L cohort of **9 patients / 7 families**; **moyamoya in 5/9**; association significance **P = 2.5072 × 10−23**; reported gnomAD presence **0.0251%** across ancestry groups (li2024homozygousvariantin pages 2-3, li2024homozygousvariantin pages 14-16).
+
+* **Mitochondrial proteomics/flux (2022, still highly relevant to 2024 genetics):** in TOMM7 p.P29L patient fibroblasts, mitochondrial proteomics detected **587 proteins**, with **91 differentially expressed** (P<0.05), and patient fibroblasts showed **elevated basal and maximal OCR** (garg2022autosomalrecessiveprogeroid pages 2-3). Variant functional assays show reduced TOMM7 interaction with TOMM40 and TOMM22 (garg2022autosomalrecessiveprogeroid pages 3-5).
+
+These numbers support the interpretation that TOMM7 variants can shift mitochondrial import/proteome balance and bioenergetics without necessarily collapsing mitochondrial respiration globally (garg2022autosomalrecessiveprogeroid pages 2-3, garg2022autosomalrecessiveprogeroid pages 3-5).
+
+### 6) Current applications and real-world implementations
+
+1. **Clinical genetics / diagnostics (2023–2024 implementation):** TOMM7 has clear relevance as a Mendelian disease gene for syndromic growth and neurodevelopmental phenotypes, and (in 2024) a distinct syndrome including **moyamoya**. These data motivate TOMM7 inclusion in diagnostic pipelines for **microcephaly + growth failure + developmental delay**, particularly when accompanied by ophthalmologic findings and/or cerebrovascular disease (li2024homozygousvariantin pages 2-3, young2023ahypomorphicvariant pages 1-2).
+
+2. **Therapeutic strategy development (mitophagy modulation):** mechanistic reconstitution of PINK1 activation at TOM explicitly frames the work as enabling **small-molecule activators of PINK1** as a therapeutic approach for Parkinson’s disease, and identifies TOM7/TOM22/TOM40 as essential components to consider in such strategies (raimi2024mechanismofhuman pages 1-2). Complementarily, earlier mechanistic work suggests that modulating **OMA1** can rescue Parkin recruitment for some PINK1 dysfunction contexts, highlighting the TOMM7–OMA1 axis as a conceptual intervention point (sekine2019reciprocalrolesof pages 1-3, pitt2021abiochemicaland pages 17-19).
+
+### 7) Expert synthesis and interpretation (authoritative sources)
+Structural/biochemical reviews emphasize that the TOM complex is not only a constitutive import machine but also a hub connecting import, mitochondrial homeostasis, and disease processes. Within that framework, TOMM7 is increasingly viewed as a **regulatory element** whose IMS-facing structural features and impact on complex stability can influence both import and quality-control signaling (nussberger2024newinsightsinto pages 2-4, su2024structureofthe pages 1-3). In Parkinson’s-related mechanisms, primary and reconstitution studies converge on TOMM7 as a component required for appropriate PINK1 behavior at the import gate during mitochondrial damage, which helps explain why TOM machinery components are repeatedly implicated in mitophagy regulation and disease-relevant stress responses (sekine2019reciprocalrolesof pages 1-3, raimi2024mechanismofhuman pages 1-2).
+
+### 8) Consolidated evidence table
+| Topic | Key findings | Evidence type | Publication (first author, year, journal) | Publication date (month/year if available) | URL | Notes for functional annotation |
+|---|---|---|---|---|---|---|
+| Identity/localization/topology | TOMM7 matches UniProt Q9P0U1: a small human TOM complex subunit in the Tom7 family. It is part of the TOM core/holo complex with TOM40, TOM22, TOM5, TOM6, and receptors TOM20/TOM70. Topology data support a single-pass outer-membrane helix with the C-terminus facing the intermembrane space (IMS); GFP fusion to the C-terminus disrupts targeting, consistent with an IMS-exposed tail. (pitt2021abiochemicaland pages 16-17, raimi2024mechanismofhuman pages 1-2, pitt2021abiochemicaland pages 3-6) | Cryo-EM, cell biology, review | Pitt, 2021, *Cells*; Raimi, 2024, *Science Advances* | 05/2021; 06/2024 | https://doi.org/10.3390/cells10051164 ; https://doi.org/10.1126/sciadv.adn7191 | Annotate as a non-enzymatic regulatory/structural TOM subunit of the mitochondrial outer membrane, not a transporter channel itself. |
+| Structural features | Human Tom7 has a kinked transmembrane helix and an elongated C-terminal/loop segment projecting toward the IMS; this IMS-directed segment is described as extended and includes a negatively charged patch. Tom7 lies peripherally adjacent to the Tom40 β-barrel and near Tom22/Tom5, helping shape the TOM core architecture. (nussberger2024newinsightsinto pages 2-4, pitt2021abiochemicaland pages 6-9, pitt2021abiochemicaland pages 11-12) | Cryo-EM, structural review | Nussberger, 2024, *Biochemical Society Transactions*; Pitt, 2021, *Cells* | 04/2024; 05/2021 | https://doi.org/10.1042/bst20231236 ; https://doi.org/10.3390/cells10051164 | Useful for annotation of topology and likely IMS-side regulatory interactions during precursor exit/complex organization. |
+| TOM assembly & stability | Tom7 is a small α-helical TOM subunit that surrounds Tom40 and participates in assembly/stability dynamics. Human and comparative studies support an antagonistic relationship with Tom6: Tom6 stabilizes TOM, whereas Tom7 can reduce stability/delay assembly; loss of Tom7 increases tetramer formation and increases hTom40 import/biogenesis in some systems. (wang2020atomicstructureof pages 1-2, pitt2021abiochemicaland pages 6-9, su2024structureofthe pages 1-3) | Cryo-EM, biochemical genetics, review | Wang, 2020, *Cell Discovery*; Pitt, 2021, *Cells*; Su, 2024, *PNAS Nexus* | 09/2020; 05/2021; 06/2024 | https://doi.org/10.1038/s41421-020-00198-2 ; https://doi.org/10.3390/cells10051164 ; https://doi.org/10.1093/pnasnexus/pgae269 | Best described as a regulator of TOM complex biogenesis/oligomeric state rather than a core receptor or pore-forming unit. |
+| PINK1/Parkin mitophagy | TOMM7 is required for efficient PINK1 stabilization/activation at damaged mitochondria and for downstream Parkin recruitment. In TOMM7-deficient cells, PINK1 fails to accumulate after depolarization; Tom7 loss allows PINK1 import/OMA1 cleavage instead of OMM arrest. OMA1 knockdown can rescue defects in some contexts. Reconstituted human TOM studies show TOM40, TOM22, and TOM7 are essential for PINK1 activation, while TOM20/TOM70 optimize activation. BN-PAGE detects full-length PINK1 in a ~700-kDa TOM-associated complex versus native TOM at ~500-kDa. (pitt2021abiochemicaland pages 16-17, raimi2024mechanismofhuman pages 1-2, sekine2019reciprocalrolesof pages 1-3, pitt2021abiochemicaland pages 17-19) | Cell biology, reconstitution, BN-PAGE | Sekine, 2019, *Molecular Cell*; Raimi, 2024, *Science Advances*; Pitt, 2021, *Cells* | 03/2019; 06/2024; 05/2021 | https://doi.org/10.1016/j.molcel.2019.01.002 ; https://doi.org/10.1126/sciadv.adn7191 ; https://doi.org/10.3390/cells10051164 | Functional annotation should mention a role in mitochondrial quality control/mitophagy via PINK1 import arrest and activation at TOM. |
+| Human disease genetics | Hypomorphic TOMM7 p.Trp25Arg (c.73T>C; p.W25R) causes syndromic short stature/developmental delay with skeletal dysplasia, hypotonia, liver steatosis, and ocular findings; proband homozygous, parents heterozygous. Prior structural interpretation places Trp25 near Arg24, predicted to affect TOMM40 interaction. (young2023ahypomorphicvariant pages 1-2) | Human genetics, mouse modeling, bioenergetics | Young, 2023, *Human Genetics and Genomics Advances* | 01/2023 | https://doi.org/10.1016/j.xhgg.2022.100148 | Supports disease relevance of partial TOMM7 loss of function and TOM complex dysregulation in growth/development. |
+| Human disease genetics | TOMM7 p.Pro29Leu (c.86C>T; p.P29L) was first linked to autosomal recessive progeroid syndrome/Garg-Mishra phenotype in a single family: severe dwarfism, mandibular hypoplasia, hyperopia/micro-ophthalmia, partial lipodystrophy. The variant is rare in gnomAD (MAF 0.000048 in East Asians in one report) and affects a fully conserved residue in the kinked helix contacting TOMM40. (garg2022autosomalrecessiveprogeroid pages 1-2, garg2022autosomalrecessiveprogeroid pages 2-3, garg2022autosomalrecessiveprogeroid pages 3-5) | Human genetics, structural interpretation, proteomics | Garg, 2022, *Journal of Clinical Investigation* | 12/2022 | https://doi.org/10.1172/jci156864 | Strong evidence that altered TOMM7-TOM interactions can produce a multisystem developmental/progeroid disorder. |
+| Human disease genetics | A 2024 study expanded p.Pro29Leu to a recurrent disease allele: homozygous TOMM7 p.P29L in 9 patients from 7 unrelated families, with postnatal growth failure/short stature, microcephaly, facial dysmorphism, developmental delay, atrophic macular scarring, and moyamoya disease in 5/9 patients. Association reached genome-wide significance (P = 2.5072 × 10^-23). The variant frequency quoted across gnomAD ancestry groups was 0.0251%, and the paper notes enrichment in the Taiwanese population. (li2024homozygousvariantin pages 2-3, li2024homozygousvariantin pages 1-2, li2024homozygousvariantin pages 14-16) | Human genetics, population analysis, iPSC/endothelial biology | Li, 2024, *eBioMedicine* | 12/2024 | https://doi.org/10.1016/j.ebiom.2024.105476 | Expands annotation to include cerebrovascular disease susceptibility and metabolic reprogramming phenotypes. |
+| Quantitative data/stats | In TOMM7 p.P29L patient fibroblasts, mitochondrial proteomics detected 587 proteins, with 91 differentially expressed proteins (P<0.05); GSEA showed enrichment of ATP-production/proton-transport proteins and reduction of phospholipid metabolic proteins. Patient fibroblasts showed elevated basal and maximal OCR. (garg2022autosomalrecessiveprogeroid pages 2-3, garg2022autosomalrecessiveprogeroid pages 3-5) | Proteomics, extracellular flux | Garg, 2022, *Journal of Clinical Investigation* | 12/2022 | https://doi.org/10.1172/jci156864 | Quantitative support that TOMM7 perturbs select mitochondrial proteome/import balance rather than abolishing respiration globally. |
+| Quantitative data/stats | p.W25R and Tomm7 deficiency produce a paradoxical bioenergetic phenotype: increased oxygen consumption despite bioenergetic deficiency, interpreted as uncoupling between oxidation and ATP synthesis rather than overt TCA/ETC failure. In 2024 endothelial/iPSC models with p.P29L, respiration was slightly decreased while glycolytic ATP production increased significantly, with elevated hexokinase 2 and enhanced glycolysis. (young2023ahypomorphicvariant pages 1-2, li2024homozygousvariantin pages 1-2) | Mouse/cell physiology, iPSC metabolism | Young, 2023, *HGGA*; Li, 2024, *eBioMedicine* | 01/2023; 12/2024 | https://doi.org/10.1016/j.xhgg.2022.100148 ; https://doi.org/10.1016/j.ebiom.2024.105476 | Suggests TOMM7 loss/hypomorphism alters mitochondrial import-linked metabolic setpoints and can trigger glycolytic compensation. |
+| Human disease genetics / mechanism | TOMM7 p.P29L retains mitochondrial localization but shows reduced interaction with TOMM40 and TOMM22, consistent with impaired integration into or regulation of the TOM complex. In contrast, Parkin-dependent mitophagy appeared largely intact in patient fibroblasts in the JCI study, indicating that not all TOMM7 disease alleles phenocopy complete TOMM7 loss for mitophagy. (garg2022autosomalrecessiveprogeroid pages 2-3, garg2022autosomalrecessiveprogeroid pages 5-6, garg2022autosomalrecessiveprogeroid pages 3-5) | Co-IP, localization, mitophagy assay | Garg, 2022, *Journal of Clinical Investigation* | 12/2022 | https://doi.org/10.1172/jci156864 | Important nuance: disease mechanism may involve selective defects in TOM assembly/import specificity rather than total mitophagy failure. |
+| Functional systems biology | In vascular/endothelial contexts, TOMM7 modulates mitochondrial Rac1/redox signaling and cerebrovascular network formation; Tomm7 loss in zebrafish and mice causes cerebrovascular abnormalities. The 2024 human p.P29L study connects this biology to moyamoya disease and endothelial tube-formation defects in edited iPSC-derived endothelial cells. (li2024homozygousvariantin pages 2-3, li2024homozygousvariantin pages 1-2) | Animal models, endothelial cell biology, iPSC | Li, 2024, *eBioMedicine* | 12/2024 | https://doi.org/10.1016/j.ebiom.2024.105476 | Real-world relevance includes developmental vascular pathology, not only mitochondrial import biochemistry. |
+
+
+*Table: This table summarizes identity, structural biology, mitochondrial import function, mitophagy roles, and disease genetics for human TOMM7 (UniProt Q9P0U1). It consolidates recent and foundational evidence, including variant-specific clinical findings and key quantitative results useful for functional annotation.*
+
+### 9) Summary functional annotation (actionable)
+**TOMM7 (Tom7)** is a small, single-pass **outer mitochondrial membrane** TOM complex subunit with an **IMS-facing extended C-terminal/loop segment** and a kinked transmembrane helix (nussberger2024newinsightsinto pages 2-4, pitt2021abiochemicaland pages 11-12). Its primary role is to **regulate TOM complex assembly/oligomeric state and stability**, acting in opposition to Tom6 in stability control, and to support the TOM complex’s function as a signaling node in mitochondrial quality control (su2024structureofthe pages 1-3, pitt2021abiochemicaland pages 6-9). TOMM7 is also **required for efficient PINK1 stabilization/activation at the TOM complex** under mitochondrial depolarization, thereby enabling **Parkin recruitment and PINK1–Parkin mitophagy** (sekine2019reciprocalrolesof pages 1-3, raimi2024mechanismofhuman pages 1-2). Human biallelic missense variants (notably **p.W25R** and **p.P29L**) cause syndromic developmental disease, and recurrent **p.P29L** is associated with a microcephalic osteodysplastic dwarfism syndrome frequently complicated by **moyamoya disease** (young2023ahypomorphicvariant pages 1-2, li2024homozygousvariantin pages 2-3).
+
+
+References
+
+1. (pitt2021abiochemicaland pages 16-17): Ashley S. Pitt and Susan K. Buchanan. A biochemical and structural understanding of tom complex interactions and implications for human health and disease. Cells, 10:1164, May 2021. URL: https://doi.org/10.3390/cells10051164, doi:10.3390/cells10051164. This article has 46 citations.
+
+2. (raimi2024mechanismofhuman pages 1-2): Olawale G. Raimi, Hina Ojha, Kenneth Ehses, Verena Dederer, Sven M. Lange, Cristian Polo Rivera, Tom D. Deegan, Yinchen Chen, Melanie Wightman, Rachel Toth, Karim P. M. Labib, Sebastian Mathea, Neil Ranson, Rubén Fernández-Busnadiego, and Miratul M. K. Muqit. Mechanism of human pink1 activation at the tom complex in a reconstituted system. Science Advances, Jun 2024. URL: https://doi.org/10.1126/sciadv.adn7191, doi:10.1126/sciadv.adn7191. This article has 40 citations and is from a highest quality peer-reviewed journal.
+
+3. (young2023ahypomorphicvariant pages 1-2): Cameron Young, Dominyka Batkovskyte, Miyuki Kitamura, Maria Shvedova, Yutaro Mihara, Jun Akiba, Wen Zhou, Anna Hammarsjö, Gen Nishimura, Shuichi Yatsuga, Giedre Grigelioniene, and Tatsuya Kobayashi. A hypomorphic variant in the translocase of the outer mitochondrial membrane complex subunit tomm7 causes short stature and developmental delay. Human Genetics and Genomics Advances, 4:100148, Jan 2023. URL: https://doi.org/10.1016/j.xhgg.2022.100148, doi:10.1016/j.xhgg.2022.100148. This article has 23 citations and is from a peer-reviewed journal.
+
+4. (su2024structureofthe pages 1-3): Jiayue Su, Xuyang Tian, Ziyi Wang, Jiawen Yang, Shan Sun, and Sen-Fang Sui. Structure of the intact tom20 receptor in the human translocase of the outer membrane complex. PNAS Nexus, Jun 2024. URL: https://doi.org/10.1093/pnasnexus/pgae269, doi:10.1093/pnasnexus/pgae269. This article has 12 citations and is from a peer-reviewed journal.
+
+5. (wang2020atomicstructureof pages 1-2): Wenhe Wang, Xudong Chen, Laixing Zhang, Jingbo Yi, Qingxi Ma, Jian Yin, Wei Zhuo, Jinke Gu, and Maojun Yang. Atomic structure of human tom core complex. Cell Discovery, Sep 2020. URL: https://doi.org/10.1038/s41421-020-00198-2, doi:10.1038/s41421-020-00198-2. This article has 151 citations and is from a peer-reviewed journal.
+
+6. (pitt2021abiochemicaland pages 6-9): Ashley S. Pitt and Susan K. Buchanan. A biochemical and structural understanding of tom complex interactions and implications for human health and disease. Cells, 10:1164, May 2021. URL: https://doi.org/10.3390/cells10051164, doi:10.3390/cells10051164. This article has 46 citations.
+
+7. (nussberger2024newinsightsinto pages 2-4): Stephan Nussberger, Robin Ghosh, and Shuo Wang. New insights into the structure and dynamics of the tom complex in mitochondria. Biochemical Society Transactions, 52:911-922, Apr 2024. URL: https://doi.org/10.1042/bst20231236, doi:10.1042/bst20231236. This article has 5 citations and is from a peer-reviewed journal.
+
+8. (pitt2021abiochemicaland pages 11-12): Ashley S. Pitt and Susan K. Buchanan. A biochemical and structural understanding of tom complex interactions and implications for human health and disease. Cells, 10:1164, May 2021. URL: https://doi.org/10.3390/cells10051164, doi:10.3390/cells10051164. This article has 46 citations.
+
+9. (sekine2019reciprocalrolesof pages 1-3): Shiori Sekine, Chunxin Wang, Dionisia P. Sideris, Eric Bunker, Zhe Zhang, and Richard J. Youle. Reciprocal roles of tom7 and oma1 during mitochondrial import and activation of pink1. Molecular cell, 73 5:1028-1043.e5, Mar 2019. URL: https://doi.org/10.1016/j.molcel.2019.01.002, doi:10.1016/j.molcel.2019.01.002. This article has 189 citations and is from a highest quality peer-reviewed journal.
+
+10. (pitt2021abiochemicaland pages 17-19): Ashley S. Pitt and Susan K. Buchanan. A biochemical and structural understanding of tom complex interactions and implications for human health and disease. Cells, 10:1164, May 2021. URL: https://doi.org/10.3390/cells10051164, doi:10.3390/cells10051164. This article has 46 citations.
+
+11. (li2024homozygousvariantin pages 2-3): Chia-Yi Li, Li-Wen Chen, Meng-Che Tsai, Yen-Yin Chou, Pei-Xuan Lin, Yu-Ming Chang, Wuh-Liang Hwu, Yin-Hsiu Chien, Ju-Li Lin, Hui-An Chen, Ni-Chung Lee, Pen-Hua Su, Tzung-Chien Hsieh, Hannah Klinkhammer, Yi-Chieh Wang, Yi-Ting Huang, Peter M. Krawitz, Sheng-Hsiang Lin, Lynn L.H. Huang, Po-Min Chiang, Min-Hsiu Shih, and Peng-Chieh Chen. Homozygous variant in translocase of outer mitochondrial membrane 7 leads to metabolic reprogramming and microcephalic osteodysplastic dwarfism with moyamoya disease. eBioMedicine, 110:105476, Dec 2024. URL: https://doi.org/10.1016/j.ebiom.2024.105476, doi:10.1016/j.ebiom.2024.105476. This article has 7 citations and is from a peer-reviewed journal.
+
+12. (li2024homozygousvariantin pages 14-16): Chia-Yi Li, Li-Wen Chen, Meng-Che Tsai, Yen-Yin Chou, Pei-Xuan Lin, Yu-Ming Chang, Wuh-Liang Hwu, Yin-Hsiu Chien, Ju-Li Lin, Hui-An Chen, Ni-Chung Lee, Pen-Hua Su, Tzung-Chien Hsieh, Hannah Klinkhammer, Yi-Chieh Wang, Yi-Ting Huang, Peter M. Krawitz, Sheng-Hsiang Lin, Lynn L.H. Huang, Po-Min Chiang, Min-Hsiu Shih, and Peng-Chieh Chen. Homozygous variant in translocase of outer mitochondrial membrane 7 leads to metabolic reprogramming and microcephalic osteodysplastic dwarfism with moyamoya disease. eBioMedicine, 110:105476, Dec 2024. URL: https://doi.org/10.1016/j.ebiom.2024.105476, doi:10.1016/j.ebiom.2024.105476. This article has 7 citations and is from a peer-reviewed journal.
+
+13. (garg2022autosomalrecessiveprogeroid pages 2-3): Abhimanyu Garg, Wee-Teik Keng, Zhenkang Chen, Adwait Amod Sathe, Chao Xing, Pavithira Devi Kailasam, Yanqiu Shao, Nicholas P. Lesner, Claire B. Llamas, Anil K. Agarwal, and Prashant Mishra. Autosomal recessive progeroid syndrome due to homozygosity for a tomm7 variant. Journal of Clinical Investigation, Dec 2022. URL: https://doi.org/10.1172/jci156864, doi:10.1172/jci156864. This article has 33 citations and is from a highest quality peer-reviewed journal.
+
+14. (garg2022autosomalrecessiveprogeroid pages 3-5): Abhimanyu Garg, Wee-Teik Keng, Zhenkang Chen, Adwait Amod Sathe, Chao Xing, Pavithira Devi Kailasam, Yanqiu Shao, Nicholas P. Lesner, Claire B. Llamas, Anil K. Agarwal, and Prashant Mishra. Autosomal recessive progeroid syndrome due to homozygosity for a tomm7 variant. Journal of Clinical Investigation, Dec 2022. URL: https://doi.org/10.1172/jci156864, doi:10.1172/jci156864. This article has 33 citations and is from a highest quality peer-reviewed journal.
+
+15. (pitt2021abiochemicaland pages 3-6): Ashley S. Pitt and Susan K. Buchanan. A biochemical and structural understanding of tom complex interactions and implications for human health and disease. Cells, 10:1164, May 2021. URL: https://doi.org/10.3390/cells10051164, doi:10.3390/cells10051164. This article has 46 citations.
+
+16. (garg2022autosomalrecessiveprogeroid pages 1-2): Abhimanyu Garg, Wee-Teik Keng, Zhenkang Chen, Adwait Amod Sathe, Chao Xing, Pavithira Devi Kailasam, Yanqiu Shao, Nicholas P. Lesner, Claire B. Llamas, Anil K. Agarwal, and Prashant Mishra. Autosomal recessive progeroid syndrome due to homozygosity for a tomm7 variant. Journal of Clinical Investigation, Dec 2022. URL: https://doi.org/10.1172/jci156864, doi:10.1172/jci156864. This article has 33 citations and is from a highest quality peer-reviewed journal.
+
+17. (li2024homozygousvariantin pages 1-2): Chia-Yi Li, Li-Wen Chen, Meng-Che Tsai, Yen-Yin Chou, Pei-Xuan Lin, Yu-Ming Chang, Wuh-Liang Hwu, Yin-Hsiu Chien, Ju-Li Lin, Hui-An Chen, Ni-Chung Lee, Pen-Hua Su, Tzung-Chien Hsieh, Hannah Klinkhammer, Yi-Chieh Wang, Yi-Ting Huang, Peter M. Krawitz, Sheng-Hsiang Lin, Lynn L.H. Huang, Po-Min Chiang, Min-Hsiu Shih, and Peng-Chieh Chen. Homozygous variant in translocase of outer mitochondrial membrane 7 leads to metabolic reprogramming and microcephalic osteodysplastic dwarfism with moyamoya disease. eBioMedicine, 110:105476, Dec 2024. URL: https://doi.org/10.1016/j.ebiom.2024.105476, doi:10.1016/j.ebiom.2024.105476. This article has 7 citations and is from a peer-reviewed journal.
+
+18. (garg2022autosomalrecessiveprogeroid pages 5-6): Abhimanyu Garg, Wee-Teik Keng, Zhenkang Chen, Adwait Amod Sathe, Chao Xing, Pavithira Devi Kailasam, Yanqiu Shao, Nicholas P. Lesner, Claire B. Llamas, Anil K. Agarwal, and Prashant Mishra. Autosomal recessive progeroid syndrome due to homozygosity for a tomm7 variant. Journal of Clinical Investigation, Dec 2022. URL: https://doi.org/10.1172/jci156864, doi:10.1172/jci156864. This article has 33 citations and is from a highest quality peer-reviewed journal.
+
+## Citations
+
+1. pitt2021abiochemicaland pages 16-17
+2. nussberger2024newinsightsinto pages 2-4
+3. pitt2021abiochemicaland pages 11-12
+4. pitt2021abiochemicaland pages 6-9
+5. su2024structureofthe pages 1-3
+6. sekine2019reciprocalrolesof pages 1-3
+7. raimi2024mechanismofhuman pages 1-2
+8. young2023ahypomorphicvariant pages 1-2
+9. li2024homozygousvariantin pages 2-3
+10. li2024homozygousvariantin pages 14-16
+11. garg2022autosomalrecessiveprogeroid pages 2-3
+12. garg2022autosomalrecessiveprogeroid pages 3-5
+13. wang2020atomicstructureof pages 1-2
+14. pitt2021abiochemicaland pages 17-19
+15. pitt2021abiochemicaland pages 3-6
+16. garg2022autosomalrecessiveprogeroid pages 1-2
+17. li2024homozygousvariantin pages 1-2
+18. garg2022autosomalrecessiveprogeroid pages 5-6
+19. https://doi.org/10.1016/j.xhgg.2022.100148
+20. https://doi.org/10.1016/j.ebiom.2024.105476
+21. https://doi.org/10.3390/cells10051164
+22. https://doi.org/10.1126/sciadv.adn7191
+23. https://doi.org/10.1042/bst20231236
+24. https://doi.org/10.1038/s41421-020-00198-2
+25. https://doi.org/10.1093/pnasnexus/pgae269
+26. https://doi.org/10.1016/j.molcel.2019.01.002
+27. https://doi.org/10.1172/jci156864
+28. https://doi.org/10.3390/cells10051164,
+29. https://doi.org/10.1126/sciadv.adn7191,
+30. https://doi.org/10.1016/j.xhgg.2022.100148,
+31. https://doi.org/10.1093/pnasnexus/pgae269,
+32. https://doi.org/10.1038/s41421-020-00198-2,
+33. https://doi.org/10.1042/bst20231236,
+34. https://doi.org/10.1016/j.molcel.2019.01.002,
+35. https://doi.org/10.1016/j.ebiom.2024.105476,
+36. https://doi.org/10.1172/jci156864,


### PR DESCRIPTION
## Summary
- Generate Falcon deep research reports for human TIMM17A, MTX2, and TOMM7.
- Complete the AI review YAMLs with evidence-backed annotation decisions and synthesized core functions.
- Render review HTML for all three genes.

## Validation
- `uv run python scripts/validate_deep_research.py genes/human/TIMM17A/TIMM17A-deep-research-falcon.md genes/human/MTX2/MTX2-deep-research-falcon.md genes/human/TOMM7/TOMM7-deep-research-falcon.md`
- `just validate human TIMM17A`
- `just validate human MTX2`
- `just validate human TOMM7`
- `just render human TIMM17A`
- `just render human MTX2`
- `just render human TOMM7`
- `git diff --check origin/main...HEAD`