### PR TITLE
[codex] Add Falcon deep research review for TOMM70

### DIFF
--- a/genes/human/TOMM70/TOMM70-ai-review.html
+++ b/genes/human/TOMM70/TOMM70-ai-review.html
@@ -1,0 +1,6570 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>TOMM70 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>TOMM70</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/O94826" target="_blank" class="term-link">
+                        O94826
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "TOMM70";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="O94826" data-a="DESCRIPTION: TOMM70 is a cytosol-facing mitochondrial outer mem..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>TOMM70 is a cytosol-facing mitochondrial outer membrane TOM receptor/adaptor. Its primary role is to dock Hsp70/Hsp90-bound hydrophobic mitochondrial precursor proteins, especially internal-signal/carrier-type substrates, and deliver them to the TOM translocation machinery. It also has supported non-core signaling roles in MAVS/IRF3 antiviral responses and PINK1/Parkin-linked mitochondrial quality control.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005741" target="_blank" class="term-link">
+                                    GO:0005741
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial outer membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O94826" data-a="GO:0005741" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct localization. TOMM70 is an outer mitochondrial membrane TOM receptor/adaptor with a cytosol-facing TPR receptor domain.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOMM70/TOMM70-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">TOMM70 is anchored in the **outer mitochondrial membrane (OMM)** with its receptor domain facing the cytosol.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008320" target="_blank" class="term-link">
+                                    GO:0008320
+                                </a>
+                            </span>
+                            <span class="term-label">protein transmembrane transporter activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O94826" data-a="GO:0008320" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Accepted as TOMM70 contribution to TOM-dependent protein transmembrane transport. TOMM70 is a receptor/adaptor, not the pore-forming subunit, but it contributes to the TOM complex import activity.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOMM70/TOMM70-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">TOMM70 is best understood as a **surface receptor/adaptor** of the **TOM (translocase of the outer membrane)** import gateway</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030150" target="_blank" class="term-link">
+                                    GO:0030150
+                                </a>
+                            </span>
+                            <span class="term-label">protein import into mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="O94826" data-a="GO:0030150" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Broadly valid as a TOM-pathway outcome, but TOMM70 is best described as an outer-membrane receptor/adaptor rather than the matrix import pore or motor.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Matrix import is one TOM-dependent route; TOMM70 has a more specific receptor/adaptor role for chaperone-bound precursors.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030943" target="_blank" class="term-link">
+                                    GO:0030943
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion targeting sequence binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O94826" data-a="GO:0030943" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Supported. TOMM70 recognizes mitochondrial precursor proteins, especially hydrophobic internal-signal substrates delivered by Hsp70/Hsp90 chaperones.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOMM70/TOMM70-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Cytosolic **Hsp70/Hsp90** chaperones bind newly synthesized hydrophobic precursors to prevent aggregation and **deliver them to TOMM70**</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045039" target="_blank" class="term-link">
+                                    GO:0045039
+                                </a>
+                            </span>
+                            <span class="term-label">protein insertion into mitochondrial inner membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="O94826" data-a="GO:0045039" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reasonable as a pathway-level consequence for carrier/internal-signal precursor delivery, but TOMM70 does not catalyze inner membrane insertion itself.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> TOMM70 acts upstream at the outer membrane before substrates are handed to downstream inner-membrane import machinery.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005741" target="_blank" class="term-link">
+                                    GO:0005741
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial outer membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O94826" data-a="GO:0005741" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct localization. TOMM70 is an outer mitochondrial membrane TOM receptor/adaptor with a cytosol-facing TPR receptor domain.
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/32353859" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:32353859
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A SARS-CoV-2 protein interaction map reveals targets for dru...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="O94826" data-a="GO:0005515" data-r="PMID:32353859" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Protein binding is too generic for TOMM70. The informative functions are chaperone-bound precursor receptor/adaptor activity, TOM association, and context-specific MAVS/PINK1 signaling.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Replace generic protein binding curation with specific adaptor, receptor, TOM complex, and pathway annotations.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/32728199" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:32728199
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    SARS-CoV-2 Orf9b suppresses type I interferon responses by t...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="O94826" data-a="GO:0005515" data-r="PMID:32728199" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Protein binding is too generic for TOMM70. The informative functions are chaperone-bound precursor receptor/adaptor activity, TOM association, and context-specific MAVS/PINK1 signaling.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Replace generic protein binding curation with specific adaptor, receptor, TOM complex, and pathway annotations.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/33060197" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:33060197
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Comparative host-coronavirus protein interaction networks re...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="O94826" data-a="GO:0005515" data-r="PMID:33060197" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Protein binding is too generic for TOMM70. The informative functions are chaperone-bound precursor receptor/adaptor activity, TOM association, and context-specific MAVS/PINK1 signaling.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Replace generic protein binding curation with specific adaptor, receptor, TOM complex, and pathway annotations.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/33845483" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:33845483
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Multilevel proteomics reveals host perturbations by SARS-CoV...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="O94826" data-a="GO:0005515" data-r="PMID:33845483" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Protein binding is too generic for TOMM70. The informative functions are chaperone-bound precursor receptor/adaptor activity, TOM association, and context-specific MAVS/PINK1 signaling.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Replace generic protein binding curation with specific adaptor, receptor, TOM complex, and pathway annotations.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/33990585" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:33990585
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Crystal structure of SARS-CoV-2 Orf9b in complex with human ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="O94826" data-a="GO:0005515" data-r="PMID:33990585" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Protein binding is too generic for TOMM70. The informative functions are chaperone-bound precursor receptor/adaptor activity, TOM association, and context-specific MAVS/PINK1 signaling.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Replace generic protein binding curation with specific adaptor, receptor, TOM complex, and pathway annotations.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/34232536" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:34232536
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Interactomes of SARS-CoV-2 and human coronaviruses reveal ho...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="O94826" data-a="GO:0005515" data-r="PMID:34232536" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Protein binding is too generic for TOMM70. The informative functions are chaperone-bound precursor receptor/adaptor activity, TOM association, and context-specific MAVS/PINK1 signaling.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Replace generic protein binding curation with specific adaptor, receptor, TOM complex, and pathway annotations.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/34502139" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:34502139
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Phosphorylation of SARS-CoV-2 Orf9b Regulates Its Targeting ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="O94826" data-a="GO:0005515" data-r="PMID:34502139" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Protein binding is too generic for TOMM70. The informative functions are chaperone-bound precursor receptor/adaptor activity, TOM association, and context-specific MAVS/PINK1 signaling.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Replace generic protein binding curation with specific adaptor, receptor, TOM complex, and pathway annotations.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/34942634" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:34942634
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Evolution of enhanced innate immune evasion by SARS-CoV-2.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="O94826" data-a="GO:0005515" data-r="PMID:34942634" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Protein binding is too generic for TOMM70. The informative functions are chaperone-bound precursor receptor/adaptor activity, TOM association, and context-specific MAVS/PINK1 signaling.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Replace generic protein binding curation with specific adaptor, receptor, TOM complex, and pathway annotations.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/36217030" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:36217030
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A comprehensive SARS-CoV-2-human protein-protein interactome...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="O94826" data-a="GO:0005515" data-r="PMID:36217030" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Protein binding is too generic for TOMM70. The informative functions are chaperone-bound precursor receptor/adaptor activity, TOM association, and context-specific MAVS/PINK1 signaling.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Replace generic protein binding curation with specific adaptor, receptor, TOM complex, and pathway annotations.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O94826" data-a="GO:0005739" data-r="GO_REF:0000120" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct but too general. TOMM70 is specifically an outer mitochondrial membrane TOM receptor/adaptor.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Subsumed by mitochondrial outer membrane and TOM complex annotations.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030150" target="_blank" class="term-link">
+                                    GO:0030150
+                                </a>
+                            </span>
+                            <span class="term-label">protein import into mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="O94826" data-a="GO:0030150" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Broadly valid as a TOM-pathway outcome, but TOMM70 is best described as an outer-membrane receptor/adaptor rather than the matrix import pore or motor.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Matrix import is one TOM-dependent route; TOMM70 has a more specific receptor/adaptor role for chaperone-bound precursors.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0061052" target="_blank" class="term-link">
+                                    GO:0061052
+                                </a>
+                            </span>
+                            <span class="term-label">negative regulation of cell growth involved in cardiac muscle cell development</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="O94826" data-a="GO:0061052" data-r="GO_REF:0000107" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Automatic orthology transfer is not supported by the TOMM70 literature synthesis as a direct function of this gene product.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Developmental/thyroxine response terms overreach beyond TOMM70&#39;s demonstrated receptor/adaptor and signaling roles.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0097068" target="_blank" class="term-link">
+                                    GO:0097068
+                                </a>
+                            </span>
+                            <span class="term-label">response to thyroxine</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="O94826" data-a="GO:0097068" data-r="GO_REF:0000107" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Automatic orthology transfer is not supported by the TOMM70 literature synthesis as a direct function of this gene product.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Developmental/thyroxine response terms overreach beyond TOMM70&#39;s demonstrated receptor/adaptor and signaling roles.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1903749" target="_blank" class="term-link">
+                                    GO:1903749
+                                </a>
+                            </span>
+                            <span class="term-label">positive regulation of protein localization to mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000107
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O94826" data-a="GO:1903749" data-r="GO_REF:0000107" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Supported broad process annotation. TOMM70 promotes mitochondrial localization/import of precursor proteins through its receptor/adaptor role.
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000052
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O94826" data-a="GO:0005739" data-r="GO_REF:0000052" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct but too general. TOMM70 is specifically an outer mitochondrial membrane TOM receptor/adaptor.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Subsumed by mitochondrial outer membrane and TOM complex annotations.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030150" target="_blank" class="term-link">
+                                    GO:0030150
+                                </a>
+                            </span>
+                            <span class="term-label">protein import into mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15644312" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15644312
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dissection of the mitochondrial import and assembly pathway ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="O94826" data-a="GO:0030150" data-r="PMID:15644312" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Broadly valid as a TOM-pathway outcome, but TOMM70 is best described as an outer-membrane receptor/adaptor rather than the matrix import pore or motor.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Matrix import is one TOM-dependent route; TOMM70 has a more specific receptor/adaptor role for chaperone-bound precursors.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005741" target="_blank" class="term-link">
+                                    GO:0005741
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial outer membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18331822" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:18331822
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Identification of Tom5 and Tom6 in the preprotein translocas...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O94826" data-a="GO:0005741" data-r="PMID:18331822" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct localization. TOMM70 is an outer mitochondrial membrane TOM receptor/adaptor with a cytosol-facing TPR receptor domain.
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045040" target="_blank" class="term-link">
+                                    GO:0045040
+                                </a>
+                            </span>
+                            <span class="term-label">protein insertion into mitochondrial outer membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18331822" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:18331822
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Identification of Tom5 and Tom6 in the preprotein translocas...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="O94826" data-a="GO:0045040" data-r="PMID:18331822" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> The annotation captures mitochondrial protein import context but overstates TOMM70 as an outer-membrane insertase.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> TOMM70 is a receptor/adaptor for precursor targeting/import, not the SAM/outer-membrane insertion machinery.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070585" target="_blank" class="term-link">
+                                    protein localization to mitochondrion
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140596" target="_blank" class="term-link">
+                                    GO:0140596
+                                </a>
+                            </span>
+                            <span class="term-label">TOM complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18331822" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:18331822
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Identification of Tom5 and Tom6 in the preprotein translocas...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O94826" data-a="GO:0140596" data-r="PMID:18331822" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct and specific. TOMM70 is a TOM-complex receptor component rather than an independent pore-forming subunit.
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005741" target="_blank" class="term-link">
+                                    GO:0005741
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial outer membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20628368" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:20628368
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Tom70 mediates activation of interferon regulatory factor 3 ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O94826" data-a="GO:0005741" data-r="PMID:20628368" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct localization. TOMM70 is an outer mitochondrial membrane TOM receptor/adaptor with a cytosol-facing TPR receptor domain.
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005741" target="_blank" class="term-link">
+                                    GO:0005741
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial outer membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25609812" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25609812
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Tom70 mediates Sendai virus-induced apoptosis on mitochondri...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O94826" data-a="GO:0005741" data-r="PMID:25609812" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct localization. TOMM70 is an outer mitochondrial membrane TOM receptor/adaptor with a cytosol-facing TPR receptor domain.
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005741" target="_blank" class="term-link">
+                                    GO:0005741
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial outer membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/33723040" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:33723040
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Toxoplasma gondii association with host mitochondria require...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O94826" data-a="GO:0005741" data-r="PMID:33723040" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct localization. TOMM70 is an outer mitochondrial membrane TOM receptor/adaptor with a cytosol-facing TPR receptor domain.
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HTP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:34800366
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Quantitative high-confidence human mitochondrial proteome an...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O94826" data-a="GO:0005739" data-r="PMID:34800366" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct but too general. TOMM70 is specifically an outer mitochondrial membrane TOM receptor/adaptor.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Subsumed by mitochondrial outer membrane and TOM complex annotations.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/35391620" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:35391620
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The role of the individual TOM subunits in the association o...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="O94826" data-a="GO:0005515" data-r="PMID:35391620" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Protein binding is too generic for TOMM70. The informative functions are chaperone-bound precursor receptor/adaptor activity, TOM association, and context-specific MAVS/PINK1 signaling.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Replace generic protein binding curation with specific adaptor, receptor, TOM complex, and pathway annotations.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030674" target="_blank" class="term-link">
+                                    GO:0030674
+                                </a>
+                            </span>
+                            <span class="term-label">protein-macromolecule adaptor activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20628368" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:20628368
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Tom70 mediates activation of interferon regulatory factor 3 ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O94826" data-a="GO:0030674" data-r="PMID:20628368" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Accepted. TOMM70 functions as a receptor/adaptor for chaperone-bound mitochondrial precursor proteins and also as a MAVS-linked signaling scaffold.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOMM70/TOMM70-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">TOMM70 is best understood as a **surface receptor/adaptor** of the **TOM (translocase of the outer membrane)** import gateway</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031966" target="_blank" class="term-link">
+                                    GO:0031966
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20628368" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:20628368
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Tom70 mediates activation of interferon regulatory factor 3 ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O94826" data-a="GO:0031966" data-r="PMID:20628368" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct but too broad. The specific supported localization is mitochondrial outer membrane, not generic mitochondrial membrane.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Subsumed by mitochondrial outer membrane annotations.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005741" target="_blank" class="term-link">
+                                    GO:0005741
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial outer membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-5205661
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O94826" data-a="GO:0005741" data-r="Reactome:R-HSA-5205661" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct localization. TOMM70 is an outer mitochondrial membrane TOM receptor/adaptor with a cytosol-facing TPR receptor domain.
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005741" target="_blank" class="term-link">
+                                    GO:0005741
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial outer membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-9685281
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O94826" data-a="GO:0005741" data-r="Reactome:R-HSA-9685281" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct localization. TOMM70 is an outer mitochondrial membrane TOM receptor/adaptor with a cytosol-facing TPR receptor domain.
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005741" target="_blank" class="term-link">
+                                    GO:0005741
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial outer membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-9709663
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O94826" data-a="GO:0005741" data-r="Reactome:R-HSA-9709663" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct localization. TOMM70 is an outer mitochondrial membrane TOM receptor/adaptor with a cytosol-facing TPR receptor domain.
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005741" target="_blank" class="term-link">
+                                    GO:0005741
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial outer membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-9709787
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O94826" data-a="GO:0005741" data-r="Reactome:R-HSA-9709787" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct localization. TOMM70 is an outer mitochondrial membrane TOM receptor/adaptor with a cytosol-facing TPR receptor domain.
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005741" target="_blank" class="term-link">
+                                    GO:0005741
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial outer membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-9709842
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O94826" data-a="GO:0005741" data-r="Reactome:R-HSA-9709842" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct localization. TOMM70 is an outer mitochondrial membrane TOM receptor/adaptor with a cytosol-facing TPR receptor domain.
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005741" target="_blank" class="term-link">
+                                    GO:0005741
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial outer membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-9709852
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O94826" data-a="GO:0005741" data-r="Reactome:R-HSA-9709852" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct localization. TOMM70 is an outer mitochondrial membrane TOM receptor/adaptor with a cytosol-facing TPR receptor domain.
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0002218" target="_blank" class="term-link">
+                                    GO:0002218
+                                </a>
+                            </span>
+                            <span class="term-label">activation of innate immune response</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20628368" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:20628368
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Tom70 mediates activation of interferon regulatory factor 3 ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="O94826" data-a="GO:0002218" data-r="PMID:20628368" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Supported in the antiviral MAVS/IRF3 literature, but this is a context-specific signaling role rather than TOMM70&#39;s core mitochondrial import function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Non-core signaling/adaptor role in antiviral innate immune response.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0002230" target="_blank" class="term-link">
+                                    GO:0002230
+                                </a>
+                            </span>
+                            <span class="term-label">positive regulation of defense response to virus by host</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20628368" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:20628368
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Tom70 mediates activation of interferon regulatory factor 3 ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="O94826" data-a="GO:0002230" data-r="PMID:20628368" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Supported in the antiviral MAVS/IRF3 literature, but this is a context-specific signaling role rather than TOMM70&#39;s core mitochondrial import function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Non-core signaling/adaptor role in antiviral innate immune response.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20628368" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:20628368
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Tom70 mediates activation of interferon regulatory factor 3 ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="O94826" data-a="GO:0005515" data-r="PMID:20628368" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Protein binding is too generic for TOMM70. The informative functions are chaperone-bound precursor receptor/adaptor activity, TOM association, and context-specific MAVS/PINK1 signaling.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Replace generic protein binding curation with specific adaptor, receptor, TOM complex, and pathway annotations.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25609812" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25609812
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Tom70 mediates Sendai virus-induced apoptosis on mitochondri...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="O94826" data-a="GO:0005515" data-r="PMID:25609812" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Protein binding is too generic for TOMM70. The informative functions are chaperone-bound precursor receptor/adaptor activity, TOM association, and context-specific MAVS/PINK1 signaling.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Replace generic protein binding curation with specific adaptor, receptor, TOM complex, and pathway annotations.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20628368" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:20628368
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Tom70 mediates activation of interferon regulatory factor 3 ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O94826" data-a="GO:0005739" data-r="PMID:20628368" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct but too general. TOMM70 is specifically an outer mitochondrial membrane TOM receptor/adaptor.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Subsumed by mitochondrial outer membrane and TOM complex annotations.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25609812" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25609812
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Tom70 mediates Sendai virus-induced apoptosis on mitochondri...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O94826" data-a="GO:0005739" data-r="PMID:25609812" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct but too general. TOMM70 is specifically an outer mitochondrial membrane TOM receptor/adaptor.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Subsumed by mitochondrial outer membrane and TOM complex annotations.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032728" target="_blank" class="term-link">
+                                    GO:0032728
+                                </a>
+                            </span>
+                            <span class="term-label">positive regulation of interferon-beta production</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20628368" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:20628368
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Tom70 mediates activation of interferon regulatory factor 3 ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="O94826" data-a="GO:0032728" data-r="PMID:20628368" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Supported in the antiviral MAVS/IRF3 literature, but this is a context-specific signaling role rather than TOMM70&#39;s core mitochondrial import function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Non-core signaling/adaptor role in antiviral innate immune response.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOMM70/TOMM70-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">TOMM70 is described as participating in antiviral innate immune signaling by acting as a **receptor/scaffold for MAVS-associated signaling**</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042981" target="_blank" class="term-link">
+                                    GO:0042981
+                                </a>
+                            </span>
+                            <span class="term-label">regulation of apoptotic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25609812" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25609812
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Tom70 mediates Sendai virus-induced apoptosis on mitochondri...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="O94826" data-a="GO:0042981" data-r="PMID:25609812" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Supported for Sendai virus-induced TOMM70/Hsp90/IRF3/BAX apoptosis context, but it is a secondary signaling phenotype.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Context-specific antiviral/apoptosis role rather than primary mitochondrial import function.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0098586" target="_blank" class="term-link">
+                                    GO:0098586
+                                </a>
+                            </span>
+                            <span class="term-label">cellular response to virus</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25609812" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25609812
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Tom70 mediates Sendai virus-induced apoptosis on mitochondri...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="O94826" data-a="GO:0098586" data-r="PMID:25609812" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Supported in the antiviral MAVS/IRF3 literature, but this is a context-specific signaling role rather than TOMM70&#39;s core mitochondrial import function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Non-core signaling/adaptor role in antiviral innate immune response.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005742" target="_blank" class="term-link">
+                                    GO:0005742
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial outer membrane translocase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O94826" data-a="GO:0005742" data-r="GO_REF:0000024" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct complex annotation. TOMM70 associates with the TOM import machinery and acts as a receptor/adaptor at the outer membrane translocase.
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008320" target="_blank" class="term-link">
+                                    GO:0008320
+                                </a>
+                            </span>
+                            <span class="term-label">protein transmembrane transporter activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O94826" data-a="GO:0008320" data-r="GO_REF:0000024" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Accepted as TOMM70 contribution to TOM-dependent protein transmembrane transport. TOMM70 is a receptor/adaptor, not the pore-forming subunit, but it contributes to the TOM complex import activity.
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030150" target="_blank" class="term-link">
+                                    GO:0030150
+                                </a>
+                            </span>
+                            <span class="term-label">protein import into mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="O94826" data-a="GO:0030150" data-r="GO_REF:0000024" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Broadly valid as a TOM-pathway outcome, but TOMM70 is best described as an outer-membrane receptor/adaptor rather than the matrix import pore or motor.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Matrix import is one TOM-dependent route; TOMM70 has a more specific receptor/adaptor role for chaperone-bound precursors.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030943" target="_blank" class="term-link">
+                                    GO:0030943
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion targeting sequence binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O94826" data-a="GO:0030943" data-r="GO_REF:0000024" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Supported. TOMM70 recognizes mitochondrial precursor proteins, especially hydrophobic internal-signal substrates delivered by Hsp70/Hsp90 chaperones.
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045039" target="_blank" class="term-link">
+                                    GO:0045039
+                                </a>
+                            </span>
+                            <span class="term-label">protein insertion into mitochondrial inner membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="O94826" data-a="GO:0045039" data-r="GO_REF:0000024" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reasonable as a pathway-level consequence for carrier/internal-signal precursor delivery, but TOMM70 does not catalyze inner membrane insertion itself.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> TOMM70 acts upstream at the outer membrane before substrates are handed to downstream inner-membrane import machinery.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070585" target="_blank" class="term-link">
+                                    GO:0070585
+                                </a>
+                            </span>
+                            <span class="term-label">protein localization to mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O94826" data-a="GO:0070585" data-r="GO_REF:0000024" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Supported broad process annotation. TOMM70 promotes mitochondrial localization/import of precursor proteins through its receptor/adaptor role.
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/23911537" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:23911537
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Cytoplasmic ribosomal protein S3 (rpS3) plays a pivotal role...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="O94826" data-a="GO:0005515" data-r="PMID:23911537" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Protein binding is too generic for TOMM70. The informative functions are chaperone-bound precursor receptor/adaptor activity, TOM association, and context-specific MAVS/PINK1 signaling.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Replace generic protein binding curation with specific adaptor, receptor, TOM complex, and pathway annotations.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20531390" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:20531390
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Suppression of the novel ER protein Maxer by mutant ataxin-1...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O94826" data-a="GO:0005739" data-r="PMID:20531390" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct but too general. TOMM70 is specifically an outer mitochondrial membrane TOM receptor/adaptor.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Subsumed by mitochondrial outer membrane and TOM complex annotations.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070062" target="_blank" class="term-link">
+                                    GO:0070062
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular exosome</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18570454" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:18570454
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Proteomic analysis of exosomes from human neural stem cells ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="O94826" data-a="GO:0070062" data-r="PMID:18570454" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput extracellular exosome detection is not supported as TOMM70 functional localization and conflicts with the mitochondrial outer membrane synthesis.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Likely high-throughput carryover/noise for an outer mitochondrial membrane TOM receptor.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                    GO:0016020
+                                </a>
+                            </span>
+                            <span class="term-label">membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19946888" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19946888
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Defining the membrane proteome of NK cells.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O94826" data-a="GO:0016020" data-r="PMID:19946888" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct but too broad. The specific supported localization is mitochondrial outer membrane, not generic membrane.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Subsumed by mitochondrial outer membrane annotations.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005742" target="_blank" class="term-link">
+                                    GO:0005742
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial outer membrane translocase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15644312" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15644312
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dissection of the mitochondrial import and assembly pathway ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O94826" data-a="GO:0005742" data-r="PMID:15644312" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct complex annotation. TOMM70 associates with the TOM import machinery and acts as a receptor/adaptor at the outer membrane translocase.
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008320" target="_blank" class="term-link">
+                                    GO:0008320
+                                </a>
+                            </span>
+                            <span class="term-label">protein transmembrane transporter activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15644312" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15644312
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dissection of the mitochondrial import and assembly pathway ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O94826" data-a="GO:0008320" data-r="PMID:15644312" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Accepted as TOMM70 contribution to TOM-dependent protein transmembrane transport. TOMM70 is a receptor/adaptor, not the pore-forming subunit, but it contributes to the TOM complex import activity.
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12526792" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12526792
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Molecular chaperones Hsp90 and Hsp70 deliver preproteins to ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="O94826" data-a="GO:0005515" data-r="PMID:12526792" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Protein binding is too generic for TOMM70. The informative functions are chaperone-bound precursor receptor/adaptor activity, TOM association, and context-specific MAVS/PINK1 signaling.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Replace generic protein binding curation with specific adaptor, receptor, TOM complex, and pathway annotations.
+                        </div>
+
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>TOMM70 is an outer-mitochondrial-membrane receptor/adaptor that docks Hsp70/Hsp90-bound hydrophobic precursor proteins and promotes their handoff to the TOM import machinery rather than acting as the pore itself.</h3>
+                <span class="vote-buttons" data-g="O94826" data-a="FUNCTION: TOMM70 is an outer-mitochondrial-membrane receptor..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030674" target="_blank" class="term-link">
+                            protein-macromolecule adaptor activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070585" target="_blank" class="term-link">
+                                protein localization to mitochondrion
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005741" target="_blank" class="term-link">
+                                mitochondrial outer membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140596" target="_blank" class="term-link">
+                            TOM complex
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/TOMM70/TOMM70-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">TOMM70 is best understood as a **surface receptor/adaptor** of the **TOM (translocase of the outer membrane)** import gateway</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/TOMM70/TOMM70-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">Cytosolic **Hsp70/Hsp90** chaperones bind newly synthesized hydrophobic precursors to prevent aggregation and **deliver them to TOMM70**</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/TOMM70/TOMM70-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">TOMM70 is anchored in the **outer mitochondrial membrane (OMM)** with its receptor domain facing the cytosol.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000024.md" target="_blank" class="term-link">
+                            GO_REF:0000024
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment of sequence similarity</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000052.md" target="_blank" class="term-link">
+                            GO_REF:0000052
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on curation of immunofluorescence data</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000107.md" target="_blank" class="term-link">
+                            GO_REF:0000107
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Automatic transfer of experimentally verified manual GO annotation data to orthologs using Ensembl Compara</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/12526792" target="_blank" class="term-link">
+                            PMID:12526792
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Molecular chaperones Hsp90 and Hsp70 deliver preproteins to the mitochondrial import receptor Tom70.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/15644312" target="_blank" class="term-link">
+                            PMID:15644312
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Dissection of the mitochondrial import and assembly pathway for human Tom40.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/18331822" target="_blank" class="term-link">
+                            PMID:18331822
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Identification of Tom5 and Tom6 in the preprotein translocase complex of human mitochondrial outer membrane.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/18570454" target="_blank" class="term-link">
+                            PMID:18570454
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Proteomic analysis of exosomes from human neural stem cells by flow field-flow fractionation and nanoflow liquid chromatography-tandem mass spectrometry.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/19946888" target="_blank" class="term-link">
+                            PMID:19946888
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Defining the membrane proteome of NK cells.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/20531390" target="_blank" class="term-link">
+                            PMID:20531390
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Suppression of the novel ER protein Maxer by mutant ataxin-1 in Bergman glia contributes to non-cell-autonomous toxicity.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/20628368" target="_blank" class="term-link">
+                            PMID:20628368
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Tom70 mediates activation of interferon regulatory factor 3 on mitochondria.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/23911537" target="_blank" class="term-link">
+                            PMID:23911537
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Cytoplasmic ribosomal protein S3 (rpS3) plays a pivotal role in mitochondrial DNA damage surveillance.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/25609812" target="_blank" class="term-link">
+                            PMID:25609812
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Tom70 mediates Sendai virus-induced apoptosis on mitochondria.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/32353859" target="_blank" class="term-link">
+                            PMID:32353859
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A SARS-CoV-2 protein interaction map reveals targets for drug repurposing.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/32728199" target="_blank" class="term-link">
+                            PMID:32728199
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">SARS-CoV-2 Orf9b suppresses type I interferon responses by targeting TOM70.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/33060197" target="_blank" class="term-link">
+                            PMID:33060197
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Comparative host-coronavirus protein interaction networks reveal pan-viral disease mechanisms.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/33723040" target="_blank" class="term-link">
+                            PMID:33723040
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Toxoplasma gondii association with host mitochondria requires key mitochondrial protein import machinery.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/33845483" target="_blank" class="term-link">
+                            PMID:33845483
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Multilevel proteomics reveals host perturbations by SARS-CoV-2 and SARS-CoV.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/33990585" target="_blank" class="term-link">
+                            PMID:33990585
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Crystal structure of SARS-CoV-2 Orf9b in complex with human TOM70 suggests unusual virus-host interactions.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/34232536" target="_blank" class="term-link">
+                            PMID:34232536
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Interactomes of SARS-CoV-2 and human coronaviruses reveal host factors potentially affecting pathogenesis.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/34502139" target="_blank" class="term-link">
+                            PMID:34502139
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Phosphorylation of SARS-CoV-2 Orf9b Regulates Its Targeting to Two Binding Sites in TOM70 and Recruitment of Hsp90.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link">
+                            PMID:34800366
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Quantitative high-confidence human mitochondrial proteome and its dynamics in cellular context.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/34942634" target="_blank" class="term-link">
+                            PMID:34942634
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Evolution of enhanced innate immune evasion by SARS-CoV-2.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/35391620" target="_blank" class="term-link">
+                            PMID:35391620
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The role of the individual TOM subunits in the association of PINK1 with depolarized mitochondria.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/36217030" target="_blank" class="term-link">
+                            PMID:36217030
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A comprehensive SARS-CoV-2-human protein-protein interactome reveals COVID-19 pathobiology and potential host therapeutic targets.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-5205661
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Pink1 is recruited from the cytoplasm to the mitochondria</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-9685281
+
+                    </span>
+                </div>
+
+                <div class="reference-title">SARS-CoV-1 3a binds TRAF3 within NLRP3 inflammasome</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-9709663
+
+                    </span>
+                </div>
+
+                <div class="reference-title">SARS-CoV-2 9b binds TOMM70</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-9709787
+
+                    </span>
+                </div>
+
+                <div class="reference-title">SARS-CoV-1 9b binds TOMM70</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-9709842
+
+                    </span>
+                </div>
+
+                <div class="reference-title">MAVS binds TOMM70</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-9709852
+
+                    </span>
+                </div>
+
+                <div class="reference-title">MAVS:TOMM70 recruits HSP90:TBK1:IRF3</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/TOMM70/TOMM70-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research report for human TOMM70</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Which mammalian TOMM70 substrates require direct chaperone docking versus direct precursor contacts?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="O94826" data-a="Q: Which mammalian TOMM70 substrates require direct c..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> How are TOMM70 import, MAVS signaling, and PINK1/Parkin quality-control roles separated by post-translational regulation?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="O94826" data-a="Q: How are TOMM70 import, MAVS signaling, and PINK1/P..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Compare import of carrier-type substrates and presequence substrates in TOMM70 knockout or knockdown cells rescued with wild-type versus chaperone-docking-defective TOMM70 variants.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: TOMM70 TPR-domain mutants that disrupt Hsp70/Hsp90 docking selectively impair carrier/internal-signal precursor import while preserving TOM core assembly.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="O94826" data-a="EXPERIMENT: Compare import of carrier-type substrates and pres..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Assay MAVS-induced IRF3 activation and mitochondrial precursor import in parallel for TOMM70 interface mutants.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: TOMM70 antiviral signaling can be separated from its import receptor activity by mutating MAVS/Hsp90 signaling interfaces outside the precursor handoff surface.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="O94826" data-a="EXPERIMENT: Assay MAVS-induced IRF3 activation and mitochondri..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Deep Research Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(TOMM70-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="O94826" data-a="DOC: Deep Research Falcon" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <hr />
+<p>provider: falcon<br />
+model: Edison Scientific Literature<br />
+cached: false<br />
+start_time: '2026-05-11T13:32:32.543116'<br />
+end_time: '2026-05-11T13:44:11.524092'<br />
+duration_seconds: 698.98<br />
+template_file: templates/gene_research_go_focused.md<br />
+template_variables:<br />
+  organism: human<br />
+  gene_id: TOMM70<br />
+  gene_symbol: TOMM70<br />
+  uniprot_accession: O94826<br />
+  protein_description: 'RecName: Full=Mitochondrial import receptor subunit TOM70<br />
+    {ECO:0000305}; AltName: Full=Mitochondrial precursor proteins import receptor;<br />
+    AltName: Full=Translocase of outer membrane 70 kDa subunit; AltName: Full=Translocase<br />
+    of outer mitochondrial membrane protein 70 {ECO:0000312|HGNC:HGNC:11985};'<br />
+  gene_info: Name=TOMM70 {ECO:0000312|HGNC:HGNC:11985}; Synonyms=KIAA0719, TOM70,<br />
+    TOMM70A;<br />
+  organism_full: Homo sapiens (Human).<br />
+  protein_family: Belongs to the Tom70 family. .<br />
+  protein_domains: TPR-like_helical_dom_sf. (IPR011990); TPR_rpt. (IPR019734); TPR_1<br />
+    (PF00515); TPR_8 (PF13181)<br />
+provider_config:<br />
+  timeout: 600<br />
+  max_retries: 3<br />
+  parameters:<br />
+    allowed_domains: []<br />
+    temperature: 0.1<br />
+citation_count: 29</p>
+<hr />
+<h2 id="question">Question</h2>
+<h1 id="gene-research-for-functional-annotation">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> O94826</li>
+<li><strong>Protein Description:</strong> RecName: Full=Mitochondrial import receptor subunit TOM70 {ECO:0000305}; AltName: Full=Mitochondrial precursor proteins import receptor; AltName: Full=Translocase of outer membrane 70 kDa subunit; AltName: Full=Translocase of outer mitochondrial membrane protein 70 {ECO:0000312|HGNC:HGNC:11985};</li>
+<li><strong>Gene Information:</strong> Name=TOMM70 {ECO:0000312|HGNC:HGNC:11985}; Synonyms=KIAA0719, TOM70, TOMM70A;</li>
+<li><strong>Organism (full):</strong> Homo sapiens (Human).</li>
+<li><strong>Protein Family:</strong> Belongs to the Tom70 family. .</li>
+<li><strong>Key Domains:</strong> TPR-like_helical_dom_sf. (IPR011990); TPR_rpt. (IPR019734); TPR_1 (PF00515); TPR_8 (PF13181)</li>
+</ul>
+<h3 id="mandatory-verification-steps">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "TOMM70" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Homo sapiens (Human).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'TOMM70' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>TOMM70</strong> (gene ID: TOMM70, UniProt: O94826) in human.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="output">Output</h2>
+<p>Question: You are an expert researcher providing comprehensive, well-cited information.</p>
+<p>Provide detailed information focusing on:<br />
+1. Key concepts and definitions with current understanding<br />
+2. Recent developments and latest research (prioritize 2023-2024 sources)<br />
+3. Current applications and real-world implementations<br />
+4. Expert opinions and analysis from authoritative sources<br />
+5. Relevant statistics and data from recent studies</p>
+<p>Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.<br />
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.</p>
+<h1 id="gene-research-for-functional-annotation_1">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context_1">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot_1">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> O94826</li>
+<li><strong>Protein Description:</strong> RecName: Full=Mitochondrial import receptor subunit TOM70 {ECO:0000305}; AltName: Full=Mitochondrial precursor proteins import receptor; AltName: Full=Translocase of outer membrane 70 kDa subunit; AltName: Full=Translocase of outer mitochondrial membrane protein 70 {ECO:0000312|HGNC:HGNC:11985};</li>
+<li><strong>Gene Information:</strong> Name=TOMM70 {ECO:0000312|HGNC:HGNC:11985}; Synonyms=KIAA0719, TOM70, TOMM70A;</li>
+<li><strong>Organism (full):</strong> Homo sapiens (Human).</li>
+<li><strong>Protein Family:</strong> Belongs to the Tom70 family. .</li>
+<li><strong>Key Domains:</strong> TPR-like_helical_dom_sf. (IPR011990); TPR_rpt. (IPR019734); TPR_1 (PF00515); TPR_8 (PF13181)</li>
+</ul>
+<h3 id="mandatory-verification-steps_1">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "TOMM70" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Homo sapiens (Human).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature_1">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'TOMM70' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target_1">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>TOMM70</strong> (gene ID: TOMM70, UniProt: O94826) in human.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="research-report-human-tomm70-uniprot-o94826-functional-annotation">Research report: Human <strong>TOMM70</strong> (UniProt <strong>O94826</strong>) functional annotation</h2>
+<h3 id="1-target-verification-geneprotein-identity">1) Target verification (gene/protein identity)</h3>
+<p>The literature retrieved and cited here matches the UniProt target <strong>O94826</strong>: <strong>human TOMM70</strong> (synonyms <strong>TOM70, TOMM70A, KIAA0719</strong>) encoding <strong>mitochondrial import receptor subunit TOM70</strong>, a Tom70-family protein anchored in the <strong>outer mitochondrial membrane (OMM)</strong> with a large cytosolic receptor domain enriched in <strong>TPR (tetratricopeptide repeat) motifs</strong>. (kreimendahl2020themitochondrialouter pages 1-3, kreimendahl2020themitochondrialouter pages 3-6)</p>
+<h3 id="2-key-concepts-definitions-and-current-understanding">2) Key concepts, definitions, and current understanding</h3>
+<h4 id="21-tomm70-as-a-mitochondrial-protein-import-receptor-core-function">2.1 TOMM70 as a mitochondrial protein import receptor (core function)</h4>
+<p><strong>Definition/role.</strong> TOMM70 is best understood as a <strong>surface receptor/adaptor</strong> of the <strong>TOM (translocase of the outer membrane)</strong> import gateway, specializing in the delivery of <strong>hydrophobic, chaperone-bound mitochondrial precursor proteins</strong> (classically including inner-membrane carrier proteins with internal targeting signals), rather than functioning as a channel itself. (kreimendahl2020themitochondrialouter pages 1-3, haastrup2023thejourneyof pages 8-10)</p>
+<p><strong>Mechanistic model.</strong> Cytosolic <strong>Hsp70/Hsp90</strong> chaperones bind newly synthesized hydrophobic precursors to prevent aggregation and <strong>deliver them to TOMM70</strong>, which then <strong>hands off</strong> substrates to other TOM components (notably <strong>TOMM22</strong> and the <strong>TOMM40</strong> pore) for translocation across the OMM; carrier precursors are then escorted by small TIM chaperones in the IMS toward <strong>TIMM22</strong> for insertion into the inner membrane. (haastrup2023thejourneyof pages 8-10, kreimendahl2020themitochondrialouter pages 12-14)</p>
+<h4 id="22-domain-architecture-and-chaperone-docking">2.2 Domain architecture and chaperone docking</h4>
+<p>Tom70-family receptors are helical solenoids; a widely cited structural description (from fungal Tom70) is <strong>~26 α-helices organized into ~11 TPR motifs</strong>, with an N-terminal membrane anchor and a cytosolic receptor domain. The N-terminal region forms a clamp-like site that binds Hsp70 (and in mammals Hsp70/Hsp90), supporting the view that TOMM70 frequently recognizes substrates <strong>indirectly via bound chaperones</strong>. (kreimendahl2020themitochondrialouter pages 3-6, kreimendahl2020themitochondrialouter pages 1-3)</p>
+<h4 id="23-subcellular-localization-beyond-mitochondrial-surface-foci-and-contact-sites">2.3 Subcellular localization beyond “mitochondrial surface”: foci and contact sites</h4>
+<p>Beyond being OMM-anchored, TOMM70 is described as enriched in <strong>defined foci</strong> and associated with <strong>ER–mitochondria contact sites (MERCS)</strong> where it can contribute to <strong>Ca2+ transfer</strong> by interacting with <strong>IP3R3</strong> (inositol-1,4,5-trisphosphate receptor type 3). This extends TOMM70’s annotation from import to <strong>organelle communication</strong> and signaling. (kreimendahl2020themitochondrialouter pages 14-16, pitt2021abiochemicaland pages 19-20)</p>
+<h4 id="24-tomm70-as-a-signaling-adaptor-in-innate-immunity">2.4 TOMM70 as a signaling adaptor in innate immunity</h4>
+<p>TOMM70 is described as participating in antiviral innate immune signaling by acting as a <strong>receptor/scaffold for MAVS-associated signaling</strong>, helping recruit/organize signaling factors (often described via an Hsp90-containing axis) that promote <strong>IRF3 activation</strong> and type I interferon responses. (pitt2021abiochemicaland pages 19-20, pitt2021abiochemicaland pages 17-19)</p>
+<h4 id="25-tomm70-in-mitochondrial-quality-control-and-mitophagy">2.5 TOMM70 in mitochondrial quality control and mitophagy</h4>
+<p>Multiple sources connect TOMM70 to <strong>PINK1/Parkin (PRKN)-dependent mitophagy</strong>, including roles in <strong>PINK1 import/accumulation at the OMM</strong>, TOM-complex ubiquitylation dynamics, and downstream mitophagy signaling. (kreimendahl2020themitochondrialouter pages 19-21, pitt2021abiochemicaland pages 17-19)</p>
+<h3 id="3-recent-developments-prioritizing-20232024">3) Recent developments (prioritizing 2023–2024)</h3>
+<h4 id="31-2024-tomm70-as-a-metabolicimmune-node-in-human-t-cells-lactate-tomm70-mgat1-import">3.1 2024: TOMM70 as a metabolic/immune node in human T cells (lactate → TOMM70 → MGAT1 import)</h4>
+<p>A 2024 <em>Journal of Clinical Investigation</em> study in human regulatory T cells (Tregs) proposed a direct metabolite–receptor interaction in which <strong>lactate binds TOM70</strong> and promotes mitochondrial import of <strong>MGAT1</strong>, supporting <strong>OXPHOS</strong> and Treg function. The authors report (i) structural/docking and autoradiography evidence for lactate binding to TOM70, including predicted binding contacts (H-bonds with <strong>SER253, ASP541, THR511</strong>; hydrophobic contacts including <strong>PHE256, GLN255, ASN509, ALA510, CYS544</strong>), and (ii) functional perturbation where <strong>TOMM70 shRNA knockdown</strong> reduced MGAT1 expression/mitochondrial colocalization and decreased <strong>basal and maximal oxygen consumption rate (OCR)</strong>. (zhou2024lactatesupportstreg pages 8-9)</p>
+<p><strong>Interpretation.</strong> This work extends TOMM70’s functional annotation into <strong>immunometabolism</strong>, framing TOMM70 not only as a protein import receptor but also as a potential “gatekeeper” for metabolically adaptive import programs in immune cells. (zhou2024lactatesupportstreg pages 8-9)</p>
+<h4 id="32-2024-human-genetic-variation-predicted-to-modulate-tomm70sarscov2-orf9b-binding">3.2 2024: Human genetic variation predicted to modulate TOMM70–SARS‑CoV‑2 ORF9b binding</h4>
+<p>A 2024 <em>Scientific Reports</em> computational study analyzed missense variants in TOMM70 at the TOMM70:ORF9b interface (structure referenced as PDB 7KDT) and predicted variant effects on binding affinity. Examples include predicted affinity increases (ΔΔG, kcal/mol) for <strong>V556L (0.905)</strong>, <strong>K576R (0.618)</strong>, <strong>A591T (0.599)</strong>, <strong>V514I (0.562)</strong>, and <strong>A483T (0.499)</strong>, while <strong>I412T (−1.054)</strong> and <strong>E477G (−1.014)</strong> were predicted to decrease affinity. The same work reports these variants as <strong>rare in gnomAD</strong>, e.g., V556L observed with allele frequency <strong>0.00007</strong> in African/African American. (waman2024predictinghumanand pages 8-10)</p>
+<p><strong>Interpretation/limits.</strong> These are <em>in silico</em> affinity predictions rather than clinical association estimates; nonetheless they provide a concrete hypothesis framework for <strong>host genetic modulation of viral immune evasion</strong> mediated via TOMM70. (waman2024predictinghumanand pages 8-10)</p>
+<h4 id="33-20232024-tomm70-highlighted-as-a-multifunctionalregulatory-tom-component">3.3 2023–2024: TOMM70 highlighted as a multifunctional/regulatory TOM component</h4>
+<p>A 2023 review on mitochondrial import-related stress signaling summarizes the import machinery as a signaling hub; it notes that Tom20 and Tom70 are the main receptors and links TOM-associated processes to mitophagy and stress responses (e.g., PINK1-related pathways when import is perturbed). (lionaki2023mitochondrialproteinimport pages 8-9)</p>
+<p>A 2024 evolutionary/functional review specifically emphasizes TOMM70 as a TOM receptor with “manifold functions” and places it in the context of evolutionary diversification of TOM composition and regulation, aligning TOMM70 with <strong>regulatory and signaling roles</strong> beyond translocation. (ozdemir2024thetomcomplex pages 1-7)</p>
+<h3 id="4-current-applications-and-real-world-implementations">4) Current applications and real-world implementations</h3>
+<h4 id="41-diagnostic-relevance-tomm70-as-a-mendelian-mitochondrial-disease-gene">4.1 Diagnostic relevance: TOMM70 as a Mendelian mitochondrial disease gene</h4>
+<p>A 2020 human genetics study reports compound heterozygous <strong>TOMM70</strong> variants (<strong>c.794C&gt;T / p.T265M</strong> and <strong>c.1745C&gt;T / p.A582V</strong>) in a patient with <strong>severe anemia, lactic acidosis, and developmental delay</strong>, with patient-derived lymphocytes showing reduced TOM70 expression and defects in TOM complexes and multi-OXPHOS, with <strong>complex IV primarily affected</strong>; WT TOM70 (but not mutant TOM70) restored the complex IV defect in a knockdown rescue model. This supports clinical use of TOMM70 in gene panels/interpretation for suspected mitochondrial disease. (wei2020mutationsintomm70 pages 1-2)</p>
+<h4 id="42-therapeutic-strategy-concepts-preclinical-modulating-tomm70-linked-pathways">4.2 Therapeutic strategy concepts (preclinical): modulating TOMM70-linked pathways</h4>
+<p>TOMM70’s central placement at the intersection of protein import, MERCS, and innate immunity has motivated proposals that targeting TOM-complex interfaces or TOMM70-linked signaling could be therapeutically relevant in contexts such as viral immune evasion and mitochondrial-stress diseases. A structural/biochemical review highlights TOMM70’s involvement in Parkin/PINK1 mitophagy and MAVS–IRF3 signaling and notes viral exploitation (e.g., ORF9b binding) as a rationale for intervention concepts. (pitt2021abiochemicaland pages 19-20, pitt2021abiochemicaland pages 17-19)</p>
+<h4 id="43-cell-therapy-context-treg-function">4.3 Cell therapy context (Treg function)</h4>
+<p>The 2024 JCI study connects TOMM70-dependent MGAT1 mitochondrial localization to improved human Treg OXPHOS and reports in vivo benefit of lactate-treated Tregs in a xenogeneic GvHD model, positioning TOMM70 mechanistically within workflows relevant to <strong>Treg reinfusion therapy</strong> (as an enabling step for mitochondrial metabolic fitness). (zhou2024lactatesupportstreg pages 8-9)</p>
+<h3 id="5-expert-opinions-and-authoritative-synthesis-how-experts-frame-tomm70">5) Expert opinions and authoritative synthesis (how experts frame TOMM70)</h3>
+<p><strong>Consensus functional framing.</strong> Authoritative reviews converge on TOMM70 as a <strong>TPR-containing OMM adaptor receptor</strong> that (i) docks Hsp70/Hsp90-bound precursors to the TOM entry gate, (ii) coordinates organelle cross-talk (MERCS; Ca2+ transfer via IP3R3), and (iii) provides a platform for innate immune signaling (MAVS/IRF3 axis) and quality control (PINK1/Parkin mitophagy). (kreimendahl2020themitochondrialouter pages 1-3, pitt2021abiochemicaland pages 19-20)</p>
+<p><strong>Mechanistic caution expressed in the literature.</strong> The same reviews highlight that substrate recognition can be predominantly <strong>chaperone-mediated</strong>, and that TOMM70’s “non-import” roles likely depend on context-specific protein–protein interactions and post-translational modifications (phosphorylation/ubiquitylation), with open questions about how these modifications reprogram TOMM70’s receptor vs signaling functions in mammals. (kreimendahl2020themitochondrialouter pages 3-6, pitt2021abiochemicaland pages 17-19)</p>
+<h3 id="6-quantitativestatistical-findings-from-recent-and-key-studies">6) Quantitative/statistical findings from recent and key studies</h3>
+<h4 id="61-structuraldomain-quantitative-descriptors">6.1 Structural/domain quantitative descriptors</h4>
+<p>A commonly cited Tom70 structural summary is <strong>~26 α-helices forming ~11 TPR motifs</strong> in the receptor domain. (kreimendahl2020themitochondrialouter pages 3-6)</p>
+<h4 id="62-import-system-scale">6.2 Import-system scale</h4>
+<p>Reviews estimate that human cells import on the order of <strong>~1,500 mitochondrial precursor proteins</strong> synthesized in the cytosol, contextualizing why TOM receptors (including TOMM70) are essential for cell viability and homeostasis. (kreimendahl2020themitochondrialouter pages 1-3)</p>
+<h4 id="63-quantitative-variant-effects-and-population-frequencies-relevant-to-tomm70orf9b-interaction-2024">6.3 Quantitative variant effects and population frequencies relevant to TOMM70–ORF9b interaction (2024)</h4>
+<p>Predicted changes in binding affinity to SARS‑CoV‑2 ORF9b for TOMM70 variants include <strong>V556L ΔΔG 0.905 kcal/mol</strong>, <strong>K576R 0.618</strong>, <strong>A591T 0.599</strong>, <strong>V514I 0.562</strong>, <strong>A483T 0.499</strong>, and affinity-reducing <strong>I412T −1.054</strong> and <strong>E477G −1.014</strong>. Reported allele frequencies are far below 1% (e.g., <strong>V556L 0.00007</strong> in African/African American). (waman2024predictinghumanand pages 8-10)</p>
+<h4 id="64-quantitativestatistical-evidence-in-the-2024-treg-study">6.4 Quantitative/statistical evidence in the 2024 Treg study</h4>
+<p>The 2024 JCI study reports statistical testing (e.g., ANOVA with P-value thresholds) for multiple mitochondrial readouts and shows that TOMM70 knockdown reduces mitochondrial MGAT1 colocalization and OCR; however, the excerpted text does not provide the exact OCR deltas, so quantitative effect sizes cannot be faithfully reproduced here without the underlying supplemental figure values. (zhou2024lactatesupportstreg pages 8-9)</p>
+<h3 id="7-visual-evidence-figures-supporting-mechanistic-understanding">7) Visual evidence (figures) supporting mechanistic understanding</h3>
+<p>A Tom70 review provides schematics that summarize: (i) Tom70’s receptor function as a docking site for chaperone-bound substrates and their delivery to the TOM pore and/or outer-membrane insertion pathways, (ii) Tom70’s role in MAVS/RIG-I pathway signaling through recruitment of Hsp90/TBK1/IRF3 complexes, and (iii) competitive binding of SARS‑CoV‑2 ORF9b to Tom70 that can suppress interferon responses. These schematics are useful for functional annotation narratives. (kreimendahl2020themitochondrialouter media bc2f2392, kreimendahl2020themitochondrialouter media 1214cc5a, kreimendahl2020themitochondrialouter media 41a8d14b, kreimendahl2020themitochondrialouter media 44199fa5, kreimendahl2020themitochondrialouter media 3b13eb9e)</p>
+<h3 id="8-summary-functional-annotation-most-defensible-primary-function">8) Summary functional annotation (most defensible “primary function”)</h3>
+<p><strong>Primary function:</strong> TOMM70 is an <strong>outer-mitochondrial-membrane receptor/adaptor</strong> that binds <strong>cytosolic chaperones (Hsp70/Hsp90) carrying hydrophobic mitochondrial precursor proteins</strong> and promotes their delivery to the TOM translocation machinery for import—particularly important for internal-signal, hydrophobic precursors such as carrier proteins. (haastrup2023thejourneyof pages 8-10, kreimendahl2020themitochondrialouter pages 12-14)</p>
+<p><strong>Where it acts:</strong> OMM, cytosol-facing receptor domain; additionally enriched at MERCS where it can participate in ER→mitochondria Ca2+ transfer and signaling assemblies. (kreimendahl2020themitochondrialouter pages 14-16, pitt2021abiochemicaland pages 19-20)</p>
+<p><strong>Key pathways:</strong> Mitochondrial biogenesis (protein import), innate immune signaling (MAVS/IRF3 axis, viral antagonism via ORF9b), and mitochondrial quality control/mitophagy (PINK1/Parkin-linked processes). (pitt2021abiochemicaland pages 19-20, kreimendahl2020themitochondrialouter pages 19-21)</p>
+<hr />
+<h3 id="evidence-mapped-reference-table">Evidence-mapped reference table</h3>
+<p>The following table consolidates identity, mechanism, pathways, 2023–2024 updates, quantitative findings, and URLs.</p>
+<table>
+<thead>
+<tr>
+<th>Category</th>
+<th>Specific details</th>
+<th>Evidence/notes</th>
+<th>Key sources with publication year</th>
+<th>URL</th>
+<th>Citation context IDs</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Identity/domains</td>
+<td>Human <strong>TOMM70</strong> corresponds to UniProt <strong>O94826</strong> and encodes the mitochondrial outer membrane import receptor <strong>Tom70/TOM70/TOMM70A</strong>. It is a Tom70-family protein with an N-terminal membrane anchor and a large cytosolic TPR-repeat receptor domain; reviews describe Tom70 as a helical receptor with ~26 α-helices and ~11 TPR motifs.</td>
+<td>Identity and function match the UniProt target, and the TPR-repeat architecture aligns with the provided InterPro/Pfam annotations. Evolutionary review notes strong conservation among animal orthologs.</td>
+<td>Kreimendahl &amp; Rassow 2020; Özdemir &amp; Dennerlein 2024</td>
+<td>https://doi.org/10.3390/ijms21197262 ; https://doi.org/10.1515/hsz-2024-0043</td>
+<td>(kreimendahl2020themitochondrialouter pages 1-3, kreimendahl2020themitochondrialouter pages 3-6, ozdemir2024thetomcomplex pages 1-7)</td>
+</tr>
+<tr>
+<td>Localization</td>
+<td>TOMM70 is anchored in the <strong>outer mitochondrial membrane (OMM)</strong> with its receptor domain facing the cytosol. In mammalian cells it is also enriched in defined foci and at <strong>ER-mitochondria contact sites (MERCS)</strong>.</td>
+<td>Reviews describe localization on the mitochondrial surface and clustering at contact sites, consistent with roles in import, Ca2+ transfer, and signaling.</td>
+<td>Kreimendahl &amp; Rassow 2020; Pitt &amp; Buchanan 2021</td>
+<td>https://doi.org/10.3390/ijms21197262 ; https://doi.org/10.3390/cells10051164</td>
+<td>(kreimendahl2020themitochondrialouter pages 1-3, kreimendahl2020themitochondrialouter pages 14-16, pitt2021abiochemicaland pages 19-20, kreimendahl2020themitochondrialouter pages 12-14)</td>
+</tr>
+<tr>
+<td>Core function in import</td>
+<td>TOMM70 is a <strong>surface receptor for chaperone-bound hydrophobic mitochondrial precursor proteins</strong>, especially multi-pass carrier proteins with internal targeting signals. Cytosolic <strong>Hsp70/Hsp90</strong> chaperones deliver precursors to TOMM70, which then transfers them to <strong>TOMM22/TOMM40</strong> for passage through the TOM pore and onward to TIM22 for inner-membrane carrier insertion.</td>
+<td>This is the best-supported primary annotation: TOMM70 acts mainly as an adaptor/docking receptor rather than as a pore-forming transporter or enzyme. TOMM20 is emphasized as the main receptor for classical N-terminal presequences, whereas TOMM70 is more associated with carrier/internal-signal substrates.</td>
+<td>Haastrup et al. 2023; Kreimendahl &amp; Rassow 2020; Lionaki et al. 2023</td>
+<td>https://doi.org/10.3390/ijms24032479 ; https://doi.org/10.3390/ijms21197262 ; https://doi.org/10.1002/bies.202200160</td>
+<td>(haastrup2023thejourneyof pages 8-10, kreimendahl2020themitochondrialouter pages 1-3, kreimendahl2020themitochondrialouter pages 12-14, lionaki2023mitochondrialproteinimport pages 8-9)</td>
+</tr>
+<tr>
+<td>Key interactions</td>
+<td>Established interactors include <strong>Hsp70/Hsp90</strong>, <strong>TOMM20/TOMM22/TOMM40</strong>, <strong>PINK1</strong>, <strong>Parkin/PRKN</strong>, <strong>MAVS</strong>, and <strong>IP3R3</strong>; mammalian studies also link TOMM70 to <strong>IRF3/TBK1 signaling complexes</strong> via Hsp90 and to viral proteins including <strong>SARS-CoV-2 ORF9b</strong>.</td>
+<td>N-terminal TPR motifs mediate chaperone docking; TOMM70 can partially/reversibly associate with the TOM core. Beyond import, it serves as a scaffold for antiviral signaling and membrane-contact functions.</td>
+<td>Kreimendahl &amp; Rassow 2020; Pitt &amp; Buchanan 2021</td>
+<td>https://doi.org/10.3390/ijms21197262 ; https://doi.org/10.3390/cells10051164</td>
+<td>(kreimendahl2020themitochondrialouter pages 1-3, kreimendahl2020themitochondrialouter pages 14-16, pitt2021abiochemicaland pages 19-20, kreimendahl2020themitochondrialouter pages 12-14, pitt2021abiochemicaland pages 17-19)</td>
+</tr>
+<tr>
+<td>Pathways</td>
+<td>Major pathways include <strong>mitochondrial protein import</strong>, <strong>PINK1/Parkin-dependent mitophagy</strong>, <strong>MAVS-mediated innate antiviral signaling</strong>, and <strong>ER-mitochondria Ca2+ transfer/MERCS</strong>.</td>
+<td>Reviews and mechanistic papers place TOMM70 at the intersection of organelle biogenesis and stress signaling: import defects can alter cytosolic proteostasis, ISR/UPR-like pathways, and mitophagy initiation.</td>
+<td>Lionaki et al. 2023; Kreimendahl &amp; Rassow 2020; Pitt &amp; Buchanan 2021</td>
+<td>https://doi.org/10.1002/bies.202200160 ; https://doi.org/10.3390/ijms21197262 ; https://doi.org/10.3390/cells10051164</td>
+<td>(lionaki2023mitochondrialproteinimport pages 8-9, kreimendahl2020themitochondrialouter pages 19-21, pitt2021abiochemicaland pages 19-20)</td>
+</tr>
+<tr>
+<td>Disease/clinical relevance</td>
+<td>Pathogenic <strong>TOMM70</strong> variants cause a rare mitochondrial disease with <strong>multi-OXPHOS deficiency</strong>, severe <strong>anemia</strong>, <strong>lactic acidosis</strong>, and <strong>developmental delay</strong>. Reported patient variants include <strong>p.T265M</strong> and <strong>p.A582V</strong>. TOMM70 dysregulation is also discussed in cardiac injury/remodeling, neurodegeneration/mitophagy, and antiviral immune evasion.</td>
+<td>Patient-derived lymphocytes showed reduced TOM70 expression and TOM complex defects; only wild-type TOM70 restored defects in rescue assays. Reviews link reduced TOM70 to impaired mitochondrial quality control and stress susceptibility.</td>
+<td>Wei et al. 2020; Palmer et al. 2021; Kreimendahl &amp; Rassow 2020</td>
+<td>https://doi.org/10.1038/s10038-019-0714-1 ; https://doi.org/10.1002/1873-3468.14022 ; https://doi.org/10.3390/ijms21197262</td>
+<td>(wei2020mutationsintomm70 pages 1-2, kreimendahl2020themitochondrialouter pages 19-21)</td>
+</tr>
+<tr>
+<td>2023-2024 updates</td>
+<td><strong>2024 JCI</strong>: lactate was shown to bind TOM70 and promote <strong>MGAT1-TOM70</strong> interaction and mitochondrial translocation of MGAT1 in human Tregs, supporting OXPHOS and Treg function. <strong>2024 Sci Rep</strong>: human TOMM70 missense variants were computationally predicted to alter binding to <strong>SARS-CoV-2 ORF9b</strong>. <strong>2024 review</strong>: TOMM70 highlighted as an evolutionarily flexible TOM component with signaling and contact-site functions beyond import.</td>
+<td>These recent papers expand TOMM70 biology from import receptor to broader signaling node in immune metabolism and host-virus interaction. The 2024 review emphasizes TOMM70 as a regulatory, non-core-pore TOM component with manifold functions.</td>
+<td>Zhou et al. 2024; Waman et al. 2024; Özdemir &amp; Dennerlein 2024</td>
+<td>https://doi.org/10.1172/jci175897 ; https://doi.org/10.1038/s41598-024-61541-1 ; https://doi.org/10.1515/hsz-2024-0043</td>
+<td>(zhou2024lactatesupportstreg pages 8-9, waman2024predictinghumanand pages 8-10, ozdemir2024thetomcomplex pages 1-7)</td>
+</tr>
+<tr>
+<td>Quantitative/statistical data</td>
+<td>Recent quantitative details include: <strong>~26 α-helices / ~11 TPR motifs</strong> for Tom70 architecture; human mitochondrial proteome estimate of <strong>up to ~1,500 proteins</strong> requiring import; lactate-TOM70 docking implicated residues <strong>SER253, ASP541, THR511, PHE256, GLN255, ASN509, ALA510, CYS544</strong>; predicted TOMM70 variant effects on ORF9b binding include <strong>V556L ΔΔG 0.905 kcal/mol</strong>, <strong>K576R 0.618</strong>, <strong>A591T 0.599</strong>, <strong>V514I 0.562</strong>, <strong>A483T 0.499</strong>, while <strong>I412T -1.054</strong> and <strong>E477G -1.014 kcal/mol</strong> were predicted to reduce affinity; the reported mitochondrial disease prevalence background cited is <strong>5-15 per 100,000 live births</strong>.</td>
+<td>Quantitative figures are heterogeneous: some are structural descriptors, some are computational affinity estimates, and some are disease epidemiology/background. Several functional studies reported significant changes (e.g., OCR decline after TOMM70 knockdown) but the excerpted text did not provide exact numeric effect sizes. Rare TOMM70 affinity-enhancing variants had gnomAD frequencies far below 1% (e.g., V556L African/AA <strong>0.00007</strong>).</td>
+<td>Kreimendahl &amp; Rassow 2020; Zhou et al. 2024; Waman et al. 2024; Wei et al. 2020</td>
+<td>https://doi.org/10.3390/ijms21197262 ; https://doi.org/10.1172/jci175897 ; https://doi.org/10.1038/s41598-024-61541-1 ; https://doi.org/10.1038/s10038-019-0714-1</td>
+<td>(kreimendahl2020themitochondrialouter pages 1-3, kreimendahl2020themitochondrialouter pages 3-6, zhou2024lactatesupportstreg pages 8-9, waman2024predictinghumanand pages 8-10, wei2020mutationsintomm70 pages 1-2)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the verified identity, localization, core function, interactions, pathways, disease relevance, recent 2023-2024 advances, and available quantitative findings for human TOMM70 (UniProt O94826). It is designed as a compact evidence map for functional annotation and literature-supported reporting.</em></p>
+<h3 id="key-cited-sources-publication-date-url">Key cited sources (publication date; URL)</h3>
+<ul>
+<li>Kreimendahl S, Rassow J. <em>Int J Mol Sci</em> <strong>2020-10</strong>. https://doi.org/10.3390/ijms21197262 (kreimendahl2020themitochondrialouter pages 1-3)</li>
+<li>Wei X et al. <em>Journal of Human Genetics</em> <strong>2020-01</strong> (accepted 2019-12-15). https://doi.org/10.1038/s10038-019-0714-1 (wei2020mutationsintomm70 pages 1-2)</li>
+<li>Pitt AS, Buchanan SK. <em>Cells</em> <strong>2021-05</strong>. https://doi.org/10.3390/cells10051164 (pitt2021abiochemicaland pages 19-20)</li>
+<li>Haastrup MO et al. <em>Int J Mol Sci</em> <strong>2023-01</strong>. https://doi.org/10.3390/ijms24032479 (haastrup2023thejourneyof pages 8-10)</li>
+<li>Lionaki E et al. <em>BioEssays</em> <strong>2023-01</strong>. https://doi.org/10.1002/bies.202200160 (lionaki2023mitochondrialproteinimport pages 8-9)</li>
+<li>Zhou J et al. <em>J Clin Invest</em> <strong>2024-09</strong>. https://doi.org/10.1172/jci175897 (zhou2024lactatesupportstreg pages 8-9)</li>
+<li>Özdemir M, Dennerlein S. <em>Biological Chemistry</em> <strong>2024-08</strong>. https://doi.org/10.1515/hsz-2024-0043 (ozdemir2024thetomcomplex pages 1-7)</li>
+<li>Waman VP et al. <em>Scientific Reports</em> <strong>2024-11</strong>. https://doi.org/10.1038/s41598-024-61541-1 (waman2024predictinghumanand pages 8-10)</li>
+</ul>
+<p>References</p>
+<ol>
+<li>
+<p>(kreimendahl2020themitochondrialouter pages 1-3): Sebastian Kreimendahl and Joachim Rassow. The mitochondrial outer membrane protein tom70-mediator in protein traffic, membrane contact sites and innate immunity. International Journal of Molecular Sciences, 21:7262, Oct 2020. URL: https://doi.org/10.3390/ijms21197262, doi:10.3390/ijms21197262. This article has 98 citations.</p>
+</li>
+<li>
+<p>(kreimendahl2020themitochondrialouter pages 3-6): Sebastian Kreimendahl and Joachim Rassow. The mitochondrial outer membrane protein tom70-mediator in protein traffic, membrane contact sites and innate immunity. International Journal of Molecular Sciences, 21:7262, Oct 2020. URL: https://doi.org/10.3390/ijms21197262, doi:10.3390/ijms21197262. This article has 98 citations.</p>
+</li>
+<li>
+<p>(haastrup2023thejourneyof pages 8-10): Mary Oluwadamilola Haastrup, Kunwar Somesh Vikramdeo, Seema Singh, Ajay Pratap Singh, and Santanu Dasgupta. The journey of mitochondrial protein import and the roadmap to follow. International Journal of Molecular Sciences, 24:2479, Jan 2023. URL: https://doi.org/10.3390/ijms24032479, doi:10.3390/ijms24032479. This article has 30 citations.</p>
+</li>
+<li>
+<p>(kreimendahl2020themitochondrialouter pages 12-14): Sebastian Kreimendahl and Joachim Rassow. The mitochondrial outer membrane protein tom70-mediator in protein traffic, membrane contact sites and innate immunity. International Journal of Molecular Sciences, 21:7262, Oct 2020. URL: https://doi.org/10.3390/ijms21197262, doi:10.3390/ijms21197262. This article has 98 citations.</p>
+</li>
+<li>
+<p>(kreimendahl2020themitochondrialouter pages 14-16): Sebastian Kreimendahl and Joachim Rassow. The mitochondrial outer membrane protein tom70-mediator in protein traffic, membrane contact sites and innate immunity. International Journal of Molecular Sciences, 21:7262, Oct 2020. URL: https://doi.org/10.3390/ijms21197262, doi:10.3390/ijms21197262. This article has 98 citations.</p>
+</li>
+<li>
+<p>(pitt2021abiochemicaland pages 19-20): Ashley S. Pitt and Susan K. Buchanan. A biochemical and structural understanding of tom complex interactions and implications for human health and disease. Cells, 10:1164, May 2021. URL: https://doi.org/10.3390/cells10051164, doi:10.3390/cells10051164. This article has 46 citations.</p>
+</li>
+<li>
+<p>(pitt2021abiochemicaland pages 17-19): Ashley S. Pitt and Susan K. Buchanan. A biochemical and structural understanding of tom complex interactions and implications for human health and disease. Cells, 10:1164, May 2021. URL: https://doi.org/10.3390/cells10051164, doi:10.3390/cells10051164. This article has 46 citations.</p>
+</li>
+<li>
+<p>(kreimendahl2020themitochondrialouter pages 19-21): Sebastian Kreimendahl and Joachim Rassow. The mitochondrial outer membrane protein tom70-mediator in protein traffic, membrane contact sites and innate immunity. International Journal of Molecular Sciences, 21:7262, Oct 2020. URL: https://doi.org/10.3390/ijms21197262, doi:10.3390/ijms21197262. This article has 98 citations.</p>
+</li>
+<li>
+<p>(zhou2024lactatesupportstreg pages 8-9): Jinren Zhou, Jian Gu, Qufei Qian, Yigang Zhang, Tianning Huang, Xiangyu Li, Zhuoqun Liu, Qing Shao, Yuan Liang, Lei Qiao, Xiaozhang Xu, Qiuyang Chen, Zibo Xu, Yu Li, Ji Gao, Yufeng Pan, Yiming Wang, Roderick O’Connor, Keli L. Hippen, Ling Lu, and Bruce R. Blazar. Lactate supports treg function and immune balance via mgat1 effects on n-glycosylation in the mitochondria. Journal of Clinical Investigation, Sep 2024. URL: https://doi.org/10.1172/jci175897, doi:10.1172/jci175897. This article has 48 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(waman2024predictinghumanand pages 8-10): Vaishali P. Waman, Paul Ashford, Su Datt Lam, Neeladri Sen, Mahnaz Abbasian, Laurel Woodridge, Yonathan Goldtzvik, Nicola Bordin, Jiaxin Wu, Ian Sillitoe, and Christine A Orengo. Predicting human and viral protein variants affecting covid-19 susceptibility and repurposing therapeutics. Scientific Reports, Nov 2024. URL: https://doi.org/10.1038/s41598-024-61541-1, doi:10.1038/s41598-024-61541-1. This article has 4 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lionaki2023mitochondrialproteinimport pages 8-9): Eirini Lionaki, Ilias Gkikas, and Nektarios Tavernarakis. Mitochondrial protein import machinery conveys stress signals to the cytosol and beyond. BioEssays, Jan 2023. URL: https://doi.org/10.1002/bies.202200160, doi:10.1002/bies.202200160. This article has 14 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ozdemir2024thetomcomplex pages 1-7): Metin Özdemir and Sven Dennerlein. The tom complex from an evolutionary perspective and the functions of tomm70. Biological Chemistry, 405:615-625, Aug 2024. URL: https://doi.org/10.1515/hsz-2024-0043, doi:10.1515/hsz-2024-0043. This article has 4 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(wei2020mutationsintomm70 pages 1-2): Xiujuan Wei, Miaomiao Du, Jie Xie, Ting Luo, Yan Zhou, Kun Zhang, Jin Li, Deyu Chen, Pu Xu, Manli Jia, Huaibin Zhou, Hezhi Fang, Jianxin Lyu, and Yanling Yang. Mutations in tomm70 lead to multi-oxphos deficiencies and cause severe anemia, lactic acidosis, and developmental delay. Journal of Human Genetics, 65:231-240, Jan 2020. URL: https://doi.org/10.1038/s10038-019-0714-1, doi:10.1038/s10038-019-0714-1. This article has 41 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(kreimendahl2020themitochondrialouter media bc2f2392): Sebastian Kreimendahl and Joachim Rassow. The mitochondrial outer membrane protein tom70-mediator in protein traffic, membrane contact sites and innate immunity. International Journal of Molecular Sciences, 21:7262, Oct 2020. URL: https://doi.org/10.3390/ijms21197262, doi:10.3390/ijms21197262. This article has 98 citations.</p>
+</li>
+<li>
+<p>(kreimendahl2020themitochondrialouter media 1214cc5a): Sebastian Kreimendahl and Joachim Rassow. The mitochondrial outer membrane protein tom70-mediator in protein traffic, membrane contact sites and innate immunity. International Journal of Molecular Sciences, 21:7262, Oct 2020. URL: https://doi.org/10.3390/ijms21197262, doi:10.3390/ijms21197262. This article has 98 citations.</p>
+</li>
+<li>
+<p>(kreimendahl2020themitochondrialouter media 41a8d14b): Sebastian Kreimendahl and Joachim Rassow. The mitochondrial outer membrane protein tom70-mediator in protein traffic, membrane contact sites and innate immunity. International Journal of Molecular Sciences, 21:7262, Oct 2020. URL: https://doi.org/10.3390/ijms21197262, doi:10.3390/ijms21197262. This article has 98 citations.</p>
+</li>
+<li>
+<p>(kreimendahl2020themitochondrialouter media 44199fa5): Sebastian Kreimendahl and Joachim Rassow. The mitochondrial outer membrane protein tom70-mediator in protein traffic, membrane contact sites and innate immunity. International Journal of Molecular Sciences, 21:7262, Oct 2020. URL: https://doi.org/10.3390/ijms21197262, doi:10.3390/ijms21197262. This article has 98 citations.</p>
+</li>
+<li>
+<p>(kreimendahl2020themitochondrialouter media 3b13eb9e): Sebastian Kreimendahl and Joachim Rassow. The mitochondrial outer membrane protein tom70-mediator in protein traffic, membrane contact sites and innate immunity. International Journal of Molecular Sciences, 21:7262, Oct 2020. URL: https://doi.org/10.3390/ijms21197262, doi:10.3390/ijms21197262. This article has 98 citations.</p>
+</li>
+</ol>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>zhou2024lactatesupportstreg pages 8-9</li>
+<li>waman2024predictinghumanand pages 8-10</li>
+<li>lionaki2023mitochondrialproteinimport pages 8-9</li>
+<li>ozdemir2024thetomcomplex pages 1-7</li>
+<li>kreimendahl2020themitochondrialouter pages 3-6</li>
+<li>kreimendahl2020themitochondrialouter pages 1-3</li>
+<li>pitt2021abiochemicaland pages 19-20</li>
+<li>haastrup2023thejourneyof pages 8-10</li>
+<li>kreimendahl2020themitochondrialouter pages 12-14</li>
+<li>kreimendahl2020themitochondrialouter pages 14-16</li>
+<li>pitt2021abiochemicaland pages 17-19</li>
+<li>kreimendahl2020themitochondrialouter pages 19-21</li>
+<li>https://doi.org/10.3390/ijms21197262</li>
+<li>https://doi.org/10.1515/hsz-2024-0043</li>
+<li>https://doi.org/10.3390/cells10051164</li>
+<li>https://doi.org/10.3390/ijms24032479</li>
+<li>https://doi.org/10.1002/bies.202200160</li>
+<li>https://doi.org/10.1038/s10038-019-0714-1</li>
+<li>https://doi.org/10.1002/1873-3468.14022</li>
+<li>https://doi.org/10.1172/jci175897</li>
+<li>https://doi.org/10.1038/s41598-024-61541-1</li>
+<li>https://doi.org/10.3390/ijms21197262,</li>
+<li>https://doi.org/10.3390/ijms24032479,</li>
+<li>https://doi.org/10.3390/cells10051164,</li>
+<li>https://doi.org/10.1172/jci175897,</li>
+<li>https://doi.org/10.1038/s41598-024-61541-1,</li>
+<li>https://doi.org/10.1002/bies.202200160,</li>
+<li>https://doi.org/10.1515/hsz-2024-0043,</li>
+<li>https://doi.org/10.1038/s10038-019-0714-1,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: O94826
+gene_symbol: TOMM70
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: TOMM70 is a cytosol-facing mitochondrial outer membrane TOM receptor/adaptor.
+  Its primary role is to dock Hsp70/Hsp90-bound hydrophobic mitochondrial precursor proteins,
+  especially internal-signal/carrier-type substrates, and deliver them to the TOM translocation
+  machinery. It also has supported non-core signaling roles in MAVS/IRF3 antiviral responses
+  and PINK1/Parkin-linked mitochondrial quality control.
+existing_annotations:
+- term:
+    id: GO:0005741
+    label: mitochondrial outer membrane
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: Correct localization. TOMM70 is an outer mitochondrial membrane TOM receptor/adaptor
+      with a cytosol-facing TPR receptor domain.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TOMM70/TOMM70-deep-research-falcon.md
+      supporting_text: TOMM70 is anchored in the **outer mitochondrial membrane (OMM)** with
+        its receptor domain facing the cytosol.
+- term:
+    id: GO:0008320
+    label: protein transmembrane transporter activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: contributes_to
+  review:
+    summary: Accepted as TOMM70 contribution to TOM-dependent protein transmembrane transport.
+      TOMM70 is a receptor/adaptor, not the pore-forming subunit, but it contributes to the
+      TOM complex import activity.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TOMM70/TOMM70-deep-research-falcon.md
+      supporting_text: TOMM70 is best understood as a **surface receptor/adaptor** of the
+        **TOM (translocase of the outer membrane)** import gateway
+- term:
+    id: GO:0030150
+    label: protein import into mitochondrial matrix
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: Broadly valid as a TOM-pathway outcome, but TOMM70 is best described as an outer-membrane
+      receptor/adaptor rather than the matrix import pore or motor.
+    action: KEEP_AS_NON_CORE
+    reason: Matrix import is one TOM-dependent route; TOMM70 has a more specific receptor/adaptor
+      role for chaperone-bound precursors.
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
+- term:
+    id: GO:0030943
+    label: mitochondrion targeting sequence binding
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: Supported. TOMM70 recognizes mitochondrial precursor proteins, especially hydrophobic
+      internal-signal substrates delivered by Hsp70/Hsp90 chaperones.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TOMM70/TOMM70-deep-research-falcon.md
+      supporting_text: Cytosolic **Hsp70/Hsp90** chaperones bind newly synthesized hydrophobic
+        precursors to prevent aggregation and **deliver them to TOMM70**
+- term:
+    id: GO:0045039
+    label: protein insertion into mitochondrial inner membrane
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: Reasonable as a pathway-level consequence for carrier/internal-signal precursor
+      delivery, but TOMM70 does not catalyze inner membrane insertion itself.
+    action: KEEP_AS_NON_CORE
+    reason: TOMM70 acts upstream at the outer membrane before substrates are handed to downstream
+      inner-membrane import machinery.
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
+- term:
+    id: GO:0005741
+    label: mitochondrial outer membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  review:
+    summary: Correct localization. TOMM70 is an outer mitochondrial membrane TOM receptor/adaptor
+      with a cytosol-facing TPR receptor domain.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:32353859
+  review:
+    summary: Protein binding is too generic for TOMM70. The informative functions are chaperone-bound
+      precursor receptor/adaptor activity, TOM association, and context-specific MAVS/PINK1
+      signaling.
+    action: REMOVE
+    reason: Replace generic protein binding curation with specific adaptor, receptor, TOM
+      complex, and pathway annotations.
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:32728199
+  review:
+    summary: Protein binding is too generic for TOMM70. The informative functions are chaperone-bound
+      precursor receptor/adaptor activity, TOM association, and context-specific MAVS/PINK1
+      signaling.
+    action: REMOVE
+    reason: Replace generic protein binding curation with specific adaptor, receptor, TOM
+      complex, and pathway annotations.
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:33060197
+  review:
+    summary: Protein binding is too generic for TOMM70. The informative functions are chaperone-bound
+      precursor receptor/adaptor activity, TOM association, and context-specific MAVS/PINK1
+      signaling.
+    action: REMOVE
+    reason: Replace generic protein binding curation with specific adaptor, receptor, TOM
+      complex, and pathway annotations.
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:33845483
+  review:
+    summary: Protein binding is too generic for TOMM70. The informative functions are chaperone-bound
+      precursor receptor/adaptor activity, TOM association, and context-specific MAVS/PINK1
+      signaling.
+    action: REMOVE
+    reason: Replace generic protein binding curation with specific adaptor, receptor, TOM
+      complex, and pathway annotations.
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:33990585
+  review:
+    summary: Protein binding is too generic for TOMM70. The informative functions are chaperone-bound
+      precursor receptor/adaptor activity, TOM association, and context-specific MAVS/PINK1
+      signaling.
+    action: REMOVE
+    reason: Replace generic protein binding curation with specific adaptor, receptor, TOM
+      complex, and pathway annotations.
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:34232536
+  review:
+    summary: Protein binding is too generic for TOMM70. The informative functions are chaperone-bound
+      precursor receptor/adaptor activity, TOM association, and context-specific MAVS/PINK1
+      signaling.
+    action: REMOVE
+    reason: Replace generic protein binding curation with specific adaptor, receptor, TOM
+      complex, and pathway annotations.
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:34502139
+  review:
+    summary: Protein binding is too generic for TOMM70. The informative functions are chaperone-bound
+      precursor receptor/adaptor activity, TOM association, and context-specific MAVS/PINK1
+      signaling.
+    action: REMOVE
+    reason: Replace generic protein binding curation with specific adaptor, receptor, TOM
+      complex, and pathway annotations.
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:34942634
+  review:
+    summary: Protein binding is too generic for TOMM70. The informative functions are chaperone-bound
+      precursor receptor/adaptor activity, TOM association, and context-specific MAVS/PINK1
+      signaling.
+    action: REMOVE
+    reason: Replace generic protein binding curation with specific adaptor, receptor, TOM
+      complex, and pathway annotations.
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:36217030
+  review:
+    summary: Protein binding is too generic for TOMM70. The informative functions are chaperone-bound
+      precursor receptor/adaptor activity, TOM association, and context-specific MAVS/PINK1
+      signaling.
+    action: REMOVE
+    reason: Replace generic protein binding curation with specific adaptor, receptor, TOM
+      complex, and pathway annotations.
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  review:
+    summary: Correct but too general. TOMM70 is specifically an outer mitochondrial membrane
+      TOM receptor/adaptor.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Subsumed by mitochondrial outer membrane and TOM complex annotations.
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
+- term:
+    id: GO:0030150
+    label: protein import into mitochondrial matrix
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  review:
+    summary: Broadly valid as a TOM-pathway outcome, but TOMM70 is best described as an outer-membrane
+      receptor/adaptor rather than the matrix import pore or motor.
+    action: KEEP_AS_NON_CORE
+    reason: Matrix import is one TOM-dependent route; TOMM70 has a more specific receptor/adaptor
+      role for chaperone-bound precursors.
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
+- term:
+    id: GO:0061052
+    label: negative regulation of cell growth involved in cardiac muscle cell development
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  review:
+    summary: Automatic orthology transfer is not supported by the TOMM70 literature synthesis
+      as a direct function of this gene product.
+    action: REMOVE
+    reason: Developmental/thyroxine response terms overreach beyond TOMM70&#39;s demonstrated
+      receptor/adaptor and signaling roles.
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
+- term:
+    id: GO:0097068
+    label: response to thyroxine
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  review:
+    summary: Automatic orthology transfer is not supported by the TOMM70 literature synthesis
+      as a direct function of this gene product.
+    action: REMOVE
+    reason: Developmental/thyroxine response terms overreach beyond TOMM70&#39;s demonstrated
+      receptor/adaptor and signaling roles.
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
+- term:
+    id: GO:1903749
+    label: positive regulation of protein localization to mitochondrion
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  review:
+    summary: Supported broad process annotation. TOMM70 promotes mitochondrial localization/import
+      of precursor proteins through its receptor/adaptor role.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IDA
+  original_reference_id: GO_REF:0000052
+  review:
+    summary: Correct but too general. TOMM70 is specifically an outer mitochondrial membrane
+      TOM receptor/adaptor.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Subsumed by mitochondrial outer membrane and TOM complex annotations.
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
+- term:
+    id: GO:0030150
+    label: protein import into mitochondrial matrix
+  evidence_type: TAS
+  original_reference_id: PMID:15644312
+  review:
+    summary: Broadly valid as a TOM-pathway outcome, but TOMM70 is best described as an outer-membrane
+      receptor/adaptor rather than the matrix import pore or motor.
+    action: KEEP_AS_NON_CORE
+    reason: Matrix import is one TOM-dependent route; TOMM70 has a more specific receptor/adaptor
+      role for chaperone-bound precursors.
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
+- term:
+    id: GO:0005741
+    label: mitochondrial outer membrane
+  evidence_type: NAS
+  original_reference_id: PMID:18331822
+  review:
+    summary: Correct localization. TOMM70 is an outer mitochondrial membrane TOM receptor/adaptor
+      with a cytosol-facing TPR receptor domain.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
+- term:
+    id: GO:0045040
+    label: protein insertion into mitochondrial outer membrane
+  evidence_type: NAS
+  original_reference_id: PMID:18331822
+  review:
+    summary: The annotation captures mitochondrial protein import context but overstates TOMM70
+      as an outer-membrane insertase.
+    action: MODIFY
+    reason: TOMM70 is a receptor/adaptor for precursor targeting/import, not the SAM/outer-membrane
+      insertion machinery.
+    proposed_replacement_terms:
+    - id: GO:0070585
+      label: protein localization to mitochondrion
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
+- term:
+    id: GO:0140596
+    label: TOM complex
+  evidence_type: NAS
+  original_reference_id: PMID:18331822
+  review:
+    summary: Correct and specific. TOMM70 is a TOM-complex receptor component rather than
+      an independent pore-forming subunit.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
+- term:
+    id: GO:0005741
+    label: mitochondrial outer membrane
+  evidence_type: EXP
+  original_reference_id: PMID:20628368
+  review:
+    summary: Correct localization. TOMM70 is an outer mitochondrial membrane TOM receptor/adaptor
+      with a cytosol-facing TPR receptor domain.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
+- term:
+    id: GO:0005741
+    label: mitochondrial outer membrane
+  evidence_type: EXP
+  original_reference_id: PMID:25609812
+  review:
+    summary: Correct localization. TOMM70 is an outer mitochondrial membrane TOM receptor/adaptor
+      with a cytosol-facing TPR receptor domain.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
+- term:
+    id: GO:0005741
+    label: mitochondrial outer membrane
+  evidence_type: EXP
+  original_reference_id: PMID:33723040
+  review:
+    summary: Correct localization. TOMM70 is an outer mitochondrial membrane TOM receptor/adaptor
+      with a cytosol-facing TPR receptor domain.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: HTP
+  original_reference_id: PMID:34800366
+  review:
+    summary: Correct but too general. TOMM70 is specifically an outer mitochondrial membrane
+      TOM receptor/adaptor.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Subsumed by mitochondrial outer membrane and TOM complex annotations.
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:35391620
+  review:
+    summary: Protein binding is too generic for TOMM70. The informative functions are chaperone-bound
+      precursor receptor/adaptor activity, TOM association, and context-specific MAVS/PINK1
+      signaling.
+    action: REMOVE
+    reason: Replace generic protein binding curation with specific adaptor, receptor, TOM
+      complex, and pathway annotations.
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
+- term:
+    id: GO:0030674
+    label: protein-macromolecule adaptor activity
+  evidence_type: IDA
+  original_reference_id: PMID:20628368
+  review:
+    summary: Accepted. TOMM70 functions as a receptor/adaptor for chaperone-bound mitochondrial
+      precursor proteins and also as a MAVS-linked signaling scaffold.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TOMM70/TOMM70-deep-research-falcon.md
+      supporting_text: TOMM70 is best understood as a **surface receptor/adaptor** of the
+        **TOM (translocase of the outer membrane)** import gateway
+- term:
+    id: GO:0031966
+    label: mitochondrial membrane
+  evidence_type: IDA
+  original_reference_id: PMID:20628368
+  review:
+    summary: Correct but too broad. The specific supported localization is mitochondrial outer
+      membrane, not generic mitochondrial membrane.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Subsumed by mitochondrial outer membrane annotations.
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
+- term:
+    id: GO:0005741
+    label: mitochondrial outer membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-5205661
+  review:
+    summary: Correct localization. TOMM70 is an outer mitochondrial membrane TOM receptor/adaptor
+      with a cytosol-facing TPR receptor domain.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
+- term:
+    id: GO:0005741
+    label: mitochondrial outer membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9685281
+  review:
+    summary: Correct localization. TOMM70 is an outer mitochondrial membrane TOM receptor/adaptor
+      with a cytosol-facing TPR receptor domain.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
+- term:
+    id: GO:0005741
+    label: mitochondrial outer membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9709663
+  review:
+    summary: Correct localization. TOMM70 is an outer mitochondrial membrane TOM receptor/adaptor
+      with a cytosol-facing TPR receptor domain.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
+- term:
+    id: GO:0005741
+    label: mitochondrial outer membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9709787
+  review:
+    summary: Correct localization. TOMM70 is an outer mitochondrial membrane TOM receptor/adaptor
+      with a cytosol-facing TPR receptor domain.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
+- term:
+    id: GO:0005741
+    label: mitochondrial outer membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9709842
+  review:
+    summary: Correct localization. TOMM70 is an outer mitochondrial membrane TOM receptor/adaptor
+      with a cytosol-facing TPR receptor domain.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
+- term:
+    id: GO:0005741
+    label: mitochondrial outer membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9709852
+  review:
+    summary: Correct localization. TOMM70 is an outer mitochondrial membrane TOM receptor/adaptor
+      with a cytosol-facing TPR receptor domain.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
+- term:
+    id: GO:0002218
+    label: activation of innate immune response
+  evidence_type: IDA
+  original_reference_id: PMID:20628368
+  review:
+    summary: Supported in the antiviral MAVS/IRF3 literature, but this is a context-specific
+      signaling role rather than TOMM70&#39;s core mitochondrial import function.
+    action: KEEP_AS_NON_CORE
+    reason: Non-core signaling/adaptor role in antiviral innate immune response.
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
+- term:
+    id: GO:0002230
+    label: positive regulation of defense response to virus by host
+  evidence_type: IDA
+  original_reference_id: PMID:20628368
+  review:
+    summary: Supported in the antiviral MAVS/IRF3 literature, but this is a context-specific
+      signaling role rather than TOMM70&#39;s core mitochondrial import function.
+    action: KEEP_AS_NON_CORE
+    reason: Non-core signaling/adaptor role in antiviral innate immune response.
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:20628368
+  review:
+    summary: Protein binding is too generic for TOMM70. The informative functions are chaperone-bound
+      precursor receptor/adaptor activity, TOM association, and context-specific MAVS/PINK1
+      signaling.
+    action: REMOVE
+    reason: Replace generic protein binding curation with specific adaptor, receptor, TOM
+      complex, and pathway annotations.
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:25609812
+  review:
+    summary: Protein binding is too generic for TOMM70. The informative functions are chaperone-bound
+      precursor receptor/adaptor activity, TOM association, and context-specific MAVS/PINK1
+      signaling.
+    action: REMOVE
+    reason: Replace generic protein binding curation with specific adaptor, receptor, TOM
+      complex, and pathway annotations.
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IDA
+  original_reference_id: PMID:20628368
+  review:
+    summary: Correct but too general. TOMM70 is specifically an outer mitochondrial membrane
+      TOM receptor/adaptor.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Subsumed by mitochondrial outer membrane and TOM complex annotations.
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IDA
+  original_reference_id: PMID:25609812
+  review:
+    summary: Correct but too general. TOMM70 is specifically an outer mitochondrial membrane
+      TOM receptor/adaptor.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Subsumed by mitochondrial outer membrane and TOM complex annotations.
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
+- term:
+    id: GO:0032728
+    label: positive regulation of interferon-beta production
+  evidence_type: IDA
+  original_reference_id: PMID:20628368
+  review:
+    summary: Supported in the antiviral MAVS/IRF3 literature, but this is a context-specific
+      signaling role rather than TOMM70&#39;s core mitochondrial import function.
+    action: KEEP_AS_NON_CORE
+    reason: Non-core signaling/adaptor role in antiviral innate immune response.
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TOMM70/TOMM70-deep-research-falcon.md
+      supporting_text: TOMM70 is described as participating in antiviral innate immune signaling
+        by acting as a **receptor/scaffold for MAVS-associated signaling**
+- term:
+    id: GO:0042981
+    label: regulation of apoptotic process
+  evidence_type: IDA
+  original_reference_id: PMID:25609812
+  review:
+    summary: Supported for Sendai virus-induced TOMM70/Hsp90/IRF3/BAX apoptosis context, but
+      it is a secondary signaling phenotype.
+    action: KEEP_AS_NON_CORE
+    reason: Context-specific antiviral/apoptosis role rather than primary mitochondrial import
+      function.
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
+- term:
+    id: GO:0098586
+    label: cellular response to virus
+  evidence_type: IDA
+  original_reference_id: PMID:25609812
+  review:
+    summary: Supported in the antiviral MAVS/IRF3 literature, but this is a context-specific
+      signaling role rather than TOMM70&#39;s core mitochondrial import function.
+    action: KEEP_AS_NON_CORE
+    reason: Non-core signaling/adaptor role in antiviral innate immune response.
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
+- term:
+    id: GO:0005742
+    label: mitochondrial outer membrane translocase complex
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  review:
+    summary: Correct complex annotation. TOMM70 associates with the TOM import machinery and
+      acts as a receptor/adaptor at the outer membrane translocase.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
+- term:
+    id: GO:0008320
+    label: protein transmembrane transporter activity
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  qualifier: contributes_to
+  review:
+    summary: Accepted as TOMM70 contribution to TOM-dependent protein transmembrane transport.
+      TOMM70 is a receptor/adaptor, not the pore-forming subunit, but it contributes to the
+      TOM complex import activity.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
+- term:
+    id: GO:0030150
+    label: protein import into mitochondrial matrix
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  review:
+    summary: Broadly valid as a TOM-pathway outcome, but TOMM70 is best described as an outer-membrane
+      receptor/adaptor rather than the matrix import pore or motor.
+    action: KEEP_AS_NON_CORE
+    reason: Matrix import is one TOM-dependent route; TOMM70 has a more specific receptor/adaptor
+      role for chaperone-bound precursors.
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
+- term:
+    id: GO:0030943
+    label: mitochondrion targeting sequence binding
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  review:
+    summary: Supported. TOMM70 recognizes mitochondrial precursor proteins, especially hydrophobic
+      internal-signal substrates delivered by Hsp70/Hsp90 chaperones.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
+- term:
+    id: GO:0045039
+    label: protein insertion into mitochondrial inner membrane
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  review:
+    summary: Reasonable as a pathway-level consequence for carrier/internal-signal precursor
+      delivery, but TOMM70 does not catalyze inner membrane insertion itself.
+    action: KEEP_AS_NON_CORE
+    reason: TOMM70 acts upstream at the outer membrane before substrates are handed to downstream
+      inner-membrane import machinery.
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
+- term:
+    id: GO:0070585
+    label: protein localization to mitochondrion
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  review:
+    summary: Supported broad process annotation. TOMM70 promotes mitochondrial localization/import
+      of precursor proteins through its receptor/adaptor role.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:23911537
+  review:
+    summary: Protein binding is too generic for TOMM70. The informative functions are chaperone-bound
+      precursor receptor/adaptor activity, TOM association, and context-specific MAVS/PINK1
+      signaling.
+    action: REMOVE
+    reason: Replace generic protein binding curation with specific adaptor, receptor, TOM
+      complex, and pathway annotations.
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IDA
+  original_reference_id: PMID:20531390
+  review:
+    summary: Correct but too general. TOMM70 is specifically an outer mitochondrial membrane
+      TOM receptor/adaptor.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Subsumed by mitochondrial outer membrane and TOM complex annotations.
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
+- term:
+    id: GO:0070062
+    label: extracellular exosome
+  evidence_type: HDA
+  original_reference_id: PMID:18570454
+  review:
+    summary: High-throughput extracellular exosome detection is not supported as TOMM70 functional
+      localization and conflicts with the mitochondrial outer membrane synthesis.
+    action: REMOVE
+    reason: Likely high-throughput carryover/noise for an outer mitochondrial membrane TOM
+      receptor.
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
+- term:
+    id: GO:0016020
+    label: membrane
+  evidence_type: HDA
+  original_reference_id: PMID:19946888
+  review:
+    summary: Correct but too broad. The specific supported localization is mitochondrial outer
+      membrane, not generic membrane.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Subsumed by mitochondrial outer membrane annotations.
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
+- term:
+    id: GO:0005742
+    label: mitochondrial outer membrane translocase complex
+  evidence_type: TAS
+  original_reference_id: PMID:15644312
+  review:
+    summary: Correct complex annotation. TOMM70 associates with the TOM import machinery and
+      acts as a receptor/adaptor at the outer membrane translocase.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
+- term:
+    id: GO:0008320
+    label: protein transmembrane transporter activity
+  evidence_type: TAS
+  original_reference_id: PMID:15644312
+  review:
+    summary: Accepted as TOMM70 contribution to TOM-dependent protein transmembrane transport.
+      TOMM70 is a receptor/adaptor, not the pore-forming subunit, but it contributes to the
+      TOM complex import activity.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:12526792
+  review:
+    summary: Protein binding is too generic for TOMM70. The informative functions are chaperone-bound
+      precursor receptor/adaptor activity, TOM association, and context-specific MAVS/PINK1
+      signaling.
+    action: REMOVE
+    reason: Replace generic protein binding curation with specific adaptor, receptor, TOM
+      complex, and pathway annotations.
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
+references:
+- id: GO_REF:0000024
+  title: Manual transfer of experimentally-verified manual GO annotation data to orthologs
+    by curator judgment of sequence similarity
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000052
+  title: Gene Ontology annotation based on curation of immunofluorescence data
+  findings: []
+- id: GO_REF:0000107
+  title: Automatic transfer of experimentally verified manual GO annotation data to orthologs
+    using Ensembl Compara
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: PMID:12526792
+  title: Molecular chaperones Hsp90 and Hsp70 deliver preproteins to the mitochondrial import
+    receptor Tom70.
+  findings: []
+- id: PMID:15644312
+  title: Dissection of the mitochondrial import and assembly pathway for human Tom40.
+  findings: []
+- id: PMID:18331822
+  title: Identification of Tom5 and Tom6 in the preprotein translocase complex of human mitochondrial
+    outer membrane.
+  findings: []
+- id: PMID:18570454
+  title: Proteomic analysis of exosomes from human neural stem cells by flow field-flow fractionation
+    and nanoflow liquid chromatography-tandem mass spectrometry.
+  findings: []
+- id: PMID:19946888
+  title: Defining the membrane proteome of NK cells.
+  findings: []
+- id: PMID:20531390
+  title: Suppression of the novel ER protein Maxer by mutant ataxin-1 in Bergman glia contributes
+    to non-cell-autonomous toxicity.
+  findings: []
+- id: PMID:20628368
+  title: Tom70 mediates activation of interferon regulatory factor 3 on mitochondria.
+  findings: []
+- id: PMID:23911537
+  title: Cytoplasmic ribosomal protein S3 (rpS3) plays a pivotal role in mitochondrial DNA
+    damage surveillance.
+  findings: []
+- id: PMID:25609812
+  title: Tom70 mediates Sendai virus-induced apoptosis on mitochondria.
+  findings: []
+- id: PMID:32353859
+  title: A SARS-CoV-2 protein interaction map reveals targets for drug repurposing.
+  findings: []
+- id: PMID:32728199
+  title: SARS-CoV-2 Orf9b suppresses type I interferon responses by targeting TOM70.
+  findings: []
+- id: PMID:33060197
+  title: Comparative host-coronavirus protein interaction networks reveal pan-viral disease
+    mechanisms.
+  findings: []
+- id: PMID:33723040
+  title: Toxoplasma gondii association with host mitochondria requires key mitochondrial protein
+    import machinery.
+  findings: []
+- id: PMID:33845483
+  title: Multilevel proteomics reveals host perturbations by SARS-CoV-2 and SARS-CoV.
+  findings: []
+- id: PMID:33990585
+  title: Crystal structure of SARS-CoV-2 Orf9b in complex with human TOM70 suggests unusual
+    virus-host interactions.
+  findings: []
+- id: PMID:34232536
+  title: Interactomes of SARS-CoV-2 and human coronaviruses reveal host factors potentially
+    affecting pathogenesis.
+  findings: []
+- id: PMID:34502139
+  title: Phosphorylation of SARS-CoV-2 Orf9b Regulates Its Targeting to Two Binding Sites
+    in TOM70 and Recruitment of Hsp90.
+  findings: []
+- id: PMID:34800366
+  title: Quantitative high-confidence human mitochondrial proteome and its dynamics in cellular
+    context.
+  findings: []
+- id: PMID:34942634
+  title: Evolution of enhanced innate immune evasion by SARS-CoV-2.
+  findings: []
+- id: PMID:35391620
+  title: The role of the individual TOM subunits in the association of PINK1 with depolarized
+    mitochondria.
+  findings: []
+- id: PMID:36217030
+  title: A comprehensive SARS-CoV-2-human protein-protein interactome reveals COVID-19 pathobiology
+    and potential host therapeutic targets.
+  findings: []
+- id: Reactome:R-HSA-5205661
+  title: Pink1 is recruited from the cytoplasm to the mitochondria
+  findings: []
+- id: Reactome:R-HSA-9685281
+  title: SARS-CoV-1 3a binds TRAF3 within NLRP3 inflammasome
+  findings: []
+- id: Reactome:R-HSA-9709663
+  title: SARS-CoV-2 9b binds TOMM70
+  findings: []
+- id: Reactome:R-HSA-9709787
+  title: SARS-CoV-1 9b binds TOMM70
+  findings: []
+- id: Reactome:R-HSA-9709842
+  title: MAVS binds TOMM70
+  findings: []
+- id: Reactome:R-HSA-9709852
+  title: MAVS:TOMM70 recruits HSP90:TBK1:IRF3
+  findings: []
+- id: file:human/TOMM70/TOMM70-deep-research-falcon.md
+  title: Falcon deep research report for human TOMM70
+  findings: []
+core_functions:
+- description: TOMM70 is an outer-mitochondrial-membrane receptor/adaptor that docks Hsp70/Hsp90-bound
+    hydrophobic precursor proteins and promotes their handoff to the TOM import machinery
+    rather than acting as the pore itself.
+  supported_by:
+  - reference_id: file:human/TOMM70/TOMM70-deep-research-falcon.md
+    supporting_text: TOMM70 is best understood as a **surface receptor/adaptor** of the **TOM
+      (translocase of the outer membrane)** import gateway
+  - reference_id: file:human/TOMM70/TOMM70-deep-research-falcon.md
+    supporting_text: Cytosolic **Hsp70/Hsp90** chaperones bind newly synthesized hydrophobic
+      precursors to prevent aggregation and **deliver them to TOMM70**
+  - reference_id: file:human/TOMM70/TOMM70-deep-research-falcon.md
+    supporting_text: TOMM70 is anchored in the **outer mitochondrial membrane (OMM)** with
+      its receptor domain facing the cytosol.
+  molecular_function:
+    id: GO:0030674
+    label: protein-macromolecule adaptor activity
+  contributes_to_molecular_function:
+    id: GO:0008320
+    label: protein transmembrane transporter activity
+  directly_involved_in:
+  - id: GO:0070585
+    label: protein localization to mitochondrion
+  locations:
+  - id: GO:0005741
+    label: mitochondrial outer membrane
+  in_complex:
+    id: GO:0140596
+    label: TOM complex
+proposed_new_terms: []
+suggested_questions:
+- question: Which mammalian TOMM70 substrates require direct chaperone docking versus direct
+    precursor contacts?
+  experts: []
+- question: How are TOMM70 import, MAVS signaling, and PINK1/Parkin quality-control roles
+    separated by post-translational regulation?
+  experts: []
+suggested_experiments:
+- hypothesis: TOMM70 TPR-domain mutants that disrupt Hsp70/Hsp90 docking selectively impair
+    carrier/internal-signal precursor import while preserving TOM core assembly.
+  description: Compare import of carrier-type substrates and presequence substrates in TOMM70
+    knockout or knockdown cells rescued with wild-type versus chaperone-docking-defective
+    TOMM70 variants.
+- hypothesis: TOMM70 antiviral signaling can be separated from its import receptor activity
+    by mutating MAVS/Hsp90 signaling interfaces outside the precursor handoff surface.
+  description: Assay MAVS-induced IRF3 activation and mitochondrial precursor import in parallel
+    for TOMM70 interface mutants.
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/human/TOMM70/TOMM70-ai-review.html
+++ b/genes/human/TOMM70/TOMM70-ai-review.html
@@ -1383,10 +1383,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-remove">
-                            REMOVE
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="O94826" data-a="GO:0005515" data-r="PMID:33990585" data-act="REMOVE">
+                        <span class="vote-buttons" data-g="O94826" data-a="GO:0005515" data-r="PMID:33990585" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1399,7 +1399,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> Replace generic protein binding curation with specific adaptor, receptor, TOM complex, and pathway annotations.
+                            <strong>Reason:</strong> The interaction is documented, but generic protein binding should be superseded by specific adaptor, receptor, TOM complex, and pathway annotations.
                         </div>
 
 
@@ -2482,10 +2482,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-remove">
-                            REMOVE
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="O94826" data-a="GO:0005515" data-r="PMID:35391620" data-act="REMOVE">
+                        <span class="vote-buttons" data-g="O94826" data-a="GO:0005515" data-r="PMID:35391620" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -2498,7 +2498,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> Replace generic protein binding curation with specific adaptor, receptor, TOM complex, and pathway annotations.
+                            <strong>Reason:</strong> The interaction is documented, but generic protein binding should be superseded by specific adaptor, receptor, TOM complex, and pathway annotations.
                         </div>
 
 
@@ -4190,10 +4190,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-remove">
-                            REMOVE
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="O94826" data-a="GO:0005515" data-r="PMID:12526792" data-act="REMOVE">
+                        <span class="vote-buttons" data-g="O94826" data-a="GO:0005515" data-r="PMID:12526792" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -4206,7 +4206,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> Replace generic protein binding curation with specific adaptor, receptor, TOM complex, and pathway annotations.
+                            <strong>Reason:</strong> The interaction is documented, but generic protein binding should be superseded by specific adaptor, receptor, TOM complex, and pathway annotations.
                         </div>
 
 
@@ -5475,9 +5475,9 @@ existing_annotations:
     summary: Protein binding is too generic for TOMM70. The informative functions are chaperone-bound
       precursor receptor/adaptor activity, TOM association, and context-specific MAVS/PINK1
       signaling.
-    action: REMOVE
-    reason: Replace generic protein binding curation with specific adaptor, receptor, TOM
-      complex, and pathway annotations.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: The interaction is documented, but generic protein binding should be superseded
+      by specific adaptor, receptor, TOM complex, and pathway annotations.
     additional_reference_ids:
     - file:human/TOMM70/TOMM70-deep-research-falcon.md
 - term:
@@ -5715,9 +5715,9 @@ existing_annotations:
     summary: Protein binding is too generic for TOMM70. The informative functions are chaperone-bound
       precursor receptor/adaptor activity, TOM association, and context-specific MAVS/PINK1
       signaling.
-    action: REMOVE
-    reason: Replace generic protein binding curation with specific adaptor, receptor, TOM
-      complex, and pathway annotations.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: The interaction is documented, but generic protein binding should be superseded
+      by specific adaptor, receptor, TOM complex, and pathway annotations.
     additional_reference_ids:
     - file:human/TOMM70/TOMM70-deep-research-falcon.md
 - term:
@@ -6085,9 +6085,9 @@ existing_annotations:
     summary: Protein binding is too generic for TOMM70. The informative functions are chaperone-bound
       precursor receptor/adaptor activity, TOM association, and context-specific MAVS/PINK1
       signaling.
-    action: REMOVE
-    reason: Replace generic protein binding curation with specific adaptor, receptor, TOM
-      complex, and pathway annotations.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: The interaction is documented, but generic protein binding should be superseded
+      by specific adaptor, receptor, TOM complex, and pathway annotations.
     additional_reference_ids:
     - file:human/TOMM70/TOMM70-deep-research-falcon.md
 references:

--- a/genes/human/TOMM70/TOMM70-ai-review.yaml
+++ b/genes/human/TOMM70/TOMM70-ai-review.yaml
@@ -1,11 +1,15 @@
 id: O94826
 gene_symbol: TOMM70
 product_type: PROTEIN
-status: INITIALIZED
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
-description: 'TODO: Add description for TOMM70'
+description: TOMM70 is a cytosol-facing mitochondrial outer membrane TOM receptor/adaptor.
+  Its primary role is to dock Hsp70/Hsp90-bound hydrophobic mitochondrial precursor proteins,
+  especially internal-signal/carrier-type substrates, and deliver them to the TOM translocation
+  machinery. It also has supported non-core signaling roles in MAVS/IRF3 antiviral responses
+  and PINK1/Parkin-linked mitochondrial quality control.
 existing_annotations:
 - term:
     id: GO:0005741
@@ -13,8 +17,15 @@ existing_annotations:
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct localization. TOMM70 is an outer mitochondrial membrane TOM receptor/adaptor
+      with a cytosol-facing TPR receptor domain.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TOMM70/TOMM70-deep-research-falcon.md
+      supporting_text: TOMM70 is anchored in the **outer mitochondrial membrane (OMM)** with
+        its receptor domain facing the cytosol.
 - term:
     id: GO:0008320
     label: protein transmembrane transporter activity
@@ -22,376 +33,599 @@ existing_annotations:
   original_reference_id: GO_REF:0000033
   qualifier: contributes_to
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Accepted as TOMM70 contribution to TOM-dependent protein transmembrane transport.
+      TOMM70 is a receptor/adaptor, not the pore-forming subunit, but it contributes to the
+      TOM complex import activity.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TOMM70/TOMM70-deep-research-falcon.md
+      supporting_text: TOMM70 is best understood as a **surface receptor/adaptor** of the
+        **TOM (translocase of the outer membrane)** import gateway
 - term:
     id: GO:0030150
     label: protein import into mitochondrial matrix
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Broadly valid as a TOM-pathway outcome, but TOMM70 is best described as an outer-membrane
+      receptor/adaptor rather than the matrix import pore or motor.
+    action: KEEP_AS_NON_CORE
+    reason: Matrix import is one TOM-dependent route; TOMM70 has a more specific receptor/adaptor
+      role for chaperone-bound precursors.
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
 - term:
     id: GO:0030943
     label: mitochondrion targeting sequence binding
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Supported. TOMM70 recognizes mitochondrial precursor proteins, especially hydrophobic
+      internal-signal substrates delivered by Hsp70/Hsp90 chaperones.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TOMM70/TOMM70-deep-research-falcon.md
+      supporting_text: Cytosolic **Hsp70/Hsp90** chaperones bind newly synthesized hydrophobic
+        precursors to prevent aggregation and **deliver them to TOMM70**
 - term:
     id: GO:0045039
     label: protein insertion into mitochondrial inner membrane
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Reasonable as a pathway-level consequence for carrier/internal-signal precursor
+      delivery, but TOMM70 does not catalyze inner membrane insertion itself.
+    action: KEEP_AS_NON_CORE
+    reason: TOMM70 acts upstream at the outer membrane before substrates are handed to downstream
+      inner-membrane import machinery.
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
 - term:
     id: GO:0005741
     label: mitochondrial outer membrane
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct localization. TOMM70 is an outer mitochondrial membrane TOM receptor/adaptor
+      with a cytosol-facing TPR receptor domain.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:32353859
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Protein binding is too generic for TOMM70. The informative functions are chaperone-bound
+      precursor receptor/adaptor activity, TOM association, and context-specific MAVS/PINK1
+      signaling.
+    action: REMOVE
+    reason: Replace generic protein binding curation with specific adaptor, receptor, TOM
+      complex, and pathway annotations.
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:32728199
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Protein binding is too generic for TOMM70. The informative functions are chaperone-bound
+      precursor receptor/adaptor activity, TOM association, and context-specific MAVS/PINK1
+      signaling.
+    action: REMOVE
+    reason: Replace generic protein binding curation with specific adaptor, receptor, TOM
+      complex, and pathway annotations.
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:33060197
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Protein binding is too generic for TOMM70. The informative functions are chaperone-bound
+      precursor receptor/adaptor activity, TOM association, and context-specific MAVS/PINK1
+      signaling.
+    action: REMOVE
+    reason: Replace generic protein binding curation with specific adaptor, receptor, TOM
+      complex, and pathway annotations.
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:33845483
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Protein binding is too generic for TOMM70. The informative functions are chaperone-bound
+      precursor receptor/adaptor activity, TOM association, and context-specific MAVS/PINK1
+      signaling.
+    action: REMOVE
+    reason: Replace generic protein binding curation with specific adaptor, receptor, TOM
+      complex, and pathway annotations.
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:33990585
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Protein binding is too generic for TOMM70. The informative functions are chaperone-bound
+      precursor receptor/adaptor activity, TOM association, and context-specific MAVS/PINK1
+      signaling.
+    action: REMOVE
+    reason: Replace generic protein binding curation with specific adaptor, receptor, TOM
+      complex, and pathway annotations.
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:34232536
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Protein binding is too generic for TOMM70. The informative functions are chaperone-bound
+      precursor receptor/adaptor activity, TOM association, and context-specific MAVS/PINK1
+      signaling.
+    action: REMOVE
+    reason: Replace generic protein binding curation with specific adaptor, receptor, TOM
+      complex, and pathway annotations.
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:34502139
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Protein binding is too generic for TOMM70. The informative functions are chaperone-bound
+      precursor receptor/adaptor activity, TOM association, and context-specific MAVS/PINK1
+      signaling.
+    action: REMOVE
+    reason: Replace generic protein binding curation with specific adaptor, receptor, TOM
+      complex, and pathway annotations.
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:34942634
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Protein binding is too generic for TOMM70. The informative functions are chaperone-bound
+      precursor receptor/adaptor activity, TOM association, and context-specific MAVS/PINK1
+      signaling.
+    action: REMOVE
+    reason: Replace generic protein binding curation with specific adaptor, receptor, TOM
+      complex, and pathway annotations.
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:36217030
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Protein binding is too generic for TOMM70. The informative functions are chaperone-bound
+      precursor receptor/adaptor activity, TOM association, and context-specific MAVS/PINK1
+      signaling.
+    action: REMOVE
+    reason: Replace generic protein binding curation with specific adaptor, receptor, TOM
+      complex, and pathway annotations.
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
 - term:
     id: GO:0005739
     label: mitochondrion
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct but too general. TOMM70 is specifically an outer mitochondrial membrane
+      TOM receptor/adaptor.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Subsumed by mitochondrial outer membrane and TOM complex annotations.
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
 - term:
     id: GO:0030150
     label: protein import into mitochondrial matrix
   evidence_type: IEA
   original_reference_id: GO_REF:0000107
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Broadly valid as a TOM-pathway outcome, but TOMM70 is best described as an outer-membrane
+      receptor/adaptor rather than the matrix import pore or motor.
+    action: KEEP_AS_NON_CORE
+    reason: Matrix import is one TOM-dependent route; TOMM70 has a more specific receptor/adaptor
+      role for chaperone-bound precursors.
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
 - term:
     id: GO:0061052
     label: negative regulation of cell growth involved in cardiac muscle cell development
   evidence_type: IEA
   original_reference_id: GO_REF:0000107
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Automatic orthology transfer is not supported by the TOMM70 literature synthesis
+      as a direct function of this gene product.
+    action: REMOVE
+    reason: Developmental/thyroxine response terms overreach beyond TOMM70's demonstrated
+      receptor/adaptor and signaling roles.
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
 - term:
     id: GO:0097068
     label: response to thyroxine
   evidence_type: IEA
   original_reference_id: GO_REF:0000107
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Automatic orthology transfer is not supported by the TOMM70 literature synthesis
+      as a direct function of this gene product.
+    action: REMOVE
+    reason: Developmental/thyroxine response terms overreach beyond TOMM70's demonstrated
+      receptor/adaptor and signaling roles.
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
 - term:
     id: GO:1903749
     label: positive regulation of protein localization to mitochondrion
   evidence_type: IEA
   original_reference_id: GO_REF:0000107
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Supported broad process annotation. TOMM70 promotes mitochondrial localization/import
+      of precursor proteins through its receptor/adaptor role.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
 - term:
     id: GO:0005739
     label: mitochondrion
   evidence_type: IDA
   original_reference_id: GO_REF:0000052
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct but too general. TOMM70 is specifically an outer mitochondrial membrane
+      TOM receptor/adaptor.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Subsumed by mitochondrial outer membrane and TOM complex annotations.
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
 - term:
     id: GO:0030150
     label: protein import into mitochondrial matrix
   evidence_type: TAS
   original_reference_id: PMID:15644312
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Broadly valid as a TOM-pathway outcome, but TOMM70 is best described as an outer-membrane
+      receptor/adaptor rather than the matrix import pore or motor.
+    action: KEEP_AS_NON_CORE
+    reason: Matrix import is one TOM-dependent route; TOMM70 has a more specific receptor/adaptor
+      role for chaperone-bound precursors.
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
 - term:
     id: GO:0005741
     label: mitochondrial outer membrane
   evidence_type: NAS
   original_reference_id: PMID:18331822
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct localization. TOMM70 is an outer mitochondrial membrane TOM receptor/adaptor
+      with a cytosol-facing TPR receptor domain.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
 - term:
     id: GO:0045040
     label: protein insertion into mitochondrial outer membrane
   evidence_type: NAS
   original_reference_id: PMID:18331822
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: The annotation captures mitochondrial protein import context but overstates TOMM70
+      as an outer-membrane insertase.
+    action: MODIFY
+    reason: TOMM70 is a receptor/adaptor for precursor targeting/import, not the SAM/outer-membrane
+      insertion machinery.
+    proposed_replacement_terms:
+    - id: GO:0070585
+      label: protein localization to mitochondrion
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
 - term:
     id: GO:0140596
     label: TOM complex
   evidence_type: NAS
   original_reference_id: PMID:18331822
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct and specific. TOMM70 is a TOM-complex receptor component rather than
+      an independent pore-forming subunit.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
 - term:
     id: GO:0005741
     label: mitochondrial outer membrane
   evidence_type: EXP
   original_reference_id: PMID:20628368
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct localization. TOMM70 is an outer mitochondrial membrane TOM receptor/adaptor
+      with a cytosol-facing TPR receptor domain.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
 - term:
     id: GO:0005741
     label: mitochondrial outer membrane
   evidence_type: EXP
   original_reference_id: PMID:25609812
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct localization. TOMM70 is an outer mitochondrial membrane TOM receptor/adaptor
+      with a cytosol-facing TPR receptor domain.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
 - term:
     id: GO:0005741
     label: mitochondrial outer membrane
   evidence_type: EXP
   original_reference_id: PMID:33723040
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct localization. TOMM70 is an outer mitochondrial membrane TOM receptor/adaptor
+      with a cytosol-facing TPR receptor domain.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
 - term:
     id: GO:0005739
     label: mitochondrion
   evidence_type: HTP
   original_reference_id: PMID:34800366
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct but too general. TOMM70 is specifically an outer mitochondrial membrane
+      TOM receptor/adaptor.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Subsumed by mitochondrial outer membrane and TOM complex annotations.
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:35391620
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Protein binding is too generic for TOMM70. The informative functions are chaperone-bound
+      precursor receptor/adaptor activity, TOM association, and context-specific MAVS/PINK1
+      signaling.
+    action: REMOVE
+    reason: Replace generic protein binding curation with specific adaptor, receptor, TOM
+      complex, and pathway annotations.
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
 - term:
     id: GO:0030674
     label: protein-macromolecule adaptor activity
   evidence_type: IDA
   original_reference_id: PMID:20628368
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Accepted. TOMM70 functions as a receptor/adaptor for chaperone-bound mitochondrial
+      precursor proteins and also as a MAVS-linked signaling scaffold.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TOMM70/TOMM70-deep-research-falcon.md
+      supporting_text: TOMM70 is best understood as a **surface receptor/adaptor** of the
+        **TOM (translocase of the outer membrane)** import gateway
 - term:
     id: GO:0031966
     label: mitochondrial membrane
   evidence_type: IDA
   original_reference_id: PMID:20628368
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct but too broad. The specific supported localization is mitochondrial outer
+      membrane, not generic mitochondrial membrane.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Subsumed by mitochondrial outer membrane annotations.
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
 - term:
     id: GO:0005741
     label: mitochondrial outer membrane
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-5205661
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct localization. TOMM70 is an outer mitochondrial membrane TOM receptor/adaptor
+      with a cytosol-facing TPR receptor domain.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
 - term:
     id: GO:0005741
     label: mitochondrial outer membrane
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-9685281
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct localization. TOMM70 is an outer mitochondrial membrane TOM receptor/adaptor
+      with a cytosol-facing TPR receptor domain.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
 - term:
     id: GO:0005741
     label: mitochondrial outer membrane
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-9709663
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct localization. TOMM70 is an outer mitochondrial membrane TOM receptor/adaptor
+      with a cytosol-facing TPR receptor domain.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
 - term:
     id: GO:0005741
     label: mitochondrial outer membrane
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-9709787
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct localization. TOMM70 is an outer mitochondrial membrane TOM receptor/adaptor
+      with a cytosol-facing TPR receptor domain.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
 - term:
     id: GO:0005741
     label: mitochondrial outer membrane
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-9709842
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct localization. TOMM70 is an outer mitochondrial membrane TOM receptor/adaptor
+      with a cytosol-facing TPR receptor domain.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
 - term:
     id: GO:0005741
     label: mitochondrial outer membrane
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-9709852
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct localization. TOMM70 is an outer mitochondrial membrane TOM receptor/adaptor
+      with a cytosol-facing TPR receptor domain.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
 - term:
     id: GO:0002218
     label: activation of innate immune response
   evidence_type: IDA
   original_reference_id: PMID:20628368
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Supported in the antiviral MAVS/IRF3 literature, but this is a context-specific
+      signaling role rather than TOMM70's core mitochondrial import function.
+    action: KEEP_AS_NON_CORE
+    reason: Non-core signaling/adaptor role in antiviral innate immune response.
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
 - term:
     id: GO:0002230
     label: positive regulation of defense response to virus by host
   evidence_type: IDA
   original_reference_id: PMID:20628368
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Supported in the antiviral MAVS/IRF3 literature, but this is a context-specific
+      signaling role rather than TOMM70's core mitochondrial import function.
+    action: KEEP_AS_NON_CORE
+    reason: Non-core signaling/adaptor role in antiviral innate immune response.
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:20628368
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Protein binding is too generic for TOMM70. The informative functions are chaperone-bound
+      precursor receptor/adaptor activity, TOM association, and context-specific MAVS/PINK1
+      signaling.
+    action: REMOVE
+    reason: Replace generic protein binding curation with specific adaptor, receptor, TOM
+      complex, and pathway annotations.
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:25609812
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Protein binding is too generic for TOMM70. The informative functions are chaperone-bound
+      precursor receptor/adaptor activity, TOM association, and context-specific MAVS/PINK1
+      signaling.
+    action: REMOVE
+    reason: Replace generic protein binding curation with specific adaptor, receptor, TOM
+      complex, and pathway annotations.
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
 - term:
     id: GO:0005739
     label: mitochondrion
   evidence_type: IDA
   original_reference_id: PMID:20628368
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct but too general. TOMM70 is specifically an outer mitochondrial membrane
+      TOM receptor/adaptor.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Subsumed by mitochondrial outer membrane and TOM complex annotations.
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
 - term:
     id: GO:0005739
     label: mitochondrion
   evidence_type: IDA
   original_reference_id: PMID:25609812
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct but too general. TOMM70 is specifically an outer mitochondrial membrane
+      TOM receptor/adaptor.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Subsumed by mitochondrial outer membrane and TOM complex annotations.
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
 - term:
     id: GO:0032728
     label: positive regulation of interferon-beta production
   evidence_type: IDA
   original_reference_id: PMID:20628368
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Supported in the antiviral MAVS/IRF3 literature, but this is a context-specific
+      signaling role rather than TOMM70's core mitochondrial import function.
+    action: KEEP_AS_NON_CORE
+    reason: Non-core signaling/adaptor role in antiviral innate immune response.
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TOMM70/TOMM70-deep-research-falcon.md
+      supporting_text: TOMM70 is described as participating in antiviral innate immune signaling
+        by acting as a **receptor/scaffold for MAVS-associated signaling**
 - term:
     id: GO:0042981
     label: regulation of apoptotic process
   evidence_type: IDA
   original_reference_id: PMID:25609812
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Supported for Sendai virus-induced TOMM70/Hsp90/IRF3/BAX apoptosis context, but
+      it is a secondary signaling phenotype.
+    action: KEEP_AS_NON_CORE
+    reason: Context-specific antiviral/apoptosis role rather than primary mitochondrial import
+      function.
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
 - term:
     id: GO:0098586
     label: cellular response to virus
   evidence_type: IDA
   original_reference_id: PMID:25609812
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Supported in the antiviral MAVS/IRF3 literature, but this is a context-specific
+      signaling role rather than TOMM70's core mitochondrial import function.
+    action: KEEP_AS_NON_CORE
+    reason: Non-core signaling/adaptor role in antiviral innate immune response.
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
 - term:
     id: GO:0005742
     label: mitochondrial outer membrane translocase complex
   evidence_type: ISS
   original_reference_id: GO_REF:0000024
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct complex annotation. TOMM70 associates with the TOM import machinery and
+      acts as a receptor/adaptor at the outer membrane translocase.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
 - term:
     id: GO:0008320
     label: protein transmembrane transporter activity
@@ -399,96 +633,148 @@ existing_annotations:
   original_reference_id: GO_REF:0000024
   qualifier: contributes_to
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Accepted as TOMM70 contribution to TOM-dependent protein transmembrane transport.
+      TOMM70 is a receptor/adaptor, not the pore-forming subunit, but it contributes to the
+      TOM complex import activity.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
 - term:
     id: GO:0030150
     label: protein import into mitochondrial matrix
   evidence_type: ISS
   original_reference_id: GO_REF:0000024
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Broadly valid as a TOM-pathway outcome, but TOMM70 is best described as an outer-membrane
+      receptor/adaptor rather than the matrix import pore or motor.
+    action: KEEP_AS_NON_CORE
+    reason: Matrix import is one TOM-dependent route; TOMM70 has a more specific receptor/adaptor
+      role for chaperone-bound precursors.
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
 - term:
     id: GO:0030943
     label: mitochondrion targeting sequence binding
   evidence_type: ISS
   original_reference_id: GO_REF:0000024
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Supported. TOMM70 recognizes mitochondrial precursor proteins, especially hydrophobic
+      internal-signal substrates delivered by Hsp70/Hsp90 chaperones.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
 - term:
     id: GO:0045039
     label: protein insertion into mitochondrial inner membrane
   evidence_type: ISS
   original_reference_id: GO_REF:0000024
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Reasonable as a pathway-level consequence for carrier/internal-signal precursor
+      delivery, but TOMM70 does not catalyze inner membrane insertion itself.
+    action: KEEP_AS_NON_CORE
+    reason: TOMM70 acts upstream at the outer membrane before substrates are handed to downstream
+      inner-membrane import machinery.
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
 - term:
     id: GO:0070585
     label: protein localization to mitochondrion
   evidence_type: ISS
   original_reference_id: GO_REF:0000024
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Supported broad process annotation. TOMM70 promotes mitochondrial localization/import
+      of precursor proteins through its receptor/adaptor role.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:23911537
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Protein binding is too generic for TOMM70. The informative functions are chaperone-bound
+      precursor receptor/adaptor activity, TOM association, and context-specific MAVS/PINK1
+      signaling.
+    action: REMOVE
+    reason: Replace generic protein binding curation with specific adaptor, receptor, TOM
+      complex, and pathway annotations.
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
 - term:
     id: GO:0005739
     label: mitochondrion
   evidence_type: IDA
   original_reference_id: PMID:20531390
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct but too general. TOMM70 is specifically an outer mitochondrial membrane
+      TOM receptor/adaptor.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Subsumed by mitochondrial outer membrane and TOM complex annotations.
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
 - term:
     id: GO:0070062
     label: extracellular exosome
   evidence_type: HDA
   original_reference_id: PMID:18570454
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: High-throughput extracellular exosome detection is not supported as TOMM70 functional
+      localization and conflicts with the mitochondrial outer membrane synthesis.
+    action: REMOVE
+    reason: Likely high-throughput carryover/noise for an outer mitochondrial membrane TOM
+      receptor.
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
 - term:
     id: GO:0016020
     label: membrane
   evidence_type: HDA
   original_reference_id: PMID:19946888
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct but too broad. The specific supported localization is mitochondrial outer
+      membrane, not generic membrane.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Subsumed by mitochondrial outer membrane annotations.
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
 - term:
     id: GO:0005742
     label: mitochondrial outer membrane translocase complex
   evidence_type: TAS
   original_reference_id: PMID:15644312
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct complex annotation. TOMM70 associates with the TOM import machinery and
+      acts as a receptor/adaptor at the outer membrane translocase.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
 - term:
     id: GO:0008320
     label: protein transmembrane transporter activity
   evidence_type: TAS
   original_reference_id: PMID:15644312
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Accepted as TOMM70 contribution to TOM-dependent protein transmembrane transport.
+      TOMM70 is a receptor/adaptor, not the pore-forming subunit, but it contributes to the
+      TOM complex import activity.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:12526792
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Protein binding is too generic for TOMM70. The informative functions are chaperone-bound
+      precursor receptor/adaptor activity, TOM association, and context-specific MAVS/PINK1
+      signaling.
+    action: REMOVE
+    reason: Replace generic protein binding curation with specific adaptor, receptor, TOM
+      complex, and pathway annotations.
+    additional_reference_ids:
+    - file:human/TOMM70/TOMM70-deep-research-falcon.md
 references:
 - id: GO_REF:0000024
   title: Manual transfer of experimentally-verified manual GO annotation data to orthologs
@@ -501,40 +787,40 @@ references:
   title: Gene Ontology annotation based on curation of immunofluorescence data
   findings: []
 - id: GO_REF:0000107
-  title: Automatic transfer of experimentally verified manual GO annotation data to
-    orthologs using Ensembl Compara
+  title: Automatic transfer of experimentally verified manual GO annotation data to orthologs
+    using Ensembl Compara
   findings: []
 - id: GO_REF:0000120
   title: Combined Automated Annotation using Multiple IEA Methods
   findings: []
 - id: PMID:12526792
-  title: Molecular chaperones Hsp90 and Hsp70 deliver preproteins to the mitochondrial
-    import receptor Tom70.
+  title: Molecular chaperones Hsp90 and Hsp70 deliver preproteins to the mitochondrial import
+    receptor Tom70.
   findings: []
 - id: PMID:15644312
   title: Dissection of the mitochondrial import and assembly pathway for human Tom40.
   findings: []
 - id: PMID:18331822
-  title: Identification of Tom5 and Tom6 in the preprotein translocase complex of
-    human mitochondrial outer membrane.
+  title: Identification of Tom5 and Tom6 in the preprotein translocase complex of human mitochondrial
+    outer membrane.
   findings: []
 - id: PMID:18570454
-  title: Proteomic analysis of exosomes from human neural stem cells by flow field-flow
-    fractionation and nanoflow liquid chromatography-tandem mass spectrometry.
+  title: Proteomic analysis of exosomes from human neural stem cells by flow field-flow fractionation
+    and nanoflow liquid chromatography-tandem mass spectrometry.
   findings: []
 - id: PMID:19946888
   title: Defining the membrane proteome of NK cells.
   findings: []
 - id: PMID:20531390
-  title: Suppression of the novel ER protein Maxer by mutant ataxin-1 in Bergman glia
-    contributes to non-cell-autonomous toxicity.
+  title: Suppression of the novel ER protein Maxer by mutant ataxin-1 in Bergman glia contributes
+    to non-cell-autonomous toxicity.
   findings: []
 - id: PMID:20628368
   title: Tom70 mediates activation of interferon regulatory factor 3 on mitochondria.
   findings: []
 - id: PMID:23911537
-  title: Cytoplasmic ribosomal protein S3 (rpS3) plays a pivotal role in mitochondrial
-    DNA damage surveillance.
+  title: Cytoplasmic ribosomal protein S3 (rpS3) plays a pivotal role in mitochondrial DNA
+    damage surveillance.
   findings: []
 - id: PMID:25609812
   title: Tom70 mediates Sendai virus-induced apoptosis on mitochondria.
@@ -546,42 +832,42 @@ references:
   title: SARS-CoV-2 Orf9b suppresses type I interferon responses by targeting TOM70.
   findings: []
 - id: PMID:33060197
-  title: Comparative host-coronavirus protein interaction networks reveal pan-viral
-    disease mechanisms.
+  title: Comparative host-coronavirus protein interaction networks reveal pan-viral disease
+    mechanisms.
   findings: []
 - id: PMID:33723040
-  title: Toxoplasma gondii association with host mitochondria requires key mitochondrial
-    protein import machinery.
+  title: Toxoplasma gondii association with host mitochondria requires key mitochondrial protein
+    import machinery.
   findings: []
 - id: PMID:33845483
   title: Multilevel proteomics reveals host perturbations by SARS-CoV-2 and SARS-CoV.
   findings: []
 - id: PMID:33990585
-  title: Crystal structure of SARS-CoV-2 Orf9b in complex with human TOM70 suggests
-    unusual virus-host interactions.
+  title: Crystal structure of SARS-CoV-2 Orf9b in complex with human TOM70 suggests unusual
+    virus-host interactions.
   findings: []
 - id: PMID:34232536
   title: Interactomes of SARS-CoV-2 and human coronaviruses reveal host factors potentially
     affecting pathogenesis.
   findings: []
 - id: PMID:34502139
-  title: Phosphorylation of SARS-CoV-2 Orf9b Regulates Its Targeting to Two Binding
-    Sites in TOM70 and Recruitment of Hsp90.
+  title: Phosphorylation of SARS-CoV-2 Orf9b Regulates Its Targeting to Two Binding Sites
+    in TOM70 and Recruitment of Hsp90.
   findings: []
 - id: PMID:34800366
-  title: Quantitative high-confidence human mitochondrial proteome and its dynamics
-    in cellular context.
+  title: Quantitative high-confidence human mitochondrial proteome and its dynamics in cellular
+    context.
   findings: []
 - id: PMID:34942634
   title: Evolution of enhanced innate immune evasion by SARS-CoV-2.
   findings: []
 - id: PMID:35391620
-  title: The role of the individual TOM subunits in the association of PINK1 with
-    depolarized mitochondria.
+  title: The role of the individual TOM subunits in the association of PINK1 with depolarized
+    mitochondria.
   findings: []
 - id: PMID:36217030
-  title: A comprehensive SARS-CoV-2-human protein-protein interactome reveals COVID-19
-    pathobiology and potential host therapeutic targets.
+  title: A comprehensive SARS-CoV-2-human protein-protein interactome reveals COVID-19 pathobiology
+    and potential host therapeutic targets.
   findings: []
 - id: Reactome:R-HSA-5205661
   title: Pink1 is recruited from the cytoplasm to the mitochondria
@@ -601,3 +887,53 @@ references:
 - id: Reactome:R-HSA-9709852
   title: MAVS:TOMM70 recruits HSP90:TBK1:IRF3
   findings: []
+- id: file:human/TOMM70/TOMM70-deep-research-falcon.md
+  title: Falcon deep research report for human TOMM70
+  findings: []
+core_functions:
+- description: TOMM70 is an outer-mitochondrial-membrane receptor/adaptor that docks Hsp70/Hsp90-bound
+    hydrophobic precursor proteins and promotes their handoff to the TOM import machinery
+    rather than acting as the pore itself.
+  supported_by:
+  - reference_id: file:human/TOMM70/TOMM70-deep-research-falcon.md
+    supporting_text: TOMM70 is best understood as a **surface receptor/adaptor** of the **TOM
+      (translocase of the outer membrane)** import gateway
+  - reference_id: file:human/TOMM70/TOMM70-deep-research-falcon.md
+    supporting_text: Cytosolic **Hsp70/Hsp90** chaperones bind newly synthesized hydrophobic
+      precursors to prevent aggregation and **deliver them to TOMM70**
+  - reference_id: file:human/TOMM70/TOMM70-deep-research-falcon.md
+    supporting_text: TOMM70 is anchored in the **outer mitochondrial membrane (OMM)** with
+      its receptor domain facing the cytosol.
+  molecular_function:
+    id: GO:0030674
+    label: protein-macromolecule adaptor activity
+  contributes_to_molecular_function:
+    id: GO:0008320
+    label: protein transmembrane transporter activity
+  directly_involved_in:
+  - id: GO:0070585
+    label: protein localization to mitochondrion
+  locations:
+  - id: GO:0005741
+    label: mitochondrial outer membrane
+  in_complex:
+    id: GO:0140596
+    label: TOM complex
+proposed_new_terms: []
+suggested_questions:
+- question: Which mammalian TOMM70 substrates require direct chaperone docking versus direct
+    precursor contacts?
+  experts: []
+- question: How are TOMM70 import, MAVS signaling, and PINK1/Parkin quality-control roles
+    separated by post-translational regulation?
+  experts: []
+suggested_experiments:
+- hypothesis: TOMM70 TPR-domain mutants that disrupt Hsp70/Hsp90 docking selectively impair
+    carrier/internal-signal precursor import while preserving TOM core assembly.
+  description: Compare import of carrier-type substrates and presequence substrates in TOMM70
+    knockout or knockdown cells rescued with wild-type versus chaperone-docking-defective
+    TOMM70 variants.
+- hypothesis: TOMM70 antiviral signaling can be separated from its import receptor activity
+    by mutating MAVS/Hsp90 signaling interfaces outside the precursor handoff surface.
+  description: Assay MAVS-induced IRF3 activation and mitochondrial precursor import in parallel
+    for TOMM70 interface mutants.

--- a/genes/human/TOMM70/TOMM70-ai-review.yaml
+++ b/genes/human/TOMM70/TOMM70-ai-review.yaml
@@ -160,9 +160,9 @@ existing_annotations:
     summary: Protein binding is too generic for TOMM70. The informative functions are chaperone-bound
       precursor receptor/adaptor activity, TOM association, and context-specific MAVS/PINK1
       signaling.
-    action: REMOVE
-    reason: Replace generic protein binding curation with specific adaptor, receptor, TOM
-      complex, and pathway annotations.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: The interaction is documented, but generic protein binding should be superseded
+      by specific adaptor, receptor, TOM complex, and pathway annotations.
     additional_reference_ids:
     - file:human/TOMM70/TOMM70-deep-research-falcon.md
 - term:
@@ -400,9 +400,9 @@ existing_annotations:
     summary: Protein binding is too generic for TOMM70. The informative functions are chaperone-bound
       precursor receptor/adaptor activity, TOM association, and context-specific MAVS/PINK1
       signaling.
-    action: REMOVE
-    reason: Replace generic protein binding curation with specific adaptor, receptor, TOM
-      complex, and pathway annotations.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: The interaction is documented, but generic protein binding should be superseded
+      by specific adaptor, receptor, TOM complex, and pathway annotations.
     additional_reference_ids:
     - file:human/TOMM70/TOMM70-deep-research-falcon.md
 - term:
@@ -770,9 +770,9 @@ existing_annotations:
     summary: Protein binding is too generic for TOMM70. The informative functions are chaperone-bound
       precursor receptor/adaptor activity, TOM association, and context-specific MAVS/PINK1
       signaling.
-    action: REMOVE
-    reason: Replace generic protein binding curation with specific adaptor, receptor, TOM
-      complex, and pathway annotations.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: The interaction is documented, but generic protein binding should be superseded
+      by specific adaptor, receptor, TOM complex, and pathway annotations.
     additional_reference_ids:
     - file:human/TOMM70/TOMM70-deep-research-falcon.md
 references:

--- a/genes/human/TOMM70/TOMM70-deep-research-falcon.md
+++ b/genes/human/TOMM70/TOMM70-deep-research-falcon.md
@@ -1,0 +1,321 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-11T13:32:32.543116'
+end_time: '2026-05-11T13:44:11.524092'
+duration_seconds: 698.98
+template_file: templates/gene_research_go_focused.md
+template_variables:
+  organism: human
+  gene_id: TOMM70
+  gene_symbol: TOMM70
+  uniprot_accession: O94826
+  protein_description: 'RecName: Full=Mitochondrial import receptor subunit TOM70
+    {ECO:0000305}; AltName: Full=Mitochondrial precursor proteins import receptor;
+    AltName: Full=Translocase of outer membrane 70 kDa subunit; AltName: Full=Translocase
+    of outer mitochondrial membrane protein 70 {ECO:0000312|HGNC:HGNC:11985};'
+  gene_info: Name=TOMM70 {ECO:0000312|HGNC:HGNC:11985}; Synonyms=KIAA0719, TOM70,
+    TOMM70A;
+  organism_full: Homo sapiens (Human).
+  protein_family: Belongs to the Tom70 family. .
+  protein_domains: TPR-like_helical_dom_sf. (IPR011990); TPR_rpt. (IPR019734); TPR_1
+    (PF00515); TPR_8 (PF13181)
+provider_config:
+  timeout: 600
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 29
+---
+
+## Question
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** O94826
+- **Protein Description:** RecName: Full=Mitochondrial import receptor subunit TOM70 {ECO:0000305}; AltName: Full=Mitochondrial precursor proteins import receptor; AltName: Full=Translocase of outer membrane 70 kDa subunit; AltName: Full=Translocase of outer mitochondrial membrane protein 70 {ECO:0000312|HGNC:HGNC:11985};
+- **Gene Information:** Name=TOMM70 {ECO:0000312|HGNC:HGNC:11985}; Synonyms=KIAA0719, TOM70, TOMM70A;
+- **Organism (full):** Homo sapiens (Human).
+- **Protein Family:** Belongs to the Tom70 family. .
+- **Key Domains:** TPR-like_helical_dom_sf. (IPR011990); TPR_rpt. (IPR019734); TPR_1 (PF00515); TPR_8 (PF13181)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "TOMM70" matches the protein description above**
+2. **Verify the organism is correct:** Homo sapiens (Human).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'TOMM70' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **TOMM70** (gene ID: TOMM70, UniProt: O94826) in human.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** O94826
+- **Protein Description:** RecName: Full=Mitochondrial import receptor subunit TOM70 {ECO:0000305}; AltName: Full=Mitochondrial precursor proteins import receptor; AltName: Full=Translocase of outer membrane 70 kDa subunit; AltName: Full=Translocase of outer mitochondrial membrane protein 70 {ECO:0000312|HGNC:HGNC:11985};
+- **Gene Information:** Name=TOMM70 {ECO:0000312|HGNC:HGNC:11985}; Synonyms=KIAA0719, TOM70, TOMM70A;
+- **Organism (full):** Homo sapiens (Human).
+- **Protein Family:** Belongs to the Tom70 family. .
+- **Key Domains:** TPR-like_helical_dom_sf. (IPR011990); TPR_rpt. (IPR019734); TPR_1 (PF00515); TPR_8 (PF13181)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "TOMM70" matches the protein description above**
+2. **Verify the organism is correct:** Homo sapiens (Human).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'TOMM70' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **TOMM70** (gene ID: TOMM70, UniProt: O94826) in human.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Research report: Human **TOMM70** (UniProt **O94826**) functional annotation
+
+### 1) Target verification (gene/protein identity)
+The literature retrieved and cited here matches the UniProt target **O94826**: **human TOMM70** (synonyms **TOM70, TOMM70A, KIAA0719**) encoding **mitochondrial import receptor subunit TOM70**, a Tom70-family protein anchored in the **outer mitochondrial membrane (OMM)** with a large cytosolic receptor domain enriched in **TPR (tetratricopeptide repeat) motifs**. (kreimendahl2020themitochondrialouter pages 1-3, kreimendahl2020themitochondrialouter pages 3-6)
+
+### 2) Key concepts, definitions, and current understanding
+
+#### 2.1 TOMM70 as a mitochondrial protein import receptor (core function)
+**Definition/role.** TOMM70 is best understood as a **surface receptor/adaptor** of the **TOM (translocase of the outer membrane)** import gateway, specializing in the delivery of **hydrophobic, chaperone-bound mitochondrial precursor proteins** (classically including inner-membrane carrier proteins with internal targeting signals), rather than functioning as a channel itself. (kreimendahl2020themitochondrialouter pages 1-3, haastrup2023thejourneyof pages 8-10)
+
+**Mechanistic model.** Cytosolic **Hsp70/Hsp90** chaperones bind newly synthesized hydrophobic precursors to prevent aggregation and **deliver them to TOMM70**, which then **hands off** substrates to other TOM components (notably **TOMM22** and the **TOMM40** pore) for translocation across the OMM; carrier precursors are then escorted by small TIM chaperones in the IMS toward **TIMM22** for insertion into the inner membrane. (haastrup2023thejourneyof pages 8-10, kreimendahl2020themitochondrialouter pages 12-14)
+
+#### 2.2 Domain architecture and chaperone docking
+Tom70-family receptors are helical solenoids; a widely cited structural description (from fungal Tom70) is **~26 α-helices organized into ~11 TPR motifs**, with an N-terminal membrane anchor and a cytosolic receptor domain. The N-terminal region forms a clamp-like site that binds Hsp70 (and in mammals Hsp70/Hsp90), supporting the view that TOMM70 frequently recognizes substrates **indirectly via bound chaperones**. (kreimendahl2020themitochondrialouter pages 3-6, kreimendahl2020themitochondrialouter pages 1-3)
+
+#### 2.3 Subcellular localization beyond “mitochondrial surface”: foci and contact sites
+Beyond being OMM-anchored, TOMM70 is described as enriched in **defined foci** and associated with **ER–mitochondria contact sites (MERCS)** where it can contribute to **Ca2+ transfer** by interacting with **IP3R3** (inositol-1,4,5-trisphosphate receptor type 3). This extends TOMM70’s annotation from import to **organelle communication** and signaling. (kreimendahl2020themitochondrialouter pages 14-16, pitt2021abiochemicaland pages 19-20)
+
+#### 2.4 TOMM70 as a signaling adaptor in innate immunity
+TOMM70 is described as participating in antiviral innate immune signaling by acting as a **receptor/scaffold for MAVS-associated signaling**, helping recruit/organize signaling factors (often described via an Hsp90-containing axis) that promote **IRF3 activation** and type I interferon responses. (pitt2021abiochemicaland pages 19-20, pitt2021abiochemicaland pages 17-19)
+
+#### 2.5 TOMM70 in mitochondrial quality control and mitophagy
+Multiple sources connect TOMM70 to **PINK1/Parkin (PRKN)-dependent mitophagy**, including roles in **PINK1 import/accumulation at the OMM**, TOM-complex ubiquitylation dynamics, and downstream mitophagy signaling. (kreimendahl2020themitochondrialouter pages 19-21, pitt2021abiochemicaland pages 17-19)
+
+### 3) Recent developments (prioritizing 2023–2024)
+
+#### 3.1 2024: TOMM70 as a metabolic/immune node in human T cells (lactate → TOMM70 → MGAT1 import)
+A 2024 *Journal of Clinical Investigation* study in human regulatory T cells (Tregs) proposed a direct metabolite–receptor interaction in which **lactate binds TOM70** and promotes mitochondrial import of **MGAT1**, supporting **OXPHOS** and Treg function. The authors report (i) structural/docking and autoradiography evidence for lactate binding to TOM70, including predicted binding contacts (H-bonds with **SER253, ASP541, THR511**; hydrophobic contacts including **PHE256, GLN255, ASN509, ALA510, CYS544**), and (ii) functional perturbation where **TOMM70 shRNA knockdown** reduced MGAT1 expression/mitochondrial colocalization and decreased **basal and maximal oxygen consumption rate (OCR)**. (zhou2024lactatesupportstreg pages 8-9)
+
+**Interpretation.** This work extends TOMM70’s functional annotation into **immunometabolism**, framing TOMM70 not only as a protein import receptor but also as a potential “gatekeeper” for metabolically adaptive import programs in immune cells. (zhou2024lactatesupportstreg pages 8-9)
+
+#### 3.2 2024: Human genetic variation predicted to modulate TOMM70–SARS‑CoV‑2 ORF9b binding
+A 2024 *Scientific Reports* computational study analyzed missense variants in TOMM70 at the TOMM70:ORF9b interface (structure referenced as PDB 7KDT) and predicted variant effects on binding affinity. Examples include predicted affinity increases (ΔΔG, kcal/mol) for **V556L (0.905)**, **K576R (0.618)**, **A591T (0.599)**, **V514I (0.562)**, and **A483T (0.499)**, while **I412T (−1.054)** and **E477G (−1.014)** were predicted to decrease affinity. The same work reports these variants as **rare in gnomAD**, e.g., V556L observed with allele frequency **0.00007** in African/African American. (waman2024predictinghumanand pages 8-10)
+
+**Interpretation/limits.** These are *in silico* affinity predictions rather than clinical association estimates; nonetheless they provide a concrete hypothesis framework for **host genetic modulation of viral immune evasion** mediated via TOMM70. (waman2024predictinghumanand pages 8-10)
+
+#### 3.3 2023–2024: TOMM70 highlighted as a multifunctional/regulatory TOM component
+A 2023 review on mitochondrial import-related stress signaling summarizes the import machinery as a signaling hub; it notes that Tom20 and Tom70 are the main receptors and links TOM-associated processes to mitophagy and stress responses (e.g., PINK1-related pathways when import is perturbed). (lionaki2023mitochondrialproteinimport pages 8-9)
+
+A 2024 evolutionary/functional review specifically emphasizes TOMM70 as a TOM receptor with “manifold functions” and places it in the context of evolutionary diversification of TOM composition and regulation, aligning TOMM70 with **regulatory and signaling roles** beyond translocation. (ozdemir2024thetomcomplex pages 1-7)
+
+### 4) Current applications and real-world implementations
+
+#### 4.1 Diagnostic relevance: TOMM70 as a Mendelian mitochondrial disease gene
+A 2020 human genetics study reports compound heterozygous **TOMM70** variants (**c.794C>T / p.T265M** and **c.1745C>T / p.A582V**) in a patient with **severe anemia, lactic acidosis, and developmental delay**, with patient-derived lymphocytes showing reduced TOM70 expression and defects in TOM complexes and multi-OXPHOS, with **complex IV primarily affected**; WT TOM70 (but not mutant TOM70) restored the complex IV defect in a knockdown rescue model. This supports clinical use of TOMM70 in gene panels/interpretation for suspected mitochondrial disease. (wei2020mutationsintomm70 pages 1-2)
+
+#### 4.2 Therapeutic strategy concepts (preclinical): modulating TOMM70-linked pathways
+TOMM70’s central placement at the intersection of protein import, MERCS, and innate immunity has motivated proposals that targeting TOM-complex interfaces or TOMM70-linked signaling could be therapeutically relevant in contexts such as viral immune evasion and mitochondrial-stress diseases. A structural/biochemical review highlights TOMM70’s involvement in Parkin/PINK1 mitophagy and MAVS–IRF3 signaling and notes viral exploitation (e.g., ORF9b binding) as a rationale for intervention concepts. (pitt2021abiochemicaland pages 19-20, pitt2021abiochemicaland pages 17-19)
+
+#### 4.3 Cell therapy context (Treg function)
+The 2024 JCI study connects TOMM70-dependent MGAT1 mitochondrial localization to improved human Treg OXPHOS and reports in vivo benefit of lactate-treated Tregs in a xenogeneic GvHD model, positioning TOMM70 mechanistically within workflows relevant to **Treg reinfusion therapy** (as an enabling step for mitochondrial metabolic fitness). (zhou2024lactatesupportstreg pages 8-9)
+
+### 5) Expert opinions and authoritative synthesis (how experts frame TOMM70)
+
+**Consensus functional framing.** Authoritative reviews converge on TOMM70 as a **TPR-containing OMM adaptor receptor** that (i) docks Hsp70/Hsp90-bound precursors to the TOM entry gate, (ii) coordinates organelle cross-talk (MERCS; Ca2+ transfer via IP3R3), and (iii) provides a platform for innate immune signaling (MAVS/IRF3 axis) and quality control (PINK1/Parkin mitophagy). (kreimendahl2020themitochondrialouter pages 1-3, pitt2021abiochemicaland pages 19-20)
+
+**Mechanistic caution expressed in the literature.** The same reviews highlight that substrate recognition can be predominantly **chaperone-mediated**, and that TOMM70’s “non-import” roles likely depend on context-specific protein–protein interactions and post-translational modifications (phosphorylation/ubiquitylation), with open questions about how these modifications reprogram TOMM70’s receptor vs signaling functions in mammals. (kreimendahl2020themitochondrialouter pages 3-6, pitt2021abiochemicaland pages 17-19)
+
+### 6) Quantitative/statistical findings from recent and key studies
+
+#### 6.1 Structural/domain quantitative descriptors
+A commonly cited Tom70 structural summary is **~26 α-helices forming ~11 TPR motifs** in the receptor domain. (kreimendahl2020themitochondrialouter pages 3-6)
+
+#### 6.2 Import-system scale
+Reviews estimate that human cells import on the order of **~1,500 mitochondrial precursor proteins** synthesized in the cytosol, contextualizing why TOM receptors (including TOMM70) are essential for cell viability and homeostasis. (kreimendahl2020themitochondrialouter pages 1-3)
+
+#### 6.3 Quantitative variant effects and population frequencies relevant to TOMM70–ORF9b interaction (2024)
+Predicted changes in binding affinity to SARS‑CoV‑2 ORF9b for TOMM70 variants include **V556L ΔΔG 0.905 kcal/mol**, **K576R 0.618**, **A591T 0.599**, **V514I 0.562**, **A483T 0.499**, and affinity-reducing **I412T −1.054** and **E477G −1.014**. Reported allele frequencies are far below 1% (e.g., **V556L 0.00007** in African/African American). (waman2024predictinghumanand pages 8-10)
+
+#### 6.4 Quantitative/statistical evidence in the 2024 Treg study
+The 2024 JCI study reports statistical testing (e.g., ANOVA with P-value thresholds) for multiple mitochondrial readouts and shows that TOMM70 knockdown reduces mitochondrial MGAT1 colocalization and OCR; however, the excerpted text does not provide the exact OCR deltas, so quantitative effect sizes cannot be faithfully reproduced here without the underlying supplemental figure values. (zhou2024lactatesupportstreg pages 8-9)
+
+### 7) Visual evidence (figures) supporting mechanistic understanding
+A Tom70 review provides schematics that summarize: (i) Tom70’s receptor function as a docking site for chaperone-bound substrates and their delivery to the TOM pore and/or outer-membrane insertion pathways, (ii) Tom70’s role in MAVS/RIG-I pathway signaling through recruitment of Hsp90/TBK1/IRF3 complexes, and (iii) competitive binding of SARS‑CoV‑2 ORF9b to Tom70 that can suppress interferon responses. These schematics are useful for functional annotation narratives. (kreimendahl2020themitochondrialouter media bc2f2392, kreimendahl2020themitochondrialouter media 1214cc5a, kreimendahl2020themitochondrialouter media 41a8d14b, kreimendahl2020themitochondrialouter media 44199fa5, kreimendahl2020themitochondrialouter media 3b13eb9e)
+
+### 8) Summary functional annotation (most defensible “primary function”)
+**Primary function:** TOMM70 is an **outer-mitochondrial-membrane receptor/adaptor** that binds **cytosolic chaperones (Hsp70/Hsp90) carrying hydrophobic mitochondrial precursor proteins** and promotes their delivery to the TOM translocation machinery for import—particularly important for internal-signal, hydrophobic precursors such as carrier proteins. (haastrup2023thejourneyof pages 8-10, kreimendahl2020themitochondrialouter pages 12-14)
+
+**Where it acts:** OMM, cytosol-facing receptor domain; additionally enriched at MERCS where it can participate in ER→mitochondria Ca2+ transfer and signaling assemblies. (kreimendahl2020themitochondrialouter pages 14-16, pitt2021abiochemicaland pages 19-20)
+
+**Key pathways:** Mitochondrial biogenesis (protein import), innate immune signaling (MAVS/IRF3 axis, viral antagonism via ORF9b), and mitochondrial quality control/mitophagy (PINK1/Parkin-linked processes). (pitt2021abiochemicaland pages 19-20, kreimendahl2020themitochondrialouter pages 19-21)
+
+---
+
+### Evidence-mapped reference table
+The following table consolidates identity, mechanism, pathways, 2023–2024 updates, quantitative findings, and URLs.
+
+| Category | Specific details | Evidence/notes | Key sources with publication year | URL | Citation context IDs |
+|---|---|---|---|---|---|
+| Identity/domains | Human **TOMM70** corresponds to UniProt **O94826** and encodes the mitochondrial outer membrane import receptor **Tom70/TOM70/TOMM70A**. It is a Tom70-family protein with an N-terminal membrane anchor and a large cytosolic TPR-repeat receptor domain; reviews describe Tom70 as a helical receptor with ~26 α-helices and ~11 TPR motifs. | Identity and function match the UniProt target, and the TPR-repeat architecture aligns with the provided InterPro/Pfam annotations. Evolutionary review notes strong conservation among animal orthologs. | Kreimendahl & Rassow 2020; Özdemir & Dennerlein 2024 | https://doi.org/10.3390/ijms21197262 ; https://doi.org/10.1515/hsz-2024-0043 | (kreimendahl2020themitochondrialouter pages 1-3, kreimendahl2020themitochondrialouter pages 3-6, ozdemir2024thetomcomplex pages 1-7) |
+| Localization | TOMM70 is anchored in the **outer mitochondrial membrane (OMM)** with its receptor domain facing the cytosol. In mammalian cells it is also enriched in defined foci and at **ER-mitochondria contact sites (MERCS)**. | Reviews describe localization on the mitochondrial surface and clustering at contact sites, consistent with roles in import, Ca2+ transfer, and signaling. | Kreimendahl & Rassow 2020; Pitt & Buchanan 2021 | https://doi.org/10.3390/ijms21197262 ; https://doi.org/10.3390/cells10051164 | (kreimendahl2020themitochondrialouter pages 1-3, kreimendahl2020themitochondrialouter pages 14-16, pitt2021abiochemicaland pages 19-20, kreimendahl2020themitochondrialouter pages 12-14) |
+| Core function in import | TOMM70 is a **surface receptor for chaperone-bound hydrophobic mitochondrial precursor proteins**, especially multi-pass carrier proteins with internal targeting signals. Cytosolic **Hsp70/Hsp90** chaperones deliver precursors to TOMM70, which then transfers them to **TOMM22/TOMM40** for passage through the TOM pore and onward to TIM22 for inner-membrane carrier insertion. | This is the best-supported primary annotation: TOMM70 acts mainly as an adaptor/docking receptor rather than as a pore-forming transporter or enzyme. TOMM20 is emphasized as the main receptor for classical N-terminal presequences, whereas TOMM70 is more associated with carrier/internal-signal substrates. | Haastrup et al. 2023; Kreimendahl & Rassow 2020; Lionaki et al. 2023 | https://doi.org/10.3390/ijms24032479 ; https://doi.org/10.3390/ijms21197262 ; https://doi.org/10.1002/bies.202200160 | (haastrup2023thejourneyof pages 8-10, kreimendahl2020themitochondrialouter pages 1-3, kreimendahl2020themitochondrialouter pages 12-14, lionaki2023mitochondrialproteinimport pages 8-9) |
+| Key interactions | Established interactors include **Hsp70/Hsp90**, **TOMM20/TOMM22/TOMM40**, **PINK1**, **Parkin/PRKN**, **MAVS**, and **IP3R3**; mammalian studies also link TOMM70 to **IRF3/TBK1 signaling complexes** via Hsp90 and to viral proteins including **SARS-CoV-2 ORF9b**. | N-terminal TPR motifs mediate chaperone docking; TOMM70 can partially/reversibly associate with the TOM core. Beyond import, it serves as a scaffold for antiviral signaling and membrane-contact functions. | Kreimendahl & Rassow 2020; Pitt & Buchanan 2021 | https://doi.org/10.3390/ijms21197262 ; https://doi.org/10.3390/cells10051164 | (kreimendahl2020themitochondrialouter pages 1-3, kreimendahl2020themitochondrialouter pages 14-16, pitt2021abiochemicaland pages 19-20, kreimendahl2020themitochondrialouter pages 12-14, pitt2021abiochemicaland pages 17-19) |
+| Pathways | Major pathways include **mitochondrial protein import**, **PINK1/Parkin-dependent mitophagy**, **MAVS-mediated innate antiviral signaling**, and **ER-mitochondria Ca2+ transfer/MERCS**. | Reviews and mechanistic papers place TOMM70 at the intersection of organelle biogenesis and stress signaling: import defects can alter cytosolic proteostasis, ISR/UPR-like pathways, and mitophagy initiation. | Lionaki et al. 2023; Kreimendahl & Rassow 2020; Pitt & Buchanan 2021 | https://doi.org/10.1002/bies.202200160 ; https://doi.org/10.3390/ijms21197262 ; https://doi.org/10.3390/cells10051164 | (lionaki2023mitochondrialproteinimport pages 8-9, kreimendahl2020themitochondrialouter pages 19-21, pitt2021abiochemicaland pages 19-20) |
+| Disease/clinical relevance | Pathogenic **TOMM70** variants cause a rare mitochondrial disease with **multi-OXPHOS deficiency**, severe **anemia**, **lactic acidosis**, and **developmental delay**. Reported patient variants include **p.T265M** and **p.A582V**. TOMM70 dysregulation is also discussed in cardiac injury/remodeling, neurodegeneration/mitophagy, and antiviral immune evasion. | Patient-derived lymphocytes showed reduced TOM70 expression and TOM complex defects; only wild-type TOM70 restored defects in rescue assays. Reviews link reduced TOM70 to impaired mitochondrial quality control and stress susceptibility. | Wei et al. 2020; Palmer et al. 2021; Kreimendahl & Rassow 2020 | https://doi.org/10.1038/s10038-019-0714-1 ; https://doi.org/10.1002/1873-3468.14022 ; https://doi.org/10.3390/ijms21197262 | (wei2020mutationsintomm70 pages 1-2, kreimendahl2020themitochondrialouter pages 19-21) |
+| 2023-2024 updates | **2024 JCI**: lactate was shown to bind TOM70 and promote **MGAT1-TOM70** interaction and mitochondrial translocation of MGAT1 in human Tregs, supporting OXPHOS and Treg function. **2024 Sci Rep**: human TOMM70 missense variants were computationally predicted to alter binding to **SARS-CoV-2 ORF9b**. **2024 review**: TOMM70 highlighted as an evolutionarily flexible TOM component with signaling and contact-site functions beyond import. | These recent papers expand TOMM70 biology from import receptor to broader signaling node in immune metabolism and host-virus interaction. The 2024 review emphasizes TOMM70 as a regulatory, non-core-pore TOM component with manifold functions. | Zhou et al. 2024; Waman et al. 2024; Özdemir & Dennerlein 2024 | https://doi.org/10.1172/jci175897 ; https://doi.org/10.1038/s41598-024-61541-1 ; https://doi.org/10.1515/hsz-2024-0043 | (zhou2024lactatesupportstreg pages 8-9, waman2024predictinghumanand pages 8-10, ozdemir2024thetomcomplex pages 1-7) |
+| Quantitative/statistical data | Recent quantitative details include: **~26 α-helices / ~11 TPR motifs** for Tom70 architecture; human mitochondrial proteome estimate of **up to ~1,500 proteins** requiring import; lactate-TOM70 docking implicated residues **SER253, ASP541, THR511, PHE256, GLN255, ASN509, ALA510, CYS544**; predicted TOMM70 variant effects on ORF9b binding include **V556L ΔΔG 0.905 kcal/mol**, **K576R 0.618**, **A591T 0.599**, **V514I 0.562**, **A483T 0.499**, while **I412T -1.054** and **E477G -1.014 kcal/mol** were predicted to reduce affinity; the reported mitochondrial disease prevalence background cited is **5-15 per 100,000 live births**. | Quantitative figures are heterogeneous: some are structural descriptors, some are computational affinity estimates, and some are disease epidemiology/background. Several functional studies reported significant changes (e.g., OCR decline after TOMM70 knockdown) but the excerpted text did not provide exact numeric effect sizes. Rare TOMM70 affinity-enhancing variants had gnomAD frequencies far below 1% (e.g., V556L African/AA **0.00007**). | Kreimendahl & Rassow 2020; Zhou et al. 2024; Waman et al. 2024; Wei et al. 2020 | https://doi.org/10.3390/ijms21197262 ; https://doi.org/10.1172/jci175897 ; https://doi.org/10.1038/s41598-024-61541-1 ; https://doi.org/10.1038/s10038-019-0714-1 | (kreimendahl2020themitochondrialouter pages 1-3, kreimendahl2020themitochondrialouter pages 3-6, zhou2024lactatesupportstreg pages 8-9, waman2024predictinghumanand pages 8-10, wei2020mutationsintomm70 pages 1-2) |
+
+
+*Table: This table summarizes the verified identity, localization, core function, interactions, pathways, disease relevance, recent 2023-2024 advances, and available quantitative findings for human TOMM70 (UniProt O94826). It is designed as a compact evidence map for functional annotation and literature-supported reporting.*
+
+### Key cited sources (publication date; URL)
+- Kreimendahl S, Rassow J. *Int J Mol Sci* **2020-10**. https://doi.org/10.3390/ijms21197262 (kreimendahl2020themitochondrialouter pages 1-3)
+- Wei X et al. *Journal of Human Genetics* **2020-01** (accepted 2019-12-15). https://doi.org/10.1038/s10038-019-0714-1 (wei2020mutationsintomm70 pages 1-2)
+- Pitt AS, Buchanan SK. *Cells* **2021-05**. https://doi.org/10.3390/cells10051164 (pitt2021abiochemicaland pages 19-20)
+- Haastrup MO et al. *Int J Mol Sci* **2023-01**. https://doi.org/10.3390/ijms24032479 (haastrup2023thejourneyof pages 8-10)
+- Lionaki E et al. *BioEssays* **2023-01**. https://doi.org/10.1002/bies.202200160 (lionaki2023mitochondrialproteinimport pages 8-9)
+- Zhou J et al. *J Clin Invest* **2024-09**. https://doi.org/10.1172/jci175897 (zhou2024lactatesupportstreg pages 8-9)
+- Özdemir M, Dennerlein S. *Biological Chemistry* **2024-08**. https://doi.org/10.1515/hsz-2024-0043 (ozdemir2024thetomcomplex pages 1-7)
+- Waman VP et al. *Scientific Reports* **2024-11**. https://doi.org/10.1038/s41598-024-61541-1 (waman2024predictinghumanand pages 8-10)
+
+
+References
+
+1. (kreimendahl2020themitochondrialouter pages 1-3): Sebastian Kreimendahl and Joachim Rassow. The mitochondrial outer membrane protein tom70-mediator in protein traffic, membrane contact sites and innate immunity. International Journal of Molecular Sciences, 21:7262, Oct 2020. URL: https://doi.org/10.3390/ijms21197262, doi:10.3390/ijms21197262. This article has 98 citations.
+
+2. (kreimendahl2020themitochondrialouter pages 3-6): Sebastian Kreimendahl and Joachim Rassow. The mitochondrial outer membrane protein tom70-mediator in protein traffic, membrane contact sites and innate immunity. International Journal of Molecular Sciences, 21:7262, Oct 2020. URL: https://doi.org/10.3390/ijms21197262, doi:10.3390/ijms21197262. This article has 98 citations.
+
+3. (haastrup2023thejourneyof pages 8-10): Mary Oluwadamilola Haastrup, Kunwar Somesh Vikramdeo, Seema Singh, Ajay Pratap Singh, and Santanu Dasgupta. The journey of mitochondrial protein import and the roadmap to follow. International Journal of Molecular Sciences, 24:2479, Jan 2023. URL: https://doi.org/10.3390/ijms24032479, doi:10.3390/ijms24032479. This article has 30 citations.
+
+4. (kreimendahl2020themitochondrialouter pages 12-14): Sebastian Kreimendahl and Joachim Rassow. The mitochondrial outer membrane protein tom70-mediator in protein traffic, membrane contact sites and innate immunity. International Journal of Molecular Sciences, 21:7262, Oct 2020. URL: https://doi.org/10.3390/ijms21197262, doi:10.3390/ijms21197262. This article has 98 citations.
+
+5. (kreimendahl2020themitochondrialouter pages 14-16): Sebastian Kreimendahl and Joachim Rassow. The mitochondrial outer membrane protein tom70-mediator in protein traffic, membrane contact sites and innate immunity. International Journal of Molecular Sciences, 21:7262, Oct 2020. URL: https://doi.org/10.3390/ijms21197262, doi:10.3390/ijms21197262. This article has 98 citations.
+
+6. (pitt2021abiochemicaland pages 19-20): Ashley S. Pitt and Susan K. Buchanan. A biochemical and structural understanding of tom complex interactions and implications for human health and disease. Cells, 10:1164, May 2021. URL: https://doi.org/10.3390/cells10051164, doi:10.3390/cells10051164. This article has 46 citations.
+
+7. (pitt2021abiochemicaland pages 17-19): Ashley S. Pitt and Susan K. Buchanan. A biochemical and structural understanding of tom complex interactions and implications for human health and disease. Cells, 10:1164, May 2021. URL: https://doi.org/10.3390/cells10051164, doi:10.3390/cells10051164. This article has 46 citations.
+
+8. (kreimendahl2020themitochondrialouter pages 19-21): Sebastian Kreimendahl and Joachim Rassow. The mitochondrial outer membrane protein tom70-mediator in protein traffic, membrane contact sites and innate immunity. International Journal of Molecular Sciences, 21:7262, Oct 2020. URL: https://doi.org/10.3390/ijms21197262, doi:10.3390/ijms21197262. This article has 98 citations.
+
+9. (zhou2024lactatesupportstreg pages 8-9): Jinren Zhou, Jian Gu, Qufei Qian, Yigang Zhang, Tianning Huang, Xiangyu Li, Zhuoqun Liu, Qing Shao, Yuan Liang, Lei Qiao, Xiaozhang Xu, Qiuyang Chen, Zibo Xu, Yu Li, Ji Gao, Yufeng Pan, Yiming Wang, Roderick O’Connor, Keli L. Hippen, Ling Lu, and Bruce R. Blazar. Lactate supports treg function and immune balance via mgat1 effects on n-glycosylation in the mitochondria. Journal of Clinical Investigation, Sep 2024. URL: https://doi.org/10.1172/jci175897, doi:10.1172/jci175897. This article has 48 citations and is from a highest quality peer-reviewed journal.
+
+10. (waman2024predictinghumanand pages 8-10): Vaishali P. Waman, Paul Ashford, Su Datt Lam, Neeladri Sen, Mahnaz Abbasian, Laurel Woodridge, Yonathan Goldtzvik, Nicola Bordin, Jiaxin Wu, Ian Sillitoe, and Christine A Orengo. Predicting human and viral protein variants affecting covid-19 susceptibility and repurposing therapeutics. Scientific Reports, Nov 2024. URL: https://doi.org/10.1038/s41598-024-61541-1, doi:10.1038/s41598-024-61541-1. This article has 4 citations and is from a peer-reviewed journal.
+
+11. (lionaki2023mitochondrialproteinimport pages 8-9): Eirini Lionaki, Ilias Gkikas, and Nektarios Tavernarakis. Mitochondrial protein import machinery conveys stress signals to the cytosol and beyond. BioEssays, Jan 2023. URL: https://doi.org/10.1002/bies.202200160, doi:10.1002/bies.202200160. This article has 14 citations and is from a peer-reviewed journal.
+
+12. (ozdemir2024thetomcomplex pages 1-7): Metin Özdemir and Sven Dennerlein. The tom complex from an evolutionary perspective and the functions of tomm70. Biological Chemistry, 405:615-625, Aug 2024. URL: https://doi.org/10.1515/hsz-2024-0043, doi:10.1515/hsz-2024-0043. This article has 4 citations and is from a peer-reviewed journal.
+
+13. (wei2020mutationsintomm70 pages 1-2): Xiujuan Wei, Miaomiao Du, Jie Xie, Ting Luo, Yan Zhou, Kun Zhang, Jin Li, Deyu Chen, Pu Xu, Manli Jia, Huaibin Zhou, Hezhi Fang, Jianxin Lyu, and Yanling Yang. Mutations in tomm70 lead to multi-oxphos deficiencies and cause severe anemia, lactic acidosis, and developmental delay. Journal of Human Genetics, 65:231-240, Jan 2020. URL: https://doi.org/10.1038/s10038-019-0714-1, doi:10.1038/s10038-019-0714-1. This article has 41 citations and is from a peer-reviewed journal.
+
+14. (kreimendahl2020themitochondrialouter media bc2f2392): Sebastian Kreimendahl and Joachim Rassow. The mitochondrial outer membrane protein tom70-mediator in protein traffic, membrane contact sites and innate immunity. International Journal of Molecular Sciences, 21:7262, Oct 2020. URL: https://doi.org/10.3390/ijms21197262, doi:10.3390/ijms21197262. This article has 98 citations.
+
+15. (kreimendahl2020themitochondrialouter media 1214cc5a): Sebastian Kreimendahl and Joachim Rassow. The mitochondrial outer membrane protein tom70-mediator in protein traffic, membrane contact sites and innate immunity. International Journal of Molecular Sciences, 21:7262, Oct 2020. URL: https://doi.org/10.3390/ijms21197262, doi:10.3390/ijms21197262. This article has 98 citations.
+
+16. (kreimendahl2020themitochondrialouter media 41a8d14b): Sebastian Kreimendahl and Joachim Rassow. The mitochondrial outer membrane protein tom70-mediator in protein traffic, membrane contact sites and innate immunity. International Journal of Molecular Sciences, 21:7262, Oct 2020. URL: https://doi.org/10.3390/ijms21197262, doi:10.3390/ijms21197262. This article has 98 citations.
+
+17. (kreimendahl2020themitochondrialouter media 44199fa5): Sebastian Kreimendahl and Joachim Rassow. The mitochondrial outer membrane protein tom70-mediator in protein traffic, membrane contact sites and innate immunity. International Journal of Molecular Sciences, 21:7262, Oct 2020. URL: https://doi.org/10.3390/ijms21197262, doi:10.3390/ijms21197262. This article has 98 citations.
+
+18. (kreimendahl2020themitochondrialouter media 3b13eb9e): Sebastian Kreimendahl and Joachim Rassow. The mitochondrial outer membrane protein tom70-mediator in protein traffic, membrane contact sites and innate immunity. International Journal of Molecular Sciences, 21:7262, Oct 2020. URL: https://doi.org/10.3390/ijms21197262, doi:10.3390/ijms21197262. This article has 98 citations.
+
+## Citations
+
+1. zhou2024lactatesupportstreg pages 8-9
+2. waman2024predictinghumanand pages 8-10
+3. lionaki2023mitochondrialproteinimport pages 8-9
+4. ozdemir2024thetomcomplex pages 1-7
+5. kreimendahl2020themitochondrialouter pages 3-6
+6. kreimendahl2020themitochondrialouter pages 1-3
+7. pitt2021abiochemicaland pages 19-20
+8. haastrup2023thejourneyof pages 8-10
+9. kreimendahl2020themitochondrialouter pages 12-14
+10. kreimendahl2020themitochondrialouter pages 14-16
+11. pitt2021abiochemicaland pages 17-19
+12. kreimendahl2020themitochondrialouter pages 19-21
+13. https://doi.org/10.3390/ijms21197262
+14. https://doi.org/10.1515/hsz-2024-0043
+15. https://doi.org/10.3390/cells10051164
+16. https://doi.org/10.3390/ijms24032479
+17. https://doi.org/10.1002/bies.202200160
+18. https://doi.org/10.1038/s10038-019-0714-1
+19. https://doi.org/10.1002/1873-3468.14022
+20. https://doi.org/10.1172/jci175897
+21. https://doi.org/10.1038/s41598-024-61541-1
+22. https://doi.org/10.3390/ijms21197262,
+23. https://doi.org/10.3390/ijms24032479,
+24. https://doi.org/10.3390/cells10051164,
+25. https://doi.org/10.1172/jci175897,
+26. https://doi.org/10.1038/s41598-024-61541-1,
+27. https://doi.org/10.1002/bies.202200160,
+28. https://doi.org/10.1515/hsz-2024-0043,
+29. https://doi.org/10.1038/s10038-019-0714-1,


### PR DESCRIPTION
## Summary
- Add a Falcon deep research report for human TOMM70.
- Curate the TOMM70 review from INITIALIZED to COMPLETE using the Falcon evidence.
- Render the TOMM70 review HTML.

## Validation
- `uv run python scripts/validate_deep_research.py genes/human/TOMM70/TOMM70-deep-research-falcon.md`
- `just validate human TOMM70`
- `just render human TOMM70`
- `git diff --cached --check`