### PR TITLE
[codex] Add Falcon research reviews for TIMM genes

### DIFF
--- a/genes/human/TIMM44/TIMM44-ai-review.html
+++ b/genes/human/TIMM44/TIMM44-ai-review.html
@@ -1,0 +1,4663 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>TIMM44 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>TIMM44</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/O43615" target="_blank" class="term-link">
+                        O43615
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "TIMM44";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="O43615" data-a="DESCRIPTION: TIMM44 encodes a matrix-facing, peripheral inner m..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>TIMM44 encodes a matrix-facing, peripheral inner mitochondrial membrane coupling/scaffold component of the PAM import motor. It bridges the TIM23 channel to mitochondrial HSP70 and PAM co-chaperones, enabling ATP-dependent translocation of presequence-containing proteins into the mitochondrial matrix.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001405" target="_blank" class="term-link">
+                                    GO:0001405
+                                </a>
+                            </span>
+                            <span class="term-label">PAM complex, Tim23 associated import motor</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O43615" data-a="GO:0001405" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct and core. TIMM44 is a matrix-facing component of the PAM import motor coupled to TIM23.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM44/TIMM44-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Human **TIMM44** encodes *mitochondrial import inner membrane translocase subunit TIM44 (Tim44)*, a matrix-exposed component of the mitochondrial presequence import pathway that functionally couples the **TIM23** inner-membrane translocation channel to the **PAM** (presequence translocase–associated motor) mtHsp70-based import motor.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM44/TIMM44-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Human **TIMM44** is a matrix-facing, inner-membrane–associated coupling/scaffold protein that is essential for **TIM23-mediated presequence protein import** by physically and functionally bridging the TIM23 channel (notably via Tim17 binding) to the **PAM mtHsp70 motor** (via N-terminal interactions with mtHsp70 and Pam16/Pam18), enabling ATP-driven translocation into the mitochondrial matrix.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030674" target="_blank" class="term-link">
+                                    GO:0030674
+                                </a>
+                            </span>
+                            <span class="term-label">protein-macromolecule adaptor activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O43615" data-a="GO:0030674" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct and core. TIMM44 functions as a coupling/scaffold adaptor between TIM23 channel components and the PAM mtHsp70 motor.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM44/TIMM44-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Primary function (conceptual definition):** TIMM44 is best understood as a **two-domain coupling protein/scaffold** positioned at the matrix face of the inner membrane that (i) binds components of the TIM23 channel and (ii) recruits/positions mtHsp70 and its co-chaperones so that cycles of ATP-dependent substrate binding and release can drive vectorial translocation.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM44/TIMM44-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">In a mechanistic dissection of Tim44 (yeast Tim44; with explicit relevance to human TIMM44 via conserved architecture and discussion of a human variant), the **N-terminal domain** binds import-motor components including **mtHsp70** and the **Tim14–Tim16 (Pam18–Pam16)** subcomplex, whereas the **C-terminal domain** binds the channel, with a particularly strong interaction with **Tim17**, and lies near translocating precursor polypeptides.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM44/TIMM44-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Human **TIMM44** is a matrix-facing, inner-membrane–associated coupling/scaffold protein that is essential for **TIM23-mediated presequence protein import** by physically and functionally bridging the TIM23 channel (notably via Tim17 binding) to the **PAM mtHsp70 motor** (via N-terminal interactions with mtHsp70 and Pam16/Pam18), enabling ATP-driven translocation into the mitochondrial matrix.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030150" target="_blank" class="term-link">
+                                    GO:0030150
+                                </a>
+                            </span>
+                            <span class="term-label">protein import into mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O43615" data-a="GO:0030150" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct and core. TIMM44 enables ATP-dependent TIM23/PAM-mediated import of presequence-containing proteins into the mitochondrial matrix.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM44/TIMM44-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A large fraction of nuclear-encoded mitochondrial proteins are synthesized in the cytosol as precursors with N-terminal targeting presequences and are imported across the inner membrane through the **TIM23** translocase.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM44/TIMM44-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Human **TIMM44** is a matrix-facing, inner-membrane–associated coupling/scaffold protein that is essential for **TIM23-mediated presequence protein import** by physically and functionally bridging the TIM23 channel (notably via Tim17 binding) to the **PAM mtHsp70 motor** (via N-terminal interactions with mtHsp70 and Pam16/Pam18), enabling ATP-driven translocation into the mitochondrial matrix.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051087" target="_blank" class="term-link">
+                                    GO:0051087
+                                </a>
+                            </span>
+                            <span class="term-label">protein-folding chaperone binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O43615" data-a="GO:0051087" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct. TIMM44 recruits and positions mtHsp70 and PAM co-chaperones at the matrix side of TIM23, making chaperone binding central to its import-motor role.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM44/TIMM44-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Primary function (conceptual definition):** TIMM44 is best understood as a **two-domain coupling protein/scaffold** positioned at the matrix face of the inner membrane that (i) binds components of the TIM23 channel and (ii) recruits/positions mtHsp70 and its co-chaperones so that cycles of ATP-dependent substrate binding and release can drive vectorial translocation.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM44/TIMM44-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">In a mechanistic dissection of Tim44 (yeast Tim44; with explicit relevance to human TIMM44 via conserved architecture and discussion of a human variant), the **N-terminal domain** binds import-motor components including **mtHsp70** and the **Tim14–Tim16 (Pam18–Pam16)** subcomplex, whereas the **C-terminal domain** binds the channel, with a particularly strong interaction with **Tim17**, and lies near translocating precursor polypeptides.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005743" target="_blank" class="term-link">
+                                    GO:0005743
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial inner membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O43615" data-a="GO:0005743" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct. TIMM44 is matrix-exposed and peripherally associated with the mitochondrial inner membrane.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM44/TIMM44-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">TIMM44 is **matrix-exposed** and **peripherally associated with the inner mitochondrial membrane** (i.e., it is not itself the transmembrane pore).</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM44/TIMM44-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Human **TIMM44** is a matrix-facing, inner-membrane–associated coupling/scaffold protein that is essential for **TIM23-mediated presequence protein import** by physically and functionally bridging the TIM23 channel (notably via Tim17 binding) to the **PAM mtHsp70 motor** (via N-terminal interactions with mtHsp70 and Pam16/Pam18), enabling ATP-driven translocation into the mitochondrial matrix.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O43615" data-a="GO:0005759" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct. TIMM44 is matrix-exposed and peripherally associated with the mitochondrial inner membrane.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM44/TIMM44-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">TIMM44 is **matrix-exposed** and **peripherally associated with the inner mitochondrial membrane** (i.e., it is not itself the transmembrane pore).</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM44/TIMM44-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Human **TIMM44** is a matrix-facing, inner-membrane–associated coupling/scaffold protein that is essential for **TIM23-mediated presequence protein import** by physically and functionally bridging the TIM23 channel (notably via Tim17 binding) to the **PAM mtHsp70 motor** (via N-terminal interactions with mtHsp70 and Pam16/Pam18), enabling ATP-driven translocation into the mitochondrial matrix.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030150" target="_blank" class="term-link">
+                                    GO:0030150
+                                </a>
+                            </span>
+                            <span class="term-label">protein import into mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O43615" data-a="GO:0030150" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct and core. TIMM44 enables ATP-dependent TIM23/PAM-mediated import of presequence-containing proteins into the mitochondrial matrix.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM44/TIMM44-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A large fraction of nuclear-encoded mitochondrial proteins are synthesized in the cytosol as precursors with N-terminal targeting presequences and are imported across the inner membrane through the **TIM23** translocase.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM44/TIMM44-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Human **TIMM44** is a matrix-facing, inner-membrane–associated coupling/scaffold protein that is essential for **TIM23-mediated presequence protein import** by physically and functionally bridging the TIM23 channel (notably via Tim17 binding) to the **PAM mtHsp70 motor** (via N-terminal interactions with mtHsp70 and Pam16/Pam18), enabling ATP-driven translocation into the mitochondrial matrix.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045184" target="_blank" class="term-link">
+                                    GO:0045184
+                                </a>
+                            </span>
+                            <span class="term-label">establishment of protein localization</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O43615" data-a="GO:0045184" data-r="GO_REF:0000117" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct pathway family but too broad. TIMM44 specifically supports mitochondrial presequence protein import via TIM23/PAM.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Use mitochondrial matrix import and PAM adaptor/chaperone-binding terms instead of generic establishment of protein localization.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM44/TIMM44-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A large fraction of nuclear-encoded mitochondrial proteins are synthesized in the cytosol as precursors with N-terminal targeting presequences and are imported across the inner membrane through the **TIM23** translocase.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM44/TIMM44-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Human **TIMM44** is a matrix-facing, inner-membrane–associated coupling/scaffold protein that is essential for **TIM23-mediated presequence protein import** by physically and functionally bridging the TIM23 channel (notably via Tim17 binding) to the **PAM mtHsp70 motor** (via N-terminal interactions with mtHsp70 and Pam16/Pam18), enabling ATP-driven translocation into the mitochondrial matrix.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051087" target="_blank" class="term-link">
+                                    GO:0051087
+                                </a>
+                            </span>
+                            <span class="term-label">protein-folding chaperone binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O43615" data-a="GO:0051087" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct. TIMM44 recruits and positions mtHsp70 and PAM co-chaperones at the matrix side of TIM23, making chaperone binding central to its import-motor role.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM44/TIMM44-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Primary function (conceptual definition):** TIMM44 is best understood as a **two-domain coupling protein/scaffold** positioned at the matrix face of the inner membrane that (i) binds components of the TIM23 channel and (ii) recruits/positions mtHsp70 and its co-chaperones so that cycles of ATP-dependent substrate binding and release can drive vectorial translocation.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM44/TIMM44-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">In a mechanistic dissection of Tim44 (yeast Tim44; with explicit relevance to human TIMM44 via conserved architecture and discussion of a human variant), the **N-terminal domain** binds import-motor components including **mtHsp70** and the **Tim14–Tim16 (Pam18–Pam16)** subcomplex, whereas the **C-terminal domain** binds the channel, with a particularly strong interaction with **Tim17**, and lies near translocating precursor polypeptides.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12620389" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12620389
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Novel raf kinase protein-protein interactions found by an ex...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O43615" data-a="GO:0005515" data-r="PMID:12620389" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Protein binding is too generic for TIMM44. The informative molecular role is adaptor/scaffold coupling of TIM23 channel components with mtHsp70/PAM motor components.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Replace generic protein-binding capture with protein-macromolecule adaptor activity and protein-folding chaperone binding where supported.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM44/TIMM44-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Primary function (conceptual definition):** TIMM44 is best understood as a **two-domain coupling protein/scaffold** positioned at the matrix face of the inner membrane that (i) binds components of the TIM23 channel and (ii) recruits/positions mtHsp70 and its co-chaperones so that cycles of ATP-dependent substrate binding and release can drive vectorial translocation.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM44/TIMM44-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">In a mechanistic dissection of Tim44 (yeast Tim44; with explicit relevance to human TIMM44 via conserved architecture and discussion of a human variant), the **N-terminal domain** binds import-motor components including **mtHsp70** and the **Tim14–Tim16 (Pam18–Pam16)** subcomplex, whereas the **C-terminal domain** binds the channel, with a particularly strong interaction with **Tim17**, and lies near translocating precursor polypeptides.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25416956" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25416956
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A proteome-scale map of the human interactome network.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O43615" data-a="GO:0005515" data-r="PMID:25416956" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Protein binding is too generic for TIMM44. The informative molecular role is adaptor/scaffold coupling of TIM23 channel components with mtHsp70/PAM motor components.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Replace generic protein-binding capture with protein-macromolecule adaptor activity and protein-folding chaperone binding where supported.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM44/TIMM44-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Primary function (conceptual definition):** TIMM44 is best understood as a **two-domain coupling protein/scaffold** positioned at the matrix face of the inner membrane that (i) binds components of the TIM23 channel and (ii) recruits/positions mtHsp70 and its co-chaperones so that cycles of ATP-dependent substrate binding and release can drive vectorial translocation.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM44/TIMM44-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">In a mechanistic dissection of Tim44 (yeast Tim44; with explicit relevance to human TIMM44 via conserved architecture and discussion of a human variant), the **N-terminal domain** binds import-motor components including **mtHsp70** and the **Tim14–Tim16 (Pam18–Pam16)** subcomplex, whereas the **C-terminal domain** binds the channel, with a particularly strong interaction with **Tim17**, and lies near translocating precursor polypeptides.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25910212" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25910212
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Widespread macromolecular interaction perturbations in human...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O43615" data-a="GO:0005515" data-r="PMID:25910212" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Protein binding is too generic for TIMM44. The informative molecular role is adaptor/scaffold coupling of TIM23 channel components with mtHsp70/PAM motor components.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Replace generic protein-binding capture with protein-macromolecule adaptor activity and protein-folding chaperone binding where supported.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM44/TIMM44-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Primary function (conceptual definition):** TIMM44 is best understood as a **two-domain coupling protein/scaffold** positioned at the matrix face of the inner membrane that (i) binds components of the TIM23 channel and (ii) recruits/positions mtHsp70 and its co-chaperones so that cycles of ATP-dependent substrate binding and release can drive vectorial translocation.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM44/TIMM44-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">In a mechanistic dissection of Tim44 (yeast Tim44; with explicit relevance to human TIMM44 via conserved architecture and discussion of a human variant), the **N-terminal domain** binds import-motor components including **mtHsp70** and the **Tim14–Tim16 (Pam18–Pam16)** subcomplex, whereas the **C-terminal domain** binds the channel, with a particularly strong interaction with **Tim17**, and lies near translocating precursor polypeptides.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:32296183
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A reference map of the human binary protein interactome.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O43615" data-a="GO:0005515" data-r="PMID:32296183" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Protein binding is too generic for TIMM44. The informative molecular role is adaptor/scaffold coupling of TIM23 channel components with mtHsp70/PAM motor components.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Replace generic protein-binding capture with protein-macromolecule adaptor activity and protein-folding chaperone binding where supported.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM44/TIMM44-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Primary function (conceptual definition):** TIMM44 is best understood as a **two-domain coupling protein/scaffold** positioned at the matrix face of the inner membrane that (i) binds components of the TIM23 channel and (ii) recruits/positions mtHsp70 and its co-chaperones so that cycles of ATP-dependent substrate binding and release can drive vectorial translocation.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM44/TIMM44-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">In a mechanistic dissection of Tim44 (yeast Tim44; with explicit relevance to human TIMM44 via conserved architecture and discussion of a human variant), the **N-terminal domain** binds import-motor components including **mtHsp70** and the **Tim14–Tim16 (Pam18–Pam16)** subcomplex, whereas the **C-terminal domain** binds the channel, with a particularly strong interaction with **Tim17**, and lies near translocating precursor polypeptides.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/32814053" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:32814053
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Interactome Mapping Provides a Network of Neurodegenerative ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O43615" data-a="GO:0005515" data-r="PMID:32814053" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Protein binding is too generic for TIMM44. The informative molecular role is adaptor/scaffold coupling of TIM23 channel components with mtHsp70/PAM motor components.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Replace generic protein-binding capture with protein-macromolecule adaptor activity and protein-folding chaperone binding where supported.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM44/TIMM44-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Primary function (conceptual definition):** TIMM44 is best understood as a **two-domain coupling protein/scaffold** positioned at the matrix face of the inner membrane that (i) binds components of the TIM23 channel and (ii) recruits/positions mtHsp70 and its co-chaperones so that cycles of ATP-dependent substrate binding and release can drive vectorial translocation.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM44/TIMM44-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">In a mechanistic dissection of Tim44 (yeast Tim44; with explicit relevance to human TIMM44 via conserved architecture and discussion of a human variant), the **N-terminal domain** binds import-motor components including **mtHsp70** and the **Tim14–Tim16 (Pam18–Pam16)** subcomplex, whereas the **C-terminal domain** binds the channel, with a particularly strong interaction with **Tim17**, and lies near translocating precursor polypeptides.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005743" target="_blank" class="term-link">
+                                    GO:0005743
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial inner membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10339406" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10339406
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Genetic and structural characterization of the human mitocho...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O43615" data-a="GO:0005743" data-r="PMID:10339406" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct. TIMM44 is matrix-exposed and peripherally associated with the mitochondrial inner membrane.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM44/TIMM44-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">TIMM44 is **matrix-exposed** and **peripherally associated with the inner mitochondrial membrane** (i.e., it is not itself the transmembrane pore).</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM44/TIMM44-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Human **TIMM44** is a matrix-facing, inner-membrane–associated coupling/scaffold protein that is essential for **TIM23-mediated presequence protein import** by physically and functionally bridging the TIM23 channel (notably via Tim17 binding) to the **PAM mtHsp70 motor** (via N-terminal interactions with mtHsp70 and Pam16/Pam18), enabling ATP-driven translocation into the mitochondrial matrix.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005744" target="_blank" class="term-link">
+                                    GO:0005744
+                                </a>
+                            </span>
+                            <span class="term-label">TIM23 mitochondrial import inner membrane translocase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10339406" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10339406
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Genetic and structural characterization of the human mitocho...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="O43615" data-a="GO:0005744" data-r="PMID:10339406" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> TIMM44 is functionally coupled to TIM23, but the more precise complex term is PAM complex rather than the TIM23 translocase core complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Use the PAM complex term for TIMM44 complex membership; TIMM44 bridges to TIM23 but is best curated as a PAM import-motor component.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001405" target="_blank" class="term-link">
+                                    PAM complex, Tim23 associated import motor
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM44/TIMM44-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Human **TIMM44** encodes *mitochondrial import inner membrane translocase subunit TIM44 (Tim44)*, a matrix-exposed component of the mitochondrial presequence import pathway that functionally couples the **TIM23** inner-membrane translocation channel to the **PAM** (presequence translocase–associated motor) mtHsp70-based import motor.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM44/TIMM44-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Human **TIMM44** is a matrix-facing, inner-membrane–associated coupling/scaffold protein that is essential for **TIM23-mediated presequence protein import** by physically and functionally bridging the TIM23 channel (notably via Tim17 binding) to the **PAM mtHsp70 motor** (via N-terminal interactions with mtHsp70 and Pam16/Pam18), enabling ATP-driven translocation into the mitochondrial matrix.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006886" target="_blank" class="term-link">
+                                    GO:0006886
+                                </a>
+                            </span>
+                            <span class="term-label">intracellular protein transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10339406" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10339406
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Genetic and structural characterization of the human mitocho...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O43615" data-a="GO:0006886" data-r="PMID:10339406" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct pathway family but too broad. TIMM44 functions in TIM23/PAM-mediated mitochondrial presequence import, not general intracellular protein transport.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Prefer protein import into mitochondrial matrix and PAM complex terms.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM44/TIMM44-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A large fraction of nuclear-encoded mitochondrial proteins are synthesized in the cytosol as precursors with N-terminal targeting presequences and are imported across the inner membrane through the **TIM23** translocase.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM44/TIMM44-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Human **TIMM44** is a matrix-facing, inner-membrane–associated coupling/scaffold protein that is essential for **TIM23-mediated presequence protein import** by physically and functionally bridging the TIM23 channel (notably via Tim17 binding) to the **PAM mtHsp70 motor** (via N-terminal interactions with mtHsp70 and Pam16/Pam18), enabling ATP-driven translocation into the mitochondrial matrix.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030150" target="_blank" class="term-link">
+                                    GO:0030150
+                                </a>
+                            </span>
+                            <span class="term-label">protein import into mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10339406" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10339406
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Genetic and structural characterization of the human mitocho...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O43615" data-a="GO:0030150" data-r="PMID:10339406" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct and core. TIMM44 enables ATP-dependent TIM23/PAM-mediated import of presequence-containing proteins into the mitochondrial matrix.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM44/TIMM44-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A large fraction of nuclear-encoded mitochondrial proteins are synthesized in the cytosol as precursors with N-terminal targeting presequences and are imported across the inner membrane through the **TIM23** translocase.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM44/TIMM44-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Human **TIMM44** is a matrix-facing, inner-membrane–associated coupling/scaffold protein that is essential for **TIM23-mediated presequence protein import** by physically and functionally bridging the TIM23 channel (notably via Tim17 binding) to the **PAM mtHsp70 motor** (via N-terminal interactions with mtHsp70 and Pam16/Pam18), enabling ATP-driven translocation into the mitochondrial matrix.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000052
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O43615" data-a="GO:0005739" data-r="GO_REF:0000052" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct but broad. TIMM44 is specifically matrix-facing and associated with the mitochondrial inner membrane/PAM import motor.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Prefer mitochondrial inner membrane, mitochondrial matrix, and PAM complex annotations over generic mitochondrion.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM44/TIMM44-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">TIMM44 is **matrix-exposed** and **peripherally associated with the inner mitochondrial membrane** (i.e., it is not itself the transmembrane pore).</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM44/TIMM44-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Human **TIMM44** is a matrix-facing, inner-membrane–associated coupling/scaffold protein that is essential for **TIM23-mediated presequence protein import** by physically and functionally bridging the TIM23 channel (notably via Tim17 binding) to the **PAM mtHsp70 motor** (via N-terminal interactions with mtHsp70 and Pam16/Pam18), enabling ATP-driven translocation into the mitochondrial matrix.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HTP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:34800366
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Quantitative high-confidence human mitochondrial proteome an...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O43615" data-a="GO:0005739" data-r="PMID:34800366" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct but broad. TIMM44 is specifically matrix-facing and associated with the mitochondrial inner membrane/PAM import motor.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Prefer mitochondrial inner membrane, mitochondrial matrix, and PAM complex annotations over generic mitochondrion.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM44/TIMM44-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">TIMM44 is **matrix-exposed** and **peripherally associated with the inner mitochondrial membrane** (i.e., it is not itself the transmembrane pore).</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM44/TIMM44-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Human **TIMM44** is a matrix-facing, inner-membrane–associated coupling/scaffold protein that is essential for **TIM23-mediated presequence protein import** by physically and functionally bridging the TIM23 channel (notably via Tim17 binding) to the **PAM mtHsp70 motor** (via N-terminal interactions with mtHsp70 and Pam16/Pam18), enabling ATP-driven translocation into the mitochondrial matrix.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005744" target="_blank" class="term-link">
+                                    GO:0005744
+                                </a>
+                            </span>
+                            <span class="term-label">TIM23 mitochondrial import inner membrane translocase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/30598479" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:30598479
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    ROMO1 is a constituent of the human presequence translocase ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="O43615" data-a="GO:0005744" data-r="PMID:30598479" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> TIMM44 is functionally coupled to TIM23, but the more precise complex term is PAM complex rather than the TIM23 translocase core complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Use the PAM complex term for TIMM44 complex membership; TIMM44 bridges to TIM23 but is best curated as a PAM import-motor component.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001405" target="_blank" class="term-link">
+                                    PAM complex, Tim23 associated import motor
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM44/TIMM44-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Human **TIMM44** encodes *mitochondrial import inner membrane translocase subunit TIM44 (Tim44)*, a matrix-exposed component of the mitochondrial presequence import pathway that functionally couples the **TIM23** inner-membrane translocation channel to the **PAM** (presequence translocase–associated motor) mtHsp70-based import motor.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM44/TIMM44-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Human **TIMM44** is a matrix-facing, inner-membrane–associated coupling/scaffold protein that is essential for **TIM23-mediated presequence protein import** by physically and functionally bridging the TIM23 channel (notably via Tim17 binding) to the **PAM mtHsp70 motor** (via N-terminal interactions with mtHsp70 and Pam16/Pam18), enabling ATP-driven translocation into the mitochondrial matrix.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005743" target="_blank" class="term-link">
+                                    GO:0005743
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial inner membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20053669" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:20053669
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Role of Magmas in protein transport and human mitochondria b...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O43615" data-a="GO:0005743" data-r="PMID:20053669" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct. TIMM44 is matrix-exposed and peripherally associated with the mitochondrial inner membrane.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM44/TIMM44-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">TIMM44 is **matrix-exposed** and **peripherally associated with the inner mitochondrial membrane** (i.e., it is not itself the transmembrane pore).</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM44/TIMM44-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Human **TIMM44** is a matrix-facing, inner-membrane–associated coupling/scaffold protein that is essential for **TIM23-mediated presequence protein import** by physically and functionally bridging the TIM23 channel (notably via Tim17 binding) to the **PAM mtHsp70 motor** (via N-terminal interactions with mtHsp70 and Pam16/Pam18), enabling ATP-driven translocation into the mitochondrial matrix.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005743" target="_blank" class="term-link">
+                                    GO:0005743
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial inner membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10339406" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10339406
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Genetic and structural characterization of the human mitocho...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O43615" data-a="GO:0005743" data-r="PMID:10339406" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct. TIMM44 is matrix-exposed and peripherally associated with the mitochondrial inner membrane.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM44/TIMM44-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">TIMM44 is **matrix-exposed** and **peripherally associated with the inner mitochondrial membrane** (i.e., it is not itself the transmembrane pore).</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM44/TIMM44-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Human **TIMM44** is a matrix-facing, inner-membrane–associated coupling/scaffold protein that is essential for **TIM23-mediated presequence protein import** by physically and functionally bridging the TIM23 channel (notably via Tim17 binding) to the **PAM mtHsp70 motor** (via N-terminal interactions with mtHsp70 and Pam16/Pam18), enabling ATP-driven translocation into the mitochondrial matrix.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10339406" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10339406
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Genetic and structural characterization of the human mitocho...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O43615" data-a="GO:0005759" data-r="PMID:10339406" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct. TIMM44 is matrix-exposed and peripherally associated with the mitochondrial inner membrane.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM44/TIMM44-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">TIMM44 is **matrix-exposed** and **peripherally associated with the inner mitochondrial membrane** (i.e., it is not itself the transmembrane pore).</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM44/TIMM44-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Human **TIMM44** is a matrix-facing, inner-membrane–associated coupling/scaffold protein that is essential for **TIM23-mediated presequence protein import** by physically and functionally bridging the TIM23 channel (notably via Tim17 binding) to the **PAM mtHsp70 motor** (via N-terminal interactions with mtHsp70 and Pam16/Pam18), enabling ATP-driven translocation into the mitochondrial matrix.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>TIMM44 is the matrix-facing PAM complex coupling/scaffold subunit that connects the TIM23 channel to mtHsp70 and PAM co-chaperones, enabling ATP-dependent translocation of presequence-containing proteins into the mitochondrial matrix.</h3>
+                <span class="vote-buttons" data-g="O43615" data-a="FUNCTION: TIMM44 is the matrix-facing PAM complex coupling/s..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030674" target="_blank" class="term-link">
+                            protein-macromolecule adaptor activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030150" target="_blank" class="term-link">
+                                protein import into mitochondrial matrix
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005743" target="_blank" class="term-link">
+                                mitochondrial inner membrane
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                mitochondrial matrix
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001405" target="_blank" class="term-link">
+                            PAM complex, Tim23 associated import motor
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/TIMM44/TIMM44-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">Human **TIMM44** encodes *mitochondrial import inner membrane translocase subunit TIM44 (Tim44)*, a matrix-exposed component of the mitochondrial presequence import pathway that functionally couples the **TIM23** inner-membrane translocation channel to the **PAM** (presequence translocase–associated motor) mtHsp70-based import motor.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/TIMM44/TIMM44-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">**Primary function (conceptual definition):** TIMM44 is best understood as a **two-domain coupling protein/scaffold** positioned at the matrix face of the inner membrane that (i) binds components of the TIM23 channel and (ii) recruits/positions mtHsp70 and its co-chaperones so that cycles of ATP-dependent substrate binding and release can drive vectorial translocation.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/TIMM44/TIMM44-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">In a mechanistic dissection of Tim44 (yeast Tim44; with explicit relevance to human TIMM44 via conserved architecture and discussion of a human variant), the **N-terminal domain** binds import-motor components including **mtHsp70** and the **Tim14–Tim16 (Pam18–Pam16)** subcomplex, whereas the **C-terminal domain** binds the channel, with a particularly strong interaction with **Tim17**, and lies near translocating precursor polypeptides.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/TIMM44/TIMM44-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">Human **TIMM44** is a matrix-facing, inner-membrane–associated coupling/scaffold protein that is essential for **TIM23-mediated presequence protein import** by physically and functionally bridging the TIM23 channel (notably via Tim17 binding) to the **PAM mtHsp70 motor** (via N-terminal interactions with mtHsp70 and Pam16/Pam18), enabling ATP-driven translocation into the mitochondrial matrix.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000052.md" target="_blank" class="term-link">
+                            GO_REF:0000052
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on curation of immunofluorescence data</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
+                            GO_REF:0000117
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/10339406" target="_blank" class="term-link">
+                            PMID:10339406
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Genetic and structural characterization of the human mitochondrial inner membrane translocase.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/12620389" target="_blank" class="term-link">
+                            PMID:12620389
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Novel raf kinase protein-protein interactions found by an exhaustive yeast two-hybrid analysis.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/20053669" target="_blank" class="term-link">
+                            PMID:20053669
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Role of Magmas in protein transport and human mitochondria biogenesis.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/25416956" target="_blank" class="term-link">
+                            PMID:25416956
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A proteome-scale map of the human interactome network.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/25910212" target="_blank" class="term-link">
+                            PMID:25910212
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Widespread macromolecular interaction perturbations in human genetic disorders.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/30598479" target="_blank" class="term-link">
+                            PMID:30598479
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">ROMO1 is a constituent of the human presequence translocase required for YME1L protease import.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
+                            PMID:32296183
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A reference map of the human binary protein interactome.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/32814053" target="_blank" class="term-link">
+                            PMID:32814053
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Interactome Mapping Provides a Network of Neurodegenerative Disease Proteins and Uncovers Widespread Protein Aggregation in Affected Brains.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link">
+                            PMID:34800366
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Quantitative high-confidence human mitochondrial proteome and its dynamics in cellular context.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/TIMM44/TIMM44-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research report for human TIMM44</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Which TIMM44 surfaces most strongly determine TIM23 channel binding versus mtHsp70/PAM motor recruitment in human cells?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="O43615" data-a="Q: Which TIMM44 surfaces most strongly determine TIM2..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Do cancer and angiogenesis phenotypes from TIMM44 inhibition reflect direct import failure, secondary ATP/ROS stress, or both?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="O43615" data-a="Q: Do cancer and angiogenesis phenotypes from TIMM44 ..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Perform rescue of TIMM44-depleted human cells with N-domain and C-domain interface mutants, then quantify TIM23 complex association, mtHsp70 recruitment, and matrix-import reporter flux.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: TIMM44 channel-binding and motor-recruitment functions can be separated by domain-specific mutants.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="O43615" data-a="EXPERIMENT: Perform rescue of TIMM44-depleted human cells with..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Compare MB-10 treatment with TIMM44 knockout and resistant TIMM44 rescue for acute precursor import, PAM/TIM23 assembly, ATP/ROS changes, and Akt-mTOR signaling readouts.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: MB-10 phenotypes primarily reflect inhibition of TIMM44-dependent protein import.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="O43615" data-a="EXPERIMENT: Compare MB-10 treatment with TIMM44 knockout and r..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Deep Research Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(TIMM44-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="O43615" data-a="DOC: Deep Research Falcon" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <hr />
+<p>provider: falcon<br />
+model: Edison Scientific Literature<br />
+cached: false<br />
+start_time: '2026-05-11T16:35:51.753745'<br />
+end_time: '2026-05-11T16:50:32.852225'<br />
+duration_seconds: 881.1<br />
+template_file: templates/gene_research_go_focused.md<br />
+template_variables:<br />
+  organism: human<br />
+  gene_id: TIMM44<br />
+  gene_symbol: TIMM44<br />
+  uniprot_accession: O43615<br />
+  protein_description: 'RecName: Full=Mitochondrial import inner membrane translocase<br />
+    subunit TIM44; Flags: Precursor;'<br />
+  gene_info: Name=TIMM44; Synonyms=MIMT44, TIM44;<br />
+  organism_full: Homo sapiens (Human).<br />
+  protein_family: Belongs to the Tim44 family. .<br />
+  protein_domains: NTF2-like_dom_sf. (IPR032710); Tim44. (IPR017303); Tim44-like.<br />
+    (IPR039544); Tim44-like_dom. (IPR007379); Tim44 (PF04280)<br />
+provider_config:<br />
+  timeout: 600<br />
+  max_retries: 3<br />
+  parameters:<br />
+    allowed_domains: []<br />
+    temperature: 0.1<br />
+citation_count: 30</p>
+<hr />
+<h2 id="question">Question</h2>
+<h1 id="gene-research-for-functional-annotation">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> O43615</li>
+<li><strong>Protein Description:</strong> RecName: Full=Mitochondrial import inner membrane translocase subunit TIM44; Flags: Precursor;</li>
+<li><strong>Gene Information:</strong> Name=TIMM44; Synonyms=MIMT44, TIM44;</li>
+<li><strong>Organism (full):</strong> Homo sapiens (Human).</li>
+<li><strong>Protein Family:</strong> Belongs to the Tim44 family. .</li>
+<li><strong>Key Domains:</strong> NTF2-like_dom_sf. (IPR032710); Tim44. (IPR017303); Tim44-like. (IPR039544); Tim44-like_dom. (IPR007379); Tim44 (PF04280)</li>
+</ul>
+<h3 id="mandatory-verification-steps">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "TIMM44" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Homo sapiens (Human).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'TIMM44' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>TIMM44</strong> (gene ID: TIMM44, UniProt: O43615) in human.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="output">Output</h2>
+<p>Question: You are an expert researcher providing comprehensive, well-cited information.</p>
+<p>Provide detailed information focusing on:<br />
+1. Key concepts and definitions with current understanding<br />
+2. Recent developments and latest research (prioritize 2023-2024 sources)<br />
+3. Current applications and real-world implementations<br />
+4. Expert opinions and analysis from authoritative sources<br />
+5. Relevant statistics and data from recent studies</p>
+<p>Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.<br />
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.</p>
+<h1 id="gene-research-for-functional-annotation_1">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context_1">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot_1">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> O43615</li>
+<li><strong>Protein Description:</strong> RecName: Full=Mitochondrial import inner membrane translocase subunit TIM44; Flags: Precursor;</li>
+<li><strong>Gene Information:</strong> Name=TIMM44; Synonyms=MIMT44, TIM44;</li>
+<li><strong>Organism (full):</strong> Homo sapiens (Human).</li>
+<li><strong>Protein Family:</strong> Belongs to the Tim44 family. .</li>
+<li><strong>Key Domains:</strong> NTF2-like_dom_sf. (IPR032710); Tim44. (IPR017303); Tim44-like. (IPR039544); Tim44-like_dom. (IPR007379); Tim44 (PF04280)</li>
+</ul>
+<h3 id="mandatory-verification-steps_1">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "TIMM44" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Homo sapiens (Human).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature_1">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'TIMM44' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target_1">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>TIMM44</strong> (gene ID: TIMM44, UniProt: O43615) in human.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="research-report-human-timm44-uniprot-o43615-functional-annotation-and-recent-research">Research report: Human <strong>TIMM44</strong> (UniProt O43615) — functional annotation and recent research</h1>
+<h2 id="1-target-verification-geneprotein-identity">1) Target verification (gene/protein identity)</h2>
+<p>Human <strong>TIMM44</strong> encodes <em>mitochondrial import inner membrane translocase subunit TIM44 (Tim44)</em>, a matrix-exposed component of the mitochondrial presequence import pathway that functionally couples the <strong>TIM23</strong> inner-membrane translocation channel to the <strong>PAM</strong> (presequence translocase–associated motor) mtHsp70-based import motor. (demishteinzohary2017thetim23mitochondrial pages 3-4, demishteinzohary2017thetim23mitochondrial pages 4-5, demishteinzohary2017thetim23mitochondrial pages 1-3)</p>
+<h2 id="2-key-concepts-definitions-and-current-mechanistic-understanding">2) Key concepts, definitions, and current mechanistic understanding</h2>
+<h3 id="21-mitochondrial-presequence-import-via-tim23-and-the-pam-motor">2.1 Mitochondrial presequence import via TIM23 and the PAM motor</h3>
+<p>A large fraction of nuclear-encoded mitochondrial proteins are synthesized in the cytosol as precursors with N-terminal targeting presequences and are imported across the inner membrane through the <strong>TIM23</strong> translocase. Import across the inner membrane is driven by the <strong>membrane potential</strong> and by ATP hydrolysis by an mtHsp70-based motor on the matrix side (PAM). Tim44/TIMM44 is a core motor-associated component that organizes this coupling between the pore and the motor. (demishteinzohary2017thetim23mitochondrial pages 4-5, demishteinzohary2017thetim23mitochondrial pages 1-3)</p>
+<h3 id="22-primary-molecular-function-of-timm44-couplingscaffold-for-channelmotor-communication">2.2 Primary molecular function of TIMM44: coupling/scaffold for channel–motor communication</h3>
+<p><strong>Primary function (conceptual definition):</strong> TIMM44 is best understood as a <strong>two-domain coupling protein/scaffold</strong> positioned at the matrix face of the inner membrane that (i) binds components of the TIM23 channel and (ii) recruits/positions mtHsp70 and its co-chaperones so that cycles of ATP-dependent substrate binding and release can drive vectorial translocation. (banerjee2015proteintranslocationchannel pages 11-13, banerjee2015proteintranslocationchannel pages 9-11, banerjee2015proteintranslocationchannel pages 7-9)</p>
+<p><strong>Domain-resolved interactions (mechanistic evidence):</strong> In a mechanistic dissection of Tim44 (yeast Tim44; with explicit relevance to human TIMM44 via conserved architecture and discussion of a human variant), the <strong>N-terminal domain</strong> binds import-motor components including <strong>mtHsp70</strong> and the <strong>Tim14–Tim16 (Pam18–Pam16)</strong> subcomplex, whereas the <strong>C-terminal domain</strong> binds the channel, with a particularly strong interaction with <strong>Tim17</strong>, and lies near translocating precursor polypeptides. (banerjee2015proteintranslocationchannel pages 11-13, banerjee2015proteintranslocationchannel pages 9-11, banerjee2015proteintranslocationchannel pages 7-9)</p>
+<p><strong>Communication model:</strong> Banerjee et al. propose that translocating proteins stimulate rearrangements between Tim44’s N- and C-domains, enabling communication between TIM23 channel conformational states and PAM motor activity (notably Tim14/Tim16 stimulation of mtHsp70 ATPase cycling). (banerjee2015proteintranslocationchannel pages 11-13, banerjee2015proteintranslocationchannel pages 1-2)</p>
+<h3 id="23-sub-mitochondrial-localization">2.3 Sub-mitochondrial localization</h3>
+<p>TIMM44 is <strong>matrix-exposed</strong> and <strong>peripherally associated with the inner mitochondrial membrane</strong> (i.e., it is not itself the transmembrane pore). It functions as a membrane-proximal docking platform for the motor on the matrix side, positioned at the outlet of the TIM23 channel to coordinate engagement of emerging polypeptides by mtHsp70. (demishteinzohary2017thetim23mitochondrial pages 3-4, demishteinzohary2017thetim23mitochondrial pages 4-5)</p>
+<h3 id="24-membrane-recruitment-and-lipid-interactions">2.4 Membrane recruitment and lipid interactions</h3>
+<p>A central segment of Tim44 contains amphipathic membrane-recruitment helices that support association with cardiolipin-containing membranes, consistent with a peripheral inner-membrane anchor that can transmit conformational changes between channel-contacting and motor-contacting regions. (banerjee2015proteintranslocationchannel pages 11-13, banerjee2015proteintranslocationchannel pages 9-11)</p>
+<h3 id="25-human-specific-notes-and-disease-linked-variant">2.5 Human-specific notes and disease-linked variant</h3>
+<p>Banerjee et al. discuss a <strong>human missense variant Pro308Gln</strong> linked to familial oncocytic thyroid carcinoma and map it to a short loop in the C-terminal domain; the analogous mutation in yeast reduces thermal stability, supporting the interpretation that C-domain conformational integrity/flexibility is important for Tim44/TIMM44 function. (banerjee2015proteintranslocationchannel pages 11-13, banerjee2015proteintranslocationchannel pages 9-11)</p>
+<h2 id="3-recent-developments-prioritizing-20232024">3) Recent developments (prioritizing 2023–2024)</h2>
+<h3 id="31-timm44-as-a-modulator-of-angiogenesis-2023">3.1 TIMM44 as a modulator of angiogenesis (2023)</h3>
+<p>A 2023 study reported that TIMM44 is <strong>required for angiogenesis</strong> in multiple endothelial systems (HUVECs, retinal microvascular endothelial cells, and brain endothelial cells) and in mouse retinal angiogenesis assays. TIMM44 silencing or knockout suppressed proliferation, migration, and tube formation and induced mitochondrial dysfunction characterized by impaired mitochondrial protein import, reduced ATP, increased ROS, mitochondrial depolarization, and apoptosis activation. (published May 2023; <em>Cell Death &amp; Disease</em>; https://doi.org/10.1038/s41419-023-05826-9) (ma2023themitochondrialprotein pages 1-3)</p>
+<p>The same study reported that <strong>MB-10 (MitoBloCK-10)</strong>, described as a TIMM44 blocker that binds a pocket in the TIMM44 C-terminal domain, phenocopied TIMM44 loss and suppressed endothelial angiogenic activity and retinal angiogenesis, with oxidative injury readouts in vivo. (ma2023themitochondrialprotein pages 8-10, ma2023themitochondrialprotein pages 10-12)</p>
+<h3 id="32-timm44-as-a-druggable-mitochondrial-import-target-in-bladder-cancer-2024">3.2 TIMM44 as a druggable mitochondrial import target in bladder cancer (2024)</h3>
+<p>A 2024 study reported that TIMM44 mRNA and protein are elevated in human bladder cancer tissues/cells and that TIMM44 supports malignant phenotypes. Pharmacologic inhibition with <strong>MB-10 (MitoBloCK-10)</strong> reduced bladder cancer cell viability/proliferation and motility and induced apoptosis and cell-cycle arrest, while disrupting mitochondrial function (depolarization, oxidative stress, ATP reduction); genetic <strong>CRISPR-Cas9 TIMM44 depletion</strong> phenocopied these effects and rendered cells insensitive to MB-10, supporting on-target activity. (published Mar 2024; <em>Cell Death &amp; Disease</em>; https://doi.org/10.1038/s41419-024-06585-x) (zhang2024afirstinclasstimm44 pages 1-2, zhang2024afirstinclasstimm44 pages 6-8)</p>
+<p>A key mechanistic assertion of the 2024 study is that TIMM44 positively supports <strong>Akt–mTOR pathway activity</strong> (assessed via Akt/S6K1 phosphorylation): MB-10 or TIMM44 knockout reduced Akt–S6K1 phosphorylation, whereas TIMM44 overexpression increased it, and constitutively active Akt1 partially mitigated MB-10 cytotoxicity. (zhang2024afirstinclasstimm44 pages 1-2, zhang2024afirstinclasstimm44 pages 13-14)</p>
+<h3 id="33-timm44-regulation-in-inflammatory-stress-models-2024-preprint">3.3 TIMM44 regulation in inflammatory stress models (2024 preprint)</h3>
+<p>A 2024 preprint studying sepsis-induced cardiomyopathy included TIMM44 as a member of the TIM23 complex in an LPS time course. In HL-1 cardiomyocytes, TIMM44 (along with other TIM23 components) was upregulated at 6 h after LPS and decreased relative to 6 h by 24 h, with TIMM44 remaining elevated versus control; RT-qPCR results were reported as mean ± SD from three independent experiments. The clinical cohort reported in the same preprint included peripheral blood from <strong>74 sepsis patients and 31 controls</strong> (though clinical qPCR results highlighted TIMM17b and TIMM23 rather than TIMM44 in the provided excerpt). (posted Jan 2024; Research Square; https://doi.org/10.21203/rs.3.rs-3802999/v1) (weng2024exploringthegenetic pages 7-10, weng2024exploringthegenetic pages 3-7)</p>
+<h2 id="4-current-applications-and-real-world-implementations">4) Current applications and real-world implementations</h2>
+<h3 id="41-pharmacologic-targeting-of-timm44-mb-10-mitoblock-10">4.1 Pharmacologic targeting of TIMM44 (MB-10 / MitoBloCK-10)</h3>
+<p>The most explicit real-world implementation in the recent literature is use of the small-molecule <strong>MB-10</strong> as a <strong>functional TIMM44 inhibitor</strong>:<br />
+- <strong>Bladder cancer model:</strong> MB-10 tested in patient-derived primary bladder cancer cells and an immortalized line (T24), with in vivo xenograft inhibition via intraperitoneal administration; effects were coupled to mitochondrial dysfunction, oxidative stress, ATP depletion, and Akt–mTOR pathway inhibition. (zhang2024afirstinclasstimm44 pages 1-2, zhang2024afirstinclasstimm44 pages 6-8)<br />
+- <strong>Angiogenesis model:</strong> MB-10 used in endothelial systems and delivered intravitreally in mouse retina to inhibit angiogenesis, with evidence of oxidative injury in tissue readouts. (ma2023themitochondrialprotein pages 8-10, ma2023themitochondrialprotein pages 10-12)</p>
+<p>Collectively, these studies position TIMM44 as a candidate target at the intersection of mitochondrial protein import, cellular bioenergetics, and stress signaling. (zhang2024afirstinclasstimm44 pages 1-2, ma2023themitochondrialprotein pages 8-10)</p>
+<h3 id="42-genetic-perturbation-shrnacrispr-as-functional-validation">4.2 Genetic perturbation (shRNA/CRISPR) as functional validation</h3>
+<p>Both 2023 and 2024 studies used <strong>TIMM44 knockdown/knockout</strong> as functional perturbations to demonstrate that observed phenotypes (angiogenesis suppression; anti-tumor effects) are specifically driven by TIMM44 loss of function and mitochondrial dysfunction signatures (ATP down, ROS up, depolarization, apoptosis). (ma2023themitochondrialprotein pages 1-3, zhang2024afirstinclasstimm44 pages 6-8)</p>
+<h3 id="43-clinical-genetics-susceptibility-discussions">4.3 Clinical genetics / susceptibility discussions</h3>
+<p>TIMM44 has been discussed as a candidate susceptibility gene in <strong>familial oncocytic thyroid tumors</strong> (including literature discussing TIMM44 variants). Mechanistic work mapping a human Pro308Gln variant to the TIMM44 C-terminal domain provides a plausible structure–function basis for how variants might affect mitochondrial import coupling, but the overall body of validated monogenic TIMM44-linked disease remains comparatively limited relative to other TIM23/PAM genes. (banerjee2015proteintranslocationchannel pages 11-13, banerjee2015proteintranslocationchannel pages 9-11)</p>
+<h2 id="5-expert-opinion-and-synthesis-authoritative-sources">5) Expert opinion and synthesis (authoritative sources)</h2>
+<h3 id="51-consensus-mechanistic-view-from-core-tim23-literature">5.1 Consensus mechanistic view from core TIM23 literature</h3>
+<p>Authoritative mechanistic and review sources converge on a model in which TIMM44/Tim44 is a <strong>core organizational element</strong> of the TIM23/PAM machinery: it provides a matrix-side platform that physically and functionally coordinates TIM23 channel activity with mtHsp70-driven ATP cycles, enabling efficient and directional matrix import. (banerjee2015proteintranslocationchannel pages 11-13, demishteinzohary2017thetim23mitochondrial pages 3-4, demishteinzohary2017thetim23mitochondrial pages 4-5)</p>
+<h3 id="52-interpretation-of-20232024-cancerangiogenesis-studies-in-light-of-canonical-function">5.2 Interpretation of 2023–2024 cancer/angiogenesis studies in light of canonical function</h3>
+<p>The cancer/angiogenesis studies can be interpreted as downstream consequences of perturbing a fundamental mitochondrial “throughput” function (presequence import), which would be expected to impact ATP production, ROS homeostasis, and cell survival/proliferation programs. The 2024 bladder cancer paper’s linkage of TIMM44 to <strong>Akt–mTOR</strong> signaling is consistent with the idea that bioenergetic state and redox stress can gate growth signaling and apoptosis sensitivity, although the precise molecular steps connecting import efficiency to Akt regulation remain to be established in mechanistic detail. (zhang2024afirstinclasstimm44 pages 13-14, zhang2024afirstinclasstimm44 pages 6-8)</p>
+<h2 id="6-key-statistics-and-quantitative-details-from-recent-studies">6) Key statistics and quantitative details from recent studies</h2>
+<ul>
+<li>
+<p><strong>Bladder cancer (2024, Cell Death &amp; Disease):</strong> MB-10 tested at <strong>1–50 μM</strong> with <strong>25 μM</strong> selected for most assays; many in vitro results reported with <strong>n = 5</strong> biological repeats; xenografts established with <strong>6 million cells/mouse</strong>, assessed at <strong>50 days</strong>, with <strong>n = 9 mice/group</strong> and <strong>n = 5 tissue pieces</strong> analyzed per xenograft. (https://doi.org/10.1038/s41419-024-06585-x; published Mar 2024) (zhang2024afirstinclasstimm44 pages 6-8, zhang2024afirstinclasstimm44 pages 12-13)</p>
+</li>
+<li>
+<p><strong>Angiogenesis/retina (2023, Cell Death &amp; Disease):</strong> retinal angiogenesis experiments reported <strong>n = 5</strong>, repeated five times; endothelial-specific AAV-shRNA retinal experiments evaluated at <strong>10 days</strong> post intravitreal injection; MB-10 reported as used intravitreally with 48–72 h readouts. (https://doi.org/10.1038/s41419-023-05826-9; published May 2023) (ma2023themitochondrialprotein pages 1-3, ma2023themitochondrialprotein pages 10-12)</p>
+</li>
+<li>
+<p><strong>Sepsis/cardiomyocyte stress (2024, Research Square):</strong> clinical cohort included <strong>74 sepsis patients</strong> and <strong>31 healthy controls</strong>; HL-1 LPS time-course RT-qPCR used 6 h and 24 h timepoints with results from <strong>three independent experiments</strong>. (https://doi.org/10.21203/rs.3.rs-3802999/v1; posted Jan 2024) (weng2024exploringthegenetic pages 7-10, weng2024exploringthegenetic pages 3-7)</p>
+</li>
+</ul>
+<h2 id="7-visual-evidence-timm44-architecture-and-coupling-role-in-tim23pam">7) Visual evidence: TIMM44 architecture and coupling role in TIM23/PAM</h2>
+<p>A schematic domain map and mechanistic model figure supports the two-domain organization of Tim44 and its bridging interactions between the TIM23 channel (Tim17/Tim23) and PAM motor components (mtHsp70, Tim16/Pam16, Tim14/Pam18). (banerjee2015proteintranslocationchannel media c3d0a7db, banerjee2015proteintranslocationchannel media 1be7f528)</p>
+<h2 id="8-evidence-summary-table">8) Evidence summary table</h2>
+<table>
+<thead>
+<tr>
+<th>Topic</th>
+<th>System / model</th>
+<th>Key finding</th>
+<th>Interactions / mechanism</th>
+<th>Quantitative details</th>
+<th>Year / journal</th>
+<th>DOI / URL</th>
+<th>Citation</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Core TIMM44 molecular function in mitochondrial import</td>
+<td>TIM23 presequence translocase / PAM import motor; mechanistic biochemistry and structural work</td>
+<td>TIMM44 is the matrix-facing coupling/scaffold subunit that links the inner-membrane TIM23 channel to the ATP-driven PAM motor that pulls/traps preproteins into the matrix.</td>
+<td>N-terminal domain binds import-motor components including mtHsp70 and Tim14/Tim16 (Pam18/Pam16); C-terminal domain binds the channel, especially Tim17, and also contacts translocating precursor proteins; intact full-length protein is required for efficient coupling of channel and motor.</td>
+<td>Domain constructs used experimentally in mature yeast Tim44: full-length 43–431, N-domain 43–209, C-core 264–431; biochemical evidence from affinity purification, crosslinking, BN-PAGE, and precursor-arrest experiments. Human disease-linked Pro308Gln maps to the C-terminal domain loop.</td>
+<td>2015, <em>eLife</em></td>
+<td>10.7554/eLife.11897; https://doi.org/10.7554/eLife.11897</td>
+<td>(banerjee2015proteintranslocationchannel pages 11-13, banerjee2015proteintranslocationchannel pages 9-11, banerjee2015proteintranslocationchannel pages 7-9)</td>
+</tr>
+<tr>
+<td>TIMM44 as a PAM core component</td>
+<td>Review synthesis of TIM23/PAM literature</td>
+<td>TIMM44 is a core PAM component that recruits mtHsp70 to the matrix side of TIM23 so emerging precursors can be engaged immediately after crossing the channel.</td>
+<td>Functional interfaces with mtHsp70 and Tim16/Pam16; tertiary Tim23-Tim17-Tim44 interactions help coordinate precursor emergence and matrix translocation.</td>
+<td>Review notes TIM23 imports a major fraction of presequence-containing proteins and that the import motor is membrane-associated on the matrix side.</td>
+<td>2017, <em>Cell and Tissue Research</em></td>
+<td>10.1007/s00441-016-2486-7; https://doi.org/10.1007/s00441-016-2486-7</td>
+<td>(demishteinzohary2017thetim23mitochondrial pages 3-4, demishteinzohary2017thetim23mitochondrial pages 4-5, demishteinzohary2017thetim23mitochondrial pages 1-3)</td>
+</tr>
+<tr>
+<td>Sub-mitochondrial localization</td>
+<td>TIM23 complex architecture</td>
+<td>TIMM44 is not a transmembrane pore subunit; it is a peripheral inner-membrane protein exposed to the matrix, positioned at the outlet of the TIM23 channel.</td>
+<td>Acts as membrane-proximal platform for PAM assembly on the matrix side of the inner membrane.</td>
+<td>Consistent across mechanistic and review sources; matrix-exposed positioning explains direct access to translocating polypeptides and mtHsp70.</td>
+<td>2015-2017, <em>eLife</em>; <em>Cell and Tissue Research</em></td>
+<td>https://doi.org/10.7554/eLife.11897; https://doi.org/10.1007/s00441-016-2486-7</td>
+<td>(banerjee2015proteintranslocationchannel pages 11-13, demishteinzohary2017thetim23mitochondrial pages 3-4, banerjee2015proteintranslocationchannel pages 7-9, demishteinzohary2017thetim23mitochondrial pages 4-5)</td>
+</tr>
+<tr>
+<td>Domain architecture and membrane recruitment</td>
+<td>Tim44 two-domain model with human structural relevance</td>
+<td>TIMM44 has an N-terminal motor-binding domain and a C-terminal channel/precursor-binding domain connected through a central membrane-associated segment.</td>
+<td>Central segment contains two amphipathic membrane-recruitment helices; C-terminal domain has affinity for negatively charged phospholipids/cardiolipin-containing membranes; this supports peripheral IMM association and conformational communication between channel and motor.</td>
+<td>Figure evidence summarizes 44N and 44C organization and placement next to Tim17/Tim23 plus mtHsp70/Tim14/Tim16.</td>
+<td>2015, <em>eLife</em></td>
+<td>10.7554/eLife.11897; https://doi.org/10.7554/eLife.11897</td>
+<td>(banerjee2015proteintranslocationchannel pages 11-13, banerjee2015proteintranslocationchannel pages 15-16, banerjee2015proteintranslocationchannel media c3d0a7db)</td>
+</tr>
+<tr>
+<td>Recent systems-level relevance of PAM/TIMM44 to mitophagy signaling</td>
+<td>Genome-wide CRISPR and mitochondrial stress study</td>
+<td>Loss of PAM components, including TIMM44, is sufficient to reduce protein import and can trigger mitophagy in polarized mitochondria under protein-misfolding stress.</td>
+<td>PAM dissociation from import machinery lowers import capacity; links TIMM44-containing import motor to mitochondrial quality-control signaling.</td>
+<td>Genome-wide CRISPR/Cas9 screen identified PAM components as mitophagy inducers; excerpt is mechanistic but does not provide TIMM44-specific effect sizes.</td>
+<td>2022, <em>Nature Communications</em></td>
+<td>10.1038/s41467-022-32564-x; https://doi.org/10.1038/s41467-022-32564-x</td>
+<td>(OpenTargets Search: -TIMM44)</td>
+</tr>
+<tr>
+<td>2023 applied finding: angiogenesis requirement</td>
+<td>Human endothelial cells (HUVECs, retinal microvascular endothelial cells, hCMEC/D3) and mouse retina</td>
+<td>TIMM44 is required for endothelial proliferation, migration, invasion, tube formation, and retinal angiogenesis.</td>
+<td>shRNA or CRISPR loss of TIMM44 caused mitochondrial protein import arrest, ATP reduction, ROS increase, mitochondrial depolarization, and apoptosis; overexpression raised ATP and enhanced angiogenic behavior.</td>
+<td>In vivo retinal experiments reported as mean ± SD with n = 5, repeated five times; endothelial-specific AAV5-TIE1-TIMM44 shRNA injected intravitreally and tissues examined after 10 days.</td>
+<td>2023, <em>Cell Death &amp; Disease</em></td>
+<td>10.1038/s41419-023-05826-9; https://doi.org/10.1038/s41419-023-05826-9</td>
+<td>(ma2023themitochondrialprotein pages 1-3, ma2023themitochondrialprotein pages 8-10, ma2023themitochondrialprotein pages 10-12)</td>
+</tr>
+<tr>
+<td>2023 applied finding: MB-10 anti-angiogenic activity</td>
+<td>Endothelial cells and mouse retina</td>
+<td>The TIMM44 blocker MB-10 (MitoBloCK-10) phenocopied TIMM44 loss, suppressing endothelial angiogenic activity and retinal angiogenesis.</td>
+<td>MB-10 binds a pocket in the TIMM44 C-terminal domain, induces oxidative injury, decreases ATP-supporting mitochondrial function, and downregulates Opa1/Mfn1/Mfn2 in retina.</td>
+<td>Intravitreal MB-10 used at 0.25 nM in vivo; assays performed 48-72 h post-injection; retinal experiments reported with n = 5.</td>
+<td>2023, <em>Cell Death &amp; Disease</em></td>
+<td>10.1038/s41419-023-05826-9; https://doi.org/10.1038/s41419-023-05826-9</td>
+<td>(ma2023themitochondrialprotein pages 8-10, ma2023themitochondrialprotein pages 10-12, ma2023themitochondrialprotein pages 12-13)</td>
+</tr>
+<tr>
+<td>2024 applied finding: bladder cancer targetability</td>
+<td>Patient-derived primary bladder cancer cells (priBlCa-1/2/3), T24 cells, xenografts</td>
+<td>TIMM44 is overexpressed in bladder cancer and supports tumor cell viability, proliferation, migration/invasion, and Akt-mTOR signaling.</td>
+<td>MB-10 or CRISPR TIMM44 knockout reduced p-Akt/p-S6K1, impaired complex I activity, lowered ATP, increased ROS and oxidative stress, depolarized mitochondria, and activated mitochondrial apoptosis; TIMM44 overexpression had opposite effects.</td>
+<td>MB-10 tested at 1-50 μM; 25 μM used for most assays; data reported as mean ± SD with n = 5; 25 μM MB-10 spared non-cancer primary bladder epithelial cells in reported assays.</td>
+<td>2024, <em>Cell Death &amp; Disease</em></td>
+<td>10.1038/s41419-024-06585-x; https://doi.org/10.1038/s41419-024-06585-x</td>
+<td>(zhang2024afirstinclasstimm44 pages 1-2, zhang2024afirstinclasstimm44 pages 6-8)</td>
+</tr>
+<tr>
+<td>2024 applied finding: in vivo bladder cancer MB-10 / TIMM44 KO</td>
+<td>priBlCa-1 xenograft mice</td>
+<td>Pharmacologic TIMM44 inhibition and genetic TIMM44 loss both suppressed xenograft growth and reproduced mitochondrial/oxidative stress phenotypes in vivo.</td>
+<td>MB-10 and TIMM44 KO decreased ATP and GSH/GSSG balance, inhibited Akt-mTOR, and increased apoptosis markers including caspase-3 activation, PARP cleavage, and TUNEL positivity.</td>
+<td>Xenografts established with 6 million cells/mouse s.c.; tumors assessed after 50 days; n = 9 mice/group and n = 5 tissue pieces analyzed per xenograft.</td>
+<td>2024, <em>Cell Death &amp; Disease</em></td>
+<td>10.1038/s41419-024-06585-x; https://doi.org/10.1038/s41419-024-06585-x</td>
+<td>(zhang2024afirstinclasstimm44 pages 12-13, zhang2024afirstinclasstimm44 pages 13-14)</td>
+</tr>
+<tr>
+<td>Human disease genetics / expert interpretation</td>
+<td>Reviews of human mitochondrial import disorders and thyroid tumor susceptibility literature</td>
+<td>Direct Mendelian TIMM44 disease remains limited, but human TIMM44 variants have been discussed in familial oncocytic thyroid carcinoma susceptibility; mechanistic experts highlight that the reported Pro308Gln maps to a functionally sensitive C-terminal region.</td>
+<td>Supports view that subtle disruption of TIMM44 conformational flexibility or import-coupling may contribute to disease phenotypes even without a large body of monogenic case reports.</td>
+<td>Reviews cite two TIMM44 variants in thyroid tumor families and emphasize need for further confirmation rather than established causality.</td>
+<td>2021-2022 reviews; 2024 mini-review</td>
+<td>https://doi.org/10.3389/fendo.2021.691979; https://doi.org/10.3389/fendo.2022.829103; https://doi.org/10.3390/genes15121534</td>
+<td>(banerjee2015proteintranslocationchannel pages 9-11, banerjee2015proteintranslocationchannel pages 15-16)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes verified core biology of human TIMM44 in the TIM23/PAM mitochondrial import motor, its matrix-facing domain architecture, and the main 2023-2024 applied studies highlighting angiogenesis and bladder cancer targeting with MB-10.</em></p>
+<h2 id="9-database-derived-disease-association-signals-interpret-cautiously">9) Database-derived disease association signals (interpret cautiously)</h2>
+<p>Open Targets lists TIMM44 target–disease association signals for several neurodegeneration-related phenotypes (e.g., neurodegenerative disease, Alzheimer disease, Parkinson disease) based on limited evidence entries; these signals should be treated as hypothesis-generating rather than definitive causal links without corroborating mechanistic or genetic evidence. (https://platform.opentargets.org/target/ENSG00000104980; accessed via OpenTargets tool output) (OpenTargets Search: -TIMM44)</p>
+<h2 id="10-overall-conclusion-functional-annotation">10) Overall conclusion (functional annotation)</h2>
+<p>Human <strong>TIMM44</strong> is a matrix-facing, inner-membrane–associated coupling/scaffold protein that is essential for <strong>TIM23-mediated presequence protein import</strong> by physically and functionally bridging the TIM23 channel (notably via Tim17 binding) to the <strong>PAM mtHsp70 motor</strong> (via N-terminal interactions with mtHsp70 and Pam16/Pam18), enabling ATP-driven translocation into the mitochondrial matrix. (banerjee2015proteintranslocationchannel pages 11-13, demishteinzohary2017thetim23mitochondrial pages 3-4, demishteinzohary2017thetim23mitochondrial pages 4-5)</p>
+<p>Recent 2023–2024 studies extend this canonical import role into applied biomedical contexts: TIMM44 is presented as a targetable node influencing mitochondrial integrity, ATP/ROS balance, and growth signaling programs, with MB-10 used experimentally to inhibit TIMM44 function in models of angiogenesis and bladder cancer. (zhang2024afirstinclasstimm44 pages 1-2, ma2023themitochondrialprotein pages 8-10, zhang2024afirstinclasstimm44 pages 6-8)</p>
+<p>References</p>
+<ol>
+<li>
+<p>(demishteinzohary2017thetim23mitochondrial pages 3-4): Keren Demishtein-Zohary and Abdussalam Azem. The tim23 mitochondrial protein import complex: function and dysfunction. Cell and Tissue Research, 367:33-41, Sep 2017. URL: https://doi.org/10.1007/s00441-016-2486-7, doi:10.1007/s00441-016-2486-7. This article has 59 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(demishteinzohary2017thetim23mitochondrial pages 4-5): Keren Demishtein-Zohary and Abdussalam Azem. The tim23 mitochondrial protein import complex: function and dysfunction. Cell and Tissue Research, 367:33-41, Sep 2017. URL: https://doi.org/10.1007/s00441-016-2486-7, doi:10.1007/s00441-016-2486-7. This article has 59 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(demishteinzohary2017thetim23mitochondrial pages 1-3): Keren Demishtein-Zohary and Abdussalam Azem. The tim23 mitochondrial protein import complex: function and dysfunction. Cell and Tissue Research, 367:33-41, Sep 2017. URL: https://doi.org/10.1007/s00441-016-2486-7, doi:10.1007/s00441-016-2486-7. This article has 59 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(banerjee2015proteintranslocationchannel pages 11-13): Rupa Banerjee, Christina Gladkova, Koyeli Mapa, Gregor Witte, and Dejana Mokranjac. Protein translocation channel of mitochondrial inner membrane and matrix-exposed import motor communicate via two-domain coupling protein. eLife, Dec 2015. URL: https://doi.org/10.7554/elife.11897, doi:10.7554/elife.11897. This article has 64 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(banerjee2015proteintranslocationchannel pages 9-11): Rupa Banerjee, Christina Gladkova, Koyeli Mapa, Gregor Witte, and Dejana Mokranjac. Protein translocation channel of mitochondrial inner membrane and matrix-exposed import motor communicate via two-domain coupling protein. eLife, Dec 2015. URL: https://doi.org/10.7554/elife.11897, doi:10.7554/elife.11897. This article has 64 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(banerjee2015proteintranslocationchannel pages 7-9): Rupa Banerjee, Christina Gladkova, Koyeli Mapa, Gregor Witte, and Dejana Mokranjac. Protein translocation channel of mitochondrial inner membrane and matrix-exposed import motor communicate via two-domain coupling protein. eLife, Dec 2015. URL: https://doi.org/10.7554/elife.11897, doi:10.7554/elife.11897. This article has 64 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(banerjee2015proteintranslocationchannel pages 1-2): Rupa Banerjee, Christina Gladkova, Koyeli Mapa, Gregor Witte, and Dejana Mokranjac. Protein translocation channel of mitochondrial inner membrane and matrix-exposed import motor communicate via two-domain coupling protein. eLife, Dec 2015. URL: https://doi.org/10.7554/elife.11897, doi:10.7554/elife.11897. This article has 64 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ma2023themitochondrialprotein pages 1-3): Zhourui Ma, Hong-Peng Li, Shi-zhong Cai, Sheng-Yang Du, Xia Chen, Jin Yao, Xuan-Lin Cao, Yunfang Zhen, and Qian Wang. The mitochondrial protein timm44 is required for angiogenesis in vitro and in vivo. Cell Death &amp; Disease, May 2023. URL: https://doi.org/10.1038/s41419-023-05826-9, doi:10.1038/s41419-023-05826-9. This article has 15 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ma2023themitochondrialprotein pages 8-10): Zhourui Ma, Hong-Peng Li, Shi-zhong Cai, Sheng-Yang Du, Xia Chen, Jin Yao, Xuan-Lin Cao, Yunfang Zhen, and Qian Wang. The mitochondrial protein timm44 is required for angiogenesis in vitro and in vivo. Cell Death &amp; Disease, May 2023. URL: https://doi.org/10.1038/s41419-023-05826-9, doi:10.1038/s41419-023-05826-9. This article has 15 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ma2023themitochondrialprotein pages 10-12): Zhourui Ma, Hong-Peng Li, Shi-zhong Cai, Sheng-Yang Du, Xia Chen, Jin Yao, Xuan-Lin Cao, Yunfang Zhen, and Qian Wang. The mitochondrial protein timm44 is required for angiogenesis in vitro and in vivo. Cell Death &amp; Disease, May 2023. URL: https://doi.org/10.1038/s41419-023-05826-9, doi:10.1038/s41419-023-05826-9. This article has 15 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(zhang2024afirstinclasstimm44 pages 1-2): Lifeng Zhang, Xiaokai Shi, Lei Zhang, Yuanyuan Mi, Li Zuo, and Shenglin Gao. A first-in-class timm44 blocker inhibits bladder cancer cell growth. Cell Death &amp; Disease, Mar 2024. URL: https://doi.org/10.1038/s41419-024-06585-x, doi:10.1038/s41419-024-06585-x. This article has 11 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(zhang2024afirstinclasstimm44 pages 6-8): Lifeng Zhang, Xiaokai Shi, Lei Zhang, Yuanyuan Mi, Li Zuo, and Shenglin Gao. A first-in-class timm44 blocker inhibits bladder cancer cell growth. Cell Death &amp; Disease, Mar 2024. URL: https://doi.org/10.1038/s41419-024-06585-x, doi:10.1038/s41419-024-06585-x. This article has 11 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(zhang2024afirstinclasstimm44 pages 13-14): Lifeng Zhang, Xiaokai Shi, Lei Zhang, Yuanyuan Mi, Li Zuo, and Shenglin Gao. A first-in-class timm44 blocker inhibits bladder cancer cell growth. Cell Death &amp; Disease, Mar 2024. URL: https://doi.org/10.1038/s41419-024-06585-x, doi:10.1038/s41419-024-06585-x. This article has 11 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(weng2024exploringthegenetic pages 7-10): Jinsen Weng, Xiaojing Wang, Xiuling Shang, Jun Xiao, Yong Ye, Rongguo Yu, and Junya Shang. Exploring the genetic landscape of sepsis-induced cardiomyopathy: a comprehensive analysis. Jan 2024. URL: https://doi.org/10.21203/rs.3.rs-3802999/v1, doi:10.21203/rs.3.rs-3802999/v1.</p>
+</li>
+<li>
+<p>(weng2024exploringthegenetic pages 3-7): Jinsen Weng, Xiaojing Wang, Xiuling Shang, Jun Xiao, Yong Ye, Rongguo Yu, and Junya Shang. Exploring the genetic landscape of sepsis-induced cardiomyopathy: a comprehensive analysis. Jan 2024. URL: https://doi.org/10.21203/rs.3.rs-3802999/v1, doi:10.21203/rs.3.rs-3802999/v1.</p>
+</li>
+<li>
+<p>(zhang2024afirstinclasstimm44 pages 12-13): Lifeng Zhang, Xiaokai Shi, Lei Zhang, Yuanyuan Mi, Li Zuo, and Shenglin Gao. A first-in-class timm44 blocker inhibits bladder cancer cell growth. Cell Death &amp; Disease, Mar 2024. URL: https://doi.org/10.1038/s41419-024-06585-x, doi:10.1038/s41419-024-06585-x. This article has 11 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(banerjee2015proteintranslocationchannel media c3d0a7db): Rupa Banerjee, Christina Gladkova, Koyeli Mapa, Gregor Witte, and Dejana Mokranjac. Protein translocation channel of mitochondrial inner membrane and matrix-exposed import motor communicate via two-domain coupling protein. eLife, Dec 2015. URL: https://doi.org/10.7554/elife.11897, doi:10.7554/elife.11897. This article has 64 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(banerjee2015proteintranslocationchannel media 1be7f528): Rupa Banerjee, Christina Gladkova, Koyeli Mapa, Gregor Witte, and Dejana Mokranjac. Protein translocation channel of mitochondrial inner membrane and matrix-exposed import motor communicate via two-domain coupling protein. eLife, Dec 2015. URL: https://doi.org/10.7554/elife.11897, doi:10.7554/elife.11897. This article has 64 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(banerjee2015proteintranslocationchannel pages 15-16): Rupa Banerjee, Christina Gladkova, Koyeli Mapa, Gregor Witte, and Dejana Mokranjac. Protein translocation channel of mitochondrial inner membrane and matrix-exposed import motor communicate via two-domain coupling protein. eLife, Dec 2015. URL: https://doi.org/10.7554/elife.11897, doi:10.7554/elife.11897. This article has 64 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(OpenTargets Search: -TIMM44): Open Targets Query (-TIMM44, 5 results). Buniello, A. et al. (2025). Open Targets Platform: facilitating therapeutic hypotheses building in drug discovery. Nucleic Acids Research.</p>
+</li>
+<li>
+<p>(ma2023themitochondrialprotein pages 12-13): Zhourui Ma, Hong-Peng Li, Shi-zhong Cai, Sheng-Yang Du, Xia Chen, Jin Yao, Xuan-Lin Cao, Yunfang Zhen, and Qian Wang. The mitochondrial protein timm44 is required for angiogenesis in vitro and in vivo. Cell Death &amp; Disease, May 2023. URL: https://doi.org/10.1038/s41419-023-05826-9, doi:10.1038/s41419-023-05826-9. This article has 15 citations and is from a peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>ma2023themitochondrialprotein pages 1-3</li>
+<li>banerjee2015proteintranslocationchannel pages 11-13</li>
+<li>banerjee2015proteintranslocationchannel pages 9-11</li>
+<li>banerjee2015proteintranslocationchannel pages 7-9</li>
+<li>banerjee2015proteintranslocationchannel pages 1-2</li>
+<li>ma2023themitochondrialprotein pages 8-10</li>
+<li>ma2023themitochondrialprotein pages 10-12</li>
+<li>weng2024exploringthegenetic pages 7-10</li>
+<li>weng2024exploringthegenetic pages 3-7</li>
+<li>banerjee2015proteintranslocationchannel pages 15-16</li>
+<li>ma2023themitochondrialprotein pages 12-13</li>
+<li>https://doi.org/10.1038/s41419-023-05826-9</li>
+<li>https://doi.org/10.1038/s41419-024-06585-x</li>
+<li>https://doi.org/10.21203/rs.3.rs-3802999/v1</li>
+<li>https://doi.org/10.1038/s41419-024-06585-x;</li>
+<li>https://doi.org/10.1038/s41419-023-05826-9;</li>
+<li>https://doi.org/10.21203/rs.3.rs-3802999/v1;</li>
+<li>https://doi.org/10.7554/eLife.11897</li>
+<li>https://doi.org/10.1007/s00441-016-2486-7</li>
+<li>https://doi.org/10.7554/eLife.11897;</li>
+<li>https://doi.org/10.1038/s41467-022-32564-x</li>
+<li>https://doi.org/10.3389/fendo.2021.691979;</li>
+<li>https://doi.org/10.3389/fendo.2022.829103;</li>
+<li>https://doi.org/10.3390/genes15121534</li>
+<li>https://platform.opentargets.org/target/ENSG00000104980;</li>
+<li>https://doi.org/10.1007/s00441-016-2486-7,</li>
+<li>https://doi.org/10.7554/elife.11897,</li>
+<li>https://doi.org/10.1038/s41419-023-05826-9,</li>
+<li>https://doi.org/10.1038/s41419-024-06585-x,</li>
+<li>https://doi.org/10.21203/rs.3.rs-3802999/v1,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: O43615
+gene_symbol: TIMM44
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: &#39;TIMM44 encodes a matrix-facing, peripheral inner mitochondrial membrane coupling/scaffold component
+  of the PAM import motor. It bridges the TIM23 channel to mitochondrial HSP70 and PAM co-chaperones, enabling ATP-dependent
+  translocation of presequence-containing proteins into the mitochondrial matrix.&#39;
+existing_annotations:
+- term:
+    id: GO:0001405
+    label: PAM complex, Tim23 associated import motor
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: Correct and core. TIMM44 is a matrix-facing component of the PAM import motor coupled to TIM23.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TIMM44/TIMM44-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: Human **TIMM44** encodes *mitochondrial import inner membrane translocase subunit TIM44
+        (Tim44)*, a matrix-exposed component of the mitochondrial presequence import pathway that functionally
+        couples the **TIM23** inner-membrane translocation channel to the **PAM** (presequence
+        translocase–associated motor) mtHsp70-based import motor.
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: Human **TIMM44** is a matrix-facing, inner-membrane–associated coupling/scaffold
+        protein that is essential for **TIM23-mediated presequence protein import** by physically and
+        functionally bridging the TIM23 channel (notably via Tim17 binding) to the **PAM mtHsp70 motor** (via
+        N-terminal interactions with mtHsp70 and Pam16/Pam18), enabling ATP-driven translocation into the
+        mitochondrial matrix.
+- term:
+    id: GO:0030674
+    label: protein-macromolecule adaptor activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: Correct and core. TIMM44 functions as a coupling/scaffold adaptor between TIM23 channel
+      components and the PAM mtHsp70 motor.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TIMM44/TIMM44-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: &#39;**Primary function (conceptual definition):** TIMM44 is best understood as a **two-domain
+        coupling protein/scaffold** positioned at the matrix face of the inner membrane that (i) binds components
+        of the TIM23 channel and (ii) recruits/positions mtHsp70 and its co-chaperones so that cycles of ATP-dependent
+        substrate binding and release can drive vectorial translocation.&#39;
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: In a mechanistic dissection of Tim44 (yeast Tim44; with explicit relevance to human
+        TIMM44 via conserved architecture and discussion of a human variant), the **N-terminal domain** binds
+        import-motor components including **mtHsp70** and the **Tim14–Tim16 (Pam18–Pam16)** subcomplex,
+        whereas the **C-terminal domain** binds the channel, with a particularly strong interaction with
+        **Tim17**, and lies near translocating precursor polypeptides.
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: Human **TIMM44** is a matrix-facing, inner-membrane–associated coupling/scaffold
+        protein that is essential for **TIM23-mediated presequence protein import** by physically and
+        functionally bridging the TIM23 channel (notably via Tim17 binding) to the **PAM mtHsp70 motor** (via
+        N-terminal interactions with mtHsp70 and Pam16/Pam18), enabling ATP-driven translocation into the
+        mitochondrial matrix.
+- term:
+    id: GO:0030150
+    label: protein import into mitochondrial matrix
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: Correct and core. TIMM44 enables ATP-dependent TIM23/PAM-mediated import of
+      presequence-containing proteins into the mitochondrial matrix.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TIMM44/TIMM44-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: A large fraction of nuclear-encoded mitochondrial proteins are synthesized in the
+        cytosol as precursors with N-terminal targeting presequences and are imported across the inner
+        membrane through the **TIM23** translocase.
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: Human **TIMM44** is a matrix-facing, inner-membrane–associated coupling/scaffold
+        protein that is essential for **TIM23-mediated presequence protein import** by physically and
+        functionally bridging the TIM23 channel (notably via Tim17 binding) to the **PAM mtHsp70 motor** (via
+        N-terminal interactions with mtHsp70 and Pam16/Pam18), enabling ATP-driven translocation into the
+        mitochondrial matrix.
+- term:
+    id: GO:0051087
+    label: protein-folding chaperone binding
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: Correct. TIMM44 recruits and positions mtHsp70 and PAM co-chaperones at the matrix side of TIM23,
+      making chaperone binding central to its import-motor role.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TIMM44/TIMM44-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: &#39;**Primary function (conceptual definition):** TIMM44 is best understood as a **two-domain
+        coupling protein/scaffold** positioned at the matrix face of the inner membrane that (i) binds components
+        of the TIM23 channel and (ii) recruits/positions mtHsp70 and its co-chaperones so that cycles of ATP-dependent
+        substrate binding and release can drive vectorial translocation.&#39;
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: In a mechanistic dissection of Tim44 (yeast Tim44; with explicit relevance to human
+        TIMM44 via conserved architecture and discussion of a human variant), the **N-terminal domain** binds
+        import-motor components including **mtHsp70** and the **Tim14–Tim16 (Pam18–Pam16)** subcomplex,
+        whereas the **C-terminal domain** binds the channel, with a particularly strong interaction with
+        **Tim17**, and lies near translocating precursor polypeptides.
+- term:
+    id: GO:0005743
+    label: mitochondrial inner membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  review:
+    summary: Correct. TIMM44 is matrix-exposed and peripherally associated with the mitochondrial inner
+      membrane.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TIMM44/TIMM44-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: TIMM44 is **matrix-exposed** and **peripherally associated with the inner mitochondrial
+        membrane** (i.e., it is not itself the transmembrane pore).
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: Human **TIMM44** is a matrix-facing, inner-membrane–associated coupling/scaffold
+        protein that is essential for **TIM23-mediated presequence protein import** by physically and
+        functionally bridging the TIM23 channel (notably via Tim17 binding) to the **PAM mtHsp70 motor** (via
+        N-terminal interactions with mtHsp70 and Pam16/Pam18), enabling ATP-driven translocation into the
+        mitochondrial matrix.
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  review:
+    summary: Correct. TIMM44 is matrix-exposed and peripherally associated with the mitochondrial inner
+      membrane.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TIMM44/TIMM44-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: TIMM44 is **matrix-exposed** and **peripherally associated with the inner mitochondrial
+        membrane** (i.e., it is not itself the transmembrane pore).
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: Human **TIMM44** is a matrix-facing, inner-membrane–associated coupling/scaffold
+        protein that is essential for **TIM23-mediated presequence protein import** by physically and
+        functionally bridging the TIM23 channel (notably via Tim17 binding) to the **PAM mtHsp70 motor** (via
+        N-terminal interactions with mtHsp70 and Pam16/Pam18), enabling ATP-driven translocation into the
+        mitochondrial matrix.
+- term:
+    id: GO:0030150
+    label: protein import into mitochondrial matrix
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  review:
+    summary: Correct and core. TIMM44 enables ATP-dependent TIM23/PAM-mediated import of
+      presequence-containing proteins into the mitochondrial matrix.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TIMM44/TIMM44-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: A large fraction of nuclear-encoded mitochondrial proteins are synthesized in the
+        cytosol as precursors with N-terminal targeting presequences and are imported across the inner
+        membrane through the **TIM23** translocase.
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: Human **TIMM44** is a matrix-facing, inner-membrane–associated coupling/scaffold
+        protein that is essential for **TIM23-mediated presequence protein import** by physically and
+        functionally bridging the TIM23 channel (notably via Tim17 binding) to the **PAM mtHsp70 motor** (via
+        N-terminal interactions with mtHsp70 and Pam16/Pam18), enabling ATP-driven translocation into the
+        mitochondrial matrix.
+- term:
+    id: GO:0045184
+    label: establishment of protein localization
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  review:
+    summary: Correct pathway family but too broad. TIMM44 specifically supports mitochondrial presequence
+      protein import via TIM23/PAM.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/TIMM44/TIMM44-deep-research-falcon.md
+    reason: Use mitochondrial matrix import and PAM adaptor/chaperone-binding terms instead of generic
+      establishment of protein localization.
+    supported_by:
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: A large fraction of nuclear-encoded mitochondrial proteins are synthesized in the
+        cytosol as precursors with N-terminal targeting presequences and are imported across the inner
+        membrane through the **TIM23** translocase.
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: Human **TIMM44** is a matrix-facing, inner-membrane–associated coupling/scaffold
+        protein that is essential for **TIM23-mediated presequence protein import** by physically and
+        functionally bridging the TIM23 channel (notably via Tim17 binding) to the **PAM mtHsp70 motor** (via
+        N-terminal interactions with mtHsp70 and Pam16/Pam18), enabling ATP-driven translocation into the
+        mitochondrial matrix.
+- term:
+    id: GO:0051087
+    label: protein-folding chaperone binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  review:
+    summary: Correct. TIMM44 recruits and positions mtHsp70 and PAM co-chaperones at the matrix side of TIM23,
+      making chaperone binding central to its import-motor role.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TIMM44/TIMM44-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: &#39;**Primary function (conceptual definition):** TIMM44 is best understood as a **two-domain
+        coupling protein/scaffold** positioned at the matrix face of the inner membrane that (i) binds components
+        of the TIM23 channel and (ii) recruits/positions mtHsp70 and its co-chaperones so that cycles of ATP-dependent
+        substrate binding and release can drive vectorial translocation.&#39;
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: In a mechanistic dissection of Tim44 (yeast Tim44; with explicit relevance to human
+        TIMM44 via conserved architecture and discussion of a human variant), the **N-terminal domain** binds
+        import-motor components including **mtHsp70** and the **Tim14–Tim16 (Pam18–Pam16)** subcomplex,
+        whereas the **C-terminal domain** binds the channel, with a particularly strong interaction with
+        **Tim17**, and lies near translocating precursor polypeptides.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:12620389
+  review:
+    summary: Protein binding is too generic for TIMM44. The informative molecular role is adaptor/scaffold
+      coupling of TIM23 channel components with mtHsp70/PAM motor components.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/TIMM44/TIMM44-deep-research-falcon.md
+    reason: Replace generic protein-binding capture with protein-macromolecule adaptor activity and
+      protein-folding chaperone binding where supported.
+    supported_by:
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: &#39;**Primary function (conceptual definition):** TIMM44 is best understood as a **two-domain
+        coupling protein/scaffold** positioned at the matrix face of the inner membrane that (i) binds components
+        of the TIM23 channel and (ii) recruits/positions mtHsp70 and its co-chaperones so that cycles of ATP-dependent
+        substrate binding and release can drive vectorial translocation.&#39;
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: In a mechanistic dissection of Tim44 (yeast Tim44; with explicit relevance to human
+        TIMM44 via conserved architecture and discussion of a human variant), the **N-terminal domain** binds
+        import-motor components including **mtHsp70** and the **Tim14–Tim16 (Pam18–Pam16)** subcomplex,
+        whereas the **C-terminal domain** binds the channel, with a particularly strong interaction with
+        **Tim17**, and lies near translocating precursor polypeptides.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:25416956
+  review:
+    summary: Protein binding is too generic for TIMM44. The informative molecular role is adaptor/scaffold
+      coupling of TIM23 channel components with mtHsp70/PAM motor components.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/TIMM44/TIMM44-deep-research-falcon.md
+    reason: Replace generic protein-binding capture with protein-macromolecule adaptor activity and
+      protein-folding chaperone binding where supported.
+    supported_by:
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: &#39;**Primary function (conceptual definition):** TIMM44 is best understood as a **two-domain
+        coupling protein/scaffold** positioned at the matrix face of the inner membrane that (i) binds components
+        of the TIM23 channel and (ii) recruits/positions mtHsp70 and its co-chaperones so that cycles of ATP-dependent
+        substrate binding and release can drive vectorial translocation.&#39;
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: In a mechanistic dissection of Tim44 (yeast Tim44; with explicit relevance to human
+        TIMM44 via conserved architecture and discussion of a human variant), the **N-terminal domain** binds
+        import-motor components including **mtHsp70** and the **Tim14–Tim16 (Pam18–Pam16)** subcomplex,
+        whereas the **C-terminal domain** binds the channel, with a particularly strong interaction with
+        **Tim17**, and lies near translocating precursor polypeptides.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:25910212
+  review:
+    summary: Protein binding is too generic for TIMM44. The informative molecular role is adaptor/scaffold
+      coupling of TIM23 channel components with mtHsp70/PAM motor components.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/TIMM44/TIMM44-deep-research-falcon.md
+    reason: Replace generic protein-binding capture with protein-macromolecule adaptor activity and
+      protein-folding chaperone binding where supported.
+    supported_by:
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: &#39;**Primary function (conceptual definition):** TIMM44 is best understood as a **two-domain
+        coupling protein/scaffold** positioned at the matrix face of the inner membrane that (i) binds components
+        of the TIM23 channel and (ii) recruits/positions mtHsp70 and its co-chaperones so that cycles of ATP-dependent
+        substrate binding and release can drive vectorial translocation.&#39;
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: In a mechanistic dissection of Tim44 (yeast Tim44; with explicit relevance to human
+        TIMM44 via conserved architecture and discussion of a human variant), the **N-terminal domain** binds
+        import-motor components including **mtHsp70** and the **Tim14–Tim16 (Pam18–Pam16)** subcomplex,
+        whereas the **C-terminal domain** binds the channel, with a particularly strong interaction with
+        **Tim17**, and lies near translocating precursor polypeptides.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:32296183
+  review:
+    summary: Protein binding is too generic for TIMM44. The informative molecular role is adaptor/scaffold
+      coupling of TIM23 channel components with mtHsp70/PAM motor components.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/TIMM44/TIMM44-deep-research-falcon.md
+    reason: Replace generic protein-binding capture with protein-macromolecule adaptor activity and
+      protein-folding chaperone binding where supported.
+    supported_by:
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: &#39;**Primary function (conceptual definition):** TIMM44 is best understood as a **two-domain
+        coupling protein/scaffold** positioned at the matrix face of the inner membrane that (i) binds components
+        of the TIM23 channel and (ii) recruits/positions mtHsp70 and its co-chaperones so that cycles of ATP-dependent
+        substrate binding and release can drive vectorial translocation.&#39;
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: In a mechanistic dissection of Tim44 (yeast Tim44; with explicit relevance to human
+        TIMM44 via conserved architecture and discussion of a human variant), the **N-terminal domain** binds
+        import-motor components including **mtHsp70** and the **Tim14–Tim16 (Pam18–Pam16)** subcomplex,
+        whereas the **C-terminal domain** binds the channel, with a particularly strong interaction with
+        **Tim17**, and lies near translocating precursor polypeptides.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:32814053
+  review:
+    summary: Protein binding is too generic for TIMM44. The informative molecular role is adaptor/scaffold
+      coupling of TIM23 channel components with mtHsp70/PAM motor components.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/TIMM44/TIMM44-deep-research-falcon.md
+    reason: Replace generic protein-binding capture with protein-macromolecule adaptor activity and
+      protein-folding chaperone binding where supported.
+    supported_by:
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: &#39;**Primary function (conceptual definition):** TIMM44 is best understood as a **two-domain
+        coupling protein/scaffold** positioned at the matrix face of the inner membrane that (i) binds components
+        of the TIM23 channel and (ii) recruits/positions mtHsp70 and its co-chaperones so that cycles of ATP-dependent
+        substrate binding and release can drive vectorial translocation.&#39;
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: In a mechanistic dissection of Tim44 (yeast Tim44; with explicit relevance to human
+        TIMM44 via conserved architecture and discussion of a human variant), the **N-terminal domain** binds
+        import-motor components including **mtHsp70** and the **Tim14–Tim16 (Pam18–Pam16)** subcomplex,
+        whereas the **C-terminal domain** binds the channel, with a particularly strong interaction with
+        **Tim17**, and lies near translocating precursor polypeptides.
+- term:
+    id: GO:0005743
+    label: mitochondrial inner membrane
+  evidence_type: NAS
+  original_reference_id: PMID:10339406
+  review:
+    summary: Correct. TIMM44 is matrix-exposed and peripherally associated with the mitochondrial inner
+      membrane.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TIMM44/TIMM44-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: TIMM44 is **matrix-exposed** and **peripherally associated with the inner mitochondrial
+        membrane** (i.e., it is not itself the transmembrane pore).
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: Human **TIMM44** is a matrix-facing, inner-membrane–associated coupling/scaffold
+        protein that is essential for **TIM23-mediated presequence protein import** by physically and
+        functionally bridging the TIM23 channel (notably via Tim17 binding) to the **PAM mtHsp70 motor** (via
+        N-terminal interactions with mtHsp70 and Pam16/Pam18), enabling ATP-driven translocation into the
+        mitochondrial matrix.
+- term:
+    id: GO:0005744
+    label: TIM23 mitochondrial import inner membrane translocase complex
+  evidence_type: NAS
+  original_reference_id: PMID:10339406
+  review:
+    summary: TIMM44 is functionally coupled to TIM23, but the more precise complex term is PAM complex rather
+      than the TIM23 translocase core complex.
+    action: MODIFY
+    additional_reference_ids:
+    - file:human/TIMM44/TIMM44-deep-research-falcon.md
+    reason: Use the PAM complex term for TIMM44 complex membership; TIMM44 bridges to TIM23 but is best
+      curated as a PAM import-motor component.
+    proposed_replacement_terms:
+    - id: GO:0001405
+      label: PAM complex, Tim23 associated import motor
+    supported_by:
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: Human **TIMM44** encodes *mitochondrial import inner membrane translocase subunit TIM44
+        (Tim44)*, a matrix-exposed component of the mitochondrial presequence import pathway that functionally
+        couples the **TIM23** inner-membrane translocation channel to the **PAM** (presequence
+        translocase–associated motor) mtHsp70-based import motor.
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: Human **TIMM44** is a matrix-facing, inner-membrane–associated coupling/scaffold
+        protein that is essential for **TIM23-mediated presequence protein import** by physically and
+        functionally bridging the TIM23 channel (notably via Tim17 binding) to the **PAM mtHsp70 motor** (via
+        N-terminal interactions with mtHsp70 and Pam16/Pam18), enabling ATP-driven translocation into the
+        mitochondrial matrix.
+- term:
+    id: GO:0006886
+    label: intracellular protein transport
+  evidence_type: NAS
+  original_reference_id: PMID:10339406
+  review:
+    summary: Correct pathway family but too broad. TIMM44 functions in TIM23/PAM-mediated mitochondrial
+      presequence import, not general intracellular protein transport.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/TIMM44/TIMM44-deep-research-falcon.md
+    reason: Prefer protein import into mitochondrial matrix and PAM complex terms.
+    supported_by:
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: A large fraction of nuclear-encoded mitochondrial proteins are synthesized in the
+        cytosol as precursors with N-terminal targeting presequences and are imported across the inner
+        membrane through the **TIM23** translocase.
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: Human **TIMM44** is a matrix-facing, inner-membrane–associated coupling/scaffold
+        protein that is essential for **TIM23-mediated presequence protein import** by physically and
+        functionally bridging the TIM23 channel (notably via Tim17 binding) to the **PAM mtHsp70 motor** (via
+        N-terminal interactions with mtHsp70 and Pam16/Pam18), enabling ATP-driven translocation into the
+        mitochondrial matrix.
+- term:
+    id: GO:0030150
+    label: protein import into mitochondrial matrix
+  evidence_type: TAS
+  original_reference_id: PMID:10339406
+  review:
+    summary: Correct and core. TIMM44 enables ATP-dependent TIM23/PAM-mediated import of
+      presequence-containing proteins into the mitochondrial matrix.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TIMM44/TIMM44-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: A large fraction of nuclear-encoded mitochondrial proteins are synthesized in the
+        cytosol as precursors with N-terminal targeting presequences and are imported across the inner
+        membrane through the **TIM23** translocase.
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: Human **TIMM44** is a matrix-facing, inner-membrane–associated coupling/scaffold
+        protein that is essential for **TIM23-mediated presequence protein import** by physically and
+        functionally bridging the TIM23 channel (notably via Tim17 binding) to the **PAM mtHsp70 motor** (via
+        N-terminal interactions with mtHsp70 and Pam16/Pam18), enabling ATP-driven translocation into the
+        mitochondrial matrix.
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IDA
+  original_reference_id: GO_REF:0000052
+  review:
+    summary: Correct but broad. TIMM44 is specifically matrix-facing and associated with the mitochondrial
+      inner membrane/PAM import motor.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/TIMM44/TIMM44-deep-research-falcon.md
+    reason: Prefer mitochondrial inner membrane, mitochondrial matrix, and PAM complex annotations over
+      generic mitochondrion.
+    supported_by:
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: TIMM44 is **matrix-exposed** and **peripherally associated with the inner mitochondrial
+        membrane** (i.e., it is not itself the transmembrane pore).
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: Human **TIMM44** is a matrix-facing, inner-membrane–associated coupling/scaffold
+        protein that is essential for **TIM23-mediated presequence protein import** by physically and
+        functionally bridging the TIM23 channel (notably via Tim17 binding) to the **PAM mtHsp70 motor** (via
+        N-terminal interactions with mtHsp70 and Pam16/Pam18), enabling ATP-driven translocation into the
+        mitochondrial matrix.
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: HTP
+  original_reference_id: PMID:34800366
+  review:
+    summary: Correct but broad. TIMM44 is specifically matrix-facing and associated with the mitochondrial
+      inner membrane/PAM import motor.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/TIMM44/TIMM44-deep-research-falcon.md
+    reason: Prefer mitochondrial inner membrane, mitochondrial matrix, and PAM complex annotations over
+      generic mitochondrion.
+    supported_by:
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: TIMM44 is **matrix-exposed** and **peripherally associated with the inner mitochondrial
+        membrane** (i.e., it is not itself the transmembrane pore).
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: Human **TIMM44** is a matrix-facing, inner-membrane–associated coupling/scaffold
+        protein that is essential for **TIM23-mediated presequence protein import** by physically and
+        functionally bridging the TIM23 channel (notably via Tim17 binding) to the **PAM mtHsp70 motor** (via
+        N-terminal interactions with mtHsp70 and Pam16/Pam18), enabling ATP-driven translocation into the
+        mitochondrial matrix.
+- term:
+    id: GO:0005744
+    label: TIM23 mitochondrial import inner membrane translocase complex
+  evidence_type: IDA
+  original_reference_id: PMID:30598479
+  review:
+    summary: TIMM44 is functionally coupled to TIM23, but the more precise complex term is PAM complex rather
+      than the TIM23 translocase core complex.
+    action: MODIFY
+    additional_reference_ids:
+    - file:human/TIMM44/TIMM44-deep-research-falcon.md
+    reason: Use the PAM complex term for TIMM44 complex membership; TIMM44 bridges to TIM23 but is best
+      curated as a PAM import-motor component.
+    proposed_replacement_terms:
+    - id: GO:0001405
+      label: PAM complex, Tim23 associated import motor
+    supported_by:
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: Human **TIMM44** encodes *mitochondrial import inner membrane translocase subunit TIM44
+        (Tim44)*, a matrix-exposed component of the mitochondrial presequence import pathway that functionally
+        couples the **TIM23** inner-membrane translocation channel to the **PAM** (presequence
+        translocase–associated motor) mtHsp70-based import motor.
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: Human **TIMM44** is a matrix-facing, inner-membrane–associated coupling/scaffold
+        protein that is essential for **TIM23-mediated presequence protein import** by physically and
+        functionally bridging the TIM23 channel (notably via Tim17 binding) to the **PAM mtHsp70 motor** (via
+        N-terminal interactions with mtHsp70 and Pam16/Pam18), enabling ATP-driven translocation into the
+        mitochondrial matrix.
+- term:
+    id: GO:0005743
+    label: mitochondrial inner membrane
+  evidence_type: IDA
+  original_reference_id: PMID:20053669
+  review:
+    summary: Correct. TIMM44 is matrix-exposed and peripherally associated with the mitochondrial inner
+      membrane.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TIMM44/TIMM44-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: TIMM44 is **matrix-exposed** and **peripherally associated with the inner mitochondrial
+        membrane** (i.e., it is not itself the transmembrane pore).
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: Human **TIMM44** is a matrix-facing, inner-membrane–associated coupling/scaffold
+        protein that is essential for **TIM23-mediated presequence protein import** by physically and
+        functionally bridging the TIM23 channel (notably via Tim17 binding) to the **PAM mtHsp70 motor** (via
+        N-terminal interactions with mtHsp70 and Pam16/Pam18), enabling ATP-driven translocation into the
+        mitochondrial matrix.
+- term:
+    id: GO:0005743
+    label: mitochondrial inner membrane
+  evidence_type: IDA
+  original_reference_id: PMID:10339406
+  review:
+    summary: Correct. TIMM44 is matrix-exposed and peripherally associated with the mitochondrial inner
+      membrane.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TIMM44/TIMM44-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: TIMM44 is **matrix-exposed** and **peripherally associated with the inner mitochondrial
+        membrane** (i.e., it is not itself the transmembrane pore).
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: Human **TIMM44** is a matrix-facing, inner-membrane–associated coupling/scaffold
+        protein that is essential for **TIM23-mediated presequence protein import** by physically and
+        functionally bridging the TIM23 channel (notably via Tim17 binding) to the **PAM mtHsp70 motor** (via
+        N-terminal interactions with mtHsp70 and Pam16/Pam18), enabling ATP-driven translocation into the
+        mitochondrial matrix.
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: IDA
+  original_reference_id: PMID:10339406
+  review:
+    summary: Correct. TIMM44 is matrix-exposed and peripherally associated with the mitochondrial inner
+      membrane.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TIMM44/TIMM44-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: TIMM44 is **matrix-exposed** and **peripherally associated with the inner mitochondrial
+        membrane** (i.e., it is not itself the transmembrane pore).
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: Human **TIMM44** is a matrix-facing, inner-membrane–associated coupling/scaffold
+        protein that is essential for **TIM23-mediated presequence protein import** by physically and
+        functionally bridging the TIM23 channel (notably via Tim17 binding) to the **PAM mtHsp70 motor** (via
+        N-terminal interactions with mtHsp70 and Pam16/Pam18), enabling ATP-driven translocation into the
+        mitochondrial matrix.
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping,
+    accompanied by conservative changes to GO terms applied by UniProt
+  findings: []
+- id: GO_REF:0000052
+  title: Gene Ontology annotation based on curation of immunofluorescence data
+  findings: []
+- id: GO_REF:0000117
+  title: Electronic Gene Ontology annotations created by ARBA machine learning models
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: PMID:10339406
+  title: Genetic and structural characterization of the human mitochondrial inner membrane translocase.
+  findings: []
+- id: PMID:12620389
+  title: Novel raf kinase protein-protein interactions found by an exhaustive yeast two-hybrid analysis.
+  findings: []
+- id: PMID:20053669
+  title: Role of Magmas in protein transport and human mitochondria biogenesis.
+  findings: []
+- id: PMID:25416956
+  title: A proteome-scale map of the human interactome network.
+  findings: []
+- id: PMID:25910212
+  title: Widespread macromolecular interaction perturbations in human genetic disorders.
+  findings: []
+- id: PMID:30598479
+  title: ROMO1 is a constituent of the human presequence translocase required for YME1L protease import.
+  findings: []
+- id: PMID:32296183
+  title: A reference map of the human binary protein interactome.
+  findings: []
+- id: PMID:32814053
+  title: Interactome Mapping Provides a Network of Neurodegenerative Disease Proteins and Uncovers Widespread
+    Protein Aggregation in Affected Brains.
+  findings: []
+- id: PMID:34800366
+  title: Quantitative high-confidence human mitochondrial proteome and its dynamics in cellular context.
+  findings: []
+- id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+  title: Falcon deep research report for human TIMM44
+  findings: []
+core_functions:
+- description: TIMM44 is the matrix-facing PAM complex coupling/scaffold subunit that connects the TIM23
+    channel to mtHsp70 and PAM co-chaperones, enabling ATP-dependent translocation of presequence-containing
+    proteins into the mitochondrial matrix.
+  supported_by:
+  - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+    supporting_text: Human **TIMM44** encodes *mitochondrial import inner membrane translocase subunit TIM44
+      (Tim44)*, a matrix-exposed component of the mitochondrial presequence import pathway that functionally
+      couples the **TIM23** inner-membrane translocation channel to the **PAM** (presequence
+      translocase–associated motor) mtHsp70-based import motor.
+  - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+    supporting_text: &#39;**Primary function (conceptual definition):** TIMM44 is best understood as a **two-domain
+      coupling protein/scaffold** positioned at the matrix face of the inner membrane that (i) binds components
+      of the TIM23 channel and (ii) recruits/positions mtHsp70 and its co-chaperones so that cycles of ATP-dependent
+      substrate binding and release can drive vectorial translocation.&#39;
+  - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+    supporting_text: In a mechanistic dissection of Tim44 (yeast Tim44; with explicit relevance to human
+      TIMM44 via conserved architecture and discussion of a human variant), the **N-terminal domain** binds
+      import-motor components including **mtHsp70** and the **Tim14–Tim16 (Pam18–Pam16)** subcomplex, whereas
+      the **C-terminal domain** binds the channel, with a particularly strong interaction with **Tim17**, and
+      lies near translocating precursor polypeptides.
+  - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+    supporting_text: Human **TIMM44** is a matrix-facing, inner-membrane–associated coupling/scaffold protein
+      that is essential for **TIM23-mediated presequence protein import** by physically and functionally
+      bridging the TIM23 channel (notably via Tim17 binding) to the **PAM mtHsp70 motor** (via N-terminal
+      interactions with mtHsp70 and Pam16/Pam18), enabling ATP-driven translocation into the mitochondrial
+      matrix.
+  molecular_function:
+    id: GO:0030674
+    label: protein-macromolecule adaptor activity
+  directly_involved_in:
+  - id: GO:0030150
+    label: protein import into mitochondrial matrix
+  locations:
+  - id: GO:0005743
+    label: mitochondrial inner membrane
+  - id: GO:0005759
+    label: mitochondrial matrix
+  in_complex:
+    id: GO:0001405
+    label: PAM complex, Tim23 associated import motor
+proposed_new_terms: []
+suggested_questions:
+- question: Which TIMM44 surfaces most strongly determine TIM23 channel binding versus mtHsp70/PAM motor
+    recruitment in human cells?
+  experts: []
+- question: Do cancer and angiogenesis phenotypes from TIMM44 inhibition reflect direct import failure,
+    secondary ATP/ROS stress, or both?
+  experts: []
+suggested_experiments:
+- hypothesis: TIMM44 channel-binding and motor-recruitment functions can be separated by domain-specific
+    mutants.
+  description: Perform rescue of TIMM44-depleted human cells with N-domain and C-domain interface mutants,
+    then quantify TIM23 complex association, mtHsp70 recruitment, and matrix-import reporter flux.
+- hypothesis: MB-10 phenotypes primarily reflect inhibition of TIMM44-dependent protein import.
+  description: Compare MB-10 treatment with TIMM44 knockout and resistant TIMM44 rescue for acute precursor
+    import, PAM/TIM23 assembly, ATP/ROS changes, and Akt-mTOR signaling readouts.
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/human/TIMM44/TIMM44-ai-review.yaml
+++ b/genes/human/TIMM44/TIMM44-ai-review.yaml
@@ -1,11 +1,13 @@
 id: O43615
 gene_symbol: TIMM44
 product_type: PROTEIN
-status: INITIALIZED
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
-description: 'TODO: Add description for TIMM44'
+description: 'TIMM44 encodes a matrix-facing, peripheral inner mitochondrial membrane coupling/scaffold component
+  of the PAM import motor. It bridges the TIM23 channel to mitochondrial HSP70 and PAM co-chaperones, enabling ATP-dependent
+  translocation of presequence-containing proteins into the mitochondrial matrix.'
 existing_annotations:
 - term:
     id: GO:0001405
@@ -13,204 +15,573 @@ existing_annotations:
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct and core. TIMM44 is a matrix-facing component of the PAM import motor coupled to TIM23.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TIMM44/TIMM44-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: Human **TIMM44** encodes *mitochondrial import inner membrane translocase subunit TIM44
+        (Tim44)*, a matrix-exposed component of the mitochondrial presequence import pathway that functionally
+        couples the **TIM23** inner-membrane translocation channel to the **PAM** (presequence
+        translocase–associated motor) mtHsp70-based import motor.
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: Human **TIMM44** is a matrix-facing, inner-membrane–associated coupling/scaffold
+        protein that is essential for **TIM23-mediated presequence protein import** by physically and
+        functionally bridging the TIM23 channel (notably via Tim17 binding) to the **PAM mtHsp70 motor** (via
+        N-terminal interactions with mtHsp70 and Pam16/Pam18), enabling ATP-driven translocation into the
+        mitochondrial matrix.
 - term:
     id: GO:0030674
     label: protein-macromolecule adaptor activity
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct and core. TIMM44 functions as a coupling/scaffold adaptor between TIM23 channel
+      components and the PAM mtHsp70 motor.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TIMM44/TIMM44-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: '**Primary function (conceptual definition):** TIMM44 is best understood as a **two-domain
+        coupling protein/scaffold** positioned at the matrix face of the inner membrane that (i) binds components
+        of the TIM23 channel and (ii) recruits/positions mtHsp70 and its co-chaperones so that cycles of ATP-dependent
+        substrate binding and release can drive vectorial translocation.'
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: In a mechanistic dissection of Tim44 (yeast Tim44; with explicit relevance to human
+        TIMM44 via conserved architecture and discussion of a human variant), the **N-terminal domain** binds
+        import-motor components including **mtHsp70** and the **Tim14–Tim16 (Pam18–Pam16)** subcomplex,
+        whereas the **C-terminal domain** binds the channel, with a particularly strong interaction with
+        **Tim17**, and lies near translocating precursor polypeptides.
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: Human **TIMM44** is a matrix-facing, inner-membrane–associated coupling/scaffold
+        protein that is essential for **TIM23-mediated presequence protein import** by physically and
+        functionally bridging the TIM23 channel (notably via Tim17 binding) to the **PAM mtHsp70 motor** (via
+        N-terminal interactions with mtHsp70 and Pam16/Pam18), enabling ATP-driven translocation into the
+        mitochondrial matrix.
 - term:
     id: GO:0030150
     label: protein import into mitochondrial matrix
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct and core. TIMM44 enables ATP-dependent TIM23/PAM-mediated import of
+      presequence-containing proteins into the mitochondrial matrix.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TIMM44/TIMM44-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: A large fraction of nuclear-encoded mitochondrial proteins are synthesized in the
+        cytosol as precursors with N-terminal targeting presequences and are imported across the inner
+        membrane through the **TIM23** translocase.
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: Human **TIMM44** is a matrix-facing, inner-membrane–associated coupling/scaffold
+        protein that is essential for **TIM23-mediated presequence protein import** by physically and
+        functionally bridging the TIM23 channel (notably via Tim17 binding) to the **PAM mtHsp70 motor** (via
+        N-terminal interactions with mtHsp70 and Pam16/Pam18), enabling ATP-driven translocation into the
+        mitochondrial matrix.
 - term:
     id: GO:0051087
     label: protein-folding chaperone binding
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct. TIMM44 recruits and positions mtHsp70 and PAM co-chaperones at the matrix side of TIM23,
+      making chaperone binding central to its import-motor role.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TIMM44/TIMM44-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: '**Primary function (conceptual definition):** TIMM44 is best understood as a **two-domain
+        coupling protein/scaffold** positioned at the matrix face of the inner membrane that (i) binds components
+        of the TIM23 channel and (ii) recruits/positions mtHsp70 and its co-chaperones so that cycles of ATP-dependent
+        substrate binding and release can drive vectorial translocation.'
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: In a mechanistic dissection of Tim44 (yeast Tim44; with explicit relevance to human
+        TIMM44 via conserved architecture and discussion of a human variant), the **N-terminal domain** binds
+        import-motor components including **mtHsp70** and the **Tim14–Tim16 (Pam18–Pam16)** subcomplex,
+        whereas the **C-terminal domain** binds the channel, with a particularly strong interaction with
+        **Tim17**, and lies near translocating precursor polypeptides.
 - term:
     id: GO:0005743
     label: mitochondrial inner membrane
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct. TIMM44 is matrix-exposed and peripherally associated with the mitochondrial inner
+      membrane.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TIMM44/TIMM44-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: TIMM44 is **matrix-exposed** and **peripherally associated with the inner mitochondrial
+        membrane** (i.e., it is not itself the transmembrane pore).
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: Human **TIMM44** is a matrix-facing, inner-membrane–associated coupling/scaffold
+        protein that is essential for **TIM23-mediated presequence protein import** by physically and
+        functionally bridging the TIM23 channel (notably via Tim17 binding) to the **PAM mtHsp70 motor** (via
+        N-terminal interactions with mtHsp70 and Pam16/Pam18), enabling ATP-driven translocation into the
+        mitochondrial matrix.
 - term:
     id: GO:0005759
     label: mitochondrial matrix
   evidence_type: IEA
   original_reference_id: GO_REF:0000044
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct. TIMM44 is matrix-exposed and peripherally associated with the mitochondrial inner
+      membrane.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TIMM44/TIMM44-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: TIMM44 is **matrix-exposed** and **peripherally associated with the inner mitochondrial
+        membrane** (i.e., it is not itself the transmembrane pore).
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: Human **TIMM44** is a matrix-facing, inner-membrane–associated coupling/scaffold
+        protein that is essential for **TIM23-mediated presequence protein import** by physically and
+        functionally bridging the TIM23 channel (notably via Tim17 binding) to the **PAM mtHsp70 motor** (via
+        N-terminal interactions with mtHsp70 and Pam16/Pam18), enabling ATP-driven translocation into the
+        mitochondrial matrix.
 - term:
     id: GO:0030150
     label: protein import into mitochondrial matrix
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct and core. TIMM44 enables ATP-dependent TIM23/PAM-mediated import of
+      presequence-containing proteins into the mitochondrial matrix.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TIMM44/TIMM44-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: A large fraction of nuclear-encoded mitochondrial proteins are synthesized in the
+        cytosol as precursors with N-terminal targeting presequences and are imported across the inner
+        membrane through the **TIM23** translocase.
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: Human **TIMM44** is a matrix-facing, inner-membrane–associated coupling/scaffold
+        protein that is essential for **TIM23-mediated presequence protein import** by physically and
+        functionally bridging the TIM23 channel (notably via Tim17 binding) to the **PAM mtHsp70 motor** (via
+        N-terminal interactions with mtHsp70 and Pam16/Pam18), enabling ATP-driven translocation into the
+        mitochondrial matrix.
 - term:
     id: GO:0045184
     label: establishment of protein localization
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct pathway family but too broad. TIMM44 specifically supports mitochondrial presequence
+      protein import via TIM23/PAM.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/TIMM44/TIMM44-deep-research-falcon.md
+    reason: Use mitochondrial matrix import and PAM adaptor/chaperone-binding terms instead of generic
+      establishment of protein localization.
+    supported_by:
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: A large fraction of nuclear-encoded mitochondrial proteins are synthesized in the
+        cytosol as precursors with N-terminal targeting presequences and are imported across the inner
+        membrane through the **TIM23** translocase.
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: Human **TIMM44** is a matrix-facing, inner-membrane–associated coupling/scaffold
+        protein that is essential for **TIM23-mediated presequence protein import** by physically and
+        functionally bridging the TIM23 channel (notably via Tim17 binding) to the **PAM mtHsp70 motor** (via
+        N-terminal interactions with mtHsp70 and Pam16/Pam18), enabling ATP-driven translocation into the
+        mitochondrial matrix.
 - term:
     id: GO:0051087
     label: protein-folding chaperone binding
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct. TIMM44 recruits and positions mtHsp70 and PAM co-chaperones at the matrix side of TIM23,
+      making chaperone binding central to its import-motor role.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TIMM44/TIMM44-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: '**Primary function (conceptual definition):** TIMM44 is best understood as a **two-domain
+        coupling protein/scaffold** positioned at the matrix face of the inner membrane that (i) binds components
+        of the TIM23 channel and (ii) recruits/positions mtHsp70 and its co-chaperones so that cycles of ATP-dependent
+        substrate binding and release can drive vectorial translocation.'
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: In a mechanistic dissection of Tim44 (yeast Tim44; with explicit relevance to human
+        TIMM44 via conserved architecture and discussion of a human variant), the **N-terminal domain** binds
+        import-motor components including **mtHsp70** and the **Tim14–Tim16 (Pam18–Pam16)** subcomplex,
+        whereas the **C-terminal domain** binds the channel, with a particularly strong interaction with
+        **Tim17**, and lies near translocating precursor polypeptides.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:12620389
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Protein binding is too generic for TIMM44. The informative molecular role is adaptor/scaffold
+      coupling of TIM23 channel components with mtHsp70/PAM motor components.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/TIMM44/TIMM44-deep-research-falcon.md
+    reason: Replace generic protein-binding capture with protein-macromolecule adaptor activity and
+      protein-folding chaperone binding where supported.
+    supported_by:
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: '**Primary function (conceptual definition):** TIMM44 is best understood as a **two-domain
+        coupling protein/scaffold** positioned at the matrix face of the inner membrane that (i) binds components
+        of the TIM23 channel and (ii) recruits/positions mtHsp70 and its co-chaperones so that cycles of ATP-dependent
+        substrate binding and release can drive vectorial translocation.'
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: In a mechanistic dissection of Tim44 (yeast Tim44; with explicit relevance to human
+        TIMM44 via conserved architecture and discussion of a human variant), the **N-terminal domain** binds
+        import-motor components including **mtHsp70** and the **Tim14–Tim16 (Pam18–Pam16)** subcomplex,
+        whereas the **C-terminal domain** binds the channel, with a particularly strong interaction with
+        **Tim17**, and lies near translocating precursor polypeptides.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:25416956
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Protein binding is too generic for TIMM44. The informative molecular role is adaptor/scaffold
+      coupling of TIM23 channel components with mtHsp70/PAM motor components.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/TIMM44/TIMM44-deep-research-falcon.md
+    reason: Replace generic protein-binding capture with protein-macromolecule adaptor activity and
+      protein-folding chaperone binding where supported.
+    supported_by:
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: '**Primary function (conceptual definition):** TIMM44 is best understood as a **two-domain
+        coupling protein/scaffold** positioned at the matrix face of the inner membrane that (i) binds components
+        of the TIM23 channel and (ii) recruits/positions mtHsp70 and its co-chaperones so that cycles of ATP-dependent
+        substrate binding and release can drive vectorial translocation.'
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: In a mechanistic dissection of Tim44 (yeast Tim44; with explicit relevance to human
+        TIMM44 via conserved architecture and discussion of a human variant), the **N-terminal domain** binds
+        import-motor components including **mtHsp70** and the **Tim14–Tim16 (Pam18–Pam16)** subcomplex,
+        whereas the **C-terminal domain** binds the channel, with a particularly strong interaction with
+        **Tim17**, and lies near translocating precursor polypeptides.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:25910212
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Protein binding is too generic for TIMM44. The informative molecular role is adaptor/scaffold
+      coupling of TIM23 channel components with mtHsp70/PAM motor components.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/TIMM44/TIMM44-deep-research-falcon.md
+    reason: Replace generic protein-binding capture with protein-macromolecule adaptor activity and
+      protein-folding chaperone binding where supported.
+    supported_by:
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: '**Primary function (conceptual definition):** TIMM44 is best understood as a **two-domain
+        coupling protein/scaffold** positioned at the matrix face of the inner membrane that (i) binds components
+        of the TIM23 channel and (ii) recruits/positions mtHsp70 and its co-chaperones so that cycles of ATP-dependent
+        substrate binding and release can drive vectorial translocation.'
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: In a mechanistic dissection of Tim44 (yeast Tim44; with explicit relevance to human
+        TIMM44 via conserved architecture and discussion of a human variant), the **N-terminal domain** binds
+        import-motor components including **mtHsp70** and the **Tim14–Tim16 (Pam18–Pam16)** subcomplex,
+        whereas the **C-terminal domain** binds the channel, with a particularly strong interaction with
+        **Tim17**, and lies near translocating precursor polypeptides.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:32296183
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Protein binding is too generic for TIMM44. The informative molecular role is adaptor/scaffold
+      coupling of TIM23 channel components with mtHsp70/PAM motor components.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/TIMM44/TIMM44-deep-research-falcon.md
+    reason: Replace generic protein-binding capture with protein-macromolecule adaptor activity and
+      protein-folding chaperone binding where supported.
+    supported_by:
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: '**Primary function (conceptual definition):** TIMM44 is best understood as a **two-domain
+        coupling protein/scaffold** positioned at the matrix face of the inner membrane that (i) binds components
+        of the TIM23 channel and (ii) recruits/positions mtHsp70 and its co-chaperones so that cycles of ATP-dependent
+        substrate binding and release can drive vectorial translocation.'
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: In a mechanistic dissection of Tim44 (yeast Tim44; with explicit relevance to human
+        TIMM44 via conserved architecture and discussion of a human variant), the **N-terminal domain** binds
+        import-motor components including **mtHsp70** and the **Tim14–Tim16 (Pam18–Pam16)** subcomplex,
+        whereas the **C-terminal domain** binds the channel, with a particularly strong interaction with
+        **Tim17**, and lies near translocating precursor polypeptides.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:32814053
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Protein binding is too generic for TIMM44. The informative molecular role is adaptor/scaffold
+      coupling of TIM23 channel components with mtHsp70/PAM motor components.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/TIMM44/TIMM44-deep-research-falcon.md
+    reason: Replace generic protein-binding capture with protein-macromolecule adaptor activity and
+      protein-folding chaperone binding where supported.
+    supported_by:
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: '**Primary function (conceptual definition):** TIMM44 is best understood as a **two-domain
+        coupling protein/scaffold** positioned at the matrix face of the inner membrane that (i) binds components
+        of the TIM23 channel and (ii) recruits/positions mtHsp70 and its co-chaperones so that cycles of ATP-dependent
+        substrate binding and release can drive vectorial translocation.'
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: In a mechanistic dissection of Tim44 (yeast Tim44; with explicit relevance to human
+        TIMM44 via conserved architecture and discussion of a human variant), the **N-terminal domain** binds
+        import-motor components including **mtHsp70** and the **Tim14–Tim16 (Pam18–Pam16)** subcomplex,
+        whereas the **C-terminal domain** binds the channel, with a particularly strong interaction with
+        **Tim17**, and lies near translocating precursor polypeptides.
 - term:
     id: GO:0005743
     label: mitochondrial inner membrane
   evidence_type: NAS
   original_reference_id: PMID:10339406
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct. TIMM44 is matrix-exposed and peripherally associated with the mitochondrial inner
+      membrane.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TIMM44/TIMM44-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: TIMM44 is **matrix-exposed** and **peripherally associated with the inner mitochondrial
+        membrane** (i.e., it is not itself the transmembrane pore).
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: Human **TIMM44** is a matrix-facing, inner-membrane–associated coupling/scaffold
+        protein that is essential for **TIM23-mediated presequence protein import** by physically and
+        functionally bridging the TIM23 channel (notably via Tim17 binding) to the **PAM mtHsp70 motor** (via
+        N-terminal interactions with mtHsp70 and Pam16/Pam18), enabling ATP-driven translocation into the
+        mitochondrial matrix.
 - term:
     id: GO:0005744
     label: TIM23 mitochondrial import inner membrane translocase complex
   evidence_type: NAS
   original_reference_id: PMID:10339406
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: TIMM44 is functionally coupled to TIM23, but the more precise complex term is PAM complex rather
+      than the TIM23 translocase core complex.
+    action: MODIFY
+    additional_reference_ids:
+    - file:human/TIMM44/TIMM44-deep-research-falcon.md
+    reason: Use the PAM complex term for TIMM44 complex membership; TIMM44 bridges to TIM23 but is best
+      curated as a PAM import-motor component.
+    proposed_replacement_terms:
+    - id: GO:0001405
+      label: PAM complex, Tim23 associated import motor
+    supported_by:
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: Human **TIMM44** encodes *mitochondrial import inner membrane translocase subunit TIM44
+        (Tim44)*, a matrix-exposed component of the mitochondrial presequence import pathway that functionally
+        couples the **TIM23** inner-membrane translocation channel to the **PAM** (presequence
+        translocase–associated motor) mtHsp70-based import motor.
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: Human **TIMM44** is a matrix-facing, inner-membrane–associated coupling/scaffold
+        protein that is essential for **TIM23-mediated presequence protein import** by physically and
+        functionally bridging the TIM23 channel (notably via Tim17 binding) to the **PAM mtHsp70 motor** (via
+        N-terminal interactions with mtHsp70 and Pam16/Pam18), enabling ATP-driven translocation into the
+        mitochondrial matrix.
 - term:
     id: GO:0006886
     label: intracellular protein transport
   evidence_type: NAS
   original_reference_id: PMID:10339406
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct pathway family but too broad. TIMM44 functions in TIM23/PAM-mediated mitochondrial
+      presequence import, not general intracellular protein transport.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/TIMM44/TIMM44-deep-research-falcon.md
+    reason: Prefer protein import into mitochondrial matrix and PAM complex terms.
+    supported_by:
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: A large fraction of nuclear-encoded mitochondrial proteins are synthesized in the
+        cytosol as precursors with N-terminal targeting presequences and are imported across the inner
+        membrane through the **TIM23** translocase.
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: Human **TIMM44** is a matrix-facing, inner-membrane–associated coupling/scaffold
+        protein that is essential for **TIM23-mediated presequence protein import** by physically and
+        functionally bridging the TIM23 channel (notably via Tim17 binding) to the **PAM mtHsp70 motor** (via
+        N-terminal interactions with mtHsp70 and Pam16/Pam18), enabling ATP-driven translocation into the
+        mitochondrial matrix.
 - term:
     id: GO:0030150
     label: protein import into mitochondrial matrix
   evidence_type: TAS
   original_reference_id: PMID:10339406
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct and core. TIMM44 enables ATP-dependent TIM23/PAM-mediated import of
+      presequence-containing proteins into the mitochondrial matrix.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TIMM44/TIMM44-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: A large fraction of nuclear-encoded mitochondrial proteins are synthesized in the
+        cytosol as precursors with N-terminal targeting presequences and are imported across the inner
+        membrane through the **TIM23** translocase.
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: Human **TIMM44** is a matrix-facing, inner-membrane–associated coupling/scaffold
+        protein that is essential for **TIM23-mediated presequence protein import** by physically and
+        functionally bridging the TIM23 channel (notably via Tim17 binding) to the **PAM mtHsp70 motor** (via
+        N-terminal interactions with mtHsp70 and Pam16/Pam18), enabling ATP-driven translocation into the
+        mitochondrial matrix.
 - term:
     id: GO:0005739
     label: mitochondrion
   evidence_type: IDA
   original_reference_id: GO_REF:0000052
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct but broad. TIMM44 is specifically matrix-facing and associated with the mitochondrial
+      inner membrane/PAM import motor.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/TIMM44/TIMM44-deep-research-falcon.md
+    reason: Prefer mitochondrial inner membrane, mitochondrial matrix, and PAM complex annotations over
+      generic mitochondrion.
+    supported_by:
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: TIMM44 is **matrix-exposed** and **peripherally associated with the inner mitochondrial
+        membrane** (i.e., it is not itself the transmembrane pore).
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: Human **TIMM44** is a matrix-facing, inner-membrane–associated coupling/scaffold
+        protein that is essential for **TIM23-mediated presequence protein import** by physically and
+        functionally bridging the TIM23 channel (notably via Tim17 binding) to the **PAM mtHsp70 motor** (via
+        N-terminal interactions with mtHsp70 and Pam16/Pam18), enabling ATP-driven translocation into the
+        mitochondrial matrix.
 - term:
     id: GO:0005739
     label: mitochondrion
   evidence_type: HTP
   original_reference_id: PMID:34800366
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct but broad. TIMM44 is specifically matrix-facing and associated with the mitochondrial
+      inner membrane/PAM import motor.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/TIMM44/TIMM44-deep-research-falcon.md
+    reason: Prefer mitochondrial inner membrane, mitochondrial matrix, and PAM complex annotations over
+      generic mitochondrion.
+    supported_by:
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: TIMM44 is **matrix-exposed** and **peripherally associated with the inner mitochondrial
+        membrane** (i.e., it is not itself the transmembrane pore).
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: Human **TIMM44** is a matrix-facing, inner-membrane–associated coupling/scaffold
+        protein that is essential for **TIM23-mediated presequence protein import** by physically and
+        functionally bridging the TIM23 channel (notably via Tim17 binding) to the **PAM mtHsp70 motor** (via
+        N-terminal interactions with mtHsp70 and Pam16/Pam18), enabling ATP-driven translocation into the
+        mitochondrial matrix.
 - term:
     id: GO:0005744
     label: TIM23 mitochondrial import inner membrane translocase complex
   evidence_type: IDA
   original_reference_id: PMID:30598479
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: TIMM44 is functionally coupled to TIM23, but the more precise complex term is PAM complex rather
+      than the TIM23 translocase core complex.
+    action: MODIFY
+    additional_reference_ids:
+    - file:human/TIMM44/TIMM44-deep-research-falcon.md
+    reason: Use the PAM complex term for TIMM44 complex membership; TIMM44 bridges to TIM23 but is best
+      curated as a PAM import-motor component.
+    proposed_replacement_terms:
+    - id: GO:0001405
+      label: PAM complex, Tim23 associated import motor
+    supported_by:
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: Human **TIMM44** encodes *mitochondrial import inner membrane translocase subunit TIM44
+        (Tim44)*, a matrix-exposed component of the mitochondrial presequence import pathway that functionally
+        couples the **TIM23** inner-membrane translocation channel to the **PAM** (presequence
+        translocase–associated motor) mtHsp70-based import motor.
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: Human **TIMM44** is a matrix-facing, inner-membrane–associated coupling/scaffold
+        protein that is essential for **TIM23-mediated presequence protein import** by physically and
+        functionally bridging the TIM23 channel (notably via Tim17 binding) to the **PAM mtHsp70 motor** (via
+        N-terminal interactions with mtHsp70 and Pam16/Pam18), enabling ATP-driven translocation into the
+        mitochondrial matrix.
 - term:
     id: GO:0005743
     label: mitochondrial inner membrane
   evidence_type: IDA
   original_reference_id: PMID:20053669
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct. TIMM44 is matrix-exposed and peripherally associated with the mitochondrial inner
+      membrane.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TIMM44/TIMM44-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: TIMM44 is **matrix-exposed** and **peripherally associated with the inner mitochondrial
+        membrane** (i.e., it is not itself the transmembrane pore).
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: Human **TIMM44** is a matrix-facing, inner-membrane–associated coupling/scaffold
+        protein that is essential for **TIM23-mediated presequence protein import** by physically and
+        functionally bridging the TIM23 channel (notably via Tim17 binding) to the **PAM mtHsp70 motor** (via
+        N-terminal interactions with mtHsp70 and Pam16/Pam18), enabling ATP-driven translocation into the
+        mitochondrial matrix.
 - term:
     id: GO:0005743
     label: mitochondrial inner membrane
   evidence_type: IDA
   original_reference_id: PMID:10339406
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct. TIMM44 is matrix-exposed and peripherally associated with the mitochondrial inner
+      membrane.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TIMM44/TIMM44-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: TIMM44 is **matrix-exposed** and **peripherally associated with the inner mitochondrial
+        membrane** (i.e., it is not itself the transmembrane pore).
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: Human **TIMM44** is a matrix-facing, inner-membrane–associated coupling/scaffold
+        protein that is essential for **TIM23-mediated presequence protein import** by physically and
+        functionally bridging the TIM23 channel (notably via Tim17 binding) to the **PAM mtHsp70 motor** (via
+        N-terminal interactions with mtHsp70 and Pam16/Pam18), enabling ATP-driven translocation into the
+        mitochondrial matrix.
 - term:
     id: GO:0005759
     label: mitochondrial matrix
   evidence_type: IDA
   original_reference_id: PMID:10339406
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct. TIMM44 is matrix-exposed and peripherally associated with the mitochondrial inner
+      membrane.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TIMM44/TIMM44-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: TIMM44 is **matrix-exposed** and **peripherally associated with the inner mitochondrial
+        membrane** (i.e., it is not itself the transmembrane pore).
+    - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+      supporting_text: Human **TIMM44** is a matrix-facing, inner-membrane–associated coupling/scaffold
+        protein that is essential for **TIM23-mediated presequence protein import** by physically and
+        functionally bridging the TIM23 channel (notably via Tim17 binding) to the **PAM mtHsp70 motor** (via
+        N-terminal interactions with mtHsp70 and Pam16/Pam18), enabling ATP-driven translocation into the
+        mitochondrial matrix.
 references:
 - id: GO_REF:0000002
-  title: Gene Ontology annotation through association of InterPro records with GO
-    terms
+  title: Gene Ontology annotation through association of InterPro records with GO terms
   findings: []
 - id: GO_REF:0000033
   title: Annotation inferences using phylogenetic trees
   findings: []
 - id: GO_REF:0000044
-  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
-    vocabulary mapping, accompanied by conservative changes to GO terms applied by
-    UniProt
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping,
+    accompanied by conservative changes to GO terms applied by UniProt
   findings: []
 - id: GO_REF:0000052
   title: Gene Ontology annotation based on curation of immunofluorescence data
@@ -222,12 +593,10 @@ references:
   title: Combined Automated Annotation using Multiple IEA Methods
   findings: []
 - id: PMID:10339406
-  title: Genetic and structural characterization of the human mitochondrial inner
-    membrane translocase.
+  title: Genetic and structural characterization of the human mitochondrial inner membrane translocase.
   findings: []
 - id: PMID:12620389
-  title: Novel raf kinase protein-protein interactions found by an exhaustive yeast
-    two-hybrid analysis.
+  title: Novel raf kinase protein-protein interactions found by an exhaustive yeast two-hybrid analysis.
   findings: []
 - id: PMID:20053669
   title: Role of Magmas in protein transport and human mitochondria biogenesis.
@@ -239,17 +608,75 @@ references:
   title: Widespread macromolecular interaction perturbations in human genetic disorders.
   findings: []
 - id: PMID:30598479
-  title: ROMO1 is a constituent of the human presequence translocase required for
-    YME1L protease import.
+  title: ROMO1 is a constituent of the human presequence translocase required for YME1L protease import.
   findings: []
 - id: PMID:32296183
   title: A reference map of the human binary protein interactome.
   findings: []
 - id: PMID:32814053
-  title: Interactome Mapping Provides a Network of Neurodegenerative Disease Proteins
-    and Uncovers Widespread Protein Aggregation in Affected Brains.
+  title: Interactome Mapping Provides a Network of Neurodegenerative Disease Proteins and Uncovers Widespread
+    Protein Aggregation in Affected Brains.
   findings: []
 - id: PMID:34800366
-  title: Quantitative high-confidence human mitochondrial proteome and its dynamics
-    in cellular context.
+  title: Quantitative high-confidence human mitochondrial proteome and its dynamics in cellular context.
   findings: []
+- id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+  title: Falcon deep research report for human TIMM44
+  findings: []
+core_functions:
+- description: TIMM44 is the matrix-facing PAM complex coupling/scaffold subunit that connects the TIM23
+    channel to mtHsp70 and PAM co-chaperones, enabling ATP-dependent translocation of presequence-containing
+    proteins into the mitochondrial matrix.
+  supported_by:
+  - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+    supporting_text: Human **TIMM44** encodes *mitochondrial import inner membrane translocase subunit TIM44
+      (Tim44)*, a matrix-exposed component of the mitochondrial presequence import pathway that functionally
+      couples the **TIM23** inner-membrane translocation channel to the **PAM** (presequence
+      translocase–associated motor) mtHsp70-based import motor.
+  - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+    supporting_text: '**Primary function (conceptual definition):** TIMM44 is best understood as a **two-domain
+      coupling protein/scaffold** positioned at the matrix face of the inner membrane that (i) binds components
+      of the TIM23 channel and (ii) recruits/positions mtHsp70 and its co-chaperones so that cycles of ATP-dependent
+      substrate binding and release can drive vectorial translocation.'
+  - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+    supporting_text: In a mechanistic dissection of Tim44 (yeast Tim44; with explicit relevance to human
+      TIMM44 via conserved architecture and discussion of a human variant), the **N-terminal domain** binds
+      import-motor components including **mtHsp70** and the **Tim14–Tim16 (Pam18–Pam16)** subcomplex, whereas
+      the **C-terminal domain** binds the channel, with a particularly strong interaction with **Tim17**, and
+      lies near translocating precursor polypeptides.
+  - reference_id: file:human/TIMM44/TIMM44-deep-research-falcon.md
+    supporting_text: Human **TIMM44** is a matrix-facing, inner-membrane–associated coupling/scaffold protein
+      that is essential for **TIM23-mediated presequence protein import** by physically and functionally
+      bridging the TIM23 channel (notably via Tim17 binding) to the **PAM mtHsp70 motor** (via N-terminal
+      interactions with mtHsp70 and Pam16/Pam18), enabling ATP-driven translocation into the mitochondrial
+      matrix.
+  molecular_function:
+    id: GO:0030674
+    label: protein-macromolecule adaptor activity
+  directly_involved_in:
+  - id: GO:0030150
+    label: protein import into mitochondrial matrix
+  locations:
+  - id: GO:0005743
+    label: mitochondrial inner membrane
+  - id: GO:0005759
+    label: mitochondrial matrix
+  in_complex:
+    id: GO:0001405
+    label: PAM complex, Tim23 associated import motor
+proposed_new_terms: []
+suggested_questions:
+- question: Which TIMM44 surfaces most strongly determine TIM23 channel binding versus mtHsp70/PAM motor
+    recruitment in human cells?
+  experts: []
+- question: Do cancer and angiogenesis phenotypes from TIMM44 inhibition reflect direct import failure,
+    secondary ATP/ROS stress, or both?
+  experts: []
+suggested_experiments:
+- hypothesis: TIMM44 channel-binding and motor-recruitment functions can be separated by domain-specific
+    mutants.
+  description: Perform rescue of TIMM44-depleted human cells with N-domain and C-domain interface mutants,
+    then quantify TIM23 complex association, mtHsp70 recruitment, and matrix-import reporter flux.
+- hypothesis: MB-10 phenotypes primarily reflect inhibition of TIMM44-dependent protein import.
+  description: Compare MB-10 treatment with TIMM44 knockout and resistant TIMM44 rescue for acute precursor
+    import, PAM/TIM23 assembly, ATP/ROS changes, and Akt-mTOR signaling readouts.

--- a/genes/human/TIMM44/TIMM44-deep-research-falcon.md
+++ b/genes/human/TIMM44/TIMM44-deep-research-falcon.md
@@ -1,0 +1,313 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-11T16:35:51.753745'
+end_time: '2026-05-11T16:50:32.852225'
+duration_seconds: 881.1
+template_file: templates/gene_research_go_focused.md
+template_variables:
+  organism: human
+  gene_id: TIMM44
+  gene_symbol: TIMM44
+  uniprot_accession: O43615
+  protein_description: 'RecName: Full=Mitochondrial import inner membrane translocase
+    subunit TIM44; Flags: Precursor;'
+  gene_info: Name=TIMM44; Synonyms=MIMT44, TIM44;
+  organism_full: Homo sapiens (Human).
+  protein_family: Belongs to the Tim44 family. .
+  protein_domains: NTF2-like_dom_sf. (IPR032710); Tim44. (IPR017303); Tim44-like.
+    (IPR039544); Tim44-like_dom. (IPR007379); Tim44 (PF04280)
+provider_config:
+  timeout: 600
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 30
+---
+
+## Question
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** O43615
+- **Protein Description:** RecName: Full=Mitochondrial import inner membrane translocase subunit TIM44; Flags: Precursor;
+- **Gene Information:** Name=TIMM44; Synonyms=MIMT44, TIM44;
+- **Organism (full):** Homo sapiens (Human).
+- **Protein Family:** Belongs to the Tim44 family. .
+- **Key Domains:** NTF2-like_dom_sf. (IPR032710); Tim44. (IPR017303); Tim44-like. (IPR039544); Tim44-like_dom. (IPR007379); Tim44 (PF04280)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "TIMM44" matches the protein description above**
+2. **Verify the organism is correct:** Homo sapiens (Human).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'TIMM44' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **TIMM44** (gene ID: TIMM44, UniProt: O43615) in human.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** O43615
+- **Protein Description:** RecName: Full=Mitochondrial import inner membrane translocase subunit TIM44; Flags: Precursor;
+- **Gene Information:** Name=TIMM44; Synonyms=MIMT44, TIM44;
+- **Organism (full):** Homo sapiens (Human).
+- **Protein Family:** Belongs to the Tim44 family. .
+- **Key Domains:** NTF2-like_dom_sf. (IPR032710); Tim44. (IPR017303); Tim44-like. (IPR039544); Tim44-like_dom. (IPR007379); Tim44 (PF04280)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "TIMM44" matches the protein description above**
+2. **Verify the organism is correct:** Homo sapiens (Human).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'TIMM44' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **TIMM44** (gene ID: TIMM44, UniProt: O43615) in human.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+# Research report: Human **TIMM44** (UniProt O43615) — functional annotation and recent research
+
+## 1) Target verification (gene/protein identity)
+Human **TIMM44** encodes *mitochondrial import inner membrane translocase subunit TIM44 (Tim44)*, a matrix-exposed component of the mitochondrial presequence import pathway that functionally couples the **TIM23** inner-membrane translocation channel to the **PAM** (presequence translocase–associated motor) mtHsp70-based import motor. (demishteinzohary2017thetim23mitochondrial pages 3-4, demishteinzohary2017thetim23mitochondrial pages 4-5, demishteinzohary2017thetim23mitochondrial pages 1-3)
+
+## 2) Key concepts, definitions, and current mechanistic understanding
+
+### 2.1 Mitochondrial presequence import via TIM23 and the PAM motor
+A large fraction of nuclear-encoded mitochondrial proteins are synthesized in the cytosol as precursors with N-terminal targeting presequences and are imported across the inner membrane through the **TIM23** translocase. Import across the inner membrane is driven by the **membrane potential** and by ATP hydrolysis by an mtHsp70-based motor on the matrix side (PAM). Tim44/TIMM44 is a core motor-associated component that organizes this coupling between the pore and the motor. (demishteinzohary2017thetim23mitochondrial pages 4-5, demishteinzohary2017thetim23mitochondrial pages 1-3)
+
+### 2.2 Primary molecular function of TIMM44: coupling/scaffold for channel–motor communication
+**Primary function (conceptual definition):** TIMM44 is best understood as a **two-domain coupling protein/scaffold** positioned at the matrix face of the inner membrane that (i) binds components of the TIM23 channel and (ii) recruits/positions mtHsp70 and its co-chaperones so that cycles of ATP-dependent substrate binding and release can drive vectorial translocation. (banerjee2015proteintranslocationchannel pages 11-13, banerjee2015proteintranslocationchannel pages 9-11, banerjee2015proteintranslocationchannel pages 7-9)
+
+**Domain-resolved interactions (mechanistic evidence):** In a mechanistic dissection of Tim44 (yeast Tim44; with explicit relevance to human TIMM44 via conserved architecture and discussion of a human variant), the **N-terminal domain** binds import-motor components including **mtHsp70** and the **Tim14–Tim16 (Pam18–Pam16)** subcomplex, whereas the **C-terminal domain** binds the channel, with a particularly strong interaction with **Tim17**, and lies near translocating precursor polypeptides. (banerjee2015proteintranslocationchannel pages 11-13, banerjee2015proteintranslocationchannel pages 9-11, banerjee2015proteintranslocationchannel pages 7-9)
+
+**Communication model:** Banerjee et al. propose that translocating proteins stimulate rearrangements between Tim44’s N- and C-domains, enabling communication between TIM23 channel conformational states and PAM motor activity (notably Tim14/Tim16 stimulation of mtHsp70 ATPase cycling). (banerjee2015proteintranslocationchannel pages 11-13, banerjee2015proteintranslocationchannel pages 1-2)
+
+### 2.3 Sub-mitochondrial localization
+TIMM44 is **matrix-exposed** and **peripherally associated with the inner mitochondrial membrane** (i.e., it is not itself the transmembrane pore). It functions as a membrane-proximal docking platform for the motor on the matrix side, positioned at the outlet of the TIM23 channel to coordinate engagement of emerging polypeptides by mtHsp70. (demishteinzohary2017thetim23mitochondrial pages 3-4, demishteinzohary2017thetim23mitochondrial pages 4-5)
+
+### 2.4 Membrane recruitment and lipid interactions
+A central segment of Tim44 contains amphipathic membrane-recruitment helices that support association with cardiolipin-containing membranes, consistent with a peripheral inner-membrane anchor that can transmit conformational changes between channel-contacting and motor-contacting regions. (banerjee2015proteintranslocationchannel pages 11-13, banerjee2015proteintranslocationchannel pages 9-11)
+
+### 2.5 Human-specific notes and disease-linked variant
+Banerjee et al. discuss a **human missense variant Pro308Gln** linked to familial oncocytic thyroid carcinoma and map it to a short loop in the C-terminal domain; the analogous mutation in yeast reduces thermal stability, supporting the interpretation that C-domain conformational integrity/flexibility is important for Tim44/TIMM44 function. (banerjee2015proteintranslocationchannel pages 11-13, banerjee2015proteintranslocationchannel pages 9-11)
+
+## 3) Recent developments (prioritizing 2023–2024)
+
+### 3.1 TIMM44 as a modulator of angiogenesis (2023)
+A 2023 study reported that TIMM44 is **required for angiogenesis** in multiple endothelial systems (HUVECs, retinal microvascular endothelial cells, and brain endothelial cells) and in mouse retinal angiogenesis assays. TIMM44 silencing or knockout suppressed proliferation, migration, and tube formation and induced mitochondrial dysfunction characterized by impaired mitochondrial protein import, reduced ATP, increased ROS, mitochondrial depolarization, and apoptosis activation. (published May 2023; *Cell Death & Disease*; https://doi.org/10.1038/s41419-023-05826-9) (ma2023themitochondrialprotein pages 1-3)
+
+The same study reported that **MB-10 (MitoBloCK-10)**, described as a TIMM44 blocker that binds a pocket in the TIMM44 C-terminal domain, phenocopied TIMM44 loss and suppressed endothelial angiogenic activity and retinal angiogenesis, with oxidative injury readouts in vivo. (ma2023themitochondrialprotein pages 8-10, ma2023themitochondrialprotein pages 10-12)
+
+### 3.2 TIMM44 as a druggable mitochondrial import target in bladder cancer (2024)
+A 2024 study reported that TIMM44 mRNA and protein are elevated in human bladder cancer tissues/cells and that TIMM44 supports malignant phenotypes. Pharmacologic inhibition with **MB-10 (MitoBloCK-10)** reduced bladder cancer cell viability/proliferation and motility and induced apoptosis and cell-cycle arrest, while disrupting mitochondrial function (depolarization, oxidative stress, ATP reduction); genetic **CRISPR-Cas9 TIMM44 depletion** phenocopied these effects and rendered cells insensitive to MB-10, supporting on-target activity. (published Mar 2024; *Cell Death & Disease*; https://doi.org/10.1038/s41419-024-06585-x) (zhang2024afirstinclasstimm44 pages 1-2, zhang2024afirstinclasstimm44 pages 6-8)
+
+A key mechanistic assertion of the 2024 study is that TIMM44 positively supports **Akt–mTOR pathway activity** (assessed via Akt/S6K1 phosphorylation): MB-10 or TIMM44 knockout reduced Akt–S6K1 phosphorylation, whereas TIMM44 overexpression increased it, and constitutively active Akt1 partially mitigated MB-10 cytotoxicity. (zhang2024afirstinclasstimm44 pages 1-2, zhang2024afirstinclasstimm44 pages 13-14)
+
+### 3.3 TIMM44 regulation in inflammatory stress models (2024 preprint)
+A 2024 preprint studying sepsis-induced cardiomyopathy included TIMM44 as a member of the TIM23 complex in an LPS time course. In HL-1 cardiomyocytes, TIMM44 (along with other TIM23 components) was upregulated at 6 h after LPS and decreased relative to 6 h by 24 h, with TIMM44 remaining elevated versus control; RT-qPCR results were reported as mean ± SD from three independent experiments. The clinical cohort reported in the same preprint included peripheral blood from **74 sepsis patients and 31 controls** (though clinical qPCR results highlighted TIMM17b and TIMM23 rather than TIMM44 in the provided excerpt). (posted Jan 2024; Research Square; https://doi.org/10.21203/rs.3.rs-3802999/v1) (weng2024exploringthegenetic pages 7-10, weng2024exploringthegenetic pages 3-7)
+
+## 4) Current applications and real-world implementations
+
+### 4.1 Pharmacologic targeting of TIMM44 (MB-10 / MitoBloCK-10)
+The most explicit real-world implementation in the recent literature is use of the small-molecule **MB-10** as a **functional TIMM44 inhibitor**:
+- **Bladder cancer model:** MB-10 tested in patient-derived primary bladder cancer cells and an immortalized line (T24), with in vivo xenograft inhibition via intraperitoneal administration; effects were coupled to mitochondrial dysfunction, oxidative stress, ATP depletion, and Akt–mTOR pathway inhibition. (zhang2024afirstinclasstimm44 pages 1-2, zhang2024afirstinclasstimm44 pages 6-8)
+- **Angiogenesis model:** MB-10 used in endothelial systems and delivered intravitreally in mouse retina to inhibit angiogenesis, with evidence of oxidative injury in tissue readouts. (ma2023themitochondrialprotein pages 8-10, ma2023themitochondrialprotein pages 10-12)
+
+Collectively, these studies position TIMM44 as a candidate target at the intersection of mitochondrial protein import, cellular bioenergetics, and stress signaling. (zhang2024afirstinclasstimm44 pages 1-2, ma2023themitochondrialprotein pages 8-10)
+
+### 4.2 Genetic perturbation (shRNA/CRISPR) as functional validation
+Both 2023 and 2024 studies used **TIMM44 knockdown/knockout** as functional perturbations to demonstrate that observed phenotypes (angiogenesis suppression; anti-tumor effects) are specifically driven by TIMM44 loss of function and mitochondrial dysfunction signatures (ATP down, ROS up, depolarization, apoptosis). (ma2023themitochondrialprotein pages 1-3, zhang2024afirstinclasstimm44 pages 6-8)
+
+### 4.3 Clinical genetics / susceptibility discussions
+TIMM44 has been discussed as a candidate susceptibility gene in **familial oncocytic thyroid tumors** (including literature discussing TIMM44 variants). Mechanistic work mapping a human Pro308Gln variant to the TIMM44 C-terminal domain provides a plausible structure–function basis for how variants might affect mitochondrial import coupling, but the overall body of validated monogenic TIMM44-linked disease remains comparatively limited relative to other TIM23/PAM genes. (banerjee2015proteintranslocationchannel pages 11-13, banerjee2015proteintranslocationchannel pages 9-11)
+
+## 5) Expert opinion and synthesis (authoritative sources)
+
+### 5.1 Consensus mechanistic view from core TIM23 literature
+Authoritative mechanistic and review sources converge on a model in which TIMM44/Tim44 is a **core organizational element** of the TIM23/PAM machinery: it provides a matrix-side platform that physically and functionally coordinates TIM23 channel activity with mtHsp70-driven ATP cycles, enabling efficient and directional matrix import. (banerjee2015proteintranslocationchannel pages 11-13, demishteinzohary2017thetim23mitochondrial pages 3-4, demishteinzohary2017thetim23mitochondrial pages 4-5)
+
+### 5.2 Interpretation of 2023–2024 cancer/angiogenesis studies in light of canonical function
+The cancer/angiogenesis studies can be interpreted as downstream consequences of perturbing a fundamental mitochondrial “throughput” function (presequence import), which would be expected to impact ATP production, ROS homeostasis, and cell survival/proliferation programs. The 2024 bladder cancer paper’s linkage of TIMM44 to **Akt–mTOR** signaling is consistent with the idea that bioenergetic state and redox stress can gate growth signaling and apoptosis sensitivity, although the precise molecular steps connecting import efficiency to Akt regulation remain to be established in mechanistic detail. (zhang2024afirstinclasstimm44 pages 13-14, zhang2024afirstinclasstimm44 pages 6-8)
+
+## 6) Key statistics and quantitative details from recent studies
+
+- **Bladder cancer (2024, Cell Death & Disease):** MB-10 tested at **1–50 μM** with **25 μM** selected for most assays; many in vitro results reported with **n = 5** biological repeats; xenografts established with **6 million cells/mouse**, assessed at **50 days**, with **n = 9 mice/group** and **n = 5 tissue pieces** analyzed per xenograft. (https://doi.org/10.1038/s41419-024-06585-x; published Mar 2024) (zhang2024afirstinclasstimm44 pages 6-8, zhang2024afirstinclasstimm44 pages 12-13)
+
+- **Angiogenesis/retina (2023, Cell Death & Disease):** retinal angiogenesis experiments reported **n = 5**, repeated five times; endothelial-specific AAV-shRNA retinal experiments evaluated at **10 days** post intravitreal injection; MB-10 reported as used intravitreally with 48–72 h readouts. (https://doi.org/10.1038/s41419-023-05826-9; published May 2023) (ma2023themitochondrialprotein pages 1-3, ma2023themitochondrialprotein pages 10-12)
+
+- **Sepsis/cardiomyocyte stress (2024, Research Square):** clinical cohort included **74 sepsis patients** and **31 healthy controls**; HL-1 LPS time-course RT-qPCR used 6 h and 24 h timepoints with results from **three independent experiments**. (https://doi.org/10.21203/rs.3.rs-3802999/v1; posted Jan 2024) (weng2024exploringthegenetic pages 7-10, weng2024exploringthegenetic pages 3-7)
+
+## 7) Visual evidence: TIMM44 architecture and coupling role in TIM23/PAM
+A schematic domain map and mechanistic model figure supports the two-domain organization of Tim44 and its bridging interactions between the TIM23 channel (Tim17/Tim23) and PAM motor components (mtHsp70, Tim16/Pam16, Tim14/Pam18). (banerjee2015proteintranslocationchannel media c3d0a7db, banerjee2015proteintranslocationchannel media 1be7f528)
+
+## 8) Evidence summary table
+| Topic | System / model | Key finding | Interactions / mechanism | Quantitative details | Year / journal | DOI / URL | Citation |
+|---|---|---|---|---|---|---|---|
+| Core TIMM44 molecular function in mitochondrial import | TIM23 presequence translocase / PAM import motor; mechanistic biochemistry and structural work | TIMM44 is the matrix-facing coupling/scaffold subunit that links the inner-membrane TIM23 channel to the ATP-driven PAM motor that pulls/traps preproteins into the matrix. | N-terminal domain binds import-motor components including mtHsp70 and Tim14/Tim16 (Pam18/Pam16); C-terminal domain binds the channel, especially Tim17, and also contacts translocating precursor proteins; intact full-length protein is required for efficient coupling of channel and motor. | Domain constructs used experimentally in mature yeast Tim44: full-length 43–431, N-domain 43–209, C-core 264–431; biochemical evidence from affinity purification, crosslinking, BN-PAGE, and precursor-arrest experiments. Human disease-linked Pro308Gln maps to the C-terminal domain loop. | 2015, *eLife* | 10.7554/eLife.11897; https://doi.org/10.7554/eLife.11897 | (banerjee2015proteintranslocationchannel pages 11-13, banerjee2015proteintranslocationchannel pages 9-11, banerjee2015proteintranslocationchannel pages 7-9) |
+| TIMM44 as a PAM core component | Review synthesis of TIM23/PAM literature | TIMM44 is a core PAM component that recruits mtHsp70 to the matrix side of TIM23 so emerging precursors can be engaged immediately after crossing the channel. | Functional interfaces with mtHsp70 and Tim16/Pam16; tertiary Tim23-Tim17-Tim44 interactions help coordinate precursor emergence and matrix translocation. | Review notes TIM23 imports a major fraction of presequence-containing proteins and that the import motor is membrane-associated on the matrix side. | 2017, *Cell and Tissue Research* | 10.1007/s00441-016-2486-7; https://doi.org/10.1007/s00441-016-2486-7 | (demishteinzohary2017thetim23mitochondrial pages 3-4, demishteinzohary2017thetim23mitochondrial pages 4-5, demishteinzohary2017thetim23mitochondrial pages 1-3) |
+| Sub-mitochondrial localization | TIM23 complex architecture | TIMM44 is not a transmembrane pore subunit; it is a peripheral inner-membrane protein exposed to the matrix, positioned at the outlet of the TIM23 channel. | Acts as membrane-proximal platform for PAM assembly on the matrix side of the inner membrane. | Consistent across mechanistic and review sources; matrix-exposed positioning explains direct access to translocating polypeptides and mtHsp70. | 2015-2017, *eLife*; *Cell and Tissue Research* | https://doi.org/10.7554/eLife.11897; https://doi.org/10.1007/s00441-016-2486-7 | (banerjee2015proteintranslocationchannel pages 11-13, demishteinzohary2017thetim23mitochondrial pages 3-4, banerjee2015proteintranslocationchannel pages 7-9, demishteinzohary2017thetim23mitochondrial pages 4-5) |
+| Domain architecture and membrane recruitment | Tim44 two-domain model with human structural relevance | TIMM44 has an N-terminal motor-binding domain and a C-terminal channel/precursor-binding domain connected through a central membrane-associated segment. | Central segment contains two amphipathic membrane-recruitment helices; C-terminal domain has affinity for negatively charged phospholipids/cardiolipin-containing membranes; this supports peripheral IMM association and conformational communication between channel and motor. | Figure evidence summarizes 44N and 44C organization and placement next to Tim17/Tim23 plus mtHsp70/Tim14/Tim16. | 2015, *eLife* | 10.7554/eLife.11897; https://doi.org/10.7554/eLife.11897 | (banerjee2015proteintranslocationchannel pages 11-13, banerjee2015proteintranslocationchannel pages 15-16, banerjee2015proteintranslocationchannel media c3d0a7db) |
+| Recent systems-level relevance of PAM/TIMM44 to mitophagy signaling | Genome-wide CRISPR and mitochondrial stress study | Loss of PAM components, including TIMM44, is sufficient to reduce protein import and can trigger mitophagy in polarized mitochondria under protein-misfolding stress. | PAM dissociation from import machinery lowers import capacity; links TIMM44-containing import motor to mitochondrial quality-control signaling. | Genome-wide CRISPR/Cas9 screen identified PAM components as mitophagy inducers; excerpt is mechanistic but does not provide TIMM44-specific effect sizes. | 2022, *Nature Communications* | 10.1038/s41467-022-32564-x; https://doi.org/10.1038/s41467-022-32564-x | (OpenTargets Search: -TIMM44) |
+| 2023 applied finding: angiogenesis requirement | Human endothelial cells (HUVECs, retinal microvascular endothelial cells, hCMEC/D3) and mouse retina | TIMM44 is required for endothelial proliferation, migration, invasion, tube formation, and retinal angiogenesis. | shRNA or CRISPR loss of TIMM44 caused mitochondrial protein import arrest, ATP reduction, ROS increase, mitochondrial depolarization, and apoptosis; overexpression raised ATP and enhanced angiogenic behavior. | In vivo retinal experiments reported as mean ± SD with n = 5, repeated five times; endothelial-specific AAV5-TIE1-TIMM44 shRNA injected intravitreally and tissues examined after 10 days. | 2023, *Cell Death & Disease* | 10.1038/s41419-023-05826-9; https://doi.org/10.1038/s41419-023-05826-9 | (ma2023themitochondrialprotein pages 1-3, ma2023themitochondrialprotein pages 8-10, ma2023themitochondrialprotein pages 10-12) |
+| 2023 applied finding: MB-10 anti-angiogenic activity | Endothelial cells and mouse retina | The TIMM44 blocker MB-10 (MitoBloCK-10) phenocopied TIMM44 loss, suppressing endothelial angiogenic activity and retinal angiogenesis. | MB-10 binds a pocket in the TIMM44 C-terminal domain, induces oxidative injury, decreases ATP-supporting mitochondrial function, and downregulates Opa1/Mfn1/Mfn2 in retina. | Intravitreal MB-10 used at 0.25 nM in vivo; assays performed 48-72 h post-injection; retinal experiments reported with n = 5. | 2023, *Cell Death & Disease* | 10.1038/s41419-023-05826-9; https://doi.org/10.1038/s41419-023-05826-9 | (ma2023themitochondrialprotein pages 8-10, ma2023themitochondrialprotein pages 10-12, ma2023themitochondrialprotein pages 12-13) |
+| 2024 applied finding: bladder cancer targetability | Patient-derived primary bladder cancer cells (priBlCa-1/2/3), T24 cells, xenografts | TIMM44 is overexpressed in bladder cancer and supports tumor cell viability, proliferation, migration/invasion, and Akt-mTOR signaling. | MB-10 or CRISPR TIMM44 knockout reduced p-Akt/p-S6K1, impaired complex I activity, lowered ATP, increased ROS and oxidative stress, depolarized mitochondria, and activated mitochondrial apoptosis; TIMM44 overexpression had opposite effects. | MB-10 tested at 1-50 μM; 25 μM used for most assays; data reported as mean ± SD with n = 5; 25 μM MB-10 spared non-cancer primary bladder epithelial cells in reported assays. | 2024, *Cell Death & Disease* | 10.1038/s41419-024-06585-x; https://doi.org/10.1038/s41419-024-06585-x | (zhang2024afirstinclasstimm44 pages 1-2, zhang2024afirstinclasstimm44 pages 6-8) |
+| 2024 applied finding: in vivo bladder cancer MB-10 / TIMM44 KO | priBlCa-1 xenograft mice | Pharmacologic TIMM44 inhibition and genetic TIMM44 loss both suppressed xenograft growth and reproduced mitochondrial/oxidative stress phenotypes in vivo. | MB-10 and TIMM44 KO decreased ATP and GSH/GSSG balance, inhibited Akt-mTOR, and increased apoptosis markers including caspase-3 activation, PARP cleavage, and TUNEL positivity. | Xenografts established with 6 million cells/mouse s.c.; tumors assessed after 50 days; n = 9 mice/group and n = 5 tissue pieces analyzed per xenograft. | 2024, *Cell Death & Disease* | 10.1038/s41419-024-06585-x; https://doi.org/10.1038/s41419-024-06585-x | (zhang2024afirstinclasstimm44 pages 12-13, zhang2024afirstinclasstimm44 pages 13-14) |
+| Human disease genetics / expert interpretation | Reviews of human mitochondrial import disorders and thyroid tumor susceptibility literature | Direct Mendelian TIMM44 disease remains limited, but human TIMM44 variants have been discussed in familial oncocytic thyroid carcinoma susceptibility; mechanistic experts highlight that the reported Pro308Gln maps to a functionally sensitive C-terminal region. | Supports view that subtle disruption of TIMM44 conformational flexibility or import-coupling may contribute to disease phenotypes even without a large body of monogenic case reports. | Reviews cite two TIMM44 variants in thyroid tumor families and emphasize need for further confirmation rather than established causality. | 2021-2022 reviews; 2024 mini-review | https://doi.org/10.3389/fendo.2021.691979; https://doi.org/10.3389/fendo.2022.829103; https://doi.org/10.3390/genes15121534 | (banerjee2015proteintranslocationchannel pages 9-11, banerjee2015proteintranslocationchannel pages 15-16) |
+
+
+*Table: This table summarizes verified core biology of human TIMM44 in the TIM23/PAM mitochondrial import motor, its matrix-facing domain architecture, and the main 2023-2024 applied studies highlighting angiogenesis and bladder cancer targeting with MB-10.*
+
+## 9) Database-derived disease association signals (interpret cautiously)
+Open Targets lists TIMM44 target–disease association signals for several neurodegeneration-related phenotypes (e.g., neurodegenerative disease, Alzheimer disease, Parkinson disease) based on limited evidence entries; these signals should be treated as hypothesis-generating rather than definitive causal links without corroborating mechanistic or genetic evidence. (https://platform.opentargets.org/target/ENSG00000104980; accessed via OpenTargets tool output) (OpenTargets Search: -TIMM44)
+
+## 10) Overall conclusion (functional annotation)
+Human **TIMM44** is a matrix-facing, inner-membrane–associated coupling/scaffold protein that is essential for **TIM23-mediated presequence protein import** by physically and functionally bridging the TIM23 channel (notably via Tim17 binding) to the **PAM mtHsp70 motor** (via N-terminal interactions with mtHsp70 and Pam16/Pam18), enabling ATP-driven translocation into the mitochondrial matrix. (banerjee2015proteintranslocationchannel pages 11-13, demishteinzohary2017thetim23mitochondrial pages 3-4, demishteinzohary2017thetim23mitochondrial pages 4-5)
+
+Recent 2023–2024 studies extend this canonical import role into applied biomedical contexts: TIMM44 is presented as a targetable node influencing mitochondrial integrity, ATP/ROS balance, and growth signaling programs, with MB-10 used experimentally to inhibit TIMM44 function in models of angiogenesis and bladder cancer. (zhang2024afirstinclasstimm44 pages 1-2, ma2023themitochondrialprotein pages 8-10, zhang2024afirstinclasstimm44 pages 6-8)
+
+References
+
+1. (demishteinzohary2017thetim23mitochondrial pages 3-4): Keren Demishtein-Zohary and Abdussalam Azem. The tim23 mitochondrial protein import complex: function and dysfunction. Cell and Tissue Research, 367:33-41, Sep 2017. URL: https://doi.org/10.1007/s00441-016-2486-7, doi:10.1007/s00441-016-2486-7. This article has 59 citations and is from a peer-reviewed journal.
+
+2. (demishteinzohary2017thetim23mitochondrial pages 4-5): Keren Demishtein-Zohary and Abdussalam Azem. The tim23 mitochondrial protein import complex: function and dysfunction. Cell and Tissue Research, 367:33-41, Sep 2017. URL: https://doi.org/10.1007/s00441-016-2486-7, doi:10.1007/s00441-016-2486-7. This article has 59 citations and is from a peer-reviewed journal.
+
+3. (demishteinzohary2017thetim23mitochondrial pages 1-3): Keren Demishtein-Zohary and Abdussalam Azem. The tim23 mitochondrial protein import complex: function and dysfunction. Cell and Tissue Research, 367:33-41, Sep 2017. URL: https://doi.org/10.1007/s00441-016-2486-7, doi:10.1007/s00441-016-2486-7. This article has 59 citations and is from a peer-reviewed journal.
+
+4. (banerjee2015proteintranslocationchannel pages 11-13): Rupa Banerjee, Christina Gladkova, Koyeli Mapa, Gregor Witte, and Dejana Mokranjac. Protein translocation channel of mitochondrial inner membrane and matrix-exposed import motor communicate via two-domain coupling protein. eLife, Dec 2015. URL: https://doi.org/10.7554/elife.11897, doi:10.7554/elife.11897. This article has 64 citations and is from a domain leading peer-reviewed journal.
+
+5. (banerjee2015proteintranslocationchannel pages 9-11): Rupa Banerjee, Christina Gladkova, Koyeli Mapa, Gregor Witte, and Dejana Mokranjac. Protein translocation channel of mitochondrial inner membrane and matrix-exposed import motor communicate via two-domain coupling protein. eLife, Dec 2015. URL: https://doi.org/10.7554/elife.11897, doi:10.7554/elife.11897. This article has 64 citations and is from a domain leading peer-reviewed journal.
+
+6. (banerjee2015proteintranslocationchannel pages 7-9): Rupa Banerjee, Christina Gladkova, Koyeli Mapa, Gregor Witte, and Dejana Mokranjac. Protein translocation channel of mitochondrial inner membrane and matrix-exposed import motor communicate via two-domain coupling protein. eLife, Dec 2015. URL: https://doi.org/10.7554/elife.11897, doi:10.7554/elife.11897. This article has 64 citations and is from a domain leading peer-reviewed journal.
+
+7. (banerjee2015proteintranslocationchannel pages 1-2): Rupa Banerjee, Christina Gladkova, Koyeli Mapa, Gregor Witte, and Dejana Mokranjac. Protein translocation channel of mitochondrial inner membrane and matrix-exposed import motor communicate via two-domain coupling protein. eLife, Dec 2015. URL: https://doi.org/10.7554/elife.11897, doi:10.7554/elife.11897. This article has 64 citations and is from a domain leading peer-reviewed journal.
+
+8. (ma2023themitochondrialprotein pages 1-3): Zhourui Ma, Hong-Peng Li, Shi-zhong Cai, Sheng-Yang Du, Xia Chen, Jin Yao, Xuan-Lin Cao, Yunfang Zhen, and Qian Wang. The mitochondrial protein timm44 is required for angiogenesis in vitro and in vivo. Cell Death &amp; Disease, May 2023. URL: https://doi.org/10.1038/s41419-023-05826-9, doi:10.1038/s41419-023-05826-9. This article has 15 citations and is from a peer-reviewed journal.
+
+9. (ma2023themitochondrialprotein pages 8-10): Zhourui Ma, Hong-Peng Li, Shi-zhong Cai, Sheng-Yang Du, Xia Chen, Jin Yao, Xuan-Lin Cao, Yunfang Zhen, and Qian Wang. The mitochondrial protein timm44 is required for angiogenesis in vitro and in vivo. Cell Death &amp; Disease, May 2023. URL: https://doi.org/10.1038/s41419-023-05826-9, doi:10.1038/s41419-023-05826-9. This article has 15 citations and is from a peer-reviewed journal.
+
+10. (ma2023themitochondrialprotein pages 10-12): Zhourui Ma, Hong-Peng Li, Shi-zhong Cai, Sheng-Yang Du, Xia Chen, Jin Yao, Xuan-Lin Cao, Yunfang Zhen, and Qian Wang. The mitochondrial protein timm44 is required for angiogenesis in vitro and in vivo. Cell Death &amp; Disease, May 2023. URL: https://doi.org/10.1038/s41419-023-05826-9, doi:10.1038/s41419-023-05826-9. This article has 15 citations and is from a peer-reviewed journal.
+
+11. (zhang2024afirstinclasstimm44 pages 1-2): Lifeng Zhang, Xiaokai Shi, Lei Zhang, Yuanyuan Mi, Li Zuo, and Shenglin Gao. A first-in-class timm44 blocker inhibits bladder cancer cell growth. Cell Death &amp; Disease, Mar 2024. URL: https://doi.org/10.1038/s41419-024-06585-x, doi:10.1038/s41419-024-06585-x. This article has 11 citations and is from a peer-reviewed journal.
+
+12. (zhang2024afirstinclasstimm44 pages 6-8): Lifeng Zhang, Xiaokai Shi, Lei Zhang, Yuanyuan Mi, Li Zuo, and Shenglin Gao. A first-in-class timm44 blocker inhibits bladder cancer cell growth. Cell Death &amp; Disease, Mar 2024. URL: https://doi.org/10.1038/s41419-024-06585-x, doi:10.1038/s41419-024-06585-x. This article has 11 citations and is from a peer-reviewed journal.
+
+13. (zhang2024afirstinclasstimm44 pages 13-14): Lifeng Zhang, Xiaokai Shi, Lei Zhang, Yuanyuan Mi, Li Zuo, and Shenglin Gao. A first-in-class timm44 blocker inhibits bladder cancer cell growth. Cell Death &amp; Disease, Mar 2024. URL: https://doi.org/10.1038/s41419-024-06585-x, doi:10.1038/s41419-024-06585-x. This article has 11 citations and is from a peer-reviewed journal.
+
+14. (weng2024exploringthegenetic pages 7-10): Jinsen Weng, Xiaojing Wang, Xiuling Shang, Jun Xiao, Yong Ye, Rongguo Yu, and Junya Shang. Exploring the genetic landscape of sepsis-induced cardiomyopathy: a comprehensive analysis. Jan 2024. URL: https://doi.org/10.21203/rs.3.rs-3802999/v1, doi:10.21203/rs.3.rs-3802999/v1.
+
+15. (weng2024exploringthegenetic pages 3-7): Jinsen Weng, Xiaojing Wang, Xiuling Shang, Jun Xiao, Yong Ye, Rongguo Yu, and Junya Shang. Exploring the genetic landscape of sepsis-induced cardiomyopathy: a comprehensive analysis. Jan 2024. URL: https://doi.org/10.21203/rs.3.rs-3802999/v1, doi:10.21203/rs.3.rs-3802999/v1.
+
+16. (zhang2024afirstinclasstimm44 pages 12-13): Lifeng Zhang, Xiaokai Shi, Lei Zhang, Yuanyuan Mi, Li Zuo, and Shenglin Gao. A first-in-class timm44 blocker inhibits bladder cancer cell growth. Cell Death &amp; Disease, Mar 2024. URL: https://doi.org/10.1038/s41419-024-06585-x, doi:10.1038/s41419-024-06585-x. This article has 11 citations and is from a peer-reviewed journal.
+
+17. (banerjee2015proteintranslocationchannel media c3d0a7db): Rupa Banerjee, Christina Gladkova, Koyeli Mapa, Gregor Witte, and Dejana Mokranjac. Protein translocation channel of mitochondrial inner membrane and matrix-exposed import motor communicate via two-domain coupling protein. eLife, Dec 2015. URL: https://doi.org/10.7554/elife.11897, doi:10.7554/elife.11897. This article has 64 citations and is from a domain leading peer-reviewed journal.
+
+18. (banerjee2015proteintranslocationchannel media 1be7f528): Rupa Banerjee, Christina Gladkova, Koyeli Mapa, Gregor Witte, and Dejana Mokranjac. Protein translocation channel of mitochondrial inner membrane and matrix-exposed import motor communicate via two-domain coupling protein. eLife, Dec 2015. URL: https://doi.org/10.7554/elife.11897, doi:10.7554/elife.11897. This article has 64 citations and is from a domain leading peer-reviewed journal.
+
+19. (banerjee2015proteintranslocationchannel pages 15-16): Rupa Banerjee, Christina Gladkova, Koyeli Mapa, Gregor Witte, and Dejana Mokranjac. Protein translocation channel of mitochondrial inner membrane and matrix-exposed import motor communicate via two-domain coupling protein. eLife, Dec 2015. URL: https://doi.org/10.7554/elife.11897, doi:10.7554/elife.11897. This article has 64 citations and is from a domain leading peer-reviewed journal.
+
+20. (OpenTargets Search: -TIMM44): Open Targets Query (-TIMM44, 5 results). Buniello, A. et al. (2025). Open Targets Platform: facilitating therapeutic hypotheses building in drug discovery. Nucleic Acids Research.
+
+21. (ma2023themitochondrialprotein pages 12-13): Zhourui Ma, Hong-Peng Li, Shi-zhong Cai, Sheng-Yang Du, Xia Chen, Jin Yao, Xuan-Lin Cao, Yunfang Zhen, and Qian Wang. The mitochondrial protein timm44 is required for angiogenesis in vitro and in vivo. Cell Death &amp; Disease, May 2023. URL: https://doi.org/10.1038/s41419-023-05826-9, doi:10.1038/s41419-023-05826-9. This article has 15 citations and is from a peer-reviewed journal.
+
+## Citations
+
+1. ma2023themitochondrialprotein pages 1-3
+2. banerjee2015proteintranslocationchannel pages 11-13
+3. banerjee2015proteintranslocationchannel pages 9-11
+4. banerjee2015proteintranslocationchannel pages 7-9
+5. banerjee2015proteintranslocationchannel pages 1-2
+6. ma2023themitochondrialprotein pages 8-10
+7. ma2023themitochondrialprotein pages 10-12
+8. weng2024exploringthegenetic pages 7-10
+9. weng2024exploringthegenetic pages 3-7
+10. banerjee2015proteintranslocationchannel pages 15-16
+11. ma2023themitochondrialprotein pages 12-13
+12. https://doi.org/10.1038/s41419-023-05826-9
+13. https://doi.org/10.1038/s41419-024-06585-x
+14. https://doi.org/10.21203/rs.3.rs-3802999/v1
+15. https://doi.org/10.1038/s41419-024-06585-x;
+16. https://doi.org/10.1038/s41419-023-05826-9;
+17. https://doi.org/10.21203/rs.3.rs-3802999/v1;
+18. https://doi.org/10.7554/eLife.11897
+19. https://doi.org/10.1007/s00441-016-2486-7
+20. https://doi.org/10.7554/eLife.11897;
+21. https://doi.org/10.1038/s41467-022-32564-x
+22. https://doi.org/10.3389/fendo.2021.691979;
+23. https://doi.org/10.3389/fendo.2022.829103;
+24. https://doi.org/10.3390/genes15121534
+25. https://platform.opentargets.org/target/ENSG00000104980;
+26. https://doi.org/10.1007/s00441-016-2486-7,
+27. https://doi.org/10.7554/elife.11897,
+28. https://doi.org/10.1038/s41419-023-05826-9,
+29. https://doi.org/10.1038/s41419-024-06585-x,
+30. https://doi.org/10.21203/rs.3.rs-3802999/v1,

--- a/genes/human/TIMM50/TIMM50-ai-review.html
+++ b/genes/human/TIMM50/TIMM50-ai-review.html
@@ -2392,7 +2392,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> Do not treat the noncanonical Ttm50 calpain calcium-store finding as a core human TIMM50 activity or localization without human TIMM50-specific support.
+                            <strong>Reason:</strong> PMID:32848200 studies Drosophila Ttm50, not human TIMM50. Do not treat the noncanonical Ttm50 calpain calcium-store finding as a core human TIMM50 activity or localization without human TIMM50-specific support.
                         </div>
 
 
@@ -2509,7 +2509,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> Do not treat the noncanonical Ttm50 calpain calcium-store finding as a core human TIMM50 activity or localization without human TIMM50-specific support.
+                            <strong>Reason:</strong> PMID:32848200 studies Drosophila Ttm50, not human TIMM50. Do not treat the noncanonical Ttm50 calpain calcium-store finding as a core human TIMM50 activity or localization without human TIMM50-specific support.
                         </div>
 
 
@@ -2626,7 +2626,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> Do not treat the noncanonical Ttm50 calpain calcium-store finding as a core human TIMM50 activity or localization without human TIMM50-specific support.
+                            <strong>Reason:</strong> PMID:32848200 studies Drosophila Ttm50, not human TIMM50. Do not treat the noncanonical Ttm50 calpain calcium-store finding as a core human TIMM50 activity or localization without human TIMM50-specific support.
                         </div>
 
 
@@ -2925,7 +2925,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> No usable evidence for IL-2 receptor binding was found in the cited cached publication or in the TIMM50 deep research report.
+                            <strong>Reason:</strong> PMID:15044455 describes human Tim50 as a mitochondrial translocator/TIM23-associated protein and contains no mention of IL-2 receptor binding. This annotation appears to be a database misattribution, because a mitochondrial inner-membrane translocase subunit is not expected to function as an IL-2 receptor ligand or receptor-binding protein.
                         </div>
 
 
@@ -5027,8 +5027,9 @@ existing_annotations:
     additional_reference_ids:
     - PMID:32848200
     - file:human/TIMM50/TIMM50-deep-research-falcon.md
-    reason: Do not treat the noncanonical Ttm50 calpain calcium-store finding as a core human TIMM50 activity
-      or localization without human TIMM50-specific support.
+    reason: PMID:32848200 studies Drosophila Ttm50, not human TIMM50. Do not treat the noncanonical
+      Ttm50 calpain calcium-store finding as a core human TIMM50 activity or localization without human
+      TIMM50-specific support.
     supported_by:
     - reference_id: PMID:32848200
       supporting_text: GluRIIA at the Drosophila neuromuscular junction as a readout, we uncovered that
@@ -5052,8 +5053,9 @@ existing_annotations:
     additional_reference_ids:
     - PMID:32848200
     - file:human/TIMM50/TIMM50-deep-research-falcon.md
-    reason: Do not treat the noncanonical Ttm50 calpain calcium-store finding as a core human TIMM50 activity
-      or localization without human TIMM50-specific support.
+    reason: PMID:32848200 studies Drosophila Ttm50, not human TIMM50. Do not treat the noncanonical
+      Ttm50 calpain calcium-store finding as a core human TIMM50 activity or localization without human
+      TIMM50-specific support.
     supported_by:
     - reference_id: PMID:32848200
       supporting_text: GluRIIA at the Drosophila neuromuscular junction as a readout, we uncovered that
@@ -5077,8 +5079,9 @@ existing_annotations:
     additional_reference_ids:
     - PMID:32848200
     - file:human/TIMM50/TIMM50-deep-research-falcon.md
-    reason: Do not treat the noncanonical Ttm50 calpain calcium-store finding as a core human TIMM50 activity
-      or localization without human TIMM50-specific support.
+    reason: PMID:32848200 studies Drosophila Ttm50, not human TIMM50. Do not treat the noncanonical
+      Ttm50 calpain calcium-store finding as a core human TIMM50 activity or localization without human
+      TIMM50-specific support.
     supported_by:
     - reference_id: PMID:32848200
       supporting_text: GluRIIA at the Drosophila neuromuscular junction as a readout, we uncovered that
@@ -5143,8 +5146,10 @@ existing_annotations:
     action: REMOVE
     additional_reference_ids:
     - file:human/TIMM50/TIMM50-deep-research-falcon.md
-    reason: No usable evidence for IL-2 receptor binding was found in the cited cached publication or in the
-      TIMM50 deep research report.
+    reason: PMID:15044455 describes human Tim50 as a mitochondrial translocator/TIM23-associated protein
+      and contains no mention of IL-2 receptor binding. This annotation appears to be a database
+      misattribution, because a mitochondrial inner-membrane translocase subunit is not expected to function
+      as an IL-2 receptor ligand or receptor-binding protein.
     supported_by:
     - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
       supporting_text: Therefore, based on available evidence, the primary validated function remains

--- a/genes/human/TIMM50/TIMM50-ai-review.html
+++ b/genes/human/TIMM50/TIMM50-ai-review.html
@@ -1,0 +1,5745 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>TIMM50 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>TIMM50</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q3ZCQ8" target="_blank" class="term-link">
+                        Q3ZCQ8
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "TIMM50";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q3ZCQ8" data-a="DESCRIPTION: TIMM50 encodes the single-pass mitochondrial inner..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>TIMM50 encodes the single-pass mitochondrial inner membrane Tim50 subunit of the TIM23 presequence translocase. TIMM50 acts from the intermembrane-space side as a primary presequence receptor and gatekeeper for TIM23-dependent import of transit peptide-containing precursor proteins, while its reported phosphatase, nuclear Tim50a, and calpain-associated roles are secondary or insufficiently established as core human TIMM50 functions.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030150" target="_blank" class="term-link">
+                                    GO:0030150
+                                </a>
+                            </span>
+                            <span class="term-label">protein import into mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q3ZCQ8" data-a="GO:0030150" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct and core. TIMM50 is the TIM23 presequence receptor/gatekeeper needed for import of transit peptide-containing precursors through the inner membrane toward the matrix or IMM sorting pathway.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM50/TIMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Tim50 is widely regarded as the **primary presequence receptor at the inner membrane**, positioned in the **intermembrane space (IMS)** to receive precursors emerging from the TOM pore and coordinate their entry into TIM23.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM50/TIMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">TIMM50 primarily acts on **presequence-containing precursor proteins**, which constitute a large fraction of the mitochondrial proteome and are imported through the TIM23 pathway for matrix delivery or IMM insertion.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM50/TIMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">This receptor/gating logic is supported by direct presequence-binding mapping and the conclusion that Tim50 binding to Tim23 can induce channel closure when no substrate is being transported.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005744" target="_blank" class="term-link">
+                                    GO:0005744
+                                </a>
+                            </span>
+                            <span class="term-label">TIM23 mitochondrial import inner membrane translocase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q3ZCQ8" data-a="GO:0005744" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct and core. TIMM50 is a core TIM23 complex subunit that directly coordinates presequence handoff and channel gating.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM50/TIMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Tim50 is widely regarded as the **primary presequence receptor at the inner membrane**, positioned in the **intermembrane space (IMS)** to receive precursors emerging from the TOM pore and coordinate their entry into TIM23.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM50/TIMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">This receptor/gating logic is supported by direct presequence-binding mapping and the conclusion that Tim50 binding to Tim23 can induce channel closure when no substrate is being transported.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15044455" target="_blank" class="term-link">
+                                        PMID:15044455
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">complex with human Tim23. Down-regulation of human Tim50 expression by RNA</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004722" target="_blank" class="term-link">
+                                    GO:0004722
+                                </a>
+                            </span>
+                            <span class="term-label">protein serine/threonine phosphatase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q3ZCQ8" data-a="GO:0004722" data-r="GO_REF:0000117" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct assays reported phosphatase activity, but current synthesis indicates the physiological substrate and in vivo relevance remain unclear; TIMM50 should be curated primarily as a TIM23 presequence receptor/gatekeeper.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The phosphatase activity is not the core validated biological function of TIMM50 and has no established physiological substrate in the import pathway.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15044455" target="_blank" class="term-link">
+                                        PMID:15044455
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">demonstrate that human Tim50 possesses phosphatase activity and is present in a</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM50/TIMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Therefore, based on available evidence, the primary validated function remains **protein import receptor/gating**, not a defined metabolic reaction with established substrates.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005743" target="_blank" class="term-link">
+                                    GO:0005743
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial inner membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q3ZCQ8" data-a="GO:0005743" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct. Canonical TIMM50 is a single-pass mitochondrial inner membrane protein with its receptor/gating domain exposed to the intermembrane space.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM50/TIMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">TIMM50 is a **single-pass IMM protein** with an N-terminal mitochondrial targeting sequence, a transmembrane anchor, and a large **IMS-exposed hydrophilic domain** that mediates receptor/gating functions.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016607" target="_blank" class="term-link">
+                                    GO:0016607
+                                </a>
+                            </span>
+                            <span class="term-label">nuclear speck</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+                        <br>
+                        <span class="isoform-badge" title="This annotation was made on a specific isoform">
+                            <a href="https://www.uniprot.org/uniprotkb/Q3ZCQ8-2" target="_blank" class="term-link" style="font-size: 0.7rem;">
+                                Q3ZCQ8-2
+                            </a>
+                        </span>
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q3ZCQ8" data-a="GO:0016607" data-r="GO_REF:0000044" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Supported for the Tim50a isoform, but not the core function of the canonical mitochondrial TIMM50 protein.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Track as isoform-specific, non-core nuclear localization; canonical TIMM50 function is mitochondrial TIM23 import.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16008839" target="_blank" class="term-link">
+                                        PMID:16008839
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">cytoplasm and mitochondria, Tim50a is strictly nuclear and is enriched in</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12620389" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12620389
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Novel raf kinase protein-protein interactions found by an ex...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q3ZCQ8" data-a="GO:0005515" data-r="PMID:12620389" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Protein binding is true but uninformative for TIMM50. The biologically meaningful interaction context is TIM23 presequence receptor/gating and TIMM23/TIM17 complex membership.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Replace generic interaction capture with TIM23 complex membership and presequence/targeting-sequence binding where supported.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM50/TIMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Tim50 is widely regarded as the **primary presequence receptor at the inner membrane**, positioned in the **intermembrane space (IMS)** to receive precursors emerging from the TOM pore and coordinate their entry into TIM23.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM50/TIMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">This receptor/gating logic is supported by direct presequence-binding mapping and the conclusion that Tim50 binding to Tim23 can induce channel closure when no substrate is being transported.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25852190" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25852190
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Integrative analysis of kinase networks in TRAIL-induced apo...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q3ZCQ8" data-a="GO:0005515" data-r="PMID:25852190" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Protein binding is true but uninformative for TIMM50. The biologically meaningful interaction context is TIM23 presequence receptor/gating and TIMM23/TIM17 complex membership.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Replace generic interaction capture with TIM23 complex membership and presequence/targeting-sequence binding where supported.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM50/TIMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Tim50 is widely regarded as the **primary presequence receptor at the inner membrane**, positioned in the **intermembrane space (IMS)** to receive precursors emerging from the TOM pore and coordinate their entry into TIM23.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM50/TIMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">This receptor/gating logic is supported by direct presequence-binding mapping and the conclusion that Tim50 binding to Tim23 can induce channel closure when no substrate is being transported.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/31980649" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:31980649
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Extensive rewiring of the EGFR network in colorectal cancer ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q3ZCQ8" data-a="GO:0005515" data-r="PMID:31980649" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Protein binding is true but uninformative for TIMM50. The biologically meaningful interaction context is TIM23 presequence receptor/gating and TIMM23/TIM17 complex membership.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Replace generic interaction capture with TIM23 complex membership and presequence/targeting-sequence binding where supported.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM50/TIMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Tim50 is widely regarded as the **primary presequence receptor at the inner membrane**, positioned in the **intermembrane space (IMS)** to receive precursors emerging from the TOM pore and coordinate their entry into TIM23.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM50/TIMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">This receptor/gating logic is supported by direct presequence-binding mapping and the conclusion that Tim50 binding to Tim23 can induce channel closure when no substrate is being transported.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/37045861" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:37045861
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Interactome dynamics of RAF1-BRAF kinase monomers and dimers...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q3ZCQ8" data-a="GO:0005515" data-r="PMID:37045861" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Protein binding is true but uninformative for TIMM50. The biologically meaningful interaction context is TIM23 presequence receptor/gating and TIMM23/TIM17 complex membership.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Replace generic interaction capture with TIM23 complex membership and presequence/targeting-sequence binding where supported.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM50/TIMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Tim50 is widely regarded as the **primary presequence receptor at the inner membrane**, positioned in the **intermembrane space (IMS)** to receive precursors emerging from the TOM pore and coordinate their entry into TIM23.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM50/TIMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">This receptor/gating logic is supported by direct presequence-binding mapping and the conclusion that Tim50 binding to Tim23 can induce channel closure when no substrate is being transported.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005743" target="_blank" class="term-link">
+                                    GO:0005743
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial inner membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15044455" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15044455
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Tim50, a component of the mitochondrial translocator, regula...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q3ZCQ8" data-a="GO:0005743" data-r="PMID:15044455" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct. Canonical TIMM50 is a single-pass mitochondrial inner membrane protein with its receptor/gating domain exposed to the intermembrane space.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM50/TIMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">TIMM50 is a **single-pass IMM protein** with an N-terminal mitochondrial targeting sequence, a transmembrane anchor, and a large **IMS-exposed hydrophilic domain** that mediates receptor/gating functions.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005743" target="_blank" class="term-link">
+                                    GO:0005743
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial inner membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10339406" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10339406
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Genetic and structural characterization of the human mitocho...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q3ZCQ8" data-a="GO:0005743" data-r="PMID:10339406" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct. Canonical TIMM50 is a single-pass mitochondrial inner membrane protein with its receptor/gating domain exposed to the intermembrane space.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM50/TIMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">TIMM50 is a **single-pass IMM protein** with an N-terminal mitochondrial targeting sequence, a transmembrane anchor, and a large **IMS-exposed hydrophilic domain** that mediates receptor/gating functions.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005744" target="_blank" class="term-link">
+                                    GO:0005744
+                                </a>
+                            </span>
+                            <span class="term-label">TIM23 mitochondrial import inner membrane translocase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10339406" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10339406
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Genetic and structural characterization of the human mitocho...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q3ZCQ8" data-a="GO:0005744" data-r="PMID:10339406" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct and core. TIMM50 is a core TIM23 complex subunit that directly coordinates presequence handoff and channel gating.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM50/TIMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Tim50 is widely regarded as the **primary presequence receptor at the inner membrane**, positioned in the **intermembrane space (IMS)** to receive precursors emerging from the TOM pore and coordinate their entry into TIM23.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM50/TIMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">This receptor/gating logic is supported by direct presequence-binding mapping and the conclusion that Tim50 binding to Tim23 can induce channel closure when no substrate is being transported.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15044455" target="_blank" class="term-link">
+                                        PMID:15044455
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">complex with human Tim23. Down-regulation of human Tim50 expression by RNA</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006886" target="_blank" class="term-link">
+                                    GO:0006886
+                                </a>
+                            </span>
+                            <span class="term-label">intracellular protein transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10339406" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10339406
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Genetic and structural characterization of the human mitocho...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q3ZCQ8" data-a="GO:0006886" data-r="PMID:10339406" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct pathway family but too broad. TIMM50 specifically mediates TIM23-dependent mitochondrial presequence protein import rather than general intracellular protein transport.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Use mitochondrial matrix import/TIM23 terms instead of generic intracellular transport.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM50/TIMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">TIMM50 primarily acts on **presequence-containing precursor proteins**, which constitute a large fraction of the mitochondrial proteome and are imported through the TIM23 pathway for matrix delivery or IMM insertion.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM50/TIMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Tim50 is widely regarded as the **primary presequence receptor at the inner membrane**, positioned in the **intermembrane space (IMS)** to receive precursors emerging from the TOM pore and coordinate their entry into TIM23.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
+                                    GO:0005654
+                                </a>
+                            </span>
+                            <span class="term-label">nucleoplasm</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000052
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q3ZCQ8" data-a="GO:0005654" data-r="GO_REF:0000052" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Broad nuclear localization is less informative than the isoform-specific nuclear speck evidence for Tim50a and is not the canonical TIMM50 localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Use isoform-specific nuclear speck annotation for Tim50a; canonical TIMM50 is an inner mitochondrial membrane TIM23 subunit.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16008839" target="_blank" class="term-link">
+                                        PMID:16008839
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">cytoplasm and mitochondria, Tim50a is strictly nuclear and is enriched in</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM50/TIMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">TIMM50 is a **single-pass IMM protein** with an N-terminal mitochondrial targeting sequence, a transmembrane anchor, and a large **IMS-exposed hydrophilic domain** that mediates receptor/gating functions.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000052
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q3ZCQ8" data-a="GO:0005739" data-r="GO_REF:0000052" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct but broad. Canonical TIMM50 is specifically an inner mitochondrial membrane TIM23 complex subunit.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Prefer mitochondrial inner membrane and TIM23 complex annotations over generic mitochondrion.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM50/TIMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">TIMM50 is a **single-pass IMM protein** with an N-terminal mitochondrial targeting sequence, a transmembrane anchor, and a large **IMS-exposed hydrophilic domain** that mediates receptor/gating functions.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030150" target="_blank" class="term-link">
+                                    GO:0030150
+                                </a>
+                            </span>
+                            <span class="term-label">protein import into mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/38828998" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:38828998
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Reduced Protein Import via TIM23 SORT Drives Disease Patholo...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q3ZCQ8" data-a="GO:0030150" data-r="PMID:38828998" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct and core. TIMM50 is the TIM23 presequence receptor/gatekeeper needed for import of transit peptide-containing precursors through the inner membrane toward the matrix or IMM sorting pathway.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM50/TIMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Tim50 is widely regarded as the **primary presequence receptor at the inner membrane**, positioned in the **intermembrane space (IMS)** to receive precursors emerging from the TOM pore and coordinate their entry into TIM23.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM50/TIMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">TIMM50 primarily acts on **presequence-containing precursor proteins**, which constitute a large fraction of the mitochondrial proteome and are imported through the TIM23 pathway for matrix delivery or IMM insertion.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM50/TIMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">This receptor/gating logic is supported by direct presequence-binding mapping and the conclusion that Tim50 binding to Tim23 can induce channel closure when no substrate is being transported.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HTP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:34800366
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Quantitative high-confidence human mitochondrial proteome an...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q3ZCQ8" data-a="GO:0005739" data-r="PMID:34800366" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct but broad. Canonical TIMM50 is specifically an inner mitochondrial membrane TIM23 complex subunit.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Prefer mitochondrial inner membrane and TIM23 complex annotations over generic mitochondrion.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM50/TIMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">TIMM50 is a **single-pass IMM protein** with an N-terminal mitochondrial targeting sequence, a transmembrane anchor, and a large **IMS-exposed hydrophilic domain** that mediates receptor/gating functions.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005744" target="_blank" class="term-link">
+                                    GO:0005744
+                                </a>
+                            </span>
+                            <span class="term-label">TIM23 mitochondrial import inner membrane translocase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/30598479" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:30598479
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    ROMO1 is a constituent of the human presequence translocase ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q3ZCQ8" data-a="GO:0005744" data-r="PMID:30598479" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct and core. TIMM50 is a core TIM23 complex subunit that directly coordinates presequence handoff and channel gating.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM50/TIMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Tim50 is widely regarded as the **primary presequence receptor at the inner membrane**, positioned in the **intermembrane space (IMS)** to receive precursors emerging from the TOM pore and coordinate their entry into TIM23.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM50/TIMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">This receptor/gating logic is supported by direct presequence-binding mapping and the conclusion that Tim50 binding to Tim23 can induce channel closure when no substrate is being transported.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15044455" target="_blank" class="term-link">
+                                        PMID:15044455
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">complex with human Tim23. Down-regulation of human Tim50 expression by RNA</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/32848200" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:32848200
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Ttm50 facilitates calpain activation by anchoring it to calc...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q3ZCQ8" data-a="GO:0005739" data-r="PMID:32848200" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct but broad. Canonical TIMM50 is specifically an inner mitochondrial membrane TIM23 complex subunit.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Prefer mitochondrial inner membrane and TIM23 complex annotations over generic mitochondrion.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM50/TIMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">TIMM50 is a **single-pass IMM protein** with an N-terminal mitochondrial targeting sequence, a transmembrane anchor, and a large **IMS-exposed hydrophilic domain** that mediates receptor/gating functions.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005783" target="_blank" class="term-link">
+                                    GO:0005783
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/32848200" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:32848200
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Ttm50 facilitates calpain activation by anchoring it to calc...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q3ZCQ8" data-a="GO:0005783" data-r="PMID:32848200" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> The cited FlyBase-sourced study supports a Drosophila Ttm50 calpain/ER-Golgi calcium-store context, but the human TIMM50 synthesis supports mitochondrial TIM23 import as the established function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Do not treat the noncanonical Ttm50 calpain calcium-store finding as a core human TIMM50 activity or localization without human TIMM50-specific support.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/32848200" target="_blank" class="term-link">
+                                        PMID:32848200
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">GluRIIA at the Drosophila neuromuscular junction as a readout, we uncovered that</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/32848200" target="_blank" class="term-link">
+                                        PMID:32848200
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">stores Golgi and endoplasmic reticulum (ER), and Ttm50 interacts with calpain</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/32848200" target="_blank" class="term-link">
+                                        PMID:32848200
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">magnitude. Our findings reveal the regulation of calpain activation by Ttm50,</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM50/TIMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Tim50 is widely regarded as the **primary presequence receptor at the inner membrane**, positioned in the **intermembrane space (IMS)** to receive precursors emerging from the TOM pore and coordinate their entry into TIM23.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005794" target="_blank" class="term-link">
+                                    GO:0005794
+                                </a>
+                            </span>
+                            <span class="term-label">Golgi apparatus</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/32848200" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:32848200
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Ttm50 facilitates calpain activation by anchoring it to calc...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q3ZCQ8" data-a="GO:0005794" data-r="PMID:32848200" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> The cited FlyBase-sourced study supports a Drosophila Ttm50 calpain/ER-Golgi calcium-store context, but the human TIMM50 synthesis supports mitochondrial TIM23 import as the established function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Do not treat the noncanonical Ttm50 calpain calcium-store finding as a core human TIMM50 activity or localization without human TIMM50-specific support.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/32848200" target="_blank" class="term-link">
+                                        PMID:32848200
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">GluRIIA at the Drosophila neuromuscular junction as a readout, we uncovered that</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/32848200" target="_blank" class="term-link">
+                                        PMID:32848200
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">stores Golgi and endoplasmic reticulum (ER), and Ttm50 interacts with calpain</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/32848200" target="_blank" class="term-link">
+                                        PMID:32848200
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">magnitude. Our findings reveal the regulation of calpain activation by Ttm50,</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM50/TIMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Tim50 is widely regarded as the **primary presequence receptor at the inner membrane**, positioned in the **intermembrane space (IMS)** to receive precursors emerging from the TOM pore and coordinate their entry into TIM23.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140608" target="_blank" class="term-link">
+                                    GO:0140608
+                                </a>
+                            </span>
+                            <span class="term-label">cysteine-type endopeptidase activator activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/32848200" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:32848200
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Ttm50 facilitates calpain activation by anchoring it to calc...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q3ZCQ8" data-a="GO:0140608" data-r="PMID:32848200" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> The cited FlyBase-sourced study supports a Drosophila Ttm50 calpain/ER-Golgi calcium-store context, but the human TIMM50 synthesis supports mitochondrial TIM23 import as the established function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Do not treat the noncanonical Ttm50 calpain calcium-store finding as a core human TIMM50 activity or localization without human TIMM50-specific support.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/32848200" target="_blank" class="term-link">
+                                        PMID:32848200
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">GluRIIA at the Drosophila neuromuscular junction as a readout, we uncovered that</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/32848200" target="_blank" class="term-link">
+                                        PMID:32848200
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">stores Golgi and endoplasmic reticulum (ER), and Ttm50 interacts with calpain</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/32848200" target="_blank" class="term-link">
+                                        PMID:32848200
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">magnitude. Our findings reveal the regulation of calpain activation by Ttm50,</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM50/TIMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Tim50 is widely regarded as the **primary presequence receptor at the inner membrane**, positioned in the **intermembrane space (IMS)** to receive precursors emerging from the TOM pore and coordinate their entry into TIM23.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001836" target="_blank" class="term-link">
+                                    GO:0001836
+                                </a>
+                            </span>
+                            <span class="term-label">release of cytochrome c from mitochondria</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15044455" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15044455
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Tim50, a component of the mitochondrial translocator, regula...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q3ZCQ8" data-a="GO:0001836" data-r="PMID:15044455" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Supported as a downstream consequence of TIMM50 depletion and mitochondrial membrane dysfunction, but it is not the core molecular/cellular role of TIMM50.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> TIMM50 loss can accelerate cytochrome c release, but TIMM50 itself is primarily a TIM23 import receptor/gatekeeper.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15044455" target="_blank" class="term-link">
+                                        PMID:15044455
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">accelerating the release of cytochrome c from the mitochondria. Furthermore,</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM50/TIMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Tim50 is widely regarded as the **primary presequence receptor at the inner membrane**, positioned in the **intermembrane space (IMS)** to receive precursors emerging from the TOM pore and coordinate their entry into TIM23.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004721" target="_blank" class="term-link">
+                                    GO:0004721
+                                </a>
+                            </span>
+                            <span class="term-label">phosphoprotein phosphatase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15044455" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15044455
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Tim50, a component of the mitochondrial translocator, regula...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q3ZCQ8" data-a="GO:0004721" data-r="PMID:15044455" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct assays reported phosphatase activity, but current synthesis indicates the physiological substrate and in vivo relevance remain unclear; TIMM50 should be curated primarily as a TIM23 presequence receptor/gatekeeper.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The phosphatase activity is not the core validated biological function of TIMM50 and has no established physiological substrate in the import pathway.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15044455" target="_blank" class="term-link">
+                                        PMID:15044455
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">demonstrate that human Tim50 possesses phosphatase activity and is present in a</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM50/TIMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Therefore, based on available evidence, the primary validated function remains **protein import receptor/gating**, not a defined metabolic reaction with established substrates.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005134" target="_blank" class="term-link">
+                                    GO:0005134
+                                </a>
+                            </span>
+                            <span class="term-label">interleukin-2 receptor binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15044455" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15044455
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Tim50, a component of the mitochondrial translocator, regula...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="Q3ZCQ8" data-a="GO:0005134" data-r="PMID:15044455" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> The cited Tim50 paper and Falcon synthesis do not support an interleukin-2 receptor binding activity for TIMM50; the established molecular role is TIM23 presequence receptor/gating.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> No usable evidence for IL-2 receptor binding was found in the cited cached publication or in the TIMM50 deep research report.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM50/TIMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Therefore, based on available evidence, the primary validated function remains **protein import receptor/gating**, not a defined metabolic reaction with established substrates.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM50/TIMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Tim50 is widely regarded as the **primary presequence receptor at the inner membrane**, positioned in the **intermembrane space (IMS)** to receive precursors emerging from the TOM pore and coordinate their entry into TIM23.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005744" target="_blank" class="term-link">
+                                    GO:0005744
+                                </a>
+                            </span>
+                            <span class="term-label">TIM23 mitochondrial import inner membrane translocase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15044455" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15044455
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Tim50, a component of the mitochondrial translocator, regula...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q3ZCQ8" data-a="GO:0005744" data-r="PMID:15044455" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct and core. TIMM50 is a core TIM23 complex subunit that directly coordinates presequence handoff and channel gating.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM50/TIMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Tim50 is widely regarded as the **primary presequence receptor at the inner membrane**, positioned in the **intermembrane space (IMS)** to receive precursors emerging from the TOM pore and coordinate their entry into TIM23.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM50/TIMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">This receptor/gating logic is supported by direct presequence-binding mapping and the conclusion that Tim50 binding to Tim23 can induce channel closure when no substrate is being transported.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15044455" target="_blank" class="term-link">
+                                        PMID:15044455
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">complex with human Tim23. Down-regulation of human Tim50 expression by RNA</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004722" target="_blank" class="term-link">
+                                    GO:0004722
+                                </a>
+                            </span>
+                            <span class="term-label">protein serine/threonine phosphatase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15044455" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15044455
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Tim50, a component of the mitochondrial translocator, regula...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q3ZCQ8" data-a="GO:0004722" data-r="PMID:15044455" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct assays reported phosphatase activity, but current synthesis indicates the physiological substrate and in vivo relevance remain unclear; TIMM50 should be curated primarily as a TIM23 presequence receptor/gatekeeper.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The phosphatase activity is not the core validated biological function of TIMM50 and has no established physiological substrate in the import pathway.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15044455" target="_blank" class="term-link">
+                                        PMID:15044455
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">demonstrate that human Tim50 possesses phosphatase activity and is present in a</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM50/TIMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Therefore, based on available evidence, the primary validated function remains **protein import receptor/gating**, not a defined metabolic reaction with established substrates.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004725" target="_blank" class="term-link">
+                                    GO:0004725
+                                </a>
+                            </span>
+                            <span class="term-label">protein tyrosine phosphatase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15044455" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15044455
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Tim50, a component of the mitochondrial translocator, regula...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q3ZCQ8" data-a="GO:0004725" data-r="PMID:15044455" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct assays reported phosphatase activity, but current synthesis indicates the physiological substrate and in vivo relevance remain unclear; TIMM50 should be curated primarily as a TIM23 presequence receptor/gatekeeper.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The phosphatase activity is not the core validated biological function of TIMM50 and has no established physiological substrate in the import pathway.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15044455" target="_blank" class="term-link">
+                                        PMID:15044455
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">demonstrate that human Tim50 possesses phosphatase activity and is present in a</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM50/TIMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Therefore, based on available evidence, the primary validated function remains **protein import receptor/gating**, not a defined metabolic reaction with established substrates.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15044455" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15044455
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Tim50, a component of the mitochondrial translocator, regula...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q3ZCQ8" data-a="GO:0005515" data-r="PMID:15044455" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Protein binding is true but uninformative for TIMM50. The biologically meaningful interaction context is TIM23 presequence receptor/gating and TIMM23/TIM17 complex membership.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Replace generic interaction capture with TIM23 complex membership and presequence/targeting-sequence binding where supported.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM50/TIMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Tim50 is widely regarded as the **primary presequence receptor at the inner membrane**, positioned in the **intermembrane space (IMS)** to receive precursors emerging from the TOM pore and coordinate their entry into TIM23.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM50/TIMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">This receptor/gating logic is supported by direct presequence-binding mapping and the conclusion that Tim50 binding to Tim23 can induce channel closure when no substrate is being transported.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007006" target="_blank" class="term-link">
+                                    GO:0007006
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial membrane organization</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15044455" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15044455
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Tim50, a component of the mitochondrial translocator, regula...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q3ZCQ8" data-a="GO:0007006" data-r="PMID:15044455" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Supported as a cellular consequence of TIMM50 loss causing mitochondrial membrane permeabilization/dysfunction, but it is downstream of the core TIM23 import role.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Keep as non-core because membrane organization phenotypes arise from impaired mitochondrial import/integrity rather than a direct membrane-organizing function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15044455" target="_blank" class="term-link">
+                                        PMID:15044455
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">indicate that loss of Tim50 in vertebrates causes mitochondrial membrane</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM50/TIMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Tim50 is widely regarded as the **primary presequence receptor at the inner membrane**, positioned in the **intermembrane space (IMS)** to receive precursors emerging from the TOM pore and coordinate their entry into TIM23.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016607" target="_blank" class="term-link">
+                                    GO:0016607
+                                </a>
+                            </span>
+                            <span class="term-label">nuclear speck</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+                        <br>
+                        <span class="isoform-badge" title="This annotation was made on a specific isoform">
+                            <a href="https://www.uniprot.org/uniprotkb/Q3ZCQ8-2" target="_blank" class="term-link" style="font-size: 0.7rem;">
+                                Q3ZCQ8-2
+                            </a>
+                        </span>
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16008839" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16008839
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Tim50a, a nuclear isoform of the mitochondrial Tim50, intera...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q3ZCQ8" data-a="GO:0016607" data-r="PMID:16008839" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Supported for the Tim50a isoform, but not the core function of the canonical mitochondrial TIMM50 protein.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Track as isoform-specific, non-core nuclear localization; canonical TIMM50 function is mitochondrial TIM23 import.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16008839" target="_blank" class="term-link">
+                                        PMID:16008839
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">cytoplasm and mitochondria, Tim50a is strictly nuclear and is enriched in</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043021" target="_blank" class="term-link">
+                                    GO:0043021
+                                </a>
+                            </span>
+                            <span class="term-label">ribonucleoprotein complex binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+                        <br>
+                        <span class="isoform-badge" title="This annotation was made on a specific isoform">
+                            <a href="https://www.uniprot.org/uniprotkb/Q3ZCQ8-2" target="_blank" class="term-link" style="font-size: 0.7rem;">
+                                Q3ZCQ8-2
+                            </a>
+                        </span>
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16008839" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16008839
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Tim50a, a nuclear isoform of the mitochondrial Tim50, intera...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q3ZCQ8" data-a="GO:0043021" data-r="PMID:16008839" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Supported for the nuclear Tim50a isoform, which interacts with snRNP-associated proteins, but this is not the canonical mitochondrial import function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Keep as an isoform-specific non-core activity distinct from TIM23 presequence import.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16008839" target="_blank" class="term-link">
+                                        PMID:16008839
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">In addition to coilin, Tim50a interacts with snRNPs and</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16008839" target="_blank" class="term-link">
+                                        PMID:16008839
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">cytoplasm and mitochondria, Tim50a is strictly nuclear and is enriched in</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030943" target="_blank" class="term-link">
+                                    GO:0030943
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion targeting sequence binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            file:human/TIMM50/TIMM50-deep-research-falcon.md
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="Q3ZCQ8" data-a="GO:0030943" data-r="file:human/TIMM50/TIMM50-deep-research-falcon.md" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> TIMM50 is described as the primary inner-membrane presequence receptor for TIM23 substrates, so mitochondrion targeting sequence binding captures its core molecular function better than generic protein binding.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Existing GOA lacks a specific molecular-function term for TIMM50 presequence/targeting-signal receptor activity.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM50/TIMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Tim50 is widely regarded as the **primary presequence receptor at the inner membrane**, positioned in the **intermembrane space (IMS)** to receive precursors emerging from the TOM pore and coordinate their entry into TIM23.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM50/TIMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">TIMM50 primarily acts on **presequence-containing precursor proteins**, which constitute a large fraction of the mitochondrial proteome and are imported through the TIM23 pathway for matrix delivery or IMM insertion.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TIMM50/TIMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">This receptor/gating logic is supported by direct presequence-binding mapping and the conclusion that Tim50 binding to Tim23 can induce channel closure when no substrate is being transported.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>TIMM50 is the inner-membrane TIM23 presequence receptor and gatekeeper that captures transit peptide-containing mitochondrial precursors on the intermembrane-space side, coordinates TIM23 channel gating, and supports import into the matrix or IMM sorting pathway.</h3>
+                <span class="vote-buttons" data-g="Q3ZCQ8" data-a="FUNCTION: TIMM50 is the inner-membrane TIM23 presequence rec..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030943" target="_blank" class="term-link">
+                            mitochondrion targeting sequence binding
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030150" target="_blank" class="term-link">
+                                protein import into mitochondrial matrix
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005743" target="_blank" class="term-link">
+                                mitochondrial inner membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005744" target="_blank" class="term-link">
+                            TIM23 mitochondrial import inner membrane translocase complex
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/TIMM50/TIMM50-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">Tim50 is widely regarded as the **primary presequence receptor at the inner membrane**, positioned in the **intermembrane space (IMS)** to receive precursors emerging from the TOM pore and coordinate their entry into TIM23.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/TIMM50/TIMM50-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">TIMM50 primarily acts on **presequence-containing precursor proteins**, which constitute a large fraction of the mitochondrial proteome and are imported through the TIM23 pathway for matrix delivery or IMM insertion.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/TIMM50/TIMM50-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">This receptor/gating logic is supported by direct presequence-binding mapping and the conclusion that Tim50 binding to Tim23 can induce channel closure when no substrate is being transported.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/TIMM50/TIMM50-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">TIMM50 is a **single-pass IMM protein** with an N-terminal mitochondrial targeting sequence, a transmembrane anchor, and a large **IMS-exposed hydrophilic domain** that mediates receptor/gating functions.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000052.md" target="_blank" class="term-link">
+                            GO_REF:0000052
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on curation of immunofluorescence data</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
+                            GO_REF:0000117
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/10339406" target="_blank" class="term-link">
+                            PMID:10339406
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Genetic and structural characterization of the human mitochondrial inner membrane translocase.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/12620389" target="_blank" class="term-link">
+                            PMID:12620389
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Novel raf kinase protein-protein interactions found by an exhaustive yeast two-hybrid analysis.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/15044455" target="_blank" class="term-link">
+                            PMID:15044455
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Tim50, a component of the mitochondrial translocator, regulates mitochondrial integrity and cell death.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/16008839" target="_blank" class="term-link">
+                            PMID:16008839
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Tim50a, a nuclear isoform of the mitochondrial Tim50, interacts with proteins involved in snRNP biogenesis.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/25852190" target="_blank" class="term-link">
+                            PMID:25852190
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Integrative analysis of kinase networks in TRAIL-induced apoptosis provides a source of potential targets for combination therapy.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/30598479" target="_blank" class="term-link">
+                            PMID:30598479
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">ROMO1 is a constituent of the human presequence translocase required for YME1L protease import.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/31980649" target="_blank" class="term-link">
+                            PMID:31980649
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Extensive rewiring of the EGFR network in colorectal cancer cells expressing transforming levels of KRAS(G13D).</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/32848200" target="_blank" class="term-link">
+                            PMID:32848200
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Ttm50 facilitates calpain activation by anchoring it to calcium stores and increasing its sensitivity to calcium.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link">
+                            PMID:34800366
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Quantitative high-confidence human mitochondrial proteome and its dynamics in cellular context.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/37045861" target="_blank" class="term-link">
+                            PMID:37045861
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Interactome dynamics of RAF1-BRAF kinase monomers and dimers.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/38828998" target="_blank" class="term-link">
+                            PMID:38828998
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Reduced Protein Import via TIM23 SORT Drives Disease Pathology in TIMM50-Associated Mitochondrial Disease.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/TIMM50/TIMM50-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research report for human TIMM50</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> What are the physiological substrates, if any, of the TIMM50 phosphatase-like domain in human cells?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q3ZCQ8" data-a="Q: What are the physiological substrates, if any, of ..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Which human TIM23SORT substrates depend most strongly on TIMM50 presequence recognition or gating?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q3ZCQ8" data-a="Q: Which human TIM23SORT substrates depend most stron..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Is the Tim50a nuclear speck/snRNP role broadly physiological or restricted to specific transformed or neural cell contexts?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q3ZCQ8" data-a="Q: Is the Tim50a nuclear speck/snRNP role broadly phy..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Use TIMM50 rescue mutants affecting presequence-binding and TIMM23-interaction surfaces in TIMM50-deficient human cells, then measure TIM23 complex assembly, channel gating, and import of TIM23MOTOR versus TIM23SORT reporter substrates.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: TIMM50 presequence binding and channel-gating surfaces are separable.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="Q3ZCQ8" data-a="EXPERIMENT: Use TIMM50 rescue mutants affecting presequence-bi..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Compare phosphatase-dead TIMM50 mutants with receptor/gating mutants for rescue of matrix import, IMM sorting, TIM23 complex stability, and patient-cell respiratory phenotypes.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: TIMM50 phosphatase-like activity is dispensable for most TIM23 import functions.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="Q3ZCQ8" data-a="EXPERIMENT: Compare phosphatase-dead TIMM50 mutants with recep..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Deep Research Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(TIMM50-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q3ZCQ8" data-a="DOC: Deep Research Falcon" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <hr />
+<p>provider: falcon<br />
+model: Edison Scientific Literature<br />
+cached: false<br />
+start_time: '2026-05-11T16:35:51.753785'<br />
+end_time: '2026-05-11T16:49:10.112666'<br />
+duration_seconds: 798.36<br />
+template_file: templates/gene_research_go_focused.md<br />
+template_variables:<br />
+  organism: human<br />
+  gene_id: TIMM50<br />
+  gene_symbol: TIMM50<br />
+  uniprot_accession: Q3ZCQ8<br />
+  protein_description: 'RecName: Full=Mitochondrial import inner membrane translocase<br />
+    subunit TIM50; Flags: Precursor;'<br />
+  gene_info: Name=TIMM50; Synonyms=TIM50; ORFNames=PRO1512;<br />
+  organism_full: Homo sapiens (Human).<br />
+  protein_family: Belongs to the TIM50 family. .<br />
+  protein_domains: FCP1_dom. (IPR004274); HAD-like_sf. (IPR036412); HAD_sf. (IPR023214);<br />
+    TIM50. (IPR050365); NIF (PF03031)<br />
+provider_config:<br />
+  timeout: 600<br />
+  max_retries: 3<br />
+  parameters:<br />
+    allowed_domains: []<br />
+    temperature: 0.1<br />
+citation_count: 38</p>
+<hr />
+<h2 id="question">Question</h2>
+<h1 id="gene-research-for-functional-annotation">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> Q3ZCQ8</li>
+<li><strong>Protein Description:</strong> RecName: Full=Mitochondrial import inner membrane translocase subunit TIM50; Flags: Precursor;</li>
+<li><strong>Gene Information:</strong> Name=TIMM50; Synonyms=TIM50; ORFNames=PRO1512;</li>
+<li><strong>Organism (full):</strong> Homo sapiens (Human).</li>
+<li><strong>Protein Family:</strong> Belongs to the TIM50 family. .</li>
+<li><strong>Key Domains:</strong> FCP1_dom. (IPR004274); HAD-like_sf. (IPR036412); HAD_sf. (IPR023214); TIM50. (IPR050365); NIF (PF03031)</li>
+</ul>
+<h3 id="mandatory-verification-steps">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "TIMM50" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Homo sapiens (Human).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'TIMM50' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>TIMM50</strong> (gene ID: TIMM50, UniProt: Q3ZCQ8) in human.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="output">Output</h2>
+<p>Question: You are an expert researcher providing comprehensive, well-cited information.</p>
+<p>Provide detailed information focusing on:<br />
+1. Key concepts and definitions with current understanding<br />
+2. Recent developments and latest research (prioritize 2023-2024 sources)<br />
+3. Current applications and real-world implementations<br />
+4. Expert opinions and analysis from authoritative sources<br />
+5. Relevant statistics and data from recent studies</p>
+<p>Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.<br />
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.</p>
+<h1 id="gene-research-for-functional-annotation_1">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context_1">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot_1">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> Q3ZCQ8</li>
+<li><strong>Protein Description:</strong> RecName: Full=Mitochondrial import inner membrane translocase subunit TIM50; Flags: Precursor;</li>
+<li><strong>Gene Information:</strong> Name=TIMM50; Synonyms=TIM50; ORFNames=PRO1512;</li>
+<li><strong>Organism (full):</strong> Homo sapiens (Human).</li>
+<li><strong>Protein Family:</strong> Belongs to the TIM50 family. .</li>
+<li><strong>Key Domains:</strong> FCP1_dom. (IPR004274); HAD-like_sf. (IPR036412); HAD_sf. (IPR023214); TIM50. (IPR050365); NIF (PF03031)</li>
+</ul>
+<h3 id="mandatory-verification-steps_1">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "TIMM50" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Homo sapiens (Human).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature_1">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'TIMM50' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target_1">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>TIMM50</strong> (gene ID: TIMM50, UniProt: Q3ZCQ8) in human.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="timm50-uniprot-q3zcq8-functional-annotation-research-report-human">TIMM50 (UniProt Q3ZCQ8) Functional Annotation Research Report (Human)</h1>
+<h2 id="1-target-verification-critical-identity-check">1) Target verification (critical identity check)</h2>
+<p>The UniProt accession <strong>Q3ZCQ8</strong> corresponds to <strong>Homo sapiens TIMM50 (Tim50)</strong>, annotated as <strong>mitochondrial import inner membrane translocase subunit TIM50, precursor</strong> and belonging to the <strong>TIM50 family</strong>. Recent primary and review literature consistently places TIMM50 as a <strong>core subunit of the mitochondrial inner membrane TIM23 (“presequence”) translocase</strong>, together with TIMM23 and TIMM17A/B, confirming that the gene symbol <strong>TIMM50</strong> matches the protein description provided and that the organism context is human. (crameri2024reducedproteinimport pages 1-3, paz2024biochemicalandneurophysiological pages 1-2)</p>
+<h2 id="2-key-concepts-definitions-current-understanding">2) Key concepts &amp; definitions (current understanding)</h2>
+<h3 id="21-mitochondrial-protein-import-via-tom-and-tim23">2.1 Mitochondrial protein import via TOM and TIM23</h3>
+<p>Most mitochondrial proteins are encoded in the nucleus and must be imported post-translationally. The <strong>TIM23 complex</strong> is the major inner-membrane import route for proteins carrying <strong>N-terminal, positively charged amphipathic targeting signals (“presequences” / MTSs)</strong>, delivering clients to the <strong>matrix</strong> or inserting some clients into the <strong>inner mitochondrial membrane (IMM)</strong>. (paz2024biochemicalandneurophysiological pages 1-2, fielden2023centralroleof pages 1-4)</p>
+<h3 id="22-timm50tim50-primary-inner-membrane-presequence-receptor-and-gate-regulator">2.2 TIMM50/Tim50: primary inner-membrane presequence receptor and gate regulator</h3>
+<p>Tim50 is widely regarded as the <strong>primary presequence receptor at the inner membrane</strong>, positioned in the <strong>intermembrane space (IMS)</strong> to receive precursors emerging from the TOM pore and coordinate their entry into TIM23. A foundational mechanistic study mapped presequence contact sites and concluded Tim50 is the <strong>primary presequence receptor</strong> and that presequences and Tim50 regulate the Tim23 channel <strong>antagonistically</strong>, consistent with a receptor-plus-gating function. (schulz2011tim50’spresequencereceptor pages 1-2)</p>
+<h3 id="23-tim23-modularity-import-to-matrix-versus-inner-membrane-sorting">2.3 TIM23 modularity: import-to-matrix versus inner-membrane sorting</h3>
+<p>Human TIM23 exists in at least two functional assemblies:<br />
+- <strong>TIM23MOTOR</strong>, which couples the translocase to the ATP-driven import motor (PAM) to achieve full matrix translocation.<br />
+- <strong>TIM23SORT</strong>, which supports <strong>lateral release</strong> of hydrophobic segments into the IMM (inner-membrane insertion/sorting).<br />
+A 2024 human study operationalized these modules and used them to interpret selective substrate sensitivity in TIMM50 disease. (crameri2024reducedproteinimport pages 1-3)</p>
+<h2 id="3-molecular-function-localization-and-mechanism">3) Molecular function, localization, and mechanism</h2>
+<h3 id="31-subcellular-localization-and-topology">3.1 Subcellular localization and topology</h3>
+<p>TIMM50 is a <strong>single-pass IMM protein</strong> with an N-terminal mitochondrial targeting sequence, a transmembrane anchor, and a large <strong>IMS-exposed hydrophilic domain</strong> that mediates receptor/gating functions. (demishteinzohary2017thetim23mitochondrial pages 3-4, genge2023twodomainsof pages 1-2)</p>
+<h3 id="32-core-function-substrate-class-and-substrate-specificity">3.2 Core function: substrate class and “substrate specificity”</h3>
+<p>TIMM50 is not a transporter of small molecules; rather, its substrate specificity is defined by the <strong>type of protein precursors</strong> it helps import. TIMM50 primarily acts on <strong>presequence-containing precursor proteins</strong>, which constitute a large fraction of the mitochondrial proteome and are imported through the TIM23 pathway for matrix delivery or IMM insertion. (crameri2024reducedproteinimport pages 1-3, paz2024biochemicalandneurophysiological pages 1-2)</p>
+<h3 id="33-timm50-as-receptor-and-gatekeeper-interaction-logic">3.3 TIMM50 as receptor and gatekeeper (interaction logic)</h3>
+<p>Mechanistic and review evidence supports the following model:<br />
+1. Presequence-containing precursors are recognized at the outer membrane and pass through TOM.<br />
+2. On the IMS side, <strong>TIMM50/Tim50 captures the presequence</strong> as it emerges from TOM.<br />
+3. TIMM50 interacts with <strong>Tim23</strong> in the IMS and helps regulate channel opening/closure, keeping the pathway closed in the absence of import substrates and switching states upon presequence engagement.<br />
+This receptor/gating logic is supported by direct presequence-binding mapping and the conclusion that Tim50 binding to Tim23 can induce channel closure when no substrate is being transported. (schulz2011tim50’spresequencereceptor pages 1-2, demishteinzohary2017thetim23mitochondrial pages 3-4)</p>
+<h3 id="34-tomtim23-handover-and-coupling-across-two-membranes">3.4 TOM–TIM23 handover and coupling across two membranes</h3>
+<p>Tim50 can be cross-linked to precursors arrested at the TOM “trans” site and can contact TOM-side components (classically described for Tim50/Tim23 with Tom22/Tom40 in mechanistic syntheses), supporting the concept of transient TOM–TIM23 cooperation during active translocation. A 2023 domain-dissection study emphasized that Tim50’s IMS domain(s) coordinate TOM–TIM23 cooperation and that the Tim50 core domain contains the main presequence-binding site and recruitment point to TIM23. (genge2023twodomainsof pages 1-2)</p>
+<h3 id="35-relationship-to-2023-structural-revision-of-the-tim23-channel">3.5 Relationship to 2023 structural revision of the TIM23 channel</h3>
+<p>Two high-impact 2023 Nature papers reframed the TIM23 mechanism by emphasizing <strong>Tim17</strong> as central to the translocation path:<br />
+- Cryo-EM of the TIM23 core supports a stable Tim17–Tim23 heterodimer architecture and proposes a laterally open Tim17 cavity, with Mgr2 positioned near a lateral opening. (2023-06; https://doi.org/10.1038/s41586-023-06239-6) (sim2023structuralbasisof pages 1-4)<br />
+- In-native-membrane crosslinking mapped preprotein contacts and showed <strong>conserved negative charges in Tim17</strong> are essential to initiate presequence translocation along a distinct Tim17 cavity, enabling lateral release for IMM-sorted precursors. (2023-08; https://doi.org/10.1038/s41586-023-06477-8) (fielden2023centralroleof pages 1-4)<br />
+These findings do not diminish TIMM50’s receptor role; rather, they shift the likely <strong>translocation cavity</strong> away from Tim23 alone and toward Tim17, while TIMM50 remains essential for <strong>presequence capture, TOM–TIM coordination, and gating control</strong> at the IMS face of the machinery. (schulz2011tim50’spresequencereceptor pages 1-2, fielden2023centralroleof pages 1-4)</p>
+<h3 id="36-enzymaticphosphatase-like-domain-what-is-known-vs-uncertain">3.6 Enzymatic/phosphatase-like domain: what is known vs. uncertain</h3>
+<p>TIMM50 contains a <strong>HAD/FCP1-like phosphatase-like fold</strong>, and reviews report that human TIMM50 has <strong>dual-specificity phosphatase/phosphohydrolase activity</strong>, but the physiological substrates and relevance to import are described as <strong>unclear/“elusive.”</strong> Therefore, based on available evidence, the primary validated function remains <strong>protein import receptor/gating</strong>, not a defined metabolic reaction with established substrates. (chaudhuri2021diversefunctionsof pages 10-11, chaudhuri2021diversefunctionsof pages 13-15)</p>
+<h2 id="4-recent-developments-and-latest-research-prioritizing-20232024">4) Recent developments and latest research (prioritizing 2023–2024)</h2>
+<h3 id="41-2023-structural-mechanism-of-tim23-and-redefinition-of-channel-architecture">4.1 2023: structural mechanism of TIM23 and redefinition of channel architecture</h3>
+<p>The 2023 cryo-EM and functional mapping studies (Nature) are a major recent development because they provide structural constraints on TIM23 stoichiometry and support a model in which <strong>Tim17 provides a key transmembrane cavity for presequence protein translocation and lateral release</strong>, requiring negatively charged residues near the IMS leaflet. (sim2023structuralbasisof pages 1-4, fielden2023centralroleof pages 1-4)</p>
+<h3 id="42-2024-timm50-associated-mitochondrial-disease-mechanistically-linked-to-tim23sort">4.2 2024: TIMM50-associated mitochondrial disease mechanistically linked to TIM23SORT</h3>
+<p>A 2024 Molecular and Cellular Biology study analyzed patient fibroblasts with a homozygous <strong>TIMM50 p.(Arg113Cys)</strong> variant and a cellular disease model, and linked TIMM50 dysfunction to <strong>reduced TIM23 complex levels/activity</strong> and to a selective vulnerability of <strong>TIM23SORT (lateral insertion) substrates</strong>. (2024-06; https://doi.org/10.1080/10985549.2024.2353652) (crameri2024reducedproteinimport pages 4-5, crameri2024reducedproteinimport pages 11-12)</p>
+<p>Quantitative examples from this study (patient cells / import assays):<br />
+- TIM23MOTOR substrate <strong>OTC import ~82%</strong> of control.<br />
+- TIM23SORT substrates <strong>SURF1 ~67%</strong> and <strong>SCO2 ~62%</strong> of control.<br />
+- Total mitochondrial protein content decreased from <strong>~8% to ~6.5%</strong> of total cellular protein.<br />
+These values support a mechanistic interpretation that TIMM50 loss disproportionately compromises the sorting/lateral insertion arm of TIM23. (crameri2024reducedproteinimport pages 11-12, crameri2024reducedproteinimport pages 4-5)</p>
+<h3 id="43-2024-biochemical-and-neurophysiological-consequences-of-timm50-deficiency">4.3 2024: biochemical and neurophysiological consequences of TIMM50 deficiency</h3>
+<p>A 2024 eLife study investigated TIMM50 deficiency in patient fibroblasts and neuronal TIMM50 knockdown models and reported:<br />
+- Reduced basal/maximal/ATP-linked respiration and reduced glycolytic capacity/reserve, consistent with impaired energetic flexibility.<br />
+- Approximately <strong>twofold decrease in the percentage of mobile mitochondria</strong> in TIMM50-deficient neurons.<br />
+- No effect on mtDNA levels in the tested model systems.<br />
+(2024-12; https://doi.org/10.7554/eLife.99914) (paz2024biochemicalandneurophysiological pages 9-11)</p>
+<h3 id="44-2024-expert-synthesis-on-mutation-hotspots-in-tim23timm50-stands-out">4.4 2024: expert synthesis on mutation “hotspots” in TIM23—TIMM50 stands out</h3>
+<p>A 2024 mini-review reported that among TIM23 complex genes, <strong>TIMM50 has the highest number of reported disease-causing mutations</strong>, summarizing <strong>eight</strong> distinct TIMM50 variants and their associated phenotypes. (2024-11; https://doi.org/10.3390/genes15121534) (jain2024hotspotsfordiseasecausing pages 5-7, jain2024hotspotsfordiseasecausing pages 8-9)</p>
+<h2 id="5-current-applications-and-real-world-implementations">5) Current applications and real-world implementations</h2>
+<h3 id="51-clinical-genetics-and-diagnostic-interpretation">5.1 Clinical genetics and diagnostic interpretation</h3>
+<p>TIMM50 is clinically relevant primarily through <strong>rare-disease diagnostics</strong> for early-onset mitochondrial disorders, including <strong>3-methylglutaconic aciduria type IX (MGCA9)</strong> and related encephalopathic phenotypes. A 2024 review summarizes disease-linked variants and common clinical features, providing a starting point for variant prioritization in exome/genome sequencing pipelines. (jain2024hotspotsfordiseasecausing pages 7-8, jain2024hotspotsfordiseasecausing pages 4-5)</p>
+<h3 id="52-functional-validation-in-patient-derived-cells">5.2 Functional validation in patient-derived cells</h3>
+<p>Recent work demonstrates a practical diagnostic/interpretive workflow: identify candidate variants, then test for <strong>TIMM50 protein loss</strong>, <strong>TIM23 complex integrity (e.g., BN-PAGE)</strong>, and <strong>TIM23-dependent import defects</strong> with defined reporter substrates, including separation of TIM23MOTOR vs TIM23SORT clients. This is a real-world implementation of mechanistic import biology into disease interpretation. (crameri2024reducedproteinimport pages 4-5, crameri2024reducedproteinimport pages 11-12)</p>
+<h3 id="53-proteomics-for-mechanism-of-disease-inference">5.3 Proteomics for mechanism-of-disease inference</h3>
+<p>The 2024 TIMM50 study built a proteomic map of TIMM50-associated disease and leveraged substrate-class analysis (TIM23SORT vs TIM23MOTOR) to infer pathway-specific vulnerability, illustrating how proteomics can be used to move from “gene → mechanism” in mitochondrial disorders. (crameri2024reducedproteinimport pages 1-3)</p>
+<h2 id="6-disease-associations-phenotypes-and-recent-statisticsdata">6) Disease associations, phenotypes, and recent statistics/data</h2>
+<h3 id="61-variant-spectrum-and-phenotype-summary">6.1 Variant spectrum and phenotype summary</h3>
+<p>Reported TIMM50 variants include early truncation and multiple missense alleles (e.g., Ser9Ter, Gly87Ala, Arg114Gln/Trp, Thr149Met, Ala222Thr, Arg239Trp, Gly269Ser), with phenotypes including developmental delay/encephalopathy, seizures/epileptic spasms, lactic acidosis, OXPHOS defects, and MGCA9. (jain2024hotspotsfordiseasecausing pages 4-5)</p>
+<h3 id="62-visual-system-involvement-statistic">6.2 Visual-system involvement statistic</h3>
+<p>A 2024 mini-review reported <strong>abnormal electroretinograms in ≥60% of individuals</strong> with TIMM50 variants, highlighting visual pathway involvement as a recurrent clinical feature. (jain2024hotspotsfordiseasecausing pages 7-8)</p>
+<h3 id="63-quantitative-cellular-phenotypes-recent-primary-studies">6.3 Quantitative cellular phenotypes (recent primary studies)</h3>
+<ul>
+<li>TIMM50 p.Arg113Cys patient fibroblasts show selective reductions in TIM23SORT import (SURF1 67%, SCO2 62%) relative to a TIM23MOTOR substrate (OTC 82%), and decreased mitochondrial protein content (~8%→~6.5%). (crameri2024reducedproteinimport pages 4-5, crameri2024reducedproteinimport pages 11-12)</li>
+<li>TIMM50 deficiency causes measurable bioenergetic impairment and reduced mitochondrial motility (~2-fold reduction in mobile mitochondria) in neuronal models. (paz2024biochemicalandneurophysiological pages 9-11)</li>
+</ul>
+<h2 id="7-expert-opinions-and-authoritative-analyses-how-experts-interpret-timm50-biology">7) Expert opinions and authoritative analyses (how experts interpret TIMM50 biology)</h2>
+<h3 id="71-timm50-as-a-mechanistic-bridge-between-tom-and-tim23">7.1 TIMM50 as a mechanistic bridge between TOM and TIM23</h3>
+<p>Authoritative mechanistic interpretations emphasize TIMM50/Tim50 as an IMS receptor that couples the two membrane translocases by binding presequences and coordinating handover, with its interactions modulated by the incoming signal peptide. (genge2023twodomainsof pages 1-2, demishteinzohary2017thetim23mitochondrial pages 3-4)</p>
+<h3 id="72-timm50-mutation-hotspot-within-tim23-complex">7.2 TIMM50 mutation hotspot within TIM23 complex</h3>
+<p>Expert synthesis argues TIMM50 is a relative hotspot for disease-causing variants among TIM23 components, and that TIMM50 dysfunction can yield severe early-onset neurological disease via impaired protein import. (jain2024hotspotsfordiseasecausing pages 5-7, jain2024hotspotsfordiseasecausing pages 7-8)</p>
+<h3 id="73-timm50-and-lateral-insertion-tim23sort-as-a-disease-mechanism">7.3 TIMM50 and lateral insertion (TIM23SORT) as a disease mechanism</h3>
+<p>The 2024 patient-cell proteomics/import data support a more nuanced view: while TIMM50 is classically described as a presequence receptor, TIMM50 loss in humans disproportionately affects <strong>TIM23SORT-mediated lateral insertion</strong> clients—many of which relate to OXPHOS and mitochondrial ultrastructure—providing a plausible biochemical explanation for specific phenotypes. (crameri2024reducedproteinimport pages 1-3, crameri2024reducedproteinimport pages 11-12)</p>
+<h2 id="8-summary-table-evidence-linked">8) Summary table (evidence-linked)</h2>
+<p>The following table condenses the functional annotation, interaction network, recent structural advances, and 2024 disease evidence.</p>
+<table>
+<thead>
+<tr>
+<th>Topic</th>
+<th>Key points</th>
+<th>Representative recent sources (with year)</th>
+<th>Citation IDs</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Protein identity / topology / domains</td>
+<td>Human <strong>TIMM50</strong> encodes mitochondrial import inner membrane translocase subunit <strong>Tim50</strong> (UniProt <strong>Q3ZCQ8</strong>), a core TIM23 subunit. It is a <strong>single-pass inner mitochondrial membrane</strong> protein with an N-terminal mitochondrial targeting sequence, a transmembrane anchor, and a large <strong>IMS-exposed receptor domain</strong>. Human TIMM50 contains an <strong>FCP1-like / HAD-like phosphatase-like core (NIF/HAD fold)</strong>; unlike fungal Tim50, human TIMM50 lacks the fungal C-terminal PBD, but key groove/β-strand receptor features are conserved.</td>
+<td>Crameri et al., 2024; Chaudhuri et al., 2021; Demishtein-Zohary &amp; Azem, 2017</td>
+<td>(crameri2024reducedproteinimport pages 1-3, chaudhuri2021diversefunctionsof pages 21-22, chaudhuri2021diversefunctionsof pages 6-7, chaudhuri2021diversefunctionsof pages 10-11, demishteinzohary2017thetim23mitochondrial pages 3-4)</td>
+</tr>
+<tr>
+<td>Role in TIM23MOTOR vs TIM23SORT</td>
+<td>TIMM50 is part of the TIM23 core with TIMM23 and TIMM17A/B. In <strong>TIM23MOTOR</strong>, accessory factors such as DNAJC19/15, TIMM44, HSPA9, PAM16, and GRPEL1/2 drive ATP-dependent import of presequence proteins into the <strong>matrix</strong>. In <strong>TIM23SORT</strong>, TIMM21 and <strong>ROMO1</strong> support <strong>lateral insertion</strong> of single/dual-pass inner membrane proteins. Recent human disease proteomics indicate <strong>TIM23SORT clients are especially sensitive</strong> to TIMM50 loss.</td>
+<td>Crameri et al., 2024; Paz et al., 2024</td>
+<td>(crameri2024reducedproteinimport pages 1-3, paz2024biochemicalandneurophysiological pages 1-2)</td>
+</tr>
+<tr>
+<td>Key interaction partners</td>
+<td>TIMM50 directly/functionally associates with <strong>TIMM23</strong> and TIMM17A/B in the TIM23 core. Crosslinking and mechanistic studies place Tim50 in contact with <strong>Tom22/Tom40</strong> at the TOM trans site and with <strong>Tim21/TIMM21</strong>, linking TOM and TIM23 during precursor handover. TIM23SORT also includes <strong>ROMO1</strong>; TIM23MOTOR includes the PAM machinery (TIMM44, mtHsp70/HSPA9, DNAJC19/15, PAM16, GRPEL1/2).</td>
+<td>Genge et al., 2023; Demishtein-Zohary &amp; Azem, 2017; Crameri et al., 2024</td>
+<td>(genge2023twodomainsof pages 1-2, genge2024functionaldissectionof pages 19-22, genge2024functionaldissectionof pages 16-19, demishteinzohary2017thetim23mitochondrial pages 3-4, crameri2024reducedproteinimport pages 1-3)</td>
+</tr>
+<tr>
+<td>Mechanistic concept: presequence receptor</td>
+<td>Tim50 is the <strong>primary presequence receptor at the inner membrane</strong>. It recognizes positively charged, amphipathic N-terminal targeting sequences as they emerge from TOM and helps deliver them to the TIM23 translocase. The core IMS domain contains the principal presequence-binding site and is the main recruitment point to the TIM23 complex.</td>
+<td>Schulz et al., 2011; Genge et al., 2023</td>
+<td>(schulz2011tim50’spresequencereceptor pages 1-2, genge2023twodomainsof pages 1-2)</td>
+</tr>
+<tr>
+<td>Mechanistic concept: gating / closure</td>
+<td>Tim50 is also a <strong>gating regulator</strong>: Tim50 binding to Tim23 antagonizes channel opening and helps keep the channel <strong>closed in the absence of substrate</strong>; presequence engagement relieves this inhibitory state and promotes productive translocation. Reviews describe Tim50/Tim23 as receptor-gating components on the IMS side of the TIM23 complex.</td>
+<td>Schulz et al., 2011; Demishtein-Zohary &amp; Azem, 2017</td>
+<td>(schulz2011tim50’spresequencereceptor pages 1-2, demishteinzohary2017thetim23mitochondrial pages 3-4)</td>
+</tr>
+<tr>
+<td>Mechanistic concept: TOM–TIM23 handover</td>
+<td>Tim50 can bind precursor proteins while they are still at/near the <strong>TOM trans site</strong> and can contact <strong>Tom22</strong> and <strong>Tom40</strong>, supporting a transient <strong>TOM–TIM23 supercomplex</strong>. Presequence binding modulates Tim50 interactions with Tom22/Tim21 and coordinates handover from TOM to TIM23.</td>
+<td>Genge et al., 2023; recent mechanistic syntheses 2024–2025</td>
+<td>(genge2023twodomainsof pages 1-2, genge2024functionaldissectionof pages 19-22, genge2024functionaldissectionof pages 16-19, jain2025investigatingmitochondrialpresequence pages 20-23, jain2025investigatingmitochondrialpresequence pages 15-17)</td>
+</tr>
+<tr>
+<td>Mechanistic concept: lateral insertion</td>
+<td>New mechanistic work shifts emphasis toward <strong>Tim17</strong> as the main translocation cavity with a laterally open, negatively charged path, while TIMM50 remains essential upstream for precursor recognition and pathway selection. Human 2024 proteomics suggest TIMM50 dysfunction disproportionately affects <strong>TIM23SORT-mediated lateral insertion</strong>, implying TIMM50 has a stronger role in sorting than previously appreciated.</td>
+<td>Sim et al., 2023; Fielden et al., 2023; Crameri et al., 2024</td>
+<td>(sim2023structuralbasisof pages 1-4, fielden2023centralroleof pages 1-4, crameri2024reducedproteinimport pages 1-3)</td>
+</tr>
+<tr>
+<td>Enzymatic / phosphatase-like activity</td>
+<td>TIMM50 carries a <strong>phosphatase-like HAD/FCP1-related fold</strong>, and reviews report <strong>dual-specificity phosphatase / phosphohydrolase activity</strong> for human TIMM50. However, the <strong>physiological substrates and in vivo relevance remain unclear</strong>, so TIMM50 is functionally annotated primarily as an import receptor/gating subunit rather than a validated metabolic enzyme.</td>
+<td>Chaudhuri et al., 2021</td>
+<td>(chaudhuri2021diversefunctionsof pages 21-22, chaudhuri2021diversefunctionsof pages 10-11, chaudhuri2021diversefunctionsof pages 13-15)</td>
+</tr>
+<tr>
+<td>Evidence types supporting function</td>
+<td>Evidence spans <strong>photo-crosslinking and receptor mapping</strong> (2011), <strong>domain dissection and TOM–TIM coordination</strong> (2023), <strong>cryo-EM/structural reinterpretation of TIM23 architecture</strong> (2023), and <strong>patient-cell proteomics/import assays</strong> (2024). Together these support TIMM50 as an IMS receptor, channel regulator, and determinant of TIM23 complex integrity and substrate selectivity.</td>
+<td>Schulz et al., 2011; Sim et al., 2023; Fielden et al., 2023; Genge et al., 2023; Crameri et al., 2024</td>
+<td>(schulz2011tim50’spresequencereceptor pages 1-2, sim2023structuralbasisof pages 1-4, fielden2023centralroleof pages 1-4, genge2023twodomainsof pages 1-2, crameri2024reducedproteinimport pages 1-3)</td>
+</tr>
+<tr>
+<td>Disease genetics / clinical spectrum</td>
+<td>A 2024 mini-review identified <strong>8 distinct human TIMM50 mutations</strong>, making TIMM50 the <strong>most mutation-enriched TIM23 subunit</strong> currently known. Disease is linked to <strong>3-methylglutaconic aciduria type IX (MGCA9)</strong> and/or mitochondrial encephalopathy with <strong>failure to thrive, developmental delay, seizures/epileptic spasms, visual pathway abnormalities, optic atrophy, and elevated lactate</strong>. <strong>Abnormal electroretinograms were reported in ≥60%</strong> of affected individuals.</td>
+<td>Jain et al., 2024; Crameri et al., 2024</td>
+<td>(jain2024hotspotsfordiseasecausing pages 7-8, jain2024hotspotsfordiseasecausing pages 4-5, jain2024hotspotsfordiseasecausing pages 5-7, jain2024hotspotsfordiseasecausing pages 8-9, crameri2024reducedproteinimport pages 1-3)</td>
+</tr>
+<tr>
+<td>Quantitative findings from 2024 Crameri study</td>
+<td>In patient fibroblasts with homozygous <strong>p.Arg113Cys</strong>, TIMM50 protein was nearly absent; assembled TIM23 complex and core subunits were reduced. Import assays showed <strong>TIM23MOTOR substrate OTC at 82% of control</strong>, versus <strong>TIM23SORT substrates SURF1 at 67%</strong> and <strong>SCO2 at 62%</strong>. Total mitochondrial protein content fell from <strong>~8% to ~6.5%</strong> of total cellular protein. TIM22 substrate import was unaffected; WT TIMM50 re-expression partially rescued defects.</td>
+<td>Crameri et al., 2024</td>
+<td>(crameri2024reducedproteinimport pages 4-5, crameri2024reducedproteinimport pages 11-12)</td>
+</tr>
+<tr>
+<td>Quantitative findings from 2024 Paz study</td>
+<td>In patient fibroblasts and TIMM50-KD neurons, TIMM50 deficiency reduced <strong>basal, maximal, and ATP-linked respiration</strong> and lowered glycolytic capacity/reserve without affecting mtDNA copy number. Neuronal imaging showed an approximately <strong>2-fold decrease in the percentage of mobile mitochondria</strong>. Reported assays used <strong>n=4–6 biological repeats</strong> with significant effects.</td>
+<td>Paz et al., 2024</td>
+<td>(paz2024biochemicalandneurophysiological pages 9-11)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the core functional annotation, mechanistic biology, interaction network, recent structural advances, and 2024 disease evidence for human TIMM50 (UniProt Q3ZCQ8). It is useful as a compact reference linking molecular function to quantitative patient-cell findings and current expert interpretation.</em></p>
+<h2 id="9-key-recent-references-urls-publication-dates">9) Key recent references (URLs &amp; publication dates)</h2>
+<ul>
+<li>Sim SI et al. <strong>“Structural basis of mitochondrial protein import by the TIM23 complex.”</strong> <em>Nature</em> (2023-06). https://doi.org/10.1038/s41586-023-06239-6 (sim2023structuralbasisof pages 1-4)</li>
+<li>Fielden LF et al. <strong>“Central role of Tim17 in mitochondrial presequence protein translocation.”</strong> <em>Nature</em> (2023-08). https://doi.org/10.1038/s41586-023-06477-8 (fielden2023centralroleof pages 1-4)</li>
+<li>Genge MG et al. <strong>“Two domains of Tim50 coordinate translocation of proteins across the two mitochondrial membranes.”</strong> <em>Life Science Alliance</em> (2023-09). https://doi.org/10.26508/lsa.202302122 (genge2023twodomainsof pages 1-2)</li>
+<li>Crameri JJ et al. <strong>“Reduced Protein Import via TIM23SORT Drives Disease Pathology in TIMM50-Associated Mitochondrial Disease.”</strong> <em>Molecular and Cellular Biology</em> (2024-06). https://doi.org/10.1080/10985549.2024.2353652 (crameri2024reducedproteinimport pages 1-3)</li>
+<li>Paz E et al. <strong>“Biochemical and neurophysiological effects of deficiency of the mitochondrial import protein TIMM50.”</strong> <em>eLife</em> (2024-12). https://doi.org/10.7554/eLife.99914 (paz2024biochemicalandneurophysiological pages 1-2)</li>
+<li>Jain S et al. <strong>“Hotspots for Disease-Causing Mutations in the Mitochondrial TIM23 Import Complex.”</strong> <em>Genes</em> (2024-11). https://doi.org/10.3390/genes15121534 (jain2024hotspotsfordiseasecausing pages 7-8)</li>
+<li>Schulz C et al. <strong>“Tim50’s presequence receptor domain is essential for signal driven transport across the TIM23 complex.”</strong> <em>J Cell Biol</em> (2011-11). https://doi.org/10.1083/jcb.201105098 (schulz2011tim50’spresequencereceptor pages 1-2)</li>
+</ul>
+<h2 id="10-notes-on-limitations-and-open-questions">10) Notes on limitations and open questions</h2>
+<ul>
+<li>Many mechanistic details (e.g., exact residue-level interaction interfaces between human TIMM50 and TOM/TIM23 components; high-resolution structures of human TOM–TIM23 with substrate in transit) remain incompletely resolved in the available excerpts, and some structural insights are currently derived largely from yeast systems extrapolated to mammals. (sim2023structuralbasisof pages 1-4, genge2023twodomainsof pages 1-2)</li>
+<li>Although TIMM50 has a phosphatase-like fold and phosphatase activity has been reported in reviews, clear consensus on in vivo substrates and physiological impact remains lacking; current evidence supports prioritizing its role as an import receptor/gating component. (chaudhuri2021diversefunctionsof pages 10-11, chaudhuri2021diversefunctionsof pages 13-15)</li>
+</ul>
+<p>References</p>
+<ol>
+<li>
+<p>(crameri2024reducedproteinimport pages 1-3): Jordan J. Crameri, Catherine S. Palmer, Tegan Stait, Thomas D. Jackson, Matthew Lynch, Adriane Sinclair, Leah E. Frajman, Alison G. Compton, David Coman, David R. Thorburn, Ann E. Frazier, and Diana Stojanovski. Reduced protein import via tim23 sort drives disease pathology in timm50-associated mitochondrial disease. Molecular and Cellular Biology, 44:226-244, Jun 2024. URL: https://doi.org/10.1080/10985549.2024.2353652, doi:10.1080/10985549.2024.2353652. This article has 9 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(paz2024biochemicalandneurophysiological pages 1-2): Eyal Paz, Sahil Jain, Irit Gottfried, Orna Staretz-Chacham, Muhammad Mahajnah, Pritha Bagchi, Nicholas T Seyfried, Uri Ashery, and Abdussalam Azem. Biochemical and neurophysiological effects of deficiency of the mitochondrial import protein timm50. eLife, Dec 2024. URL: https://doi.org/10.7554/elife.99914, doi:10.7554/elife.99914. This article has 5 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(fielden2023centralroleof pages 1-4): Laura F. Fielden, Jakob D. Busch, Sandra G. Merkt, Iniyan Ganesan, Conny Steiert, Hanna B. Hasselblatt, Jon V. Busto, Christophe Wirth, Nicole Zufall, Sibylle Jungbluth, Katja Noll, Julia M. Dung, Ludmila Butenko, Karina von der Malsburg, Hans-Georg Koch, Carola Hunte, Martin van der Laan, and Nils Wiedemann. Central role of tim17 in mitochondrial presequence protein translocation. Nature, 621:627-634, Aug 2023. URL: https://doi.org/10.1038/s41586-023-06477-8, doi:10.1038/s41586-023-06477-8. This article has 64 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(schulz2011tim50’spresequencereceptor pages 1-2): Christian Schulz, Oleksandr Lytovchenko, Jonathan Melin, Agnieszka Chacinska, Bernard Guiard, Piotr Neumann, Ralf Ficner, Olaf Jahn, Bernhard Schmidt, and Peter Rehling. Tim50’s presequence receptor domain is essential for signal driven transport across the tim23 complex. The Journal of Cell Biology, 195:643-656, Nov 2011. URL: https://doi.org/10.1083/jcb.201105098, doi:10.1083/jcb.201105098. This article has 117 citations.</p>
+</li>
+<li>
+<p>(demishteinzohary2017thetim23mitochondrial pages 3-4): Keren Demishtein-Zohary and Abdussalam Azem. The tim23 mitochondrial protein import complex: function and dysfunction. Cell and Tissue Research, 367:33-41, Sep 2017. URL: https://doi.org/10.1007/s00441-016-2486-7, doi:10.1007/s00441-016-2486-7. This article has 59 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(genge2023twodomainsof pages 1-2): Marcel G Genge, Shalini Roy Chowdhury, Vít Dohnálek, Kaori Yunoki, Takashi Hirashima, Toshiya Endo, Pavel Doležal, and Dejana Mokranjac. Two domains of tim50 coordinate translocation of proteins across the two mitochondrial membranes. Life Science Alliance, 6:e202302122, Sep 2023. URL: https://doi.org/10.26508/lsa.202302122, doi:10.26508/lsa.202302122. This article has 8 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(sim2023structuralbasisof pages 1-4): Sue Im Sim, Yuanyuan Chen, Diane L. Lynch, James C. Gumbart, and Eunyong Park. Structural basis of mitochondrial protein import by the tim23 complex. Nature, 621:620-626, Jun 2023. URL: https://doi.org/10.1038/s41586-023-06239-6, doi:10.1038/s41586-023-06239-6. This article has 105 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(chaudhuri2021diversefunctionsof pages 10-11): Minu Chaudhuri, Anuj Tripathi, and Fidel Soto Gonzalez. Diverse functions of tim50, a component of the mitochondrial inner membrane protein translocase. International Journal of Molecular Sciences, 22:7779, Jul 2021. URL: https://doi.org/10.3390/ijms22157779, doi:10.3390/ijms22157779. This article has 16 citations.</p>
+</li>
+<li>
+<p>(chaudhuri2021diversefunctionsof pages 13-15): Minu Chaudhuri, Anuj Tripathi, and Fidel Soto Gonzalez. Diverse functions of tim50, a component of the mitochondrial inner membrane protein translocase. International Journal of Molecular Sciences, 22:7779, Jul 2021. URL: https://doi.org/10.3390/ijms22157779, doi:10.3390/ijms22157779. This article has 16 citations.</p>
+</li>
+<li>
+<p>(crameri2024reducedproteinimport pages 4-5): Jordan J. Crameri, Catherine S. Palmer, Tegan Stait, Thomas D. Jackson, Matthew Lynch, Adriane Sinclair, Leah E. Frajman, Alison G. Compton, David Coman, David R. Thorburn, Ann E. Frazier, and Diana Stojanovski. Reduced protein import via tim23 sort drives disease pathology in timm50-associated mitochondrial disease. Molecular and Cellular Biology, 44:226-244, Jun 2024. URL: https://doi.org/10.1080/10985549.2024.2353652, doi:10.1080/10985549.2024.2353652. This article has 9 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(crameri2024reducedproteinimport pages 11-12): Jordan J. Crameri, Catherine S. Palmer, Tegan Stait, Thomas D. Jackson, Matthew Lynch, Adriane Sinclair, Leah E. Frajman, Alison G. Compton, David Coman, David R. Thorburn, Ann E. Frazier, and Diana Stojanovski. Reduced protein import via tim23 sort drives disease pathology in timm50-associated mitochondrial disease. Molecular and Cellular Biology, 44:226-244, Jun 2024. URL: https://doi.org/10.1080/10985549.2024.2353652, doi:10.1080/10985549.2024.2353652. This article has 9 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(paz2024biochemicalandneurophysiological pages 9-11): Eyal Paz, Sahil Jain, Irit Gottfried, Orna Staretz-Chacham, Muhammad Mahajnah, Pritha Bagchi, Nicholas T Seyfried, Uri Ashery, and Abdussalam Azem. Biochemical and neurophysiological effects of deficiency of the mitochondrial import protein timm50. eLife, Dec 2024. URL: https://doi.org/10.7554/elife.99914, doi:10.7554/elife.99914. This article has 5 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(jain2024hotspotsfordiseasecausing pages 5-7): Sahil Jain, Eyal Paz, and Abdussalam Azem. Hotspots for disease-causing mutations in the mitochondrial tim23 import complex. Genes, 15:1534, Nov 2024. URL: https://doi.org/10.3390/genes15121534, doi:10.3390/genes15121534. This article has 1 citations.</p>
+</li>
+<li>
+<p>(jain2024hotspotsfordiseasecausing pages 8-9): Sahil Jain, Eyal Paz, and Abdussalam Azem. Hotspots for disease-causing mutations in the mitochondrial tim23 import complex. Genes, 15:1534, Nov 2024. URL: https://doi.org/10.3390/genes15121534, doi:10.3390/genes15121534. This article has 1 citations.</p>
+</li>
+<li>
+<p>(jain2024hotspotsfordiseasecausing pages 7-8): Sahil Jain, Eyal Paz, and Abdussalam Azem. Hotspots for disease-causing mutations in the mitochondrial tim23 import complex. Genes, 15:1534, Nov 2024. URL: https://doi.org/10.3390/genes15121534, doi:10.3390/genes15121534. This article has 1 citations.</p>
+</li>
+<li>
+<p>(jain2024hotspotsfordiseasecausing pages 4-5): Sahil Jain, Eyal Paz, and Abdussalam Azem. Hotspots for disease-causing mutations in the mitochondrial tim23 import complex. Genes, 15:1534, Nov 2024. URL: https://doi.org/10.3390/genes15121534, doi:10.3390/genes15121534. This article has 1 citations.</p>
+</li>
+<li>
+<p>(chaudhuri2021diversefunctionsof pages 21-22): Minu Chaudhuri, Anuj Tripathi, and Fidel Soto Gonzalez. Diverse functions of tim50, a component of the mitochondrial inner membrane protein translocase. International Journal of Molecular Sciences, 22:7779, Jul 2021. URL: https://doi.org/10.3390/ijms22157779, doi:10.3390/ijms22157779. This article has 16 citations.</p>
+</li>
+<li>
+<p>(chaudhuri2021diversefunctionsof pages 6-7): Minu Chaudhuri, Anuj Tripathi, and Fidel Soto Gonzalez. Diverse functions of tim50, a component of the mitochondrial inner membrane protein translocase. International Journal of Molecular Sciences, 22:7779, Jul 2021. URL: https://doi.org/10.3390/ijms22157779, doi:10.3390/ijms22157779. This article has 16 citations.</p>
+</li>
+<li>
+<p>(genge2024functionaldissectionof pages 19-22): Marcel Gilbert Genge. Functional dissection of the two domains of tim50, the main receptor of the tim23 complex. Dissertation, Jan 2024. URL: https://doi.org/10.5282/edoc.34256, doi:10.5282/edoc.34256. This article has 0 citations.</p>
+</li>
+<li>
+<p>(genge2024functionaldissectionof pages 16-19): Marcel Gilbert Genge. Functional dissection of the two domains of tim50, the main receptor of the tim23 complex. Dissertation, Jan 2024. URL: https://doi.org/10.5282/edoc.34256, doi:10.5282/edoc.34256. This article has 0 citations.</p>
+</li>
+<li>
+<p>(jain2025investigatingmitochondrialpresequence pages 20-23): Naintara Jain. Investigating Mitochondrial Presequence Import. PhD thesis, University Goettingen, 2025. URL: https://doi.org/10.53846/goediss-11596, doi:10.53846/goediss-11596.</p>
+</li>
+<li>
+<p>(jain2025investigatingmitochondrialpresequence pages 15-17): Naintara Jain. Investigating Mitochondrial Presequence Import. PhD thesis, University Goettingen, 2025. URL: https://doi.org/10.53846/goediss-11596, doi:10.53846/goediss-11596.</p>
+</li>
+</ol>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>crameri2024reducedproteinimport pages 1-3</li>
+<li>genge2023twodomainsof pages 1-2</li>
+<li>sim2023structuralbasisof pages 1-4</li>
+<li>fielden2023centralroleof pages 1-4</li>
+<li>paz2024biochemicalandneurophysiological pages 9-11</li>
+<li>jain2024hotspotsfordiseasecausing pages 4-5</li>
+<li>jain2024hotspotsfordiseasecausing pages 7-8</li>
+<li>paz2024biochemicalandneurophysiological pages 1-2</li>
+<li>chaudhuri2021diversefunctionsof pages 10-11</li>
+<li>chaudhuri2021diversefunctionsof pages 13-15</li>
+<li>crameri2024reducedproteinimport pages 4-5</li>
+<li>crameri2024reducedproteinimport pages 11-12</li>
+<li>jain2024hotspotsfordiseasecausing pages 5-7</li>
+<li>jain2024hotspotsfordiseasecausing pages 8-9</li>
+<li>chaudhuri2021diversefunctionsof pages 21-22</li>
+<li>chaudhuri2021diversefunctionsof pages 6-7</li>
+<li>genge2024functionaldissectionof pages 19-22</li>
+<li>genge2024functionaldissectionof pages 16-19</li>
+<li>jain2025investigatingmitochondrialpresequence pages 20-23</li>
+<li>jain2025investigatingmitochondrialpresequence pages 15-17</li>
+<li>https://doi.org/10.1038/s41586-023-06239-6</li>
+<li>https://doi.org/10.1038/s41586-023-06477-8</li>
+<li>https://doi.org/10.1080/10985549.2024.2353652</li>
+<li>https://doi.org/10.7554/eLife.99914</li>
+<li>https://doi.org/10.3390/genes15121534</li>
+<li>https://doi.org/10.26508/lsa.202302122</li>
+<li>https://doi.org/10.1083/jcb.201105098</li>
+<li>https://doi.org/10.1080/10985549.2024.2353652,</li>
+<li>https://doi.org/10.7554/elife.99914,</li>
+<li>https://doi.org/10.1038/s41586-023-06477-8,</li>
+<li>https://doi.org/10.1083/jcb.201105098,</li>
+<li>https://doi.org/10.1007/s00441-016-2486-7,</li>
+<li>https://doi.org/10.26508/lsa.202302122,</li>
+<li>https://doi.org/10.1038/s41586-023-06239-6,</li>
+<li>https://doi.org/10.3390/ijms22157779,</li>
+<li>https://doi.org/10.3390/genes15121534,</li>
+<li>https://doi.org/10.5282/edoc.34256,</li>
+<li>https://doi.org/10.53846/goediss-11596,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q3ZCQ8
+gene_symbol: TIMM50
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: &#39;TIMM50 encodes the single-pass mitochondrial inner membrane Tim50 subunit of the TIM23 presequence
+  translocase. TIMM50 acts from the intermembrane-space side as a primary presequence receptor and gatekeeper for
+  TIM23-dependent import of transit peptide-containing precursor proteins, while its reported phosphatase, nuclear
+  Tim50a, and calpain-associated roles are secondary or insufficiently established as core human TIMM50 functions.&#39;
+alternative_products:
+- name: &#39;1&#39;
+  id: Q3ZCQ8-1
+- name: 2 (Tim50a)
+  id: Q3ZCQ8-2
+  sequence_note: VSP_016389
+- name: &#39;3&#39;
+  id: Q3ZCQ8-3
+  sequence_note: VSP_047682, VSP_047683
+existing_annotations:
+- term:
+    id: GO:0030150
+    label: protein import into mitochondrial matrix
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: Correct and core. TIMM50 is the TIM23 presequence receptor/gatekeeper needed for import of
+      transit peptide-containing precursors through the inner membrane toward the matrix or IMM sorting
+      pathway.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TIMM50/TIMM50-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: Tim50 is widely regarded as the **primary presequence receptor at the inner membrane**,
+        positioned in the **intermembrane space (IMS)** to receive precursors emerging from the TOM pore and
+        coordinate their entry into TIM23.
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: TIMM50 primarily acts on **presequence-containing precursor proteins**, which
+        constitute a large fraction of the mitochondrial proteome and are imported through the TIM23 pathway
+        for matrix delivery or IMM insertion.
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: This receptor/gating logic is supported by direct presequence-binding mapping and the
+        conclusion that Tim50 binding to Tim23 can induce channel closure when no substrate is being
+        transported.
+- term:
+    id: GO:0005744
+    label: TIM23 mitochondrial import inner membrane translocase complex
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: Correct and core. TIMM50 is a core TIM23 complex subunit that directly coordinates presequence
+      handoff and channel gating.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TIMM50/TIMM50-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: Tim50 is widely regarded as the **primary presequence receptor at the inner membrane**,
+        positioned in the **intermembrane space (IMS)** to receive precursors emerging from the TOM pore and
+        coordinate their entry into TIM23.
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: This receptor/gating logic is supported by direct presequence-binding mapping and the
+        conclusion that Tim50 binding to Tim23 can induce channel closure when no substrate is being
+        transported.
+    - reference_id: PMID:15044455
+      supporting_text: complex with human Tim23. Down-regulation of human Tim50 expression by RNA
+- term:
+    id: GO:0004722
+    label: protein serine/threonine phosphatase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  review:
+    summary: Direct assays reported phosphatase activity, but current synthesis indicates the physiological
+      substrate and in vivo relevance remain unclear; TIMM50 should be curated primarily as a TIM23
+      presequence receptor/gatekeeper.
+    action: KEEP_AS_NON_CORE
+    additional_reference_ids:
+    - file:human/TIMM50/TIMM50-deep-research-falcon.md
+    - PMID:15044455
+    reason: The phosphatase activity is not the core validated biological function of TIMM50 and has no
+      established physiological substrate in the import pathway.
+    supported_by:
+    - reference_id: PMID:15044455
+      supporting_text: demonstrate that human Tim50 possesses phosphatase activity and is present in a
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: Therefore, based on available evidence, the primary validated function remains
+        **protein import receptor/gating**, not a defined metabolic reaction with established substrates.
+- term:
+    id: GO:0005743
+    label: mitochondrial inner membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  review:
+    summary: Correct. Canonical TIMM50 is a single-pass mitochondrial inner membrane protein with its
+      receptor/gating domain exposed to the intermembrane space.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TIMM50/TIMM50-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: TIMM50 is a **single-pass IMM protein** with an N-terminal mitochondrial targeting
+        sequence, a transmembrane anchor, and a large **IMS-exposed hydrophilic domain** that mediates
+        receptor/gating functions.
+- term:
+    id: GO:0016607
+    label: nuclear speck
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  review:
+    summary: Supported for the Tim50a isoform, but not the core function of the canonical mitochondrial TIMM50
+      protein.
+    action: KEEP_AS_NON_CORE
+    additional_reference_ids:
+    - PMID:16008839
+    reason: Track as isoform-specific, non-core nuclear localization; canonical TIMM50 function is
+      mitochondrial TIM23 import.
+    supported_by:
+    - reference_id: PMID:16008839
+      supporting_text: cytoplasm and mitochondria, Tim50a is strictly nuclear and is enriched in
+  isoform: Q3ZCQ8-2
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:12620389
+  review:
+    summary: Protein binding is true but uninformative for TIMM50. The biologically meaningful interaction
+      context is TIM23 presequence receptor/gating and TIMM23/TIM17 complex membership.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/TIMM50/TIMM50-deep-research-falcon.md
+    reason: Replace generic interaction capture with TIM23 complex membership and
+      presequence/targeting-sequence binding where supported.
+    supported_by:
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: Tim50 is widely regarded as the **primary presequence receptor at the inner membrane**,
+        positioned in the **intermembrane space (IMS)** to receive precursors emerging from the TOM pore and
+        coordinate their entry into TIM23.
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: This receptor/gating logic is supported by direct presequence-binding mapping and the
+        conclusion that Tim50 binding to Tim23 can induce channel closure when no substrate is being
+        transported.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:25852190
+  review:
+    summary: Protein binding is true but uninformative for TIMM50. The biologically meaningful interaction
+      context is TIM23 presequence receptor/gating and TIMM23/TIM17 complex membership.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/TIMM50/TIMM50-deep-research-falcon.md
+    reason: Replace generic interaction capture with TIM23 complex membership and
+      presequence/targeting-sequence binding where supported.
+    supported_by:
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: Tim50 is widely regarded as the **primary presequence receptor at the inner membrane**,
+        positioned in the **intermembrane space (IMS)** to receive precursors emerging from the TOM pore and
+        coordinate their entry into TIM23.
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: This receptor/gating logic is supported by direct presequence-binding mapping and the
+        conclusion that Tim50 binding to Tim23 can induce channel closure when no substrate is being
+        transported.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:31980649
+  review:
+    summary: Protein binding is true but uninformative for TIMM50. The biologically meaningful interaction
+      context is TIM23 presequence receptor/gating and TIMM23/TIM17 complex membership.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/TIMM50/TIMM50-deep-research-falcon.md
+    reason: Replace generic interaction capture with TIM23 complex membership and
+      presequence/targeting-sequence binding where supported.
+    supported_by:
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: Tim50 is widely regarded as the **primary presequence receptor at the inner membrane**,
+        positioned in the **intermembrane space (IMS)** to receive precursors emerging from the TOM pore and
+        coordinate their entry into TIM23.
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: This receptor/gating logic is supported by direct presequence-binding mapping and the
+        conclusion that Tim50 binding to Tim23 can induce channel closure when no substrate is being
+        transported.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:37045861
+  review:
+    summary: Protein binding is true but uninformative for TIMM50. The biologically meaningful interaction
+      context is TIM23 presequence receptor/gating and TIMM23/TIM17 complex membership.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/TIMM50/TIMM50-deep-research-falcon.md
+    reason: Replace generic interaction capture with TIM23 complex membership and
+      presequence/targeting-sequence binding where supported.
+    supported_by:
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: Tim50 is widely regarded as the **primary presequence receptor at the inner membrane**,
+        positioned in the **intermembrane space (IMS)** to receive precursors emerging from the TOM pore and
+        coordinate their entry into TIM23.
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: This receptor/gating logic is supported by direct presequence-binding mapping and the
+        conclusion that Tim50 binding to Tim23 can induce channel closure when no substrate is being
+        transported.
+- term:
+    id: GO:0005743
+    label: mitochondrial inner membrane
+  evidence_type: IDA
+  original_reference_id: PMID:15044455
+  review:
+    summary: Correct. Canonical TIMM50 is a single-pass mitochondrial inner membrane protein with its
+      receptor/gating domain exposed to the intermembrane space.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TIMM50/TIMM50-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: TIMM50 is a **single-pass IMM protein** with an N-terminal mitochondrial targeting
+        sequence, a transmembrane anchor, and a large **IMS-exposed hydrophilic domain** that mediates
+        receptor/gating functions.
+- term:
+    id: GO:0005743
+    label: mitochondrial inner membrane
+  evidence_type: NAS
+  original_reference_id: PMID:10339406
+  review:
+    summary: Correct. Canonical TIMM50 is a single-pass mitochondrial inner membrane protein with its
+      receptor/gating domain exposed to the intermembrane space.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TIMM50/TIMM50-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: TIMM50 is a **single-pass IMM protein** with an N-terminal mitochondrial targeting
+        sequence, a transmembrane anchor, and a large **IMS-exposed hydrophilic domain** that mediates
+        receptor/gating functions.
+- term:
+    id: GO:0005744
+    label: TIM23 mitochondrial import inner membrane translocase complex
+  evidence_type: NAS
+  original_reference_id: PMID:10339406
+  review:
+    summary: Correct and core. TIMM50 is a core TIM23 complex subunit that directly coordinates presequence
+      handoff and channel gating.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TIMM50/TIMM50-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: Tim50 is widely regarded as the **primary presequence receptor at the inner membrane**,
+        positioned in the **intermembrane space (IMS)** to receive precursors emerging from the TOM pore and
+        coordinate their entry into TIM23.
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: This receptor/gating logic is supported by direct presequence-binding mapping and the
+        conclusion that Tim50 binding to Tim23 can induce channel closure when no substrate is being
+        transported.
+    - reference_id: PMID:15044455
+      supporting_text: complex with human Tim23. Down-regulation of human Tim50 expression by RNA
+- term:
+    id: GO:0006886
+    label: intracellular protein transport
+  evidence_type: NAS
+  original_reference_id: PMID:10339406
+  review:
+    summary: Correct pathway family but too broad. TIMM50 specifically mediates TIM23-dependent mitochondrial
+      presequence protein import rather than general intracellular protein transport.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/TIMM50/TIMM50-deep-research-falcon.md
+    reason: Use mitochondrial matrix import/TIM23 terms instead of generic intracellular transport.
+    supported_by:
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: TIMM50 primarily acts on **presequence-containing precursor proteins**, which
+        constitute a large fraction of the mitochondrial proteome and are imported through the TIM23 pathway
+        for matrix delivery or IMM insertion.
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: Tim50 is widely regarded as the **primary presequence receptor at the inner membrane**,
+        positioned in the **intermembrane space (IMS)** to receive precursors emerging from the TOM pore and
+        coordinate their entry into TIM23.
+- term:
+    id: GO:0005654
+    label: nucleoplasm
+  evidence_type: IDA
+  original_reference_id: GO_REF:0000052
+  review:
+    summary: Broad nuclear localization is less informative than the isoform-specific nuclear speck evidence
+      for Tim50a and is not the canonical TIMM50 localization.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - PMID:16008839
+    - file:human/TIMM50/TIMM50-deep-research-falcon.md
+    reason: Use isoform-specific nuclear speck annotation for Tim50a; canonical TIMM50 is an inner
+      mitochondrial membrane TIM23 subunit.
+    supported_by:
+    - reference_id: PMID:16008839
+      supporting_text: cytoplasm and mitochondria, Tim50a is strictly nuclear and is enriched in
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: TIMM50 is a **single-pass IMM protein** with an N-terminal mitochondrial targeting
+        sequence, a transmembrane anchor, and a large **IMS-exposed hydrophilic domain** that mediates
+        receptor/gating functions.
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IDA
+  original_reference_id: GO_REF:0000052
+  review:
+    summary: Correct but broad. Canonical TIMM50 is specifically an inner mitochondrial membrane TIM23 complex
+      subunit.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/TIMM50/TIMM50-deep-research-falcon.md
+    reason: Prefer mitochondrial inner membrane and TIM23 complex annotations over generic mitochondrion.
+    supported_by:
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: TIMM50 is a **single-pass IMM protein** with an N-terminal mitochondrial targeting
+        sequence, a transmembrane anchor, and a large **IMS-exposed hydrophilic domain** that mediates
+        receptor/gating functions.
+- term:
+    id: GO:0030150
+    label: protein import into mitochondrial matrix
+  evidence_type: IDA
+  original_reference_id: PMID:38828998
+  review:
+    summary: Correct and core. TIMM50 is the TIM23 presequence receptor/gatekeeper needed for import of
+      transit peptide-containing precursors through the inner membrane toward the matrix or IMM sorting
+      pathway.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TIMM50/TIMM50-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: Tim50 is widely regarded as the **primary presequence receptor at the inner membrane**,
+        positioned in the **intermembrane space (IMS)** to receive precursors emerging from the TOM pore and
+        coordinate their entry into TIM23.
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: TIMM50 primarily acts on **presequence-containing precursor proteins**, which
+        constitute a large fraction of the mitochondrial proteome and are imported through the TIM23 pathway
+        for matrix delivery or IMM insertion.
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: This receptor/gating logic is supported by direct presequence-binding mapping and the
+        conclusion that Tim50 binding to Tim23 can induce channel closure when no substrate is being
+        transported.
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: HTP
+  original_reference_id: PMID:34800366
+  review:
+    summary: Correct but broad. Canonical TIMM50 is specifically an inner mitochondrial membrane TIM23 complex
+      subunit.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/TIMM50/TIMM50-deep-research-falcon.md
+    reason: Prefer mitochondrial inner membrane and TIM23 complex annotations over generic mitochondrion.
+    supported_by:
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: TIMM50 is a **single-pass IMM protein** with an N-terminal mitochondrial targeting
+        sequence, a transmembrane anchor, and a large **IMS-exposed hydrophilic domain** that mediates
+        receptor/gating functions.
+- term:
+    id: GO:0005744
+    label: TIM23 mitochondrial import inner membrane translocase complex
+  evidence_type: IDA
+  original_reference_id: PMID:30598479
+  review:
+    summary: Correct and core. TIMM50 is a core TIM23 complex subunit that directly coordinates presequence
+      handoff and channel gating.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TIMM50/TIMM50-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: Tim50 is widely regarded as the **primary presequence receptor at the inner membrane**,
+        positioned in the **intermembrane space (IMS)** to receive precursors emerging from the TOM pore and
+        coordinate their entry into TIM23.
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: This receptor/gating logic is supported by direct presequence-binding mapping and the
+        conclusion that Tim50 binding to Tim23 can induce channel closure when no substrate is being
+        transported.
+    - reference_id: PMID:15044455
+      supporting_text: complex with human Tim23. Down-regulation of human Tim50 expression by RNA
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IDA
+  original_reference_id: PMID:32848200
+  review:
+    summary: Correct but broad. Canonical TIMM50 is specifically an inner mitochondrial membrane TIM23 complex
+      subunit.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/TIMM50/TIMM50-deep-research-falcon.md
+    reason: Prefer mitochondrial inner membrane and TIM23 complex annotations over generic mitochondrion.
+    supported_by:
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: TIMM50 is a **single-pass IMM protein** with an N-terminal mitochondrial targeting
+        sequence, a transmembrane anchor, and a large **IMS-exposed hydrophilic domain** that mediates
+        receptor/gating functions.
+- term:
+    id: GO:0005783
+    label: endoplasmic reticulum
+  evidence_type: IDA
+  original_reference_id: PMID:32848200
+  review:
+    summary: The cited FlyBase-sourced study supports a Drosophila Ttm50 calpain/ER-Golgi calcium-store
+      context, but the human TIMM50 synthesis supports mitochondrial TIM23 import as the established function.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - PMID:32848200
+    - file:human/TIMM50/TIMM50-deep-research-falcon.md
+    reason: Do not treat the noncanonical Ttm50 calpain calcium-store finding as a core human TIMM50 activity
+      or localization without human TIMM50-specific support.
+    supported_by:
+    - reference_id: PMID:32848200
+      supporting_text: GluRIIA at the Drosophila neuromuscular junction as a readout, we uncovered that
+    - reference_id: PMID:32848200
+      supporting_text: stores Golgi and endoplasmic reticulum (ER), and Ttm50 interacts with calpain
+    - reference_id: PMID:32848200
+      supporting_text: magnitude. Our findings reveal the regulation of calpain activation by Ttm50,
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: Tim50 is widely regarded as the **primary presequence receptor at the inner membrane**,
+        positioned in the **intermembrane space (IMS)** to receive precursors emerging from the TOM pore and
+        coordinate their entry into TIM23.
+- term:
+    id: GO:0005794
+    label: Golgi apparatus
+  evidence_type: IDA
+  original_reference_id: PMID:32848200
+  review:
+    summary: The cited FlyBase-sourced study supports a Drosophila Ttm50 calpain/ER-Golgi calcium-store
+      context, but the human TIMM50 synthesis supports mitochondrial TIM23 import as the established function.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - PMID:32848200
+    - file:human/TIMM50/TIMM50-deep-research-falcon.md
+    reason: Do not treat the noncanonical Ttm50 calpain calcium-store finding as a core human TIMM50 activity
+      or localization without human TIMM50-specific support.
+    supported_by:
+    - reference_id: PMID:32848200
+      supporting_text: GluRIIA at the Drosophila neuromuscular junction as a readout, we uncovered that
+    - reference_id: PMID:32848200
+      supporting_text: stores Golgi and endoplasmic reticulum (ER), and Ttm50 interacts with calpain
+    - reference_id: PMID:32848200
+      supporting_text: magnitude. Our findings reveal the regulation of calpain activation by Ttm50,
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: Tim50 is widely regarded as the **primary presequence receptor at the inner membrane**,
+        positioned in the **intermembrane space (IMS)** to receive precursors emerging from the TOM pore and
+        coordinate their entry into TIM23.
+- term:
+    id: GO:0140608
+    label: cysteine-type endopeptidase activator activity
+  evidence_type: IDA
+  original_reference_id: PMID:32848200
+  review:
+    summary: The cited FlyBase-sourced study supports a Drosophila Ttm50 calpain/ER-Golgi calcium-store
+      context, but the human TIMM50 synthesis supports mitochondrial TIM23 import as the established function.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - PMID:32848200
+    - file:human/TIMM50/TIMM50-deep-research-falcon.md
+    reason: Do not treat the noncanonical Ttm50 calpain calcium-store finding as a core human TIMM50 activity
+      or localization without human TIMM50-specific support.
+    supported_by:
+    - reference_id: PMID:32848200
+      supporting_text: GluRIIA at the Drosophila neuromuscular junction as a readout, we uncovered that
+    - reference_id: PMID:32848200
+      supporting_text: stores Golgi and endoplasmic reticulum (ER), and Ttm50 interacts with calpain
+    - reference_id: PMID:32848200
+      supporting_text: magnitude. Our findings reveal the regulation of calpain activation by Ttm50,
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: Tim50 is widely regarded as the **primary presequence receptor at the inner membrane**,
+        positioned in the **intermembrane space (IMS)** to receive precursors emerging from the TOM pore and
+        coordinate their entry into TIM23.
+- term:
+    id: GO:0001836
+    label: release of cytochrome c from mitochondria
+  evidence_type: IDA
+  original_reference_id: PMID:15044455
+  review:
+    summary: Supported as a downstream consequence of TIMM50 depletion and mitochondrial membrane dysfunction,
+      but it is not the core molecular/cellular role of TIMM50.
+    action: KEEP_AS_NON_CORE
+    additional_reference_ids:
+    - PMID:15044455
+    - file:human/TIMM50/TIMM50-deep-research-falcon.md
+    reason: TIMM50 loss can accelerate cytochrome c release, but TIMM50 itself is primarily a TIM23 import
+      receptor/gatekeeper.
+    supported_by:
+    - reference_id: PMID:15044455
+      supporting_text: accelerating the release of cytochrome c from the mitochondria. Furthermore,
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: Tim50 is widely regarded as the **primary presequence receptor at the inner membrane**,
+        positioned in the **intermembrane space (IMS)** to receive precursors emerging from the TOM pore and
+        coordinate their entry into TIM23.
+- term:
+    id: GO:0004721
+    label: phosphoprotein phosphatase activity
+  evidence_type: IDA
+  original_reference_id: PMID:15044455
+  review:
+    summary: Direct assays reported phosphatase activity, but current synthesis indicates the physiological
+      substrate and in vivo relevance remain unclear; TIMM50 should be curated primarily as a TIM23
+      presequence receptor/gatekeeper.
+    action: KEEP_AS_NON_CORE
+    additional_reference_ids:
+    - file:human/TIMM50/TIMM50-deep-research-falcon.md
+    - PMID:15044455
+    reason: The phosphatase activity is not the core validated biological function of TIMM50 and has no
+      established physiological substrate in the import pathway.
+    supported_by:
+    - reference_id: PMID:15044455
+      supporting_text: demonstrate that human Tim50 possesses phosphatase activity and is present in a
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: Therefore, based on available evidence, the primary validated function remains
+        **protein import receptor/gating**, not a defined metabolic reaction with established substrates.
+- term:
+    id: GO:0005134
+    label: interleukin-2 receptor binding
+  evidence_type: IDA
+  original_reference_id: PMID:15044455
+  review:
+    summary: The cited Tim50 paper and Falcon synthesis do not support an interleukin-2 receptor binding
+      activity for TIMM50; the established molecular role is TIM23 presequence receptor/gating.
+    action: REMOVE
+    additional_reference_ids:
+    - file:human/TIMM50/TIMM50-deep-research-falcon.md
+    reason: No usable evidence for IL-2 receptor binding was found in the cited cached publication or in the
+      TIMM50 deep research report.
+    supported_by:
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: Therefore, based on available evidence, the primary validated function remains
+        **protein import receptor/gating**, not a defined metabolic reaction with established substrates.
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: Tim50 is widely regarded as the **primary presequence receptor at the inner membrane**,
+        positioned in the **intermembrane space (IMS)** to receive precursors emerging from the TOM pore and
+        coordinate their entry into TIM23.
+- term:
+    id: GO:0005744
+    label: TIM23 mitochondrial import inner membrane translocase complex
+  evidence_type: IPI
+  original_reference_id: PMID:15044455
+  review:
+    summary: Correct and core. TIMM50 is a core TIM23 complex subunit that directly coordinates presequence
+      handoff and channel gating.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TIMM50/TIMM50-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: Tim50 is widely regarded as the **primary presequence receptor at the inner membrane**,
+        positioned in the **intermembrane space (IMS)** to receive precursors emerging from the TOM pore and
+        coordinate their entry into TIM23.
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: This receptor/gating logic is supported by direct presequence-binding mapping and the
+        conclusion that Tim50 binding to Tim23 can induce channel closure when no substrate is being
+        transported.
+    - reference_id: PMID:15044455
+      supporting_text: complex with human Tim23. Down-regulation of human Tim50 expression by RNA
+- term:
+    id: GO:0004722
+    label: protein serine/threonine phosphatase activity
+  evidence_type: IDA
+  original_reference_id: PMID:15044455
+  review:
+    summary: Direct assays reported phosphatase activity, but current synthesis indicates the physiological
+      substrate and in vivo relevance remain unclear; TIMM50 should be curated primarily as a TIM23
+      presequence receptor/gatekeeper.
+    action: KEEP_AS_NON_CORE
+    additional_reference_ids:
+    - file:human/TIMM50/TIMM50-deep-research-falcon.md
+    - PMID:15044455
+    reason: The phosphatase activity is not the core validated biological function of TIMM50 and has no
+      established physiological substrate in the import pathway.
+    supported_by:
+    - reference_id: PMID:15044455
+      supporting_text: demonstrate that human Tim50 possesses phosphatase activity and is present in a
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: Therefore, based on available evidence, the primary validated function remains
+        **protein import receptor/gating**, not a defined metabolic reaction with established substrates.
+- term:
+    id: GO:0004725
+    label: protein tyrosine phosphatase activity
+  evidence_type: IDA
+  original_reference_id: PMID:15044455
+  review:
+    summary: Direct assays reported phosphatase activity, but current synthesis indicates the physiological
+      substrate and in vivo relevance remain unclear; TIMM50 should be curated primarily as a TIM23
+      presequence receptor/gatekeeper.
+    action: KEEP_AS_NON_CORE
+    additional_reference_ids:
+    - file:human/TIMM50/TIMM50-deep-research-falcon.md
+    - PMID:15044455
+    reason: The phosphatase activity is not the core validated biological function of TIMM50 and has no
+      established physiological substrate in the import pathway.
+    supported_by:
+    - reference_id: PMID:15044455
+      supporting_text: demonstrate that human Tim50 possesses phosphatase activity and is present in a
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: Therefore, based on available evidence, the primary validated function remains
+        **protein import receptor/gating**, not a defined metabolic reaction with established substrates.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:15044455
+  review:
+    summary: Protein binding is true but uninformative for TIMM50. The biologically meaningful interaction
+      context is TIM23 presequence receptor/gating and TIMM23/TIM17 complex membership.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/TIMM50/TIMM50-deep-research-falcon.md
+    reason: Replace generic interaction capture with TIM23 complex membership and
+      presequence/targeting-sequence binding where supported.
+    supported_by:
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: Tim50 is widely regarded as the **primary presequence receptor at the inner membrane**,
+        positioned in the **intermembrane space (IMS)** to receive precursors emerging from the TOM pore and
+        coordinate their entry into TIM23.
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: This receptor/gating logic is supported by direct presequence-binding mapping and the
+        conclusion that Tim50 binding to Tim23 can induce channel closure when no substrate is being
+        transported.
+- term:
+    id: GO:0007006
+    label: mitochondrial membrane organization
+  evidence_type: IMP
+  original_reference_id: PMID:15044455
+  review:
+    summary: Supported as a cellular consequence of TIMM50 loss causing mitochondrial membrane
+      permeabilization/dysfunction, but it is downstream of the core TIM23 import role.
+    action: KEEP_AS_NON_CORE
+    additional_reference_ids:
+    - PMID:15044455
+    - file:human/TIMM50/TIMM50-deep-research-falcon.md
+    reason: Keep as non-core because membrane organization phenotypes arise from impaired mitochondrial
+      import/integrity rather than a direct membrane-organizing function.
+    supported_by:
+    - reference_id: PMID:15044455
+      supporting_text: indicate that loss of Tim50 in vertebrates causes mitochondrial membrane
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: Tim50 is widely regarded as the **primary presequence receptor at the inner membrane**,
+        positioned in the **intermembrane space (IMS)** to receive precursors emerging from the TOM pore and
+        coordinate their entry into TIM23.
+- term:
+    id: GO:0016607
+    label: nuclear speck
+  evidence_type: IDA
+  original_reference_id: PMID:16008839
+  review:
+    summary: Supported for the Tim50a isoform, but not the core function of the canonical mitochondrial TIMM50
+      protein.
+    action: KEEP_AS_NON_CORE
+    additional_reference_ids:
+    - PMID:16008839
+    reason: Track as isoform-specific, non-core nuclear localization; canonical TIMM50 function is
+      mitochondrial TIM23 import.
+    supported_by:
+    - reference_id: PMID:16008839
+      supporting_text: cytoplasm and mitochondria, Tim50a is strictly nuclear and is enriched in
+  isoform: Q3ZCQ8-2
+- term:
+    id: GO:0043021
+    label: ribonucleoprotein complex binding
+  evidence_type: IDA
+  original_reference_id: PMID:16008839
+  review:
+    summary: Supported for the nuclear Tim50a isoform, which interacts with snRNP-associated proteins, but
+      this is not the canonical mitochondrial import function.
+    action: KEEP_AS_NON_CORE
+    additional_reference_ids:
+    - PMID:16008839
+    reason: Keep as an isoform-specific non-core activity distinct from TIM23 presequence import.
+    supported_by:
+    - reference_id: PMID:16008839
+      supporting_text: In addition to coilin, Tim50a interacts with snRNPs and
+    - reference_id: PMID:16008839
+      supporting_text: cytoplasm and mitochondria, Tim50a is strictly nuclear and is enriched in
+  isoform: Q3ZCQ8-2
+- term:
+    id: GO:0030943
+    label: mitochondrion targeting sequence binding
+  evidence_type: NAS
+  original_reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+  review:
+    summary: TIMM50 is described as the primary inner-membrane presequence receptor for TIM23 substrates, so
+      mitochondrion targeting sequence binding captures its core molecular function better than generic
+      protein binding.
+    action: NEW
+    reason: Existing GOA lacks a specific molecular-function term for TIMM50 presequence/targeting-signal
+      receptor activity.
+    supported_by:
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: Tim50 is widely regarded as the **primary presequence receptor at the inner membrane**,
+        positioned in the **intermembrane space (IMS)** to receive precursors emerging from the TOM pore and
+        coordinate their entry into TIM23.
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: TIMM50 primarily acts on **presequence-containing precursor proteins**, which
+        constitute a large fraction of the mitochondrial proteome and are imported through the TIM23 pathway
+        for matrix delivery or IMM insertion.
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: This receptor/gating logic is supported by direct presequence-binding mapping and the
+        conclusion that Tim50 binding to Tim23 can induce channel closure when no substrate is being
+        transported.
+references:
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping,
+    accompanied by conservative changes to GO terms applied by UniProt
+  findings: []
+- id: GO_REF:0000052
+  title: Gene Ontology annotation based on curation of immunofluorescence data
+  findings: []
+- id: GO_REF:0000117
+  title: Electronic Gene Ontology annotations created by ARBA machine learning models
+  findings: []
+- id: PMID:10339406
+  title: Genetic and structural characterization of the human mitochondrial inner membrane translocase.
+  findings: []
+- id: PMID:12620389
+  title: Novel raf kinase protein-protein interactions found by an exhaustive yeast two-hybrid analysis.
+  findings: []
+- id: PMID:15044455
+  title: Tim50, a component of the mitochondrial translocator, regulates mitochondrial integrity and cell
+    death.
+  findings: []
+- id: PMID:16008839
+  title: Tim50a, a nuclear isoform of the mitochondrial Tim50, interacts with proteins involved in snRNP
+    biogenesis.
+  findings: []
+- id: PMID:25852190
+  title: Integrative analysis of kinase networks in TRAIL-induced apoptosis provides a source of potential
+    targets for combination therapy.
+  findings: []
+- id: PMID:30598479
+  title: ROMO1 is a constituent of the human presequence translocase required for YME1L protease import.
+  findings: []
+- id: PMID:31980649
+  title: Extensive rewiring of the EGFR network in colorectal cancer cells expressing transforming levels of
+    KRAS(G13D).
+  findings: []
+- id: PMID:32848200
+  title: Ttm50 facilitates calpain activation by anchoring it to calcium stores and increasing its sensitivity
+    to calcium.
+  findings: []
+- id: PMID:34800366
+  title: Quantitative high-confidence human mitochondrial proteome and its dynamics in cellular context.
+  findings: []
+- id: PMID:37045861
+  title: Interactome dynamics of RAF1-BRAF kinase monomers and dimers.
+  findings: []
+- id: PMID:38828998
+  title: Reduced Protein Import via TIM23 SORT Drives Disease Pathology in TIMM50-Associated Mitochondrial
+    Disease.
+  findings: []
+- id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+  title: Falcon deep research report for human TIMM50
+  findings: []
+core_functions:
+- description: TIMM50 is the inner-membrane TIM23 presequence receptor and gatekeeper that captures transit
+    peptide-containing mitochondrial precursors on the intermembrane-space side, coordinates TIM23 channel
+    gating, and supports import into the matrix or IMM sorting pathway.
+  supported_by:
+  - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+    supporting_text: Tim50 is widely regarded as the **primary presequence receptor at the inner membrane**,
+      positioned in the **intermembrane space (IMS)** to receive precursors emerging from the TOM pore and
+      coordinate their entry into TIM23.
+  - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+    supporting_text: TIMM50 primarily acts on **presequence-containing precursor proteins**, which constitute
+      a large fraction of the mitochondrial proteome and are imported through the TIM23 pathway for matrix
+      delivery or IMM insertion.
+  - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+    supporting_text: This receptor/gating logic is supported by direct presequence-binding mapping and the
+      conclusion that Tim50 binding to Tim23 can induce channel closure when no substrate is being
+      transported.
+  - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+    supporting_text: TIMM50 is a **single-pass IMM protein** with an N-terminal mitochondrial targeting
+      sequence, a transmembrane anchor, and a large **IMS-exposed hydrophilic domain** that mediates
+      receptor/gating functions.
+  molecular_function:
+    id: GO:0030943
+    label: mitochondrion targeting sequence binding
+  directly_involved_in:
+  - id: GO:0030150
+    label: protein import into mitochondrial matrix
+  locations:
+  - id: GO:0005743
+    label: mitochondrial inner membrane
+  in_complex:
+    id: GO:0005744
+    label: TIM23 mitochondrial import inner membrane translocase complex
+proposed_new_terms: []
+suggested_questions:
+- question: What are the physiological substrates, if any, of the TIMM50 phosphatase-like domain in human
+    cells?
+  experts: []
+- question: Which human TIM23SORT substrates depend most strongly on TIMM50 presequence recognition or gating?
+  experts: []
+- question: Is the Tim50a nuclear speck/snRNP role broadly physiological or restricted to specific transformed
+    or neural cell contexts?
+  experts: []
+suggested_experiments:
+- hypothesis: TIMM50 presequence binding and channel-gating surfaces are separable.
+  description: Use TIMM50 rescue mutants affecting presequence-binding and TIMM23-interaction surfaces in
+    TIMM50-deficient human cells, then measure TIM23 complex assembly, channel gating, and import of
+    TIM23MOTOR versus TIM23SORT reporter substrates.
+- hypothesis: TIMM50 phosphatase-like activity is dispensable for most TIM23 import functions.
+  description: Compare phosphatase-dead TIMM50 mutants with receptor/gating mutants for rescue of matrix
+    import, IMM sorting, TIM23 complex stability, and patient-cell respiratory phenotypes.
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/human/TIMM50/TIMM50-ai-review.yaml
+++ b/genes/human/TIMM50/TIMM50-ai-review.yaml
@@ -1,11 +1,14 @@
 id: Q3ZCQ8
 gene_symbol: TIMM50
 product_type: PROTEIN
-status: INITIALIZED
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
-description: 'TODO: Add description for TIMM50'
+description: 'TIMM50 encodes the single-pass mitochondrial inner membrane Tim50 subunit of the TIM23 presequence
+  translocase. TIMM50 acts from the intermembrane-space side as a primary presequence receptor and gatekeeper for
+  TIM23-dependent import of transit peptide-containing precursor proteins, while its reported phosphatase, nuclear
+  Tim50a, and calpain-associated roles are secondary or insufficiently established as core human TIMM50 functions.'
 alternative_products:
 - name: '1'
   id: Q3ZCQ8-1
@@ -22,264 +25,695 @@ existing_annotations:
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct and core. TIMM50 is the TIM23 presequence receptor/gatekeeper needed for import of
+      transit peptide-containing precursors through the inner membrane toward the matrix or IMM sorting
+      pathway.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TIMM50/TIMM50-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: Tim50 is widely regarded as the **primary presequence receptor at the inner membrane**,
+        positioned in the **intermembrane space (IMS)** to receive precursors emerging from the TOM pore and
+        coordinate their entry into TIM23.
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: TIMM50 primarily acts on **presequence-containing precursor proteins**, which
+        constitute a large fraction of the mitochondrial proteome and are imported through the TIM23 pathway
+        for matrix delivery or IMM insertion.
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: This receptor/gating logic is supported by direct presequence-binding mapping and the
+        conclusion that Tim50 binding to Tim23 can induce channel closure when no substrate is being
+        transported.
 - term:
     id: GO:0005744
     label: TIM23 mitochondrial import inner membrane translocase complex
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct and core. TIMM50 is a core TIM23 complex subunit that directly coordinates presequence
+      handoff and channel gating.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TIMM50/TIMM50-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: Tim50 is widely regarded as the **primary presequence receptor at the inner membrane**,
+        positioned in the **intermembrane space (IMS)** to receive precursors emerging from the TOM pore and
+        coordinate their entry into TIM23.
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: This receptor/gating logic is supported by direct presequence-binding mapping and the
+        conclusion that Tim50 binding to Tim23 can induce channel closure when no substrate is being
+        transported.
+    - reference_id: PMID:15044455
+      supporting_text: complex with human Tim23. Down-regulation of human Tim50 expression by RNA
 - term:
     id: GO:0004722
     label: protein serine/threonine phosphatase activity
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Direct assays reported phosphatase activity, but current synthesis indicates the physiological
+      substrate and in vivo relevance remain unclear; TIMM50 should be curated primarily as a TIM23
+      presequence receptor/gatekeeper.
+    action: KEEP_AS_NON_CORE
+    additional_reference_ids:
+    - file:human/TIMM50/TIMM50-deep-research-falcon.md
+    - PMID:15044455
+    reason: The phosphatase activity is not the core validated biological function of TIMM50 and has no
+      established physiological substrate in the import pathway.
+    supported_by:
+    - reference_id: PMID:15044455
+      supporting_text: demonstrate that human Tim50 possesses phosphatase activity and is present in a
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: Therefore, based on available evidence, the primary validated function remains
+        **protein import receptor/gating**, not a defined metabolic reaction with established substrates.
 - term:
     id: GO:0005743
     label: mitochondrial inner membrane
   evidence_type: IEA
   original_reference_id: GO_REF:0000044
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct. Canonical TIMM50 is a single-pass mitochondrial inner membrane protein with its
+      receptor/gating domain exposed to the intermembrane space.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TIMM50/TIMM50-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: TIMM50 is a **single-pass IMM protein** with an N-terminal mitochondrial targeting
+        sequence, a transmembrane anchor, and a large **IMS-exposed hydrophilic domain** that mediates
+        receptor/gating functions.
 - term:
     id: GO:0016607
     label: nuclear speck
   evidence_type: IEA
   original_reference_id: GO_REF:0000044
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Supported for the Tim50a isoform, but not the core function of the canonical mitochondrial TIMM50
+      protein.
+    action: KEEP_AS_NON_CORE
+    additional_reference_ids:
+    - PMID:16008839
+    reason: Track as isoform-specific, non-core nuclear localization; canonical TIMM50 function is
+      mitochondrial TIM23 import.
+    supported_by:
+    - reference_id: PMID:16008839
+      supporting_text: cytoplasm and mitochondria, Tim50a is strictly nuclear and is enriched in
+  isoform: Q3ZCQ8-2
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:12620389
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Protein binding is true but uninformative for TIMM50. The biologically meaningful interaction
+      context is TIM23 presequence receptor/gating and TIMM23/TIM17 complex membership.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/TIMM50/TIMM50-deep-research-falcon.md
+    reason: Replace generic interaction capture with TIM23 complex membership and
+      presequence/targeting-sequence binding where supported.
+    supported_by:
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: Tim50 is widely regarded as the **primary presequence receptor at the inner membrane**,
+        positioned in the **intermembrane space (IMS)** to receive precursors emerging from the TOM pore and
+        coordinate their entry into TIM23.
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: This receptor/gating logic is supported by direct presequence-binding mapping and the
+        conclusion that Tim50 binding to Tim23 can induce channel closure when no substrate is being
+        transported.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:25852190
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Protein binding is true but uninformative for TIMM50. The biologically meaningful interaction
+      context is TIM23 presequence receptor/gating and TIMM23/TIM17 complex membership.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/TIMM50/TIMM50-deep-research-falcon.md
+    reason: Replace generic interaction capture with TIM23 complex membership and
+      presequence/targeting-sequence binding where supported.
+    supported_by:
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: Tim50 is widely regarded as the **primary presequence receptor at the inner membrane**,
+        positioned in the **intermembrane space (IMS)** to receive precursors emerging from the TOM pore and
+        coordinate their entry into TIM23.
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: This receptor/gating logic is supported by direct presequence-binding mapping and the
+        conclusion that Tim50 binding to Tim23 can induce channel closure when no substrate is being
+        transported.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:31980649
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Protein binding is true but uninformative for TIMM50. The biologically meaningful interaction
+      context is TIM23 presequence receptor/gating and TIMM23/TIM17 complex membership.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/TIMM50/TIMM50-deep-research-falcon.md
+    reason: Replace generic interaction capture with TIM23 complex membership and
+      presequence/targeting-sequence binding where supported.
+    supported_by:
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: Tim50 is widely regarded as the **primary presequence receptor at the inner membrane**,
+        positioned in the **intermembrane space (IMS)** to receive precursors emerging from the TOM pore and
+        coordinate their entry into TIM23.
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: This receptor/gating logic is supported by direct presequence-binding mapping and the
+        conclusion that Tim50 binding to Tim23 can induce channel closure when no substrate is being
+        transported.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:37045861
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Protein binding is true but uninformative for TIMM50. The biologically meaningful interaction
+      context is TIM23 presequence receptor/gating and TIMM23/TIM17 complex membership.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/TIMM50/TIMM50-deep-research-falcon.md
+    reason: Replace generic interaction capture with TIM23 complex membership and
+      presequence/targeting-sequence binding where supported.
+    supported_by:
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: Tim50 is widely regarded as the **primary presequence receptor at the inner membrane**,
+        positioned in the **intermembrane space (IMS)** to receive precursors emerging from the TOM pore and
+        coordinate their entry into TIM23.
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: This receptor/gating logic is supported by direct presequence-binding mapping and the
+        conclusion that Tim50 binding to Tim23 can induce channel closure when no substrate is being
+        transported.
 - term:
     id: GO:0005743
     label: mitochondrial inner membrane
   evidence_type: IDA
   original_reference_id: PMID:15044455
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct. Canonical TIMM50 is a single-pass mitochondrial inner membrane protein with its
+      receptor/gating domain exposed to the intermembrane space.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TIMM50/TIMM50-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: TIMM50 is a **single-pass IMM protein** with an N-terminal mitochondrial targeting
+        sequence, a transmembrane anchor, and a large **IMS-exposed hydrophilic domain** that mediates
+        receptor/gating functions.
 - term:
     id: GO:0005743
     label: mitochondrial inner membrane
   evidence_type: NAS
   original_reference_id: PMID:10339406
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct. Canonical TIMM50 is a single-pass mitochondrial inner membrane protein with its
+      receptor/gating domain exposed to the intermembrane space.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TIMM50/TIMM50-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: TIMM50 is a **single-pass IMM protein** with an N-terminal mitochondrial targeting
+        sequence, a transmembrane anchor, and a large **IMS-exposed hydrophilic domain** that mediates
+        receptor/gating functions.
 - term:
     id: GO:0005744
     label: TIM23 mitochondrial import inner membrane translocase complex
   evidence_type: NAS
   original_reference_id: PMID:10339406
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct and core. TIMM50 is a core TIM23 complex subunit that directly coordinates presequence
+      handoff and channel gating.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TIMM50/TIMM50-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: Tim50 is widely regarded as the **primary presequence receptor at the inner membrane**,
+        positioned in the **intermembrane space (IMS)** to receive precursors emerging from the TOM pore and
+        coordinate their entry into TIM23.
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: This receptor/gating logic is supported by direct presequence-binding mapping and the
+        conclusion that Tim50 binding to Tim23 can induce channel closure when no substrate is being
+        transported.
+    - reference_id: PMID:15044455
+      supporting_text: complex with human Tim23. Down-regulation of human Tim50 expression by RNA
 - term:
     id: GO:0006886
     label: intracellular protein transport
   evidence_type: NAS
   original_reference_id: PMID:10339406
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct pathway family but too broad. TIMM50 specifically mediates TIM23-dependent mitochondrial
+      presequence protein import rather than general intracellular protein transport.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/TIMM50/TIMM50-deep-research-falcon.md
+    reason: Use mitochondrial matrix import/TIM23 terms instead of generic intracellular transport.
+    supported_by:
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: TIMM50 primarily acts on **presequence-containing precursor proteins**, which
+        constitute a large fraction of the mitochondrial proteome and are imported through the TIM23 pathway
+        for matrix delivery or IMM insertion.
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: Tim50 is widely regarded as the **primary presequence receptor at the inner membrane**,
+        positioned in the **intermembrane space (IMS)** to receive precursors emerging from the TOM pore and
+        coordinate their entry into TIM23.
 - term:
     id: GO:0005654
     label: nucleoplasm
   evidence_type: IDA
   original_reference_id: GO_REF:0000052
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Broad nuclear localization is less informative than the isoform-specific nuclear speck evidence
+      for Tim50a and is not the canonical TIMM50 localization.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - PMID:16008839
+    - file:human/TIMM50/TIMM50-deep-research-falcon.md
+    reason: Use isoform-specific nuclear speck annotation for Tim50a; canonical TIMM50 is an inner
+      mitochondrial membrane TIM23 subunit.
+    supported_by:
+    - reference_id: PMID:16008839
+      supporting_text: cytoplasm and mitochondria, Tim50a is strictly nuclear and is enriched in
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: TIMM50 is a **single-pass IMM protein** with an N-terminal mitochondrial targeting
+        sequence, a transmembrane anchor, and a large **IMS-exposed hydrophilic domain** that mediates
+        receptor/gating functions.
 - term:
     id: GO:0005739
     label: mitochondrion
   evidence_type: IDA
   original_reference_id: GO_REF:0000052
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct but broad. Canonical TIMM50 is specifically an inner mitochondrial membrane TIM23 complex
+      subunit.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/TIMM50/TIMM50-deep-research-falcon.md
+    reason: Prefer mitochondrial inner membrane and TIM23 complex annotations over generic mitochondrion.
+    supported_by:
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: TIMM50 is a **single-pass IMM protein** with an N-terminal mitochondrial targeting
+        sequence, a transmembrane anchor, and a large **IMS-exposed hydrophilic domain** that mediates
+        receptor/gating functions.
 - term:
     id: GO:0030150
     label: protein import into mitochondrial matrix
   evidence_type: IDA
   original_reference_id: PMID:38828998
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct and core. TIMM50 is the TIM23 presequence receptor/gatekeeper needed for import of
+      transit peptide-containing precursors through the inner membrane toward the matrix or IMM sorting
+      pathway.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TIMM50/TIMM50-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: Tim50 is widely regarded as the **primary presequence receptor at the inner membrane**,
+        positioned in the **intermembrane space (IMS)** to receive precursors emerging from the TOM pore and
+        coordinate their entry into TIM23.
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: TIMM50 primarily acts on **presequence-containing precursor proteins**, which
+        constitute a large fraction of the mitochondrial proteome and are imported through the TIM23 pathway
+        for matrix delivery or IMM insertion.
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: This receptor/gating logic is supported by direct presequence-binding mapping and the
+        conclusion that Tim50 binding to Tim23 can induce channel closure when no substrate is being
+        transported.
 - term:
     id: GO:0005739
     label: mitochondrion
   evidence_type: HTP
   original_reference_id: PMID:34800366
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct but broad. Canonical TIMM50 is specifically an inner mitochondrial membrane TIM23 complex
+      subunit.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/TIMM50/TIMM50-deep-research-falcon.md
+    reason: Prefer mitochondrial inner membrane and TIM23 complex annotations over generic mitochondrion.
+    supported_by:
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: TIMM50 is a **single-pass IMM protein** with an N-terminal mitochondrial targeting
+        sequence, a transmembrane anchor, and a large **IMS-exposed hydrophilic domain** that mediates
+        receptor/gating functions.
 - term:
     id: GO:0005744
     label: TIM23 mitochondrial import inner membrane translocase complex
   evidence_type: IDA
   original_reference_id: PMID:30598479
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct and core. TIMM50 is a core TIM23 complex subunit that directly coordinates presequence
+      handoff and channel gating.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TIMM50/TIMM50-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: Tim50 is widely regarded as the **primary presequence receptor at the inner membrane**,
+        positioned in the **intermembrane space (IMS)** to receive precursors emerging from the TOM pore and
+        coordinate their entry into TIM23.
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: This receptor/gating logic is supported by direct presequence-binding mapping and the
+        conclusion that Tim50 binding to Tim23 can induce channel closure when no substrate is being
+        transported.
+    - reference_id: PMID:15044455
+      supporting_text: complex with human Tim23. Down-regulation of human Tim50 expression by RNA
 - term:
     id: GO:0005739
     label: mitochondrion
   evidence_type: IDA
   original_reference_id: PMID:32848200
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct but broad. Canonical TIMM50 is specifically an inner mitochondrial membrane TIM23 complex
+      subunit.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/TIMM50/TIMM50-deep-research-falcon.md
+    reason: Prefer mitochondrial inner membrane and TIM23 complex annotations over generic mitochondrion.
+    supported_by:
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: TIMM50 is a **single-pass IMM protein** with an N-terminal mitochondrial targeting
+        sequence, a transmembrane anchor, and a large **IMS-exposed hydrophilic domain** that mediates
+        receptor/gating functions.
 - term:
     id: GO:0005783
     label: endoplasmic reticulum
   evidence_type: IDA
   original_reference_id: PMID:32848200
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: The cited FlyBase-sourced study supports a Drosophila Ttm50 calpain/ER-Golgi calcium-store
+      context, but the human TIMM50 synthesis supports mitochondrial TIM23 import as the established function.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - PMID:32848200
+    - file:human/TIMM50/TIMM50-deep-research-falcon.md
+    reason: Do not treat the noncanonical Ttm50 calpain calcium-store finding as a core human TIMM50 activity
+      or localization without human TIMM50-specific support.
+    supported_by:
+    - reference_id: PMID:32848200
+      supporting_text: GluRIIA at the Drosophila neuromuscular junction as a readout, we uncovered that
+    - reference_id: PMID:32848200
+      supporting_text: stores Golgi and endoplasmic reticulum (ER), and Ttm50 interacts with calpain
+    - reference_id: PMID:32848200
+      supporting_text: magnitude. Our findings reveal the regulation of calpain activation by Ttm50,
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: Tim50 is widely regarded as the **primary presequence receptor at the inner membrane**,
+        positioned in the **intermembrane space (IMS)** to receive precursors emerging from the TOM pore and
+        coordinate their entry into TIM23.
 - term:
     id: GO:0005794
     label: Golgi apparatus
   evidence_type: IDA
   original_reference_id: PMID:32848200
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: The cited FlyBase-sourced study supports a Drosophila Ttm50 calpain/ER-Golgi calcium-store
+      context, but the human TIMM50 synthesis supports mitochondrial TIM23 import as the established function.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - PMID:32848200
+    - file:human/TIMM50/TIMM50-deep-research-falcon.md
+    reason: Do not treat the noncanonical Ttm50 calpain calcium-store finding as a core human TIMM50 activity
+      or localization without human TIMM50-specific support.
+    supported_by:
+    - reference_id: PMID:32848200
+      supporting_text: GluRIIA at the Drosophila neuromuscular junction as a readout, we uncovered that
+    - reference_id: PMID:32848200
+      supporting_text: stores Golgi and endoplasmic reticulum (ER), and Ttm50 interacts with calpain
+    - reference_id: PMID:32848200
+      supporting_text: magnitude. Our findings reveal the regulation of calpain activation by Ttm50,
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: Tim50 is widely regarded as the **primary presequence receptor at the inner membrane**,
+        positioned in the **intermembrane space (IMS)** to receive precursors emerging from the TOM pore and
+        coordinate their entry into TIM23.
 - term:
     id: GO:0140608
     label: cysteine-type endopeptidase activator activity
   evidence_type: IDA
   original_reference_id: PMID:32848200
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: The cited FlyBase-sourced study supports a Drosophila Ttm50 calpain/ER-Golgi calcium-store
+      context, but the human TIMM50 synthesis supports mitochondrial TIM23 import as the established function.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - PMID:32848200
+    - file:human/TIMM50/TIMM50-deep-research-falcon.md
+    reason: Do not treat the noncanonical Ttm50 calpain calcium-store finding as a core human TIMM50 activity
+      or localization without human TIMM50-specific support.
+    supported_by:
+    - reference_id: PMID:32848200
+      supporting_text: GluRIIA at the Drosophila neuromuscular junction as a readout, we uncovered that
+    - reference_id: PMID:32848200
+      supporting_text: stores Golgi and endoplasmic reticulum (ER), and Ttm50 interacts with calpain
+    - reference_id: PMID:32848200
+      supporting_text: magnitude. Our findings reveal the regulation of calpain activation by Ttm50,
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: Tim50 is widely regarded as the **primary presequence receptor at the inner membrane**,
+        positioned in the **intermembrane space (IMS)** to receive precursors emerging from the TOM pore and
+        coordinate their entry into TIM23.
 - term:
     id: GO:0001836
     label: release of cytochrome c from mitochondria
   evidence_type: IDA
   original_reference_id: PMID:15044455
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Supported as a downstream consequence of TIMM50 depletion and mitochondrial membrane dysfunction,
+      but it is not the core molecular/cellular role of TIMM50.
+    action: KEEP_AS_NON_CORE
+    additional_reference_ids:
+    - PMID:15044455
+    - file:human/TIMM50/TIMM50-deep-research-falcon.md
+    reason: TIMM50 loss can accelerate cytochrome c release, but TIMM50 itself is primarily a TIM23 import
+      receptor/gatekeeper.
+    supported_by:
+    - reference_id: PMID:15044455
+      supporting_text: accelerating the release of cytochrome c from the mitochondria. Furthermore,
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: Tim50 is widely regarded as the **primary presequence receptor at the inner membrane**,
+        positioned in the **intermembrane space (IMS)** to receive precursors emerging from the TOM pore and
+        coordinate their entry into TIM23.
 - term:
     id: GO:0004721
     label: phosphoprotein phosphatase activity
   evidence_type: IDA
   original_reference_id: PMID:15044455
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Direct assays reported phosphatase activity, but current synthesis indicates the physiological
+      substrate and in vivo relevance remain unclear; TIMM50 should be curated primarily as a TIM23
+      presequence receptor/gatekeeper.
+    action: KEEP_AS_NON_CORE
+    additional_reference_ids:
+    - file:human/TIMM50/TIMM50-deep-research-falcon.md
+    - PMID:15044455
+    reason: The phosphatase activity is not the core validated biological function of TIMM50 and has no
+      established physiological substrate in the import pathway.
+    supported_by:
+    - reference_id: PMID:15044455
+      supporting_text: demonstrate that human Tim50 possesses phosphatase activity and is present in a
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: Therefore, based on available evidence, the primary validated function remains
+        **protein import receptor/gating**, not a defined metabolic reaction with established substrates.
 - term:
     id: GO:0005134
     label: interleukin-2 receptor binding
   evidence_type: IDA
   original_reference_id: PMID:15044455
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: The cited Tim50 paper and Falcon synthesis do not support an interleukin-2 receptor binding
+      activity for TIMM50; the established molecular role is TIM23 presequence receptor/gating.
+    action: REMOVE
+    additional_reference_ids:
+    - file:human/TIMM50/TIMM50-deep-research-falcon.md
+    reason: No usable evidence for IL-2 receptor binding was found in the cited cached publication or in the
+      TIMM50 deep research report.
+    supported_by:
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: Therefore, based on available evidence, the primary validated function remains
+        **protein import receptor/gating**, not a defined metabolic reaction with established substrates.
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: Tim50 is widely regarded as the **primary presequence receptor at the inner membrane**,
+        positioned in the **intermembrane space (IMS)** to receive precursors emerging from the TOM pore and
+        coordinate their entry into TIM23.
 - term:
     id: GO:0005744
     label: TIM23 mitochondrial import inner membrane translocase complex
   evidence_type: IPI
   original_reference_id: PMID:15044455
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct and core. TIMM50 is a core TIM23 complex subunit that directly coordinates presequence
+      handoff and channel gating.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TIMM50/TIMM50-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: Tim50 is widely regarded as the **primary presequence receptor at the inner membrane**,
+        positioned in the **intermembrane space (IMS)** to receive precursors emerging from the TOM pore and
+        coordinate their entry into TIM23.
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: This receptor/gating logic is supported by direct presequence-binding mapping and the
+        conclusion that Tim50 binding to Tim23 can induce channel closure when no substrate is being
+        transported.
+    - reference_id: PMID:15044455
+      supporting_text: complex with human Tim23. Down-regulation of human Tim50 expression by RNA
 - term:
     id: GO:0004722
     label: protein serine/threonine phosphatase activity
   evidence_type: IDA
   original_reference_id: PMID:15044455
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Direct assays reported phosphatase activity, but current synthesis indicates the physiological
+      substrate and in vivo relevance remain unclear; TIMM50 should be curated primarily as a TIM23
+      presequence receptor/gatekeeper.
+    action: KEEP_AS_NON_CORE
+    additional_reference_ids:
+    - file:human/TIMM50/TIMM50-deep-research-falcon.md
+    - PMID:15044455
+    reason: The phosphatase activity is not the core validated biological function of TIMM50 and has no
+      established physiological substrate in the import pathway.
+    supported_by:
+    - reference_id: PMID:15044455
+      supporting_text: demonstrate that human Tim50 possesses phosphatase activity and is present in a
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: Therefore, based on available evidence, the primary validated function remains
+        **protein import receptor/gating**, not a defined metabolic reaction with established substrates.
 - term:
     id: GO:0004725
     label: protein tyrosine phosphatase activity
   evidence_type: IDA
   original_reference_id: PMID:15044455
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Direct assays reported phosphatase activity, but current synthesis indicates the physiological
+      substrate and in vivo relevance remain unclear; TIMM50 should be curated primarily as a TIM23
+      presequence receptor/gatekeeper.
+    action: KEEP_AS_NON_CORE
+    additional_reference_ids:
+    - file:human/TIMM50/TIMM50-deep-research-falcon.md
+    - PMID:15044455
+    reason: The phosphatase activity is not the core validated biological function of TIMM50 and has no
+      established physiological substrate in the import pathway.
+    supported_by:
+    - reference_id: PMID:15044455
+      supporting_text: demonstrate that human Tim50 possesses phosphatase activity and is present in a
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: Therefore, based on available evidence, the primary validated function remains
+        **protein import receptor/gating**, not a defined metabolic reaction with established substrates.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:15044455
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Protein binding is true but uninformative for TIMM50. The biologically meaningful interaction
+      context is TIM23 presequence receptor/gating and TIMM23/TIM17 complex membership.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/TIMM50/TIMM50-deep-research-falcon.md
+    reason: Replace generic interaction capture with TIM23 complex membership and
+      presequence/targeting-sequence binding where supported.
+    supported_by:
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: Tim50 is widely regarded as the **primary presequence receptor at the inner membrane**,
+        positioned in the **intermembrane space (IMS)** to receive precursors emerging from the TOM pore and
+        coordinate their entry into TIM23.
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: This receptor/gating logic is supported by direct presequence-binding mapping and the
+        conclusion that Tim50 binding to Tim23 can induce channel closure when no substrate is being
+        transported.
 - term:
     id: GO:0007006
     label: mitochondrial membrane organization
   evidence_type: IMP
   original_reference_id: PMID:15044455
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Supported as a cellular consequence of TIMM50 loss causing mitochondrial membrane
+      permeabilization/dysfunction, but it is downstream of the core TIM23 import role.
+    action: KEEP_AS_NON_CORE
+    additional_reference_ids:
+    - PMID:15044455
+    - file:human/TIMM50/TIMM50-deep-research-falcon.md
+    reason: Keep as non-core because membrane organization phenotypes arise from impaired mitochondrial
+      import/integrity rather than a direct membrane-organizing function.
+    supported_by:
+    - reference_id: PMID:15044455
+      supporting_text: indicate that loss of Tim50 in vertebrates causes mitochondrial membrane
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: Tim50 is widely regarded as the **primary presequence receptor at the inner membrane**,
+        positioned in the **intermembrane space (IMS)** to receive precursors emerging from the TOM pore and
+        coordinate their entry into TIM23.
 - term:
     id: GO:0016607
     label: nuclear speck
   evidence_type: IDA
   original_reference_id: PMID:16008839
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Supported for the Tim50a isoform, but not the core function of the canonical mitochondrial TIMM50
+      protein.
+    action: KEEP_AS_NON_CORE
+    additional_reference_ids:
+    - PMID:16008839
+    reason: Track as isoform-specific, non-core nuclear localization; canonical TIMM50 function is
+      mitochondrial TIM23 import.
+    supported_by:
+    - reference_id: PMID:16008839
+      supporting_text: cytoplasm and mitochondria, Tim50a is strictly nuclear and is enriched in
+  isoform: Q3ZCQ8-2
 - term:
     id: GO:0043021
     label: ribonucleoprotein complex binding
   evidence_type: IDA
   original_reference_id: PMID:16008839
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Supported for the nuclear Tim50a isoform, which interacts with snRNP-associated proteins, but
+      this is not the canonical mitochondrial import function.
+    action: KEEP_AS_NON_CORE
+    additional_reference_ids:
+    - PMID:16008839
+    reason: Keep as an isoform-specific non-core activity distinct from TIM23 presequence import.
+    supported_by:
+    - reference_id: PMID:16008839
+      supporting_text: In addition to coilin, Tim50a interacts with snRNPs and
+    - reference_id: PMID:16008839
+      supporting_text: cytoplasm and mitochondria, Tim50a is strictly nuclear and is enriched in
+  isoform: Q3ZCQ8-2
+- term:
+    id: GO:0030943
+    label: mitochondrion targeting sequence binding
+  evidence_type: NAS
+  original_reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+  review:
+    summary: TIMM50 is described as the primary inner-membrane presequence receptor for TIM23 substrates, so
+      mitochondrion targeting sequence binding captures its core molecular function better than generic
+      protein binding.
+    action: NEW
+    reason: Existing GOA lacks a specific molecular-function term for TIMM50 presequence/targeting-signal
+      receptor activity.
+    supported_by:
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: Tim50 is widely regarded as the **primary presequence receptor at the inner membrane**,
+        positioned in the **intermembrane space (IMS)** to receive precursors emerging from the TOM pore and
+        coordinate their entry into TIM23.
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: TIMM50 primarily acts on **presequence-containing precursor proteins**, which
+        constitute a large fraction of the mitochondrial proteome and are imported through the TIM23 pathway
+        for matrix delivery or IMM insertion.
+    - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+      supporting_text: This receptor/gating logic is supported by direct presequence-binding mapping and the
+        conclusion that Tim50 binding to Tim23 can induce channel closure when no substrate is being
+        transported.
 references:
 - id: GO_REF:0000033
   title: Annotation inferences using phylogenetic trees
   findings: []
 - id: GO_REF:0000044
-  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
-    vocabulary mapping, accompanied by conservative changes to GO terms applied by
-    UniProt
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping,
+    accompanied by conservative changes to GO terms applied by UniProt
   findings: []
 - id: GO_REF:0000052
   title: Gene Ontology annotation based on curation of immunofluorescence data
@@ -288,45 +722,95 @@ references:
   title: Electronic Gene Ontology annotations created by ARBA machine learning models
   findings: []
 - id: PMID:10339406
-  title: Genetic and structural characterization of the human mitochondrial inner
-    membrane translocase.
+  title: Genetic and structural characterization of the human mitochondrial inner membrane translocase.
   findings: []
 - id: PMID:12620389
-  title: Novel raf kinase protein-protein interactions found by an exhaustive yeast
-    two-hybrid analysis.
+  title: Novel raf kinase protein-protein interactions found by an exhaustive yeast two-hybrid analysis.
   findings: []
 - id: PMID:15044455
-  title: Tim50, a component of the mitochondrial translocator, regulates mitochondrial
-    integrity and cell death.
+  title: Tim50, a component of the mitochondrial translocator, regulates mitochondrial integrity and cell
+    death.
   findings: []
 - id: PMID:16008839
-  title: Tim50a, a nuclear isoform of the mitochondrial Tim50, interacts with proteins
-    involved in snRNP biogenesis.
+  title: Tim50a, a nuclear isoform of the mitochondrial Tim50, interacts with proteins involved in snRNP
+    biogenesis.
   findings: []
 - id: PMID:25852190
-  title: Integrative analysis of kinase networks in TRAIL-induced apoptosis provides
-    a source of potential targets for combination therapy.
+  title: Integrative analysis of kinase networks in TRAIL-induced apoptosis provides a source of potential
+    targets for combination therapy.
   findings: []
 - id: PMID:30598479
-  title: ROMO1 is a constituent of the human presequence translocase required for
-    YME1L protease import.
+  title: ROMO1 is a constituent of the human presequence translocase required for YME1L protease import.
   findings: []
 - id: PMID:31980649
-  title: Extensive rewiring of the EGFR network in colorectal cancer cells expressing
-    transforming levels of KRAS(G13D).
+  title: Extensive rewiring of the EGFR network in colorectal cancer cells expressing transforming levels of
+    KRAS(G13D).
   findings: []
 - id: PMID:32848200
-  title: Ttm50 facilitates calpain activation by anchoring it to calcium stores and
-    increasing its sensitivity to calcium.
+  title: Ttm50 facilitates calpain activation by anchoring it to calcium stores and increasing its sensitivity
+    to calcium.
   findings: []
 - id: PMID:34800366
-  title: Quantitative high-confidence human mitochondrial proteome and its dynamics
-    in cellular context.
+  title: Quantitative high-confidence human mitochondrial proteome and its dynamics in cellular context.
   findings: []
 - id: PMID:37045861
   title: Interactome dynamics of RAF1-BRAF kinase monomers and dimers.
   findings: []
 - id: PMID:38828998
-  title: Reduced Protein Import via TIM23 SORT Drives Disease Pathology in TIMM50-Associated
-    Mitochondrial Disease.
+  title: Reduced Protein Import via TIM23 SORT Drives Disease Pathology in TIMM50-Associated Mitochondrial
+    Disease.
   findings: []
+- id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+  title: Falcon deep research report for human TIMM50
+  findings: []
+core_functions:
+- description: TIMM50 is the inner-membrane TIM23 presequence receptor and gatekeeper that captures transit
+    peptide-containing mitochondrial precursors on the intermembrane-space side, coordinates TIM23 channel
+    gating, and supports import into the matrix or IMM sorting pathway.
+  supported_by:
+  - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+    supporting_text: Tim50 is widely regarded as the **primary presequence receptor at the inner membrane**,
+      positioned in the **intermembrane space (IMS)** to receive precursors emerging from the TOM pore and
+      coordinate their entry into TIM23.
+  - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+    supporting_text: TIMM50 primarily acts on **presequence-containing precursor proteins**, which constitute
+      a large fraction of the mitochondrial proteome and are imported through the TIM23 pathway for matrix
+      delivery or IMM insertion.
+  - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+    supporting_text: This receptor/gating logic is supported by direct presequence-binding mapping and the
+      conclusion that Tim50 binding to Tim23 can induce channel closure when no substrate is being
+      transported.
+  - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
+    supporting_text: TIMM50 is a **single-pass IMM protein** with an N-terminal mitochondrial targeting
+      sequence, a transmembrane anchor, and a large **IMS-exposed hydrophilic domain** that mediates
+      receptor/gating functions.
+  molecular_function:
+    id: GO:0030943
+    label: mitochondrion targeting sequence binding
+  directly_involved_in:
+  - id: GO:0030150
+    label: protein import into mitochondrial matrix
+  locations:
+  - id: GO:0005743
+    label: mitochondrial inner membrane
+  in_complex:
+    id: GO:0005744
+    label: TIM23 mitochondrial import inner membrane translocase complex
+proposed_new_terms: []
+suggested_questions:
+- question: What are the physiological substrates, if any, of the TIMM50 phosphatase-like domain in human
+    cells?
+  experts: []
+- question: Which human TIM23SORT substrates depend most strongly on TIMM50 presequence recognition or gating?
+  experts: []
+- question: Is the Tim50a nuclear speck/snRNP role broadly physiological or restricted to specific transformed
+    or neural cell contexts?
+  experts: []
+suggested_experiments:
+- hypothesis: TIMM50 presequence binding and channel-gating surfaces are separable.
+  description: Use TIMM50 rescue mutants affecting presequence-binding and TIMM23-interaction surfaces in
+    TIMM50-deficient human cells, then measure TIM23 complex assembly, channel gating, and import of
+    TIM23MOTOR versus TIM23SORT reporter substrates.
+- hypothesis: TIMM50 phosphatase-like activity is dispensable for most TIM23 import functions.
+  description: Compare phosphatase-dead TIMM50 mutants with receptor/gating mutants for rescue of matrix
+    import, IMM sorting, TIM23 complex stability, and patient-cell respiratory phenotypes.

--- a/genes/human/TIMM50/TIMM50-ai-review.yaml
+++ b/genes/human/TIMM50/TIMM50-ai-review.yaml
@@ -414,8 +414,9 @@ existing_annotations:
     additional_reference_ids:
     - PMID:32848200
     - file:human/TIMM50/TIMM50-deep-research-falcon.md
-    reason: Do not treat the noncanonical Ttm50 calpain calcium-store finding as a core human TIMM50 activity
-      or localization without human TIMM50-specific support.
+    reason: PMID:32848200 studies Drosophila Ttm50, not human TIMM50. Do not treat the noncanonical
+      Ttm50 calpain calcium-store finding as a core human TIMM50 activity or localization without human
+      TIMM50-specific support.
     supported_by:
     - reference_id: PMID:32848200
       supporting_text: GluRIIA at the Drosophila neuromuscular junction as a readout, we uncovered that
@@ -439,8 +440,9 @@ existing_annotations:
     additional_reference_ids:
     - PMID:32848200
     - file:human/TIMM50/TIMM50-deep-research-falcon.md
-    reason: Do not treat the noncanonical Ttm50 calpain calcium-store finding as a core human TIMM50 activity
-      or localization without human TIMM50-specific support.
+    reason: PMID:32848200 studies Drosophila Ttm50, not human TIMM50. Do not treat the noncanonical
+      Ttm50 calpain calcium-store finding as a core human TIMM50 activity or localization without human
+      TIMM50-specific support.
     supported_by:
     - reference_id: PMID:32848200
       supporting_text: GluRIIA at the Drosophila neuromuscular junction as a readout, we uncovered that
@@ -464,8 +466,9 @@ existing_annotations:
     additional_reference_ids:
     - PMID:32848200
     - file:human/TIMM50/TIMM50-deep-research-falcon.md
-    reason: Do not treat the noncanonical Ttm50 calpain calcium-store finding as a core human TIMM50 activity
-      or localization without human TIMM50-specific support.
+    reason: PMID:32848200 studies Drosophila Ttm50, not human TIMM50. Do not treat the noncanonical
+      Ttm50 calpain calcium-store finding as a core human TIMM50 activity or localization without human
+      TIMM50-specific support.
     supported_by:
     - reference_id: PMID:32848200
       supporting_text: GluRIIA at the Drosophila neuromuscular junction as a readout, we uncovered that
@@ -530,8 +533,10 @@ existing_annotations:
     action: REMOVE
     additional_reference_ids:
     - file:human/TIMM50/TIMM50-deep-research-falcon.md
-    reason: No usable evidence for IL-2 receptor binding was found in the cited cached publication or in the
-      TIMM50 deep research report.
+    reason: PMID:15044455 describes human Tim50 as a mitochondrial translocator/TIM23-associated protein
+      and contains no mention of IL-2 receptor binding. This annotation appears to be a database
+      misattribution, because a mitochondrial inner-membrane translocase subunit is not expected to function
+      as an IL-2 receptor ligand or receptor-binding protein.
     supported_by:
     - reference_id: file:human/TIMM50/TIMM50-deep-research-falcon.md
       supporting_text: Therefore, based on available evidence, the primary validated function remains

--- a/genes/human/TIMM50/TIMM50-deep-research-falcon.md
+++ b/genes/human/TIMM50/TIMM50-deep-research-falcon.md
@@ -1,0 +1,362 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-11T16:35:51.753785'
+end_time: '2026-05-11T16:49:10.112666'
+duration_seconds: 798.36
+template_file: templates/gene_research_go_focused.md
+template_variables:
+  organism: human
+  gene_id: TIMM50
+  gene_symbol: TIMM50
+  uniprot_accession: Q3ZCQ8
+  protein_description: 'RecName: Full=Mitochondrial import inner membrane translocase
+    subunit TIM50; Flags: Precursor;'
+  gene_info: Name=TIMM50; Synonyms=TIM50; ORFNames=PRO1512;
+  organism_full: Homo sapiens (Human).
+  protein_family: Belongs to the TIM50 family. .
+  protein_domains: FCP1_dom. (IPR004274); HAD-like_sf. (IPR036412); HAD_sf. (IPR023214);
+    TIM50. (IPR050365); NIF (PF03031)
+provider_config:
+  timeout: 600
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 38
+---
+
+## Question
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** Q3ZCQ8
+- **Protein Description:** RecName: Full=Mitochondrial import inner membrane translocase subunit TIM50; Flags: Precursor;
+- **Gene Information:** Name=TIMM50; Synonyms=TIM50; ORFNames=PRO1512;
+- **Organism (full):** Homo sapiens (Human).
+- **Protein Family:** Belongs to the TIM50 family. .
+- **Key Domains:** FCP1_dom. (IPR004274); HAD-like_sf. (IPR036412); HAD_sf. (IPR023214); TIM50. (IPR050365); NIF (PF03031)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "TIMM50" matches the protein description above**
+2. **Verify the organism is correct:** Homo sapiens (Human).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'TIMM50' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **TIMM50** (gene ID: TIMM50, UniProt: Q3ZCQ8) in human.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** Q3ZCQ8
+- **Protein Description:** RecName: Full=Mitochondrial import inner membrane translocase subunit TIM50; Flags: Precursor;
+- **Gene Information:** Name=TIMM50; Synonyms=TIM50; ORFNames=PRO1512;
+- **Organism (full):** Homo sapiens (Human).
+- **Protein Family:** Belongs to the TIM50 family. .
+- **Key Domains:** FCP1_dom. (IPR004274); HAD-like_sf. (IPR036412); HAD_sf. (IPR023214); TIM50. (IPR050365); NIF (PF03031)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "TIMM50" matches the protein description above**
+2. **Verify the organism is correct:** Homo sapiens (Human).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'TIMM50' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **TIMM50** (gene ID: TIMM50, UniProt: Q3ZCQ8) in human.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+# TIMM50 (UniProt Q3ZCQ8) Functional Annotation Research Report (Human)
+
+## 1) Target verification (critical identity check)
+The UniProt accession **Q3ZCQ8** corresponds to **Homo sapiens TIMM50 (Tim50)**, annotated as **mitochondrial import inner membrane translocase subunit TIM50, precursor** and belonging to the **TIM50 family**. Recent primary and review literature consistently places TIMM50 as a **core subunit of the mitochondrial inner membrane TIM23 (“presequence”) translocase**, together with TIMM23 and TIMM17A/B, confirming that the gene symbol **TIMM50** matches the protein description provided and that the organism context is human. (crameri2024reducedproteinimport pages 1-3, paz2024biochemicalandneurophysiological pages 1-2)
+
+## 2) Key concepts & definitions (current understanding)
+
+### 2.1 Mitochondrial protein import via TOM and TIM23
+Most mitochondrial proteins are encoded in the nucleus and must be imported post-translationally. The **TIM23 complex** is the major inner-membrane import route for proteins carrying **N-terminal, positively charged amphipathic targeting signals (“presequences” / MTSs)**, delivering clients to the **matrix** or inserting some clients into the **inner mitochondrial membrane (IMM)**. (paz2024biochemicalandneurophysiological pages 1-2, fielden2023centralroleof pages 1-4)
+
+### 2.2 TIMM50/Tim50: primary inner-membrane presequence receptor and gate regulator
+Tim50 is widely regarded as the **primary presequence receptor at the inner membrane**, positioned in the **intermembrane space (IMS)** to receive precursors emerging from the TOM pore and coordinate their entry into TIM23. A foundational mechanistic study mapped presequence contact sites and concluded Tim50 is the **primary presequence receptor** and that presequences and Tim50 regulate the Tim23 channel **antagonistically**, consistent with a receptor-plus-gating function. (schulz2011tim50’spresequencereceptor pages 1-2)
+
+### 2.3 TIM23 modularity: import-to-matrix versus inner-membrane sorting
+Human TIM23 exists in at least two functional assemblies:
+- **TIM23MOTOR**, which couples the translocase to the ATP-driven import motor (PAM) to achieve full matrix translocation.
+- **TIM23SORT**, which supports **lateral release** of hydrophobic segments into the IMM (inner-membrane insertion/sorting).
+A 2024 human study operationalized these modules and used them to interpret selective substrate sensitivity in TIMM50 disease. (crameri2024reducedproteinimport pages 1-3)
+
+## 3) Molecular function, localization, and mechanism
+
+### 3.1 Subcellular localization and topology
+TIMM50 is a **single-pass IMM protein** with an N-terminal mitochondrial targeting sequence, a transmembrane anchor, and a large **IMS-exposed hydrophilic domain** that mediates receptor/gating functions. (demishteinzohary2017thetim23mitochondrial pages 3-4, genge2023twodomainsof pages 1-2)
+
+### 3.2 Core function: substrate class and “substrate specificity”
+TIMM50 is not a transporter of small molecules; rather, its substrate specificity is defined by the **type of protein precursors** it helps import. TIMM50 primarily acts on **presequence-containing precursor proteins**, which constitute a large fraction of the mitochondrial proteome and are imported through the TIM23 pathway for matrix delivery or IMM insertion. (crameri2024reducedproteinimport pages 1-3, paz2024biochemicalandneurophysiological pages 1-2)
+
+### 3.3 TIMM50 as receptor and gatekeeper (interaction logic)
+Mechanistic and review evidence supports the following model:
+1. Presequence-containing precursors are recognized at the outer membrane and pass through TOM.
+2. On the IMS side, **TIMM50/Tim50 captures the presequence** as it emerges from TOM.
+3. TIMM50 interacts with **Tim23** in the IMS and helps regulate channel opening/closure, keeping the pathway closed in the absence of import substrates and switching states upon presequence engagement.
+This receptor/gating logic is supported by direct presequence-binding mapping and the conclusion that Tim50 binding to Tim23 can induce channel closure when no substrate is being transported. (schulz2011tim50’spresequencereceptor pages 1-2, demishteinzohary2017thetim23mitochondrial pages 3-4)
+
+### 3.4 TOM–TIM23 handover and coupling across two membranes
+Tim50 can be cross-linked to precursors arrested at the TOM “trans” site and can contact TOM-side components (classically described for Tim50/Tim23 with Tom22/Tom40 in mechanistic syntheses), supporting the concept of transient TOM–TIM23 cooperation during active translocation. A 2023 domain-dissection study emphasized that Tim50’s IMS domain(s) coordinate TOM–TIM23 cooperation and that the Tim50 core domain contains the main presequence-binding site and recruitment point to TIM23. (genge2023twodomainsof pages 1-2)
+
+### 3.5 Relationship to 2023 structural revision of the TIM23 channel
+Two high-impact 2023 Nature papers reframed the TIM23 mechanism by emphasizing **Tim17** as central to the translocation path:
+- Cryo-EM of the TIM23 core supports a stable Tim17–Tim23 heterodimer architecture and proposes a laterally open Tim17 cavity, with Mgr2 positioned near a lateral opening. (2023-06; https://doi.org/10.1038/s41586-023-06239-6) (sim2023structuralbasisof pages 1-4)
+- In-native-membrane crosslinking mapped preprotein contacts and showed **conserved negative charges in Tim17** are essential to initiate presequence translocation along a distinct Tim17 cavity, enabling lateral release for IMM-sorted precursors. (2023-08; https://doi.org/10.1038/s41586-023-06477-8) (fielden2023centralroleof pages 1-4)
+These findings do not diminish TIMM50’s receptor role; rather, they shift the likely **translocation cavity** away from Tim23 alone and toward Tim17, while TIMM50 remains essential for **presequence capture, TOM–TIM coordination, and gating control** at the IMS face of the machinery. (schulz2011tim50’spresequencereceptor pages 1-2, fielden2023centralroleof pages 1-4)
+
+### 3.6 Enzymatic/phosphatase-like domain: what is known vs. uncertain
+TIMM50 contains a **HAD/FCP1-like phosphatase-like fold**, and reviews report that human TIMM50 has **dual-specificity phosphatase/phosphohydrolase activity**, but the physiological substrates and relevance to import are described as **unclear/“elusive.”** Therefore, based on available evidence, the primary validated function remains **protein import receptor/gating**, not a defined metabolic reaction with established substrates. (chaudhuri2021diversefunctionsof pages 10-11, chaudhuri2021diversefunctionsof pages 13-15)
+
+## 4) Recent developments and latest research (prioritizing 2023–2024)
+
+### 4.1 2023: structural mechanism of TIM23 and redefinition of channel architecture
+The 2023 cryo-EM and functional mapping studies (Nature) are a major recent development because they provide structural constraints on TIM23 stoichiometry and support a model in which **Tim17 provides a key transmembrane cavity for presequence protein translocation and lateral release**, requiring negatively charged residues near the IMS leaflet. (sim2023structuralbasisof pages 1-4, fielden2023centralroleof pages 1-4)
+
+### 4.2 2024: TIMM50-associated mitochondrial disease mechanistically linked to TIM23SORT
+A 2024 Molecular and Cellular Biology study analyzed patient fibroblasts with a homozygous **TIMM50 p.(Arg113Cys)** variant and a cellular disease model, and linked TIMM50 dysfunction to **reduced TIM23 complex levels/activity** and to a selective vulnerability of **TIM23SORT (lateral insertion) substrates**. (2024-06; https://doi.org/10.1080/10985549.2024.2353652) (crameri2024reducedproteinimport pages 4-5, crameri2024reducedproteinimport pages 11-12)
+
+Quantitative examples from this study (patient cells / import assays):
+- TIM23MOTOR substrate **OTC import ~82%** of control.
+- TIM23SORT substrates **SURF1 ~67%** and **SCO2 ~62%** of control.
+- Total mitochondrial protein content decreased from **~8% to ~6.5%** of total cellular protein.
+These values support a mechanistic interpretation that TIMM50 loss disproportionately compromises the sorting/lateral insertion arm of TIM23. (crameri2024reducedproteinimport pages 11-12, crameri2024reducedproteinimport pages 4-5)
+
+### 4.3 2024: biochemical and neurophysiological consequences of TIMM50 deficiency
+A 2024 eLife study investigated TIMM50 deficiency in patient fibroblasts and neuronal TIMM50 knockdown models and reported:
+- Reduced basal/maximal/ATP-linked respiration and reduced glycolytic capacity/reserve, consistent with impaired energetic flexibility.
+- Approximately **twofold decrease in the percentage of mobile mitochondria** in TIMM50-deficient neurons.
+- No effect on mtDNA levels in the tested model systems.
+(2024-12; https://doi.org/10.7554/eLife.99914) (paz2024biochemicalandneurophysiological pages 9-11)
+
+### 4.4 2024: expert synthesis on mutation “hotspots” in TIM23—TIMM50 stands out
+A 2024 mini-review reported that among TIM23 complex genes, **TIMM50 has the highest number of reported disease-causing mutations**, summarizing **eight** distinct TIMM50 variants and their associated phenotypes. (2024-11; https://doi.org/10.3390/genes15121534) (jain2024hotspotsfordiseasecausing pages 5-7, jain2024hotspotsfordiseasecausing pages 8-9)
+
+## 5) Current applications and real-world implementations
+
+### 5.1 Clinical genetics and diagnostic interpretation
+TIMM50 is clinically relevant primarily through **rare-disease diagnostics** for early-onset mitochondrial disorders, including **3-methylglutaconic aciduria type IX (MGCA9)** and related encephalopathic phenotypes. A 2024 review summarizes disease-linked variants and common clinical features, providing a starting point for variant prioritization in exome/genome sequencing pipelines. (jain2024hotspotsfordiseasecausing pages 7-8, jain2024hotspotsfordiseasecausing pages 4-5)
+
+### 5.2 Functional validation in patient-derived cells
+Recent work demonstrates a practical diagnostic/interpretive workflow: identify candidate variants, then test for **TIMM50 protein loss**, **TIM23 complex integrity (e.g., BN-PAGE)**, and **TIM23-dependent import defects** with defined reporter substrates, including separation of TIM23MOTOR vs TIM23SORT clients. This is a real-world implementation of mechanistic import biology into disease interpretation. (crameri2024reducedproteinimport pages 4-5, crameri2024reducedproteinimport pages 11-12)
+
+### 5.3 Proteomics for mechanism-of-disease inference
+The 2024 TIMM50 study built a proteomic map of TIMM50-associated disease and leveraged substrate-class analysis (TIM23SORT vs TIM23MOTOR) to infer pathway-specific vulnerability, illustrating how proteomics can be used to move from “gene → mechanism” in mitochondrial disorders. (crameri2024reducedproteinimport pages 1-3)
+
+## 6) Disease associations, phenotypes, and recent statistics/data
+
+### 6.1 Variant spectrum and phenotype summary
+Reported TIMM50 variants include early truncation and multiple missense alleles (e.g., Ser9Ter, Gly87Ala, Arg114Gln/Trp, Thr149Met, Ala222Thr, Arg239Trp, Gly269Ser), with phenotypes including developmental delay/encephalopathy, seizures/epileptic spasms, lactic acidosis, OXPHOS defects, and MGCA9. (jain2024hotspotsfordiseasecausing pages 4-5)
+
+### 6.2 Visual-system involvement statistic
+A 2024 mini-review reported **abnormal electroretinograms in ≥60% of individuals** with TIMM50 variants, highlighting visual pathway involvement as a recurrent clinical feature. (jain2024hotspotsfordiseasecausing pages 7-8)
+
+### 6.3 Quantitative cellular phenotypes (recent primary studies)
+- TIMM50 p.Arg113Cys patient fibroblasts show selective reductions in TIM23SORT import (SURF1 67%, SCO2 62%) relative to a TIM23MOTOR substrate (OTC 82%), and decreased mitochondrial protein content (~8%→~6.5%). (crameri2024reducedproteinimport pages 4-5, crameri2024reducedproteinimport pages 11-12)
+- TIMM50 deficiency causes measurable bioenergetic impairment and reduced mitochondrial motility (~2-fold reduction in mobile mitochondria) in neuronal models. (paz2024biochemicalandneurophysiological pages 9-11)
+
+## 7) Expert opinions and authoritative analyses (how experts interpret TIMM50 biology)
+
+### 7.1 TIMM50 as a mechanistic bridge between TOM and TIM23
+Authoritative mechanistic interpretations emphasize TIMM50/Tim50 as an IMS receptor that couples the two membrane translocases by binding presequences and coordinating handover, with its interactions modulated by the incoming signal peptide. (genge2023twodomainsof pages 1-2, demishteinzohary2017thetim23mitochondrial pages 3-4)
+
+### 7.2 TIMM50 mutation hotspot within TIM23 complex
+Expert synthesis argues TIMM50 is a relative hotspot for disease-causing variants among TIM23 components, and that TIMM50 dysfunction can yield severe early-onset neurological disease via impaired protein import. (jain2024hotspotsfordiseasecausing pages 5-7, jain2024hotspotsfordiseasecausing pages 7-8)
+
+### 7.3 TIMM50 and lateral insertion (TIM23SORT) as a disease mechanism
+The 2024 patient-cell proteomics/import data support a more nuanced view: while TIMM50 is classically described as a presequence receptor, TIMM50 loss in humans disproportionately affects **TIM23SORT-mediated lateral insertion** clients—many of which relate to OXPHOS and mitochondrial ultrastructure—providing a plausible biochemical explanation for specific phenotypes. (crameri2024reducedproteinimport pages 1-3, crameri2024reducedproteinimport pages 11-12)
+
+## 8) Summary table (evidence-linked)
+The following table condenses the functional annotation, interaction network, recent structural advances, and 2024 disease evidence.
+
+| Topic | Key points | Representative recent sources (with year) | Citation IDs |
+|---|---|---|---|
+| Protein identity / topology / domains | Human **TIMM50** encodes mitochondrial import inner membrane translocase subunit **Tim50** (UniProt **Q3ZCQ8**), a core TIM23 subunit. It is a **single-pass inner mitochondrial membrane** protein with an N-terminal mitochondrial targeting sequence, a transmembrane anchor, and a large **IMS-exposed receptor domain**. Human TIMM50 contains an **FCP1-like / HAD-like phosphatase-like core (NIF/HAD fold)**; unlike fungal Tim50, human TIMM50 lacks the fungal C-terminal PBD, but key groove/β-strand receptor features are conserved. | Crameri et al., 2024; Chaudhuri et al., 2021; Demishtein-Zohary & Azem, 2017 | (crameri2024reducedproteinimport pages 1-3, chaudhuri2021diversefunctionsof pages 21-22, chaudhuri2021diversefunctionsof pages 6-7, chaudhuri2021diversefunctionsof pages 10-11, demishteinzohary2017thetim23mitochondrial pages 3-4) |
+| Role in TIM23MOTOR vs TIM23SORT | TIMM50 is part of the TIM23 core with TIMM23 and TIMM17A/B. In **TIM23MOTOR**, accessory factors such as DNAJC19/15, TIMM44, HSPA9, PAM16, and GRPEL1/2 drive ATP-dependent import of presequence proteins into the **matrix**. In **TIM23SORT**, TIMM21 and **ROMO1** support **lateral insertion** of single/dual-pass inner membrane proteins. Recent human disease proteomics indicate **TIM23SORT clients are especially sensitive** to TIMM50 loss. | Crameri et al., 2024; Paz et al., 2024 | (crameri2024reducedproteinimport pages 1-3, paz2024biochemicalandneurophysiological pages 1-2) |
+| Key interaction partners | TIMM50 directly/functionally associates with **TIMM23** and TIMM17A/B in the TIM23 core. Crosslinking and mechanistic studies place Tim50 in contact with **Tom22/Tom40** at the TOM trans site and with **Tim21/TIMM21**, linking TOM and TIM23 during precursor handover. TIM23SORT also includes **ROMO1**; TIM23MOTOR includes the PAM machinery (TIMM44, mtHsp70/HSPA9, DNAJC19/15, PAM16, GRPEL1/2). | Genge et al., 2023; Demishtein-Zohary & Azem, 2017; Crameri et al., 2024 | (genge2023twodomainsof pages 1-2, genge2024functionaldissectionof pages 19-22, genge2024functionaldissectionof pages 16-19, demishteinzohary2017thetim23mitochondrial pages 3-4, crameri2024reducedproteinimport pages 1-3) |
+| Mechanistic concept: presequence receptor | Tim50 is the **primary presequence receptor at the inner membrane**. It recognizes positively charged, amphipathic N-terminal targeting sequences as they emerge from TOM and helps deliver them to the TIM23 translocase. The core IMS domain contains the principal presequence-binding site and is the main recruitment point to the TIM23 complex. | Schulz et al., 2011; Genge et al., 2023 | (schulz2011tim50’spresequencereceptor pages 1-2, genge2023twodomainsof pages 1-2) |
+| Mechanistic concept: gating / closure | Tim50 is also a **gating regulator**: Tim50 binding to Tim23 antagonizes channel opening and helps keep the channel **closed in the absence of substrate**; presequence engagement relieves this inhibitory state and promotes productive translocation. Reviews describe Tim50/Tim23 as receptor-gating components on the IMS side of the TIM23 complex. | Schulz et al., 2011; Demishtein-Zohary & Azem, 2017 | (schulz2011tim50’spresequencereceptor pages 1-2, demishteinzohary2017thetim23mitochondrial pages 3-4) |
+| Mechanistic concept: TOM–TIM23 handover | Tim50 can bind precursor proteins while they are still at/near the **TOM trans site** and can contact **Tom22** and **Tom40**, supporting a transient **TOM–TIM23 supercomplex**. Presequence binding modulates Tim50 interactions with Tom22/Tim21 and coordinates handover from TOM to TIM23. | Genge et al., 2023; recent mechanistic syntheses 2024–2025 | (genge2023twodomainsof pages 1-2, genge2024functionaldissectionof pages 19-22, genge2024functionaldissectionof pages 16-19, jain2025investigatingmitochondrialpresequence pages 20-23, jain2025investigatingmitochondrialpresequence pages 15-17) |
+| Mechanistic concept: lateral insertion | New mechanistic work shifts emphasis toward **Tim17** as the main translocation cavity with a laterally open, negatively charged path, while TIMM50 remains essential upstream for precursor recognition and pathway selection. Human 2024 proteomics suggest TIMM50 dysfunction disproportionately affects **TIM23SORT-mediated lateral insertion**, implying TIMM50 has a stronger role in sorting than previously appreciated. | Sim et al., 2023; Fielden et al., 2023; Crameri et al., 2024 | (sim2023structuralbasisof pages 1-4, fielden2023centralroleof pages 1-4, crameri2024reducedproteinimport pages 1-3) |
+| Enzymatic / phosphatase-like activity | TIMM50 carries a **phosphatase-like HAD/FCP1-related fold**, and reviews report **dual-specificity phosphatase / phosphohydrolase activity** for human TIMM50. However, the **physiological substrates and in vivo relevance remain unclear**, so TIMM50 is functionally annotated primarily as an import receptor/gating subunit rather than a validated metabolic enzyme. | Chaudhuri et al., 2021 | (chaudhuri2021diversefunctionsof pages 21-22, chaudhuri2021diversefunctionsof pages 10-11, chaudhuri2021diversefunctionsof pages 13-15) |
+| Evidence types supporting function | Evidence spans **photo-crosslinking and receptor mapping** (2011), **domain dissection and TOM–TIM coordination** (2023), **cryo-EM/structural reinterpretation of TIM23 architecture** (2023), and **patient-cell proteomics/import assays** (2024). Together these support TIMM50 as an IMS receptor, channel regulator, and determinant of TIM23 complex integrity and substrate selectivity. | Schulz et al., 2011; Sim et al., 2023; Fielden et al., 2023; Genge et al., 2023; Crameri et al., 2024 | (schulz2011tim50’spresequencereceptor pages 1-2, sim2023structuralbasisof pages 1-4, fielden2023centralroleof pages 1-4, genge2023twodomainsof pages 1-2, crameri2024reducedproteinimport pages 1-3) |
+| Disease genetics / clinical spectrum | A 2024 mini-review identified **8 distinct human TIMM50 mutations**, making TIMM50 the **most mutation-enriched TIM23 subunit** currently known. Disease is linked to **3-methylglutaconic aciduria type IX (MGCA9)** and/or mitochondrial encephalopathy with **failure to thrive, developmental delay, seizures/epileptic spasms, visual pathway abnormalities, optic atrophy, and elevated lactate**. **Abnormal electroretinograms were reported in ≥60%** of affected individuals. | Jain et al., 2024; Crameri et al., 2024 | (jain2024hotspotsfordiseasecausing pages 7-8, jain2024hotspotsfordiseasecausing pages 4-5, jain2024hotspotsfordiseasecausing pages 5-7, jain2024hotspotsfordiseasecausing pages 8-9, crameri2024reducedproteinimport pages 1-3) |
+| Quantitative findings from 2024 Crameri study | In patient fibroblasts with homozygous **p.Arg113Cys**, TIMM50 protein was nearly absent; assembled TIM23 complex and core subunits were reduced. Import assays showed **TIM23MOTOR substrate OTC at 82% of control**, versus **TIM23SORT substrates SURF1 at 67%** and **SCO2 at 62%**. Total mitochondrial protein content fell from **~8% to ~6.5%** of total cellular protein. TIM22 substrate import was unaffected; WT TIMM50 re-expression partially rescued defects. | Crameri et al., 2024 | (crameri2024reducedproteinimport pages 4-5, crameri2024reducedproteinimport pages 11-12) |
+| Quantitative findings from 2024 Paz study | In patient fibroblasts and TIMM50-KD neurons, TIMM50 deficiency reduced **basal, maximal, and ATP-linked respiration** and lowered glycolytic capacity/reserve without affecting mtDNA copy number. Neuronal imaging showed an approximately **2-fold decrease in the percentage of mobile mitochondria**. Reported assays used **n=4–6 biological repeats** with significant effects. | Paz et al., 2024 | (paz2024biochemicalandneurophysiological pages 9-11) |
+
+
+*Table: This table summarizes the core functional annotation, mechanistic biology, interaction network, recent structural advances, and 2024 disease evidence for human TIMM50 (UniProt Q3ZCQ8). It is useful as a compact reference linking molecular function to quantitative patient-cell findings and current expert interpretation.*
+
+## 9) Key recent references (URLs & publication dates)
+- Sim SI et al. **“Structural basis of mitochondrial protein import by the TIM23 complex.”** *Nature* (2023-06). https://doi.org/10.1038/s41586-023-06239-6 (sim2023structuralbasisof pages 1-4)
+- Fielden LF et al. **“Central role of Tim17 in mitochondrial presequence protein translocation.”** *Nature* (2023-08). https://doi.org/10.1038/s41586-023-06477-8 (fielden2023centralroleof pages 1-4)
+- Genge MG et al. **“Two domains of Tim50 coordinate translocation of proteins across the two mitochondrial membranes.”** *Life Science Alliance* (2023-09). https://doi.org/10.26508/lsa.202302122 (genge2023twodomainsof pages 1-2)
+- Crameri JJ et al. **“Reduced Protein Import via TIM23SORT Drives Disease Pathology in TIMM50-Associated Mitochondrial Disease.”** *Molecular and Cellular Biology* (2024-06). https://doi.org/10.1080/10985549.2024.2353652 (crameri2024reducedproteinimport pages 1-3)
+- Paz E et al. **“Biochemical and neurophysiological effects of deficiency of the mitochondrial import protein TIMM50.”** *eLife* (2024-12). https://doi.org/10.7554/eLife.99914 (paz2024biochemicalandneurophysiological pages 1-2)
+- Jain S et al. **“Hotspots for Disease-Causing Mutations in the Mitochondrial TIM23 Import Complex.”** *Genes* (2024-11). https://doi.org/10.3390/genes15121534 (jain2024hotspotsfordiseasecausing pages 7-8)
+- Schulz C et al. **“Tim50’s presequence receptor domain is essential for signal driven transport across the TIM23 complex.”** *J Cell Biol* (2011-11). https://doi.org/10.1083/jcb.201105098 (schulz2011tim50’spresequencereceptor pages 1-2)
+
+## 10) Notes on limitations and open questions
+- Many mechanistic details (e.g., exact residue-level interaction interfaces between human TIMM50 and TOM/TIM23 components; high-resolution structures of human TOM–TIM23 with substrate in transit) remain incompletely resolved in the available excerpts, and some structural insights are currently derived largely from yeast systems extrapolated to mammals. (sim2023structuralbasisof pages 1-4, genge2023twodomainsof pages 1-2)
+- Although TIMM50 has a phosphatase-like fold and phosphatase activity has been reported in reviews, clear consensus on in vivo substrates and physiological impact remains lacking; current evidence supports prioritizing its role as an import receptor/gating component. (chaudhuri2021diversefunctionsof pages 10-11, chaudhuri2021diversefunctionsof pages 13-15)
+
+
+References
+
+1. (crameri2024reducedproteinimport pages 1-3): Jordan J. Crameri, Catherine S. Palmer, Tegan Stait, Thomas D. Jackson, Matthew Lynch, Adriane Sinclair, Leah E. Frajman, Alison G. Compton, David Coman, David R. Thorburn, Ann E. Frazier, and Diana Stojanovski. Reduced protein import via tim23 sort drives disease pathology in timm50-associated mitochondrial disease. Molecular and Cellular Biology, 44:226-244, Jun 2024. URL: https://doi.org/10.1080/10985549.2024.2353652, doi:10.1080/10985549.2024.2353652. This article has 9 citations and is from a domain leading peer-reviewed journal.
+
+2. (paz2024biochemicalandneurophysiological pages 1-2): Eyal Paz, Sahil Jain, Irit Gottfried, Orna Staretz-Chacham, Muhammad Mahajnah, Pritha Bagchi, Nicholas T Seyfried, Uri Ashery, and Abdussalam Azem. Biochemical and neurophysiological effects of deficiency of the mitochondrial import protein timm50. eLife, Dec 2024. URL: https://doi.org/10.7554/elife.99914, doi:10.7554/elife.99914. This article has 5 citations and is from a domain leading peer-reviewed journal.
+
+3. (fielden2023centralroleof pages 1-4): Laura F. Fielden, Jakob D. Busch, Sandra G. Merkt, Iniyan Ganesan, Conny Steiert, Hanna B. Hasselblatt, Jon V. Busto, Christophe Wirth, Nicole Zufall, Sibylle Jungbluth, Katja Noll, Julia M. Dung, Ludmila Butenko, Karina von der Malsburg, Hans-Georg Koch, Carola Hunte, Martin van der Laan, and Nils Wiedemann. Central role of tim17 in mitochondrial presequence protein translocation. Nature, 621:627-634, Aug 2023. URL: https://doi.org/10.1038/s41586-023-06477-8, doi:10.1038/s41586-023-06477-8. This article has 64 citations and is from a highest quality peer-reviewed journal.
+
+4. (schulz2011tim50’spresequencereceptor pages 1-2): Christian Schulz, Oleksandr Lytovchenko, Jonathan Melin, Agnieszka Chacinska, Bernard Guiard, Piotr Neumann, Ralf Ficner, Olaf Jahn, Bernhard Schmidt, and Peter Rehling. Tim50’s presequence receptor domain is essential for signal driven transport across the tim23 complex. The Journal of Cell Biology, 195:643-656, Nov 2011. URL: https://doi.org/10.1083/jcb.201105098, doi:10.1083/jcb.201105098. This article has 117 citations.
+
+5. (demishteinzohary2017thetim23mitochondrial pages 3-4): Keren Demishtein-Zohary and Abdussalam Azem. The tim23 mitochondrial protein import complex: function and dysfunction. Cell and Tissue Research, 367:33-41, Sep 2017. URL: https://doi.org/10.1007/s00441-016-2486-7, doi:10.1007/s00441-016-2486-7. This article has 59 citations and is from a peer-reviewed journal.
+
+6. (genge2023twodomainsof pages 1-2): Marcel G Genge, Shalini Roy Chowdhury, Vít Dohnálek, Kaori Yunoki, Takashi Hirashima, Toshiya Endo, Pavel Doležal, and Dejana Mokranjac. Two domains of tim50 coordinate translocation of proteins across the two mitochondrial membranes. Life Science Alliance, 6:e202302122, Sep 2023. URL: https://doi.org/10.26508/lsa.202302122, doi:10.26508/lsa.202302122. This article has 8 citations and is from a peer-reviewed journal.
+
+7. (sim2023structuralbasisof pages 1-4): Sue Im Sim, Yuanyuan Chen, Diane L. Lynch, James C. Gumbart, and Eunyong Park. Structural basis of mitochondrial protein import by the tim23 complex. Nature, 621:620-626, Jun 2023. URL: https://doi.org/10.1038/s41586-023-06239-6, doi:10.1038/s41586-023-06239-6. This article has 105 citations and is from a highest quality peer-reviewed journal.
+
+8. (chaudhuri2021diversefunctionsof pages 10-11): Minu Chaudhuri, Anuj Tripathi, and Fidel Soto Gonzalez. Diverse functions of tim50, a component of the mitochondrial inner membrane protein translocase. International Journal of Molecular Sciences, 22:7779, Jul 2021. URL: https://doi.org/10.3390/ijms22157779, doi:10.3390/ijms22157779. This article has 16 citations.
+
+9. (chaudhuri2021diversefunctionsof pages 13-15): Minu Chaudhuri, Anuj Tripathi, and Fidel Soto Gonzalez. Diverse functions of tim50, a component of the mitochondrial inner membrane protein translocase. International Journal of Molecular Sciences, 22:7779, Jul 2021. URL: https://doi.org/10.3390/ijms22157779, doi:10.3390/ijms22157779. This article has 16 citations.
+
+10. (crameri2024reducedproteinimport pages 4-5): Jordan J. Crameri, Catherine S. Palmer, Tegan Stait, Thomas D. Jackson, Matthew Lynch, Adriane Sinclair, Leah E. Frajman, Alison G. Compton, David Coman, David R. Thorburn, Ann E. Frazier, and Diana Stojanovski. Reduced protein import via tim23 sort drives disease pathology in timm50-associated mitochondrial disease. Molecular and Cellular Biology, 44:226-244, Jun 2024. URL: https://doi.org/10.1080/10985549.2024.2353652, doi:10.1080/10985549.2024.2353652. This article has 9 citations and is from a domain leading peer-reviewed journal.
+
+11. (crameri2024reducedproteinimport pages 11-12): Jordan J. Crameri, Catherine S. Palmer, Tegan Stait, Thomas D. Jackson, Matthew Lynch, Adriane Sinclair, Leah E. Frajman, Alison G. Compton, David Coman, David R. Thorburn, Ann E. Frazier, and Diana Stojanovski. Reduced protein import via tim23 sort drives disease pathology in timm50-associated mitochondrial disease. Molecular and Cellular Biology, 44:226-244, Jun 2024. URL: https://doi.org/10.1080/10985549.2024.2353652, doi:10.1080/10985549.2024.2353652. This article has 9 citations and is from a domain leading peer-reviewed journal.
+
+12. (paz2024biochemicalandneurophysiological pages 9-11): Eyal Paz, Sahil Jain, Irit Gottfried, Orna Staretz-Chacham, Muhammad Mahajnah, Pritha Bagchi, Nicholas T Seyfried, Uri Ashery, and Abdussalam Azem. Biochemical and neurophysiological effects of deficiency of the mitochondrial import protein timm50. eLife, Dec 2024. URL: https://doi.org/10.7554/elife.99914, doi:10.7554/elife.99914. This article has 5 citations and is from a domain leading peer-reviewed journal.
+
+13. (jain2024hotspotsfordiseasecausing pages 5-7): Sahil Jain, Eyal Paz, and Abdussalam Azem. Hotspots for disease-causing mutations in the mitochondrial tim23 import complex. Genes, 15:1534, Nov 2024. URL: https://doi.org/10.3390/genes15121534, doi:10.3390/genes15121534. This article has 1 citations.
+
+14. (jain2024hotspotsfordiseasecausing pages 8-9): Sahil Jain, Eyal Paz, and Abdussalam Azem. Hotspots for disease-causing mutations in the mitochondrial tim23 import complex. Genes, 15:1534, Nov 2024. URL: https://doi.org/10.3390/genes15121534, doi:10.3390/genes15121534. This article has 1 citations.
+
+15. (jain2024hotspotsfordiseasecausing pages 7-8): Sahil Jain, Eyal Paz, and Abdussalam Azem. Hotspots for disease-causing mutations in the mitochondrial tim23 import complex. Genes, 15:1534, Nov 2024. URL: https://doi.org/10.3390/genes15121534, doi:10.3390/genes15121534. This article has 1 citations.
+
+16. (jain2024hotspotsfordiseasecausing pages 4-5): Sahil Jain, Eyal Paz, and Abdussalam Azem. Hotspots for disease-causing mutations in the mitochondrial tim23 import complex. Genes, 15:1534, Nov 2024. URL: https://doi.org/10.3390/genes15121534, doi:10.3390/genes15121534. This article has 1 citations.
+
+17. (chaudhuri2021diversefunctionsof pages 21-22): Minu Chaudhuri, Anuj Tripathi, and Fidel Soto Gonzalez. Diverse functions of tim50, a component of the mitochondrial inner membrane protein translocase. International Journal of Molecular Sciences, 22:7779, Jul 2021. URL: https://doi.org/10.3390/ijms22157779, doi:10.3390/ijms22157779. This article has 16 citations.
+
+18. (chaudhuri2021diversefunctionsof pages 6-7): Minu Chaudhuri, Anuj Tripathi, and Fidel Soto Gonzalez. Diverse functions of tim50, a component of the mitochondrial inner membrane protein translocase. International Journal of Molecular Sciences, 22:7779, Jul 2021. URL: https://doi.org/10.3390/ijms22157779, doi:10.3390/ijms22157779. This article has 16 citations.
+
+19. (genge2024functionaldissectionof pages 19-22): Marcel Gilbert Genge. Functional dissection of the two domains of tim50, the main receptor of the tim23 complex. Dissertation, Jan 2024. URL: https://doi.org/10.5282/edoc.34256, doi:10.5282/edoc.34256. This article has 0 citations.
+
+20. (genge2024functionaldissectionof pages 16-19): Marcel Gilbert Genge. Functional dissection of the two domains of tim50, the main receptor of the tim23 complex. Dissertation, Jan 2024. URL: https://doi.org/10.5282/edoc.34256, doi:10.5282/edoc.34256. This article has 0 citations.
+
+21. (jain2025investigatingmitochondrialpresequence pages 20-23): Naintara Jain. Investigating Mitochondrial Presequence Import. PhD thesis, University Goettingen, 2025. URL: https://doi.org/10.53846/goediss-11596, doi:10.53846/goediss-11596.
+
+22. (jain2025investigatingmitochondrialpresequence pages 15-17): Naintara Jain. Investigating Mitochondrial Presequence Import. PhD thesis, University Goettingen, 2025. URL: https://doi.org/10.53846/goediss-11596, doi:10.53846/goediss-11596.
+
+## Citations
+
+1. crameri2024reducedproteinimport pages 1-3
+2. genge2023twodomainsof pages 1-2
+3. sim2023structuralbasisof pages 1-4
+4. fielden2023centralroleof pages 1-4
+5. paz2024biochemicalandneurophysiological pages 9-11
+6. jain2024hotspotsfordiseasecausing pages 4-5
+7. jain2024hotspotsfordiseasecausing pages 7-8
+8. paz2024biochemicalandneurophysiological pages 1-2
+9. chaudhuri2021diversefunctionsof pages 10-11
+10. chaudhuri2021diversefunctionsof pages 13-15
+11. crameri2024reducedproteinimport pages 4-5
+12. crameri2024reducedproteinimport pages 11-12
+13. jain2024hotspotsfordiseasecausing pages 5-7
+14. jain2024hotspotsfordiseasecausing pages 8-9
+15. chaudhuri2021diversefunctionsof pages 21-22
+16. chaudhuri2021diversefunctionsof pages 6-7
+17. genge2024functionaldissectionof pages 19-22
+18. genge2024functionaldissectionof pages 16-19
+19. jain2025investigatingmitochondrialpresequence pages 20-23
+20. jain2025investigatingmitochondrialpresequence pages 15-17
+21. https://doi.org/10.1038/s41586-023-06239-6
+22. https://doi.org/10.1038/s41586-023-06477-8
+23. https://doi.org/10.1080/10985549.2024.2353652
+24. https://doi.org/10.7554/eLife.99914
+25. https://doi.org/10.3390/genes15121534
+26. https://doi.org/10.26508/lsa.202302122
+27. https://doi.org/10.1083/jcb.201105098
+28. https://doi.org/10.1080/10985549.2024.2353652,
+29. https://doi.org/10.7554/elife.99914,
+30. https://doi.org/10.1038/s41586-023-06477-8,
+31. https://doi.org/10.1083/jcb.201105098,
+32. https://doi.org/10.1007/s00441-016-2486-7,
+33. https://doi.org/10.26508/lsa.202302122,
+34. https://doi.org/10.1038/s41586-023-06239-6,
+35. https://doi.org/10.3390/ijms22157779,
+36. https://doi.org/10.3390/genes15121534,
+37. https://doi.org/10.5282/edoc.34256,
+38. https://doi.org/10.53846/goediss-11596,

--- a/genes/human/TOMM22/TOMM22-ai-review.html
+++ b/genes/human/TOMM22/TOMM22-ai-review.html
@@ -1,0 +1,4586 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>TOMM22 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>TOMM22</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q9NS69" target="_blank" class="term-link">
+                        Q9NS69
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "TOMM22";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q9NS69" data-a="DESCRIPTION: TOMM22 encodes hTom22, a single-pass mitochondrial..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>TOMM22 encodes hTom22, a single-pass mitochondrial outer membrane receptor and scaffold subunit of the TOM complex. TOMM22 recognizes mitochondrial precursor proteins, helps transfer them toward the TOMM40 pore, and supports TOM complex assembly and stability; its transporter annotation is best interpreted as contribution to TOM complex protein import rather than standalone pore activity.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030150" target="_blank" class="term-link">
+                                    GO:0030150
+                                </a>
+                            </span>
+                            <span class="term-label">protein import into mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NS69" data-a="GO:0030150" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct as a TOM-complex entry step for matrix-destined mitochondrial preproteins. TOMM22 is a receptor/scaffold that recognizes precursors and transfers them toward the TOMM40 pore before downstream inner-membrane import.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOMM22/TOMM22-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The **TOM complex** is the primary entry gate for most nucleus-encoded mitochondrial proteins into mitochondria.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOMM22/TOMM22-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">TOMM22 functions as a **major preprotein-binding site** and **organizational scaffold** for the TOM complex, helping recognize mitochondrial precursor proteins and transfer them toward the **Tom40 import pore**.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005742" target="_blank" class="term-link">
+                                    GO:0005742
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial outer membrane translocase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NS69" data-a="GO:0005742" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct. TOMM22 is a core receptor/scaffold subunit of the TOM complex / mitochondrial outer membrane translocase complex.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOMM22/TOMM22-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Human **TOMM22 (Q9NS69)** encodes **hTom22**, a **single-pass outer mitochondrial membrane** subunit of the TOM complex that acts as the **central receptor** and an **assembly-organizing scaffold**.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOMM22/TOMM22-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">2) an **organizational scaffold** required for correct **TOM complex assembly** and stability.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008320" target="_blank" class="term-link">
+                                    GO:0008320
+                                </a>
+                            </span>
+                            <span class="term-label">protein transmembrane transporter activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NS69" data-a="GO:0008320" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Accepted as contribution to TOM complex protein transmembrane transporter activity. TOMM22 is the receptor/scaffold that transfers precursors toward the TOMM40 pore, not the pore-forming subunit by itself.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Retain only as complex contribution; TOMM40 is the conducting pore, whereas TOMM22 provides receptor/scaffold function needed for import.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOMM22/TOMM22-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">TOMM22 functions as a **major preprotein-binding site** and **organizational scaffold** for the TOM complex, helping recognize mitochondrial precursor proteins and transfer them toward the **Tom40 import pore**.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOMM22/TOMM22-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The 2024 PNAS Nexus study (Su et al.) reports a **human TOM holo complex cryo-EM structure** including intact Tom20 at **~6 Å** and explicitly frames Tom22 as one of the TOM receptors that recognize targeting signals and collaborate in translocation.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005741" target="_blank" class="term-link">
+                                    GO:0005741
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial outer membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NS69" data-a="GO:0005741" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct. TOMM22 is a single-pass mitochondrial outer membrane component of the TOM complex.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOMM22/TOMM22-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">hTom22 is an **outer mitochondrial membrane (OMM)** component and is structurally a **single-pass amphipathic α-helical** protein.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006886" target="_blank" class="term-link">
+                                    GO:0006886
+                                </a>
+                            </span>
+                            <span class="term-label">intracellular protein transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NS69" data-a="GO:0006886" data-r="GO_REF:0000002" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct pathway family but too broad. TOMM22 specifically functions in TOM-complex mitochondrial protein import.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Use mitochondrial protein import/localization and TOM complex terms rather than generic intracellular protein transport.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOMM22/TOMM22-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The **TOM complex** is the primary entry gate for most nucleus-encoded mitochondrial proteins into mitochondria.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOMM22/TOMM22-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">TOMM22 functions as a **major preprotein-binding site** and **organizational scaffold** for the TOM complex, helping recognize mitochondrial precursor proteins and transfer them toward the **Tom40 import pore**.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12198123" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12198123
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Insertion and assembly of human tom7 into the preprotein tra...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NS69" data-a="GO:0005515" data-r="PMID:12198123" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Protein binding is too generic for TOMM22. The informative functions are precursor/targeting-sequence recognition and TOM complex scaffold membership.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Documented interactions should be captured by TOM complex and targeting-sequence/preprotein receptor annotations rather than generic protein binding.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOMM22/TOMM22-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Within this machinery, **TOMM22/hTom22** is described as the **central receptor** of the TOM complex, functioning both as:</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOMM22/TOMM22-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">1) a **major preprotein-binding site** and transfer platform, and</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25556234" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25556234
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    New host factors important for respiratory syncytial virus (...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NS69" data-a="GO:0005515" data-r="PMID:25556234" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Protein binding is too generic for TOMM22. The informative functions are precursor/targeting-sequence recognition and TOM complex scaffold membership.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Documented interactions should be captured by TOM complex and targeting-sequence/preprotein receptor annotations rather than generic protein binding.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOMM22/TOMM22-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Within this machinery, **TOMM22/hTom22** is described as the **central receptor** of the TOM complex, functioning both as:</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOMM22/TOMM22-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">1) a **major preprotein-binding site** and transfer platform, and</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:32296183
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A reference map of the human binary protein interactome.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NS69" data-a="GO:0005515" data-r="PMID:32296183" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Protein binding is too generic for TOMM22. The informative functions are precursor/targeting-sequence recognition and TOM complex scaffold membership.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Documented interactions should be captured by TOM complex and targeting-sequence/preprotein receptor annotations rather than generic protein binding.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOMM22/TOMM22-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Within this machinery, **TOMM22/hTom22** is described as the **central receptor** of the TOM complex, functioning both as:</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOMM22/TOMM22-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">1) a **major preprotein-binding site** and transfer platform, and</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/32814053" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:32814053
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Interactome Mapping Provides a Network of Neurodegenerative ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NS69" data-a="GO:0005515" data-r="PMID:32814053" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Protein binding is too generic for TOMM22. The informative functions are precursor/targeting-sequence recognition and TOM complex scaffold membership.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Documented interactions should be captured by TOM complex and targeting-sequence/preprotein receptor annotations rather than generic protein binding.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOMM22/TOMM22-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Within this machinery, **TOMM22/hTom22** is described as the **central receptor** of the TOM complex, functioning both as:</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOMM22/TOMM22-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">1) a **major preprotein-binding site** and transfer platform, and</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030150" target="_blank" class="term-link">
+                                    GO:0030150
+                                </a>
+                            </span>
+                            <span class="term-label">protein import into mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10982837" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10982837
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Identification and functional analysis of human Tom22 for pr...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NS69" data-a="GO:0030150" data-r="PMID:10982837" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct as a TOM-complex entry step for matrix-destined mitochondrial preproteins. TOMM22 is a receptor/scaffold that recognizes precursors and transfers them toward the TOMM40 pore before downstream inner-membrane import.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOMM22/TOMM22-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The **TOM complex** is the primary entry gate for most nucleus-encoded mitochondrial proteins into mitochondria.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOMM22/TOMM22-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">TOMM22 functions as a **major preprotein-binding site** and **organizational scaffold** for the TOM complex, helping recognize mitochondrial precursor proteins and transfer them toward the **Tom40 import pore**.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000052
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NS69" data-a="GO:0005739" data-r="GO_REF:0000052" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct but broad. TOMM22 is specifically localized to the mitochondrial outer membrane/TOM complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Prefer mitochondrial outer membrane and TOM complex annotations over generic mitochondrion.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOMM22/TOMM22-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">hTom22 is an **outer mitochondrial membrane (OMM)** component and is structurally a **single-pass amphipathic α-helical** protein.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005741" target="_blank" class="term-link">
+                                    GO:0005741
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial outer membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10982837" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10982837
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Identification and functional analysis of human Tom22 for pr...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NS69" data-a="GO:0005741" data-r="PMID:10982837" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct. TOMM22 is a single-pass mitochondrial outer membrane component of the TOM complex.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOMM22/TOMM22-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">hTom22 is an **outer mitochondrial membrane (OMM)** component and is structurally a **single-pass amphipathic α-helical** protein.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030150" target="_blank" class="term-link">
+                                    GO:0030150
+                                </a>
+                            </span>
+                            <span class="term-label">protein import into mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15644312" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15644312
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dissection of the mitochondrial import and assembly pathway ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NS69" data-a="GO:0030150" data-r="PMID:15644312" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct as a TOM-complex entry step for matrix-destined mitochondrial preproteins. TOMM22 is a receptor/scaffold that recognizes precursors and transfers them toward the TOMM40 pore before downstream inner-membrane import.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOMM22/TOMM22-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The **TOM complex** is the primary entry gate for most nucleus-encoded mitochondrial proteins into mitochondria.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOMM22/TOMM22-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">TOMM22 functions as a **major preprotein-binding site** and **organizational scaffold** for the TOM complex, helping recognize mitochondrial precursor proteins and transfer them toward the **Tom40 import pore**.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005741" target="_blank" class="term-link">
+                                    GO:0005741
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial outer membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18331822" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:18331822
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Identification of Tom5 and Tom6 in the preprotein translocas...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NS69" data-a="GO:0005741" data-r="PMID:18331822" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct. TOMM22 is a single-pass mitochondrial outer membrane component of the TOM complex.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOMM22/TOMM22-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">hTom22 is an **outer mitochondrial membrane (OMM)** component and is structurally a **single-pass amphipathic α-helical** protein.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045040" target="_blank" class="term-link">
+                                    GO:0045040
+                                </a>
+                            </span>
+                            <span class="term-label">protein insertion into mitochondrial outer membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18331822" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:18331822
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Identification of Tom5 and Tom6 in the preprotein translocas...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NS69" data-a="GO:0045040" data-r="PMID:18331822" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Supported as a TOM-complex assembly/import pathway role, but TOMM22 is primarily the TOM receptor/scaffold rather than a general outer-membrane protein insertase.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Keep as non-core because TOMM22 affects TOM assembly and insertion of TOM-related substrates, while the core function is preprotein receptor/scaffold activity.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOMM22/TOMM22-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">2) an **organizational scaffold** required for correct **TOM complex assembly** and stability.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOMM22/TOMM22-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Functional perturbation evidence supports a role for Tom22 as an assembly determinant and, in some contexts, a rate-limiting factor for full TOM complex formation.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140596" target="_blank" class="term-link">
+                                    GO:0140596
+                                </a>
+                            </span>
+                            <span class="term-label">TOM complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18331822" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:18331822
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Identification of Tom5 and Tom6 in the preprotein translocas...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NS69" data-a="GO:0140596" data-r="PMID:18331822" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct. TOMM22 is a core receptor/scaffold subunit of the TOM complex / mitochondrial outer membrane translocase complex.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOMM22/TOMM22-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Human **TOMM22 (Q9NS69)** encodes **hTom22**, a **single-pass outer mitochondrial membrane** subunit of the TOM complex that acts as the **central receptor** and an **assembly-organizing scaffold**.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOMM22/TOMM22-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">2) an **organizational scaffold** required for correct **TOM complex assembly** and stability.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HTP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:34800366
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Quantitative high-confidence human mitochondrial proteome an...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NS69" data-a="GO:0005739" data-r="PMID:34800366" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct but broad. TOMM22 is specifically localized to the mitochondrial outer membrane/TOM complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Prefer mitochondrial outer membrane and TOM complex annotations over generic mitochondrion.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOMM22/TOMM22-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">hTom22 is an **outer mitochondrial membrane (OMM)** component and is structurally a **single-pass amphipathic α-helical** protein.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030943" target="_blank" class="term-link">
+                                    GO:0030943
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion targeting sequence binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/35733257" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:35733257
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structural basis of Tom20 and Tom22 cytosolic domains as the...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NS69" data-a="GO:0030943" data-r="PMID:35733257" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct and core. TOMM22 functions as a major mitochondrial preprotein/targeting-signal binding receptor in the TOM complex.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOMM22/TOMM22-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">1) a **major preprotein-binding site** and transfer platform, and</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOMM22/TOMM22-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">TOMM22 functions as a **major preprotein-binding site** and **organizational scaffold** for the TOM complex, helping recognize mitochondrial precursor proteins and transfer them toward the **Tom40 import pore**.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOMM22/TOMM22-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The 2024 PNAS Nexus study (Su et al.) reports a **human TOM holo complex cryo-EM structure** including intact Tom20 at **~6 Å** and explicitly frames Tom22 as one of the TOM receptors that recognize targeting signals and collaborate in translocation.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                    GO:0016020
+                                </a>
+                            </span>
+                            <span class="term-label">membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19946888" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19946888
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Defining the membrane proteome of NK cells.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NS69" data-a="GO:0016020" data-r="PMID:19946888" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct but very broad. TOMM22 is specifically a mitochondrial outer membrane TOM complex subunit.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Use mitochondrial outer membrane/TOM complex annotations instead of generic membrane.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOMM22/TOMM22-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">hTom22 is an **outer mitochondrial membrane (OMM)** component and is structurally a **single-pass amphipathic α-helical** protein.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005741" target="_blank" class="term-link">
+                                    GO:0005741
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial outer membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-5205661
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NS69" data-a="GO:0005741" data-r="Reactome:R-HSA-5205661" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct. TOMM22 is a single-pass mitochondrial outer membrane component of the TOM complex.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOMM22/TOMM22-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">hTom22 is an **outer mitochondrial membrane (OMM)** component and is structurally a **single-pass amphipathic α-helical** protein.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                    GO:0016020
+                                </a>
+                            </span>
+                            <span class="term-label">membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15644312" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15644312
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dissection of the mitochondrial import and assembly pathway ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NS69" data-a="GO:0016020" data-r="PMID:15644312" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct but very broad. TOMM22 is specifically a mitochondrial outer membrane TOM complex subunit.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Use mitochondrial outer membrane/TOM complex annotations instead of generic membrane.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOMM22/TOMM22-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">hTom22 is an **outer mitochondrial membrane (OMM)** component and is structurally a **single-pass amphipathic α-helical** protein.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008320" target="_blank" class="term-link">
+                                    GO:0008320
+                                </a>
+                            </span>
+                            <span class="term-label">protein transmembrane transporter activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NS69" data-a="GO:0008320" data-r="GO_REF:0000024" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Accepted as contribution to TOM complex protein transmembrane transporter activity. TOMM22 is the receptor/scaffold that transfers precursors toward the TOMM40 pore, not the pore-forming subunit by itself.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Retain only as complex contribution; TOMM40 is the conducting pore, whereas TOMM22 provides receptor/scaffold function needed for import.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOMM22/TOMM22-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">TOMM22 functions as a **major preprotein-binding site** and **organizational scaffold** for the TOM complex, helping recognize mitochondrial precursor proteins and transfer them toward the **Tom40 import pore**.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOMM22/TOMM22-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The 2024 PNAS Nexus study (Su et al.) reports a **human TOM holo complex cryo-EM structure** including intact Tom20 at **~6 Å** and explicitly frames Tom22 as one of the TOM receptors that recognize targeting signals and collaborate in translocation.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005742" target="_blank" class="term-link">
+                                    GO:0005742
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial outer membrane translocase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12198123" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12198123
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Insertion and assembly of human tom7 into the preprotein tra...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NS69" data-a="GO:0005742" data-r="PMID:12198123" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct. TOMM22 is a core receptor/scaffold subunit of the TOM complex / mitochondrial outer membrane translocase complex.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOMM22/TOMM22-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Human **TOMM22 (Q9NS69)** encodes **hTom22**, a **single-pass outer mitochondrial membrane** subunit of the TOM complex that acts as the **central receptor** and an **assembly-organizing scaffold**.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOMM22/TOMM22-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">2) an **organizational scaffold** required for correct **TOM complex assembly** and stability.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005742" target="_blank" class="term-link">
+                                    GO:0005742
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial outer membrane translocase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15644312" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15644312
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dissection of the mitochondrial import and assembly pathway ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NS69" data-a="GO:0005742" data-r="PMID:15644312" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct. TOMM22 is a core receptor/scaffold subunit of the TOM complex / mitochondrial outer membrane translocase complex.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOMM22/TOMM22-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Human **TOMM22 (Q9NS69)** encodes **hTom22**, a **single-pass outer mitochondrial membrane** subunit of the TOM complex that acts as the **central receptor** and an **assembly-organizing scaffold**.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOMM22/TOMM22-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">2) an **organizational scaffold** required for correct **TOM complex assembly** and stability.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008320" target="_blank" class="term-link">
+                                    GO:0008320
+                                </a>
+                            </span>
+                            <span class="term-label">protein transmembrane transporter activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15644312" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15644312
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dissection of the mitochondrial import and assembly pathway ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NS69" data-a="GO:0008320" data-r="PMID:15644312" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Accepted as contribution to TOM complex protein transmembrane transporter activity. TOMM22 is the receptor/scaffold that transfers precursors toward the TOMM40 pore, not the pore-forming subunit by itself.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Retain only as complex contribution; TOMM40 is the conducting pore, whereas TOMM22 provides receptor/scaffold function needed for import.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOMM22/TOMM22-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">TOMM22 functions as a **major preprotein-binding site** and **organizational scaffold** for the TOM complex, helping recognize mitochondrial precursor proteins and transfer them toward the **Tom40 import pore**.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOMM22/TOMM22-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The 2024 PNAS Nexus study (Su et al.) reports a **human TOM holo complex cryo-EM structure** including intact Tom20 at **~6 Å** and explicitly frames Tom22 as one of the TOM receptors that recognize targeting signals and collaborate in translocation.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14557246" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:14557246
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    AIP is a mitochondrial import mediator that binds to both im...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NS69" data-a="GO:0005515" data-r="PMID:14557246" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Protein binding is too generic for TOMM22. The informative functions are precursor/targeting-sequence recognition and TOM complex scaffold membership.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Documented interactions should be captured by TOM complex and targeting-sequence/preprotein receptor annotations rather than generic protein binding.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOMM22/TOMM22-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Within this machinery, **TOMM22/hTom22** is described as the **central receptor** of the TOM complex, functioning both as:</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOMM22/TOMM22-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">1) a **major preprotein-binding site** and transfer platform, and</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070585" target="_blank" class="term-link">
+                                    GO:0070585
+                                </a>
+                            </span>
+                            <span class="term-label">protein localization to mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14557246" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:14557246
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    AIP is a mitochondrial import mediator that binds to both im...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9NS69" data-a="GO:0070585" data-r="PMID:14557246" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct. TOMM22 is a central TOM-complex receptor/scaffold enabling localization/import of nuclear-encoded mitochondrial precursor proteins.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOMM22/TOMM22-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The **TOM complex** is the primary entry gate for most nucleus-encoded mitochondrial proteins into mitochondria.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOMM22/TOMM22-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">TOMM22 functions as a **major preprotein-binding site** and **organizational scaffold** for the TOM complex, helping recognize mitochondrial precursor proteins and transfer them toward the **Tom40 import pore**.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>TOMM22 is the central receptor/scaffold subunit of the mitochondrial outer membrane TOM complex, binding mitochondrial precursor proteins and transferring them toward the TOMM40 pore while stabilizing TOM complex assembly.</h3>
+                <span class="vote-buttons" data-g="Q9NS69" data-a="FUNCTION: TOMM22 is the central receptor/scaffold subunit of..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030943" target="_blank" class="term-link">
+                            mitochondrion targeting sequence binding
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070585" target="_blank" class="term-link">
+                                protein localization to mitochondrion
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030150" target="_blank" class="term-link">
+                                protein import into mitochondrial matrix
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005741" target="_blank" class="term-link">
+                                mitochondrial outer membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140596" target="_blank" class="term-link">
+                            TOM complex
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/TOMM22/TOMM22-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">Human **TOMM22 (Q9NS69)** encodes **hTom22**, a **single-pass outer mitochondrial membrane** subunit of the TOM complex that acts as the **central receptor** and an **assembly-organizing scaffold**.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/TOMM22/TOMM22-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">TOMM22 functions as a **major preprotein-binding site** and **organizational scaffold** for the TOM complex, helping recognize mitochondrial precursor proteins and transfer them toward the **Tom40 import pore**.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/TOMM22/TOMM22-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">2) an **organizational scaffold** required for correct **TOM complex assembly** and stability.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/TOMM22/TOMM22-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">hTom22 is an **outer mitochondrial membrane (OMM)** component and is structurally a **single-pass amphipathic α-helical** protein.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000024.md" target="_blank" class="term-link">
+                            GO_REF:0000024
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment of sequence similarity</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000052.md" target="_blank" class="term-link">
+                            GO_REF:0000052
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on curation of immunofluorescence data</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/10982837" target="_blank" class="term-link">
+                            PMID:10982837
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Identification and functional analysis of human Tom22 for protein import into mitochondria.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/12198123" target="_blank" class="term-link">
+                            PMID:12198123
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Insertion and assembly of human tom7 into the preprotein translocase complex of the outer mitochondrial membrane.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/14557246" target="_blank" class="term-link">
+                            PMID:14557246
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">AIP is a mitochondrial import mediator that binds to both import receptor Tom20 and preproteins.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/15644312" target="_blank" class="term-link">
+                            PMID:15644312
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Dissection of the mitochondrial import and assembly pathway for human Tom40.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/18331822" target="_blank" class="term-link">
+                            PMID:18331822
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Identification of Tom5 and Tom6 in the preprotein translocase complex of human mitochondrial outer membrane.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/19946888" target="_blank" class="term-link">
+                            PMID:19946888
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Defining the membrane proteome of NK cells.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/25556234" target="_blank" class="term-link">
+                            PMID:25556234
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">New host factors important for respiratory syncytial virus (RSV) replication revealed by a novel microfluidics screen for interactors of matrix (M) protein.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
+                            PMID:32296183
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A reference map of the human binary protein interactome.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/32814053" target="_blank" class="term-link">
+                            PMID:32814053
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Interactome Mapping Provides a Network of Neurodegenerative Disease Proteins and Uncovers Widespread Protein Aggregation in Affected Brains.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link">
+                            PMID:34800366
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Quantitative high-confidence human mitochondrial proteome and its dynamics in cellular context.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/35733257" target="_blank" class="term-link">
+                            PMID:35733257
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Structural basis of Tom20 and Tom22 cytosolic domains as the human TOM complex receptors.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-5205661
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Pink1 is recruited from the cytoplasm to the mitochondria</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/TOMM22/TOMM22-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research report for human TOMM22</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Which human mitochondrial precursor classes rely most directly on TOMM22 rather than TOMM20 or TOMM70 receptor engagement?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q9NS69" data-a="Q: Which human mitochondrial precursor classes rely m..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> How separable are TOMM22 precursor-receptor functions from its TOM complex assembly/stability role in human cells?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q9NS69" data-a="Q: How separable are TOMM22 precursor-receptor functi..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Use TOMM22 cytosolic-domain and transmembrane/interface mutants in rescue cells, then compare precursor binding, TOM complex assembly by BN-PAGE, and import of presequence versus internal-signal substrates.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: TOMM22 targeting-sequence binding and TOM complex scaffold functions are separable.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="Q9NS69" data-a="EXPERIMENT: Use TOMM22 cytosolic-domain and transmembrane/inte..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Titrate TOMM22 expression in human cells and measure TOM assembly intermediates, Tom40/Tom7 incorporation, and import flux for representative matrix, inner-membrane, and outer-membrane substrates.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: TOMM22 abundance can become rate-limiting for TOM complex assembly and mitochondrial protein import in high-biogenesis contexts.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="Q9NS69" data-a="EXPERIMENT: Titrate TOMM22 expression in human cells and measu..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Deep Research Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(TOMM22-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q9NS69" data-a="DOC: Deep Research Falcon" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <hr />
+<p>provider: falcon<br />
+model: Edison Scientific Literature<br />
+cached: false<br />
+start_time: '2026-05-11T16:35:51.753780'<br />
+end_time: '2026-05-11T16:43:40.301411'<br />
+duration_seconds: 468.55<br />
+template_file: templates/gene_research_go_focused.md<br />
+template_variables:<br />
+  organism: human<br />
+  gene_id: TOMM22<br />
+  gene_symbol: TOMM22<br />
+  uniprot_accession: Q9NS69<br />
+  protein_description: 'RecName: Full=Mitochondrial import receptor subunit TOM22<br />
+    homolog; Short=hTom22; AltName: Full=1C9-2; AltName: Full=Translocase of outer<br />
+    membrane 22 kDa subunit homolog;'<br />
+  gene_info: Name=TOMM22; Synonyms=TOM22;<br />
+  organism_full: Homo sapiens (Human).<br />
+  protein_family: Belongs to the Tom22 family. .<br />
+  protein_domains: Tom22. (IPR005683); Tom22 (PF04281)<br />
+provider_config:<br />
+  timeout: 600<br />
+  max_retries: 3<br />
+  parameters:<br />
+    allowed_domains: []<br />
+    temperature: 0.1<br />
+citation_count: 18</p>
+<hr />
+<h2 id="question">Question</h2>
+<h1 id="gene-research-for-functional-annotation">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> Q9NS69</li>
+<li><strong>Protein Description:</strong> RecName: Full=Mitochondrial import receptor subunit TOM22 homolog; Short=hTom22; AltName: Full=1C9-2; AltName: Full=Translocase of outer membrane 22 kDa subunit homolog;</li>
+<li><strong>Gene Information:</strong> Name=TOMM22; Synonyms=TOM22;</li>
+<li><strong>Organism (full):</strong> Homo sapiens (Human).</li>
+<li><strong>Protein Family:</strong> Belongs to the Tom22 family. .</li>
+<li><strong>Key Domains:</strong> Tom22. (IPR005683); Tom22 (PF04281)</li>
+</ul>
+<h3 id="mandatory-verification-steps">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "TOMM22" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Homo sapiens (Human).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'TOMM22' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>TOMM22</strong> (gene ID: TOMM22, UniProt: Q9NS69) in human.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="output">Output</h2>
+<p>Question: You are an expert researcher providing comprehensive, well-cited information.</p>
+<p>Provide detailed information focusing on:<br />
+1. Key concepts and definitions with current understanding<br />
+2. Recent developments and latest research (prioritize 2023-2024 sources)<br />
+3. Current applications and real-world implementations<br />
+4. Expert opinions and analysis from authoritative sources<br />
+5. Relevant statistics and data from recent studies</p>
+<p>Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.<br />
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.</p>
+<h1 id="gene-research-for-functional-annotation_1">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context_1">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot_1">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> Q9NS69</li>
+<li><strong>Protein Description:</strong> RecName: Full=Mitochondrial import receptor subunit TOM22 homolog; Short=hTom22; AltName: Full=1C9-2; AltName: Full=Translocase of outer membrane 22 kDa subunit homolog;</li>
+<li><strong>Gene Information:</strong> Name=TOMM22; Synonyms=TOM22;</li>
+<li><strong>Organism (full):</strong> Homo sapiens (Human).</li>
+<li><strong>Protein Family:</strong> Belongs to the Tom22 family. .</li>
+<li><strong>Key Domains:</strong> Tom22. (IPR005683); Tom22 (PF04281)</li>
+</ul>
+<h3 id="mandatory-verification-steps_1">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "TOMM22" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Homo sapiens (Human).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature_1">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'TOMM22' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target_1">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>TOMM22</strong> (gene ID: TOMM22, UniProt: Q9NS69) in human.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="research-report-human-tomm22-uniprot-q9ns69-functional-annotation-and-current-understanding">Research Report: Human <strong>TOMM22</strong> (UniProt Q9NS69) — Functional Annotation and Current Understanding</h2>
+<h3 id="1-target-verification-identity-and-disambiguation">1) Target verification (identity and disambiguation)</h3>
+<p>The UniProt accession <strong>Q9NS69</strong> corresponds to <strong>human TOMM22 (TOM22)</strong>, annotated as the <strong>mitochondrial import receptor subunit TOM22 homolog (hTom22)</strong> and a member of the <strong>Tom22 family</strong>. Multiple independent human-mitochondria studies and reviews explicitly define <strong>Tom22/TOMM22</strong> as a receptor/core subunit of the <strong>translocase of the outer mitochondrial membrane (TOM) complex</strong>, consistent with the UniProt description and expected domain/family context (Tom22 family single-pass α-helical subunit). (pitt2021abiochemicaland pages 6-9, su2024structureofthe pages 1-3, haastrup2024mitochondrialtranslocasetomm22 pages 1-3)</p>
+<h3 id="2-key-concepts-and-definitions-current-understanding">2) Key concepts and definitions (current understanding)</h3>
+<h4 id="21-the-tom-complex-and-why-tomm22-is-central">2.1 The TOM complex and why TOMM22 is central</h4>
+<p>The <strong>TOM complex</strong> is the primary entry gate for most nucleus-encoded mitochondrial proteins into mitochondria. In the human system, precursor proteins (carrying <strong>N-terminal presequences</strong> or <strong>internal targeting signals</strong>) are recognized by TOM receptors <strong>Tom20, Tom22, and Tom70</strong>, and then translocated through the <strong>Tom40</strong> pore. (su2024structureofthe pages 1-3)</p>
+<p>Within this machinery, <strong>TOMM22/hTom22</strong> is described as the <strong>central receptor</strong> of the TOM complex, functioning both as:<br />
+1) a <strong>major preprotein-binding site</strong> and transfer platform, and<br />
+2) an <strong>organizational scaffold</strong> required for correct <strong>TOM complex assembly</strong> and stability. (pitt2021abiochemicaland pages 6-9)</p>
+<p>A quantitative estimate summarized in a structural/biochemical review is that <strong>~1100 proteins out of ~1500 proteins imported by the TOM complex rely on hTom22 for import</strong>—emphasizing its broad client range and centrality among TOM receptors. (pitt2021abiochemicaland pages 13-15)</p>
+<h4 id="22-subcellular-localization-and-topology">2.2 Subcellular localization and topology</h4>
+<p>hTom22 is an <strong>outer mitochondrial membrane (OMM)</strong> component and is structurally a <strong>single-pass amphipathic α-helical</strong> protein. Cryo-EM-based descriptions place Tom22 <strong>between two Tom40 β-barrels</strong>, where it forms a key part of the <strong>dimeric interface</strong> and provides <strong>stabilizing support</strong> to Tom40. (pitt2021abiochemicaland pages 6-9)</p>
+<p>The protein contains a <strong>conserved proline</strong> that introduces a <strong>kink</strong> in the transmembrane helix. In available human TOM structures, substantial portions of Tom22 are <strong>not resolved</strong> (notably residues <strong>1–61</strong> and <strong>119–142</strong> in the cited review’s summary of structural work), implying flexible/disordered regions that may contribute to receptor function and interactions. (pitt2021abiochemicaland pages 6-9)</p>
+<p>A major conceptual update in the current understanding is that the human Tom22 IMS-facing region appears <strong>mechanistically distinct from fungal Tom22</strong>: the review notes that human Tom22 <strong>lacks</strong> the <strong>acidic patch</strong> in the IMS region implicated in the fungal “acid chain hypothesis,” and instead contains a <strong>glutamine-rich domain</strong>. This is interpreted as evidence that some mechanistic features of mitochondrial targeting and translocation characterized in fungi may not directly translate to humans. (pitt2021abiochemicaland pages 6-9)</p>
+<h4 id="23-complex-composition-and-receptor-cooperation">2.3 Complex composition and receptor cooperation</h4>
+<p>A 2024 cryo-EM study focused on receptor positioning describes the TOM complex as comprising seven subunits (<strong>Tom40, Tom20, Tom22, Tom70, Tom5, Tom6, Tom7</strong>) and supports a model in which <strong>different receptors can function simultaneously</strong> to ensure efficient translocation of precursors. This work obtained a human TOM holo complex containing an intact Tom20 receptor at <strong>~6 Å resolution</strong>, in which Tom20 is stabilized by <strong>extensive interactions with Tom22, Tom40, and Tom6</strong>. (Su et al., 2024; published online 26 Jul 2024; https://doi.org/10.1093/pnasnexus/pgae269) (su2024structureofthe pages 1-3)</p>
+<h3 id="3-molecular-function-and-pathways">3) Molecular function and pathways</h3>
+<h4 id="31-primary-function-receptorscaffold-for-mitochondrial-protein-import">3.1 Primary function: receptor/scaffold for mitochondrial protein import</h4>
+<p>The best-supported primary function of TOMM22 is as a <strong>central receptor/scaffold</strong> enabling mitochondrial protein import via the TOM complex. Functional evidence summarized in the Cells review includes perturbation experiments showing that <strong>hTom22 knockdown</strong> increases levels of <strong>stable hTOM assembly intermediates</strong>, consistent with a requirement for Tom22 in Tom40/TOM assembly; conversely, <strong>Tom22 overexpression</strong> supports the interpretation that Tom22 can be <strong>rate-limiting for assembly of complete TOM complexes</strong> and can promote integration of other subunits (e.g., Tom7) in a human cell context. (Pitt &amp; Buchanan, 2021; 11 May 2021; https://doi.org/10.3390/cells10051164) (pitt2021abiochemicaland pages 6-9)</p>
+<h4 id="32-interaction-partners-tom-complex-and-beyond">3.2 Interaction partners (TOM complex and beyond)</h4>
+<p><strong>Within TOM</strong>, Tom22 is positioned to interact closely with Tom40 and other core subunits; receptor-level cooperation includes Tom22 interactions with Tom20 (supported by cross-linking mass spectrometry evidence reported in the review, although not fully resolved structurally). (pitt2021abiochemicaland pages 6-9)</p>
+<p><strong>Beyond canonical import</strong>, Tom22 is repeatedly described as having a <strong>broad interactome</strong> that includes proteins involved in apoptosis, mitochondrial dynamics, and metabolic functions. The review highlights functional interactions relevant to:<br />
+- <strong>Apoptosis via Bax</strong> (see below) (pitt2021abiochemicaland pages 13-15)<br />
+- <strong>Mitochondrial morphology/dynamics</strong> (review summary of Tom22 perturbation phenotypes) (pitt2021abiochemicaland pages 15-16)<br />
+- <strong>Steroidogenesis</strong> via a larger metabolic protein complex involving <strong>3βHSD2</strong> and other components (pitt2021abiochemicaland pages 13-15)</p>
+<p>These broader interactions are consistent with an emerging view of import machinery components as integration points for stress and signaling, as emphasized by a 2023 review essay describing mitochondrial protein import as a signaling hub connecting mitochondrial and cellular homeostasis. (Lionaki et al., 2023; accepted 2 Jan 2023; https://doi.org/10.1002/bies.202200160) (lionaki2023mitochondrialproteinimport pages 1-2)</p>
+<h3 id="4-recent-developments-prioritizing-20232024">4) Recent developments (prioritizing 2023–2024)</h3>
+<h4 id="41-structural-biology-2024-receptor-organization-within-human-tom">4.1 Structural biology (2024): receptor organization within human TOM</h4>
+<p>The 2024 PNAS Nexus study (Su et al.) reports a <strong>human TOM holo complex cryo-EM structure</strong> including intact Tom20 at <strong>~6 Å</strong> and explicitly frames Tom22 as one of the TOM receptors that recognize targeting signals and collaborate in translocation. This work strengthens a receptor-cooperation model in which Tom22 is physically positioned to stabilize receptor arrangement and facilitate precursor delivery to Tom40. (26 Jul 2024; https://doi.org/10.1093/pnasnexus/pgae269) (su2024structureofthe pages 1-3)</p>
+<h4 id="42-cancer-biology-2024-tomm22-overexpression-in-pancreatic-cancer">4.2 Cancer biology (2024): TOMM22 overexpression in pancreatic cancer</h4>
+<p>A 2024 Molecular Cancer Research article reports that <strong>TOMM22 mRNA/protein is overexpressed in pancreatic ductal adenocarcinoma (PDAC)</strong> and is <strong>inversely correlated with disease outcomes</strong>. Functionally, in pancreatic cancer cell models, <strong>TOMM22 silencing decreased</strong> whereas <strong>forced overexpression increased</strong> growth and malignant potential. The authors further report that TOMM22 overexpression increased import of several mitochondrial proteins (including respiration-associated proteins) and was associated with increased <strong>complex I (RCI) activity</strong>, <strong>NAD+/NADH ratio</strong>, <strong>oxygen consumption rate</strong>, <strong>mitochondrial membrane potential</strong>, and <strong>ATP production</strong>; complex I inhibition reduced ATP and suppressed malignant phenotypes, linking TOMM22-driven import changes to bioenergetics and growth. (Haastrup et al., 1 Feb 2024 issue date; final article context indicates Feb 2024, with PMC availability noted Dec 2024; https://doi.org/10.1158/1541-7786.MCR-23-0138) (haastrup2024mitochondrialtranslocasetomm22 pages 1-3)</p>
+<p>Interpretation: this study supports the hypothesis that, in at least some tumors, increased TOMM22 can act as a <strong>functional enabler</strong> of mitochondrial biogenesis/respiratory capacity via increased import capacity, rather than being a passive marker of mitochondrial abundance. (haastrup2024mitochondrialtranslocasetomm22 pages 1-3)</p>
+<h4 id="43-import-machinery-as-a-stress-signaling-node-2023">4.3 Import machinery as a stress-signaling node (2023)</h4>
+<p>A 2023 review essay frames mitochondrial protein import as a <strong>regulatable signaling hub</strong>, where impairment of import induces adaptive responses inside and outside mitochondria (proteostasis and metabolic responses). While not Tom22-specific, it supports an expert consensus that TOM components (including receptor subunits like Tom22) should be considered in a systems context where changes in import efficiency can engage broader stress/quality-control pathways. (Lionaki et al., 2023; https://doi.org/10.1002/bies.202200160) (lionaki2023mitochondrialproteinimport pages 1-2)</p>
+<h3 id="5-current-applications-and-real-world-implementations">5) Current applications and real-world implementations</h3>
+<h4 id="51-biomarker-and-therapeutic-targeting-concepts-in-oncology">5.1 Biomarker and therapeutic targeting concepts in oncology</h4>
+<p>The pancreatic cancer study explicitly proposes <strong>TOMM22</strong> as having potential for <strong>early diagnostic/prognostic biomarker development</strong> and <strong>therapeutic targeting</strong> in PDAC, based on tumor overexpression, correlation with outcomes, and functional causality in cell models (gain- and loss-of-function) linked to mitochondrial import and OXPHOS-related readouts. (Haastrup et al., 2024; https://doi.org/10.1158/1541-7786.MCR-23-0138) (haastrup2024mitochondrialtranslocasetomm22 pages 1-3)</p>
+<p>Separately, a structural/biochemical review highlights that Tom22 participates in apoptosis-related interactions (notably with Bax), and discusses the concept that targeting TOM-complex components and their interactions could be a viable strategy in disease contexts where mitochondrial dysfunction is causal. (Pitt &amp; Buchanan, 2021; https://doi.org/10.3390/cells10051164) (pitt2021abiochemicaland pages 13-15)</p>
+<h4 id="52-mechanistic-disease-models-yeast-for-noncanonical-substrates">5.2 Mechanistic disease models (yeast) for noncanonical substrates</h4>
+<p>A primary research study in yeast mitochondria provides direct evidence that Tom22 can act as a receptor for <strong>amyloid-β (Aβ)</strong>: Aβ binding is reported to be mediated mainly by Tom22 rather than Tom20, and Aβ residues <strong>25–42</strong> were identified as critical for interaction. The authors propose that cytosolic Aβ is recognized by Tom22 and then transferred to Tom40 for translocation. While this is a yeast model, it is frequently used as a tractable platform to dissect TOM-mediated uptake mechanisms relevant to Alzheimer’s-disease-associated mitochondrial Aβ accumulation. (Hu et al., 2018; https://doi.org/10.1074/jbc.ra118.002713) (hu2018mitochondrialaccumulationof pages 1-2)</p>
+<h3 id="6-expert-opinions-and-analysis-authoritative-synthesis">6) Expert opinions and analysis (authoritative synthesis)</h3>
+<h4 id="61-essentiality-and-assembly-control">6.1 Essentiality and assembly control</h4>
+<p>The Cells review argues that the “structural reliance” of the core TOM complex on Tom22 is consistent with impaired viability observed when Tom22 is deficient (as discussed across model systems and mammalian contexts). The same review synthesizes perturbation evidence supporting Tom22 as an assembly organizer and potential rate-limiting component for complete TOM biogenesis under some conditions. (Pitt &amp; Buchanan, 2021; https://doi.org/10.3390/cells10051164) (pitt2021abiochemicaland pages 13-15, pitt2021abiochemicaland pages 6-9)</p>
+<h4 id="62-apoptosis-interface-bax">6.2 Apoptosis interface (Bax)</h4>
+<p>A key expert-level point emphasized in the review is that Tom22 is not merely an import receptor but also participates in <strong>Bax-mediated apoptosis</strong>: inhibition of Tom22–Bax interactions (e.g., via antibody blocking or Tom22 knockdown) is reported to inhibit Bax-mediated apoptosis, suggesting Tom22 can be an actionable node coupling mitochondrial surface machinery to apoptotic execution pathways. (Pitt &amp; Buchanan, 2021; https://doi.org/10.3390/cells10051164) (pitt2021abiochemicaland pages 13-15)</p>
+<h3 id="7-relevant-statistics-and-quantitative-data-from-recentauthoritative-sources">7) Relevant statistics and quantitative data (from recent/authoritative sources)</h3>
+<ul>
+<li><strong>Mitochondrial proteome scale (mammals):</strong> mammalian mitochondria may contain up to <strong>~1500 proteins</strong>, and only about <strong>~1%</strong> are encoded by mitochondrial DNA, implying extensive reliance on nuclear-encoded precursor import. (Lionaki et al., 2023; https://doi.org/10.1002/bies.202200160) (lionaki2023mitochondrialproteinimport pages 1-2)</li>
+<li><strong>Tom22-dependent import breadth:</strong> <strong>~1100 of ~1500 TOM-imported proteins</strong> are summarized as relying on <strong>hTom22</strong> for import (review synthesis). (Pitt &amp; Buchanan, 2021; https://doi.org/10.3390/cells10051164) (pitt2021abiochemicaland pages 13-15)</li>
+<li><strong>Structural parameters:</strong> human TOM structural work summarized in the Cells review includes a human TOM core at <strong>~3.4 Å</strong> (review summary) and an observed tetrameric form at <strong>~8.5 Å</strong> (review summary). (pitt2021abiochemicaland pages 11-12)</li>
+<li><strong>2024 cryo-EM holo complex resolution:</strong> the Tom20-containing human TOM holo complex was resolved at <strong>~6 Å</strong>. (Su et al., 2024; https://doi.org/10.1093/pnasnexus/pgae269) (su2024structureofthe pages 1-3)</li>
+<li><strong>Noncanonical substrate determinant:</strong> in the yeast Aβ study, Aβ residues <strong>25–42</strong> were implicated in Tom22-mediated interaction. (Hu et al., 2018; https://doi.org/10.1074/jbc.ra118.002713) (hu2018mitochondrialaccumulationof pages 1-2)</li>
+</ul>
+<h3 id="8-visual-evidence-figures-supporting-tomm22-placement-and-features">8) Visual evidence (figures) supporting TOMM22 placement and features</h3>
+<p>The following extracted figures visually summarize Tom22’s placement within the TOM complex and highlight its structural features/interactome in a review context. (pitt2021abiochemicaland media a23c1074, pitt2021abiochemicaland media 096ec19a, pitt2021abiochemicaland media 626e7aa4)</p>
+<h3 id="9-consolidated-functional-annotation-narrative-conclusion">9) Consolidated functional annotation (narrative conclusion)</h3>
+<p>Human <strong>TOMM22 (Q9NS69)</strong> encodes <strong>hTom22</strong>, a <strong>single-pass outer mitochondrial membrane</strong> subunit of the TOM complex that acts as the <strong>central receptor</strong> and an <strong>assembly-organizing scaffold</strong>. Its core role is to coordinate <strong>recognition/transfer of mitochondrial precursor proteins</strong> from receptor engagement toward passage through the <strong>Tom40</strong> pore, and structural work positions Tom22 at the <strong>Tom40 dimer interface</strong> with a conserved kinked helix and flexible terminal regions. Functional perturbation evidence supports a role for Tom22 as an assembly determinant and, in some contexts, a rate-limiting factor for full TOM complex formation. Beyond canonical import, authoritative synthesis highlights Tom22 as an interaction hub relevant to apoptosis (e.g., Bax-related mechanisms) and metabolic processes (e.g., steroidogenic complexes), consistent with recent frameworks that mitochondrial protein import machinery participates in broader stress-signaling networks. Recent 2024 work advances receptor-level structural organization of the human TOM holo complex and provides disease-context evidence in which TOMM22 overexpression can enhance import-linked respiratory phenotypes and tumor aggressiveness in pancreatic cancer, supporting ongoing interest in TOMM22 as a biomarker and potential therapeutic target. (pitt2021abiochemicaland pages 6-9, pitt2021abiochemicaland pages 13-15, su2024structureofthe pages 1-3, haastrup2024mitochondrialtranslocasetomm22 pages 1-3, lionaki2023mitochondrialproteinimport pages 1-2)</p>
+<hr />
+<h2 id="summary-table">Summary Table</h2>
+<table>
+<thead>
+<tr>
+<th>Category</th>
+<th>Summary</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Identity</td>
+<td><strong>TOMM22</strong> encodes the human <strong>mitochondrial import receptor subunit TOM22 homolog</strong> (hTom22), the <strong>central receptor</strong> of the TOM complex; this matches UniProt Q9NS69 and the Tom22 family assignment. It is a conserved TOM core component distinct from TOM20/TOM70 receptor subunits. (pitt2021abiochemicaland pages 6-9, su2024structureofthe pages 1-3, haastrup2024mitochondrialtranslocasetomm22 pages 1-3)</td>
+</tr>
+<tr>
+<td>Localization/topology</td>
+<td>hTom22 localizes to the <strong>outer mitochondrial membrane</strong> as a <strong>single-pass amphipathic α-helical</strong> protein. Structural work places it <strong>between the two Tom40 β-barrels</strong>, forming the <strong>dimeric interface</strong> and stabilizing the complex. Human Tom22 contains a <strong>conserved proline-induced kink</strong>; the <strong>N-terminal cytosolic</strong> and <strong>C-terminal IMS</strong> regions are partly unresolved/flexible in structures, and the human IMS region is <strong>glutamine-rich</strong> rather than carrying the fungal acidic patch. (pitt2021abiochemicaland pages 6-9, pitt2021abiochemicaland pages 11-12)</td>
+</tr>
+<tr>
+<td>Molecular function</td>
+<td>TOMM22 functions as a <strong>major preprotein-binding site</strong> and <strong>organizational scaffold</strong> for the TOM complex, helping recognize mitochondrial precursor proteins and transfer them toward the <strong>Tom40 import pore</strong>. It participates in import of precursors with <strong>N-terminal presequences</strong> or contributes to handling broader precursor classes together with Tom20/Tom70. (pitt2021abiochemicaland pages 6-9, su2024structureofthe pages 1-3, haastrup2024mitochondrialtranslocasetomm22 pages 1-3)</td>
+</tr>
+<tr>
+<td>Complex membership</td>
+<td>Human TOM complex contains <strong>Tom40, Tom20, Tom22, Tom70, Tom5, Tom6, and Tom7</strong>. Tom22 is part of the <strong>core TOM complex</strong> with Tom40/Tom5/Tom6/Tom7; cryo-EM studies resolved human TOM core structures at <strong>~3.4 Å</strong> and a TOM holo complex containing intact Tom20 at <strong>~6 Å</strong>. Tom22 is important for assembly state organization, while Tom6 stabilizes and Tom7 destabilizes TOM partly through effects linked to Tom22. (pitt2021abiochemicaland pages 11-12, su2024structureofthe pages 1-3, pitt2021abiochemicaland pages 6-9)</td>
+</tr>
+<tr>
+<td>Interaction partners</td>
+<td>Key partners include <strong>Tom40</strong>, <strong>Tom20</strong>, <strong>Tom6</strong>, <strong>Tom7</strong>, and likely <strong>Tom70</strong> within the import machinery. Outside canonical import, reported interactors include <strong>Bax</strong> (apoptosis), <strong>PINK1/Parkin pathway components</strong>, <strong>Mfn1</strong>, mito <strong>BKCa</strong> channel, <strong>3βHSD2</strong>, <strong>P450C11AS</strong>, and <strong>StAR</strong> in steroidogenic contexts. Cross-linked MS supports a Tom20–Tom22 interaction even where density is unresolved. (pitt2021abiochemicaland pages 23-24, pitt2021abiochemicaland pages 15-16, pitt2021abiochemicaland pages 13-15, pitt2021abiochemicaland pages 6-9)</td>
+</tr>
+<tr>
+<td>Regulation/quality control</td>
+<td>Tom22 is a <strong>rate-limiting factor for complete TOM assembly</strong> in some cell systems; knockdown increases stable TOM assembly intermediates, whereas overexpression promotes assembly and <strong>Tom7 integration</strong>. Reviews also note regulation through <strong>phosphorylation</strong> and quality-control pathways including <strong>Yme1-mediated degradation</strong> and import-stress signaling/mitophagy links. (pitt2021abiochemicaland pages 6-9, pitt2021abiochemicaland pages 23-24)</td>
+</tr>
+<tr>
+<td>Disease/phenotypes</td>
+<td>Reduced or defective Tom22 impairs viability and mitochondrial homeostasis; <strong>zebrafish tom22 mutants</strong> show hepatocyte apoptosis and abnormal liver organization. In human disease biology, Tom22 contributes to <strong>Bax-mediated apoptosis</strong>, has been implicated in <strong>Parkinson’s disease-related import dysfunction</strong>, and is discussed in mitochondrial stress, steroidogenesis, and metabolic disease contexts. HIV-1 protease has been reported to cleave Tom22 in apoptosis-related models. (pitt2021abiochemicaland pages 13-15, pitt2021abiochemicaland pages 23-24, pitt2021abiochemicaland pages 15-16, su2024structureofthe pages 1-3)</td>
+</tr>
+<tr>
+<td>Recent 2023-2024 developments/applications</td>
+<td><strong>2024 cryo-EM</strong> work further defined receptor organization in the <strong>human TOM holo complex</strong>, supporting simultaneous action of Tom20/Tom22/Tom70 during import. <strong>2024 pancreatic cancer</strong> data showed <strong>TOMM22 overexpression</strong> promotes aggressive growth by enhancing mitochondrial protein import, respiration-associated functions, membrane potential, and ATP production, highlighting <strong>biomarker/therapeutic</strong> potential. Reviews from <strong>2023</strong> emphasize TOM components, including Tom22, as signaling hubs in mitochondrial import stress responses. (su2024structureofthe pages 1-3, haastrup2024mitochondrialtranslocasetomm22 pages 1-3, lionaki2023mitochondrialproteinimport pages 1-2)</td>
+</tr>
+<tr>
+<td>Quantitative data</td>
+<td>Mammalian mitochondria contain up to <strong>~1500 proteins</strong>, with only <strong>~1% mtDNA-encoded</strong>; a review estimates <strong>~1100 of ~1500</strong> TOM-imported proteins rely on <strong>hTom22</strong> for import. Structural resolutions cited for human TOM include <strong>~3.4 Å</strong> for the core complex and <strong>~6 Å</strong> for the Tom20-containing holo complex; lower-resolution tetrameric TOM has been observed at <strong>~8.5 Å</strong>. In the Aβ study, residues <strong>25–42</strong> were critical for Tom22-mediated recognition in yeast. (pitt2021abiochemicaland pages 13-15, pitt2021abiochemicaland pages 11-12, lionaki2023mitochondrialproteinimport pages 1-2, su2024structureofthe pages 1-3, hu2018mitochondrialaccumulationof pages 1-2)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the key functional annotation for human TOMM22/ hTom22, including its identity, topology, role in the mitochondrial TOM complex, major interaction partners, disease links, and recent 2023-2024 developments. It is useful as a compact evidence-backed reference for narrative gene annotation.</em></p>
+<p>References</p>
+<ol>
+<li>
+<p>(pitt2021abiochemicaland pages 6-9): Ashley S. Pitt and Susan K. Buchanan. A biochemical and structural understanding of tom complex interactions and implications for human health and disease. Cells, 10:1164, May 2021. URL: https://doi.org/10.3390/cells10051164, doi:10.3390/cells10051164. This article has 46 citations.</p>
+</li>
+<li>
+<p>(su2024structureofthe pages 1-3): Jiayue Su, Xuyang Tian, Ziyi Wang, Jiawen Yang, Shan Sun, and Sen-Fang Sui. Structure of the intact tom20 receptor in the human translocase of the outer membrane complex. PNAS Nexus, Jun 2024. URL: https://doi.org/10.1093/pnasnexus/pgae269, doi:10.1093/pnasnexus/pgae269. This article has 12 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(haastrup2024mitochondrialtranslocasetomm22 pages 1-3): Mary Oluwadamilola Haastrup, Kunwar Somesh Vikramdeo, Shashi Anand, Mohammad Aslam Khan, James Elliot Carter, Seema Singh, Ajay Pratap Singh, and Santanu Dasgupta. Mitochondrial translocase tomm22 is overexpressed in pancreatic cancer and promotes aggressive growth by modulating mitochondrial protein import and function. Molecular cancer research : MCR, 22:197-208, Oct 2024. URL: https://doi.org/10.1158/1541-7786.mcr-23-0138, doi:10.1158/1541-7786.mcr-23-0138. This article has 10 citations.</p>
+</li>
+<li>
+<p>(pitt2021abiochemicaland pages 13-15): Ashley S. Pitt and Susan K. Buchanan. A biochemical and structural understanding of tom complex interactions and implications for human health and disease. Cells, 10:1164, May 2021. URL: https://doi.org/10.3390/cells10051164, doi:10.3390/cells10051164. This article has 46 citations.</p>
+</li>
+<li>
+<p>(pitt2021abiochemicaland pages 15-16): Ashley S. Pitt and Susan K. Buchanan. A biochemical and structural understanding of tom complex interactions and implications for human health and disease. Cells, 10:1164, May 2021. URL: https://doi.org/10.3390/cells10051164, doi:10.3390/cells10051164. This article has 46 citations.</p>
+</li>
+<li>
+<p>(lionaki2023mitochondrialproteinimport pages 1-2): Eirini Lionaki, Ilias Gkikas, and Nektarios Tavernarakis. Mitochondrial protein import machinery conveys stress signals to the cytosol and beyond. BioEssays, Jan 2023. URL: https://doi.org/10.1002/bies.202200160, doi:10.1002/bies.202200160. This article has 14 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(hu2018mitochondrialaccumulationof pages 1-2): Wenxin Hu, Zhiming Wang, and Hongjin Zheng. Mitochondrial accumulation of amyloid β (aβ) peptides requires tomm22 as a main aβ receptor in yeast. Journal of Biological Chemistry, 293:12681-12689, Aug 2018. URL: https://doi.org/10.1074/jbc.ra118.002713, doi:10.1074/jbc.ra118.002713. This article has 51 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(pitt2021abiochemicaland pages 11-12): Ashley S. Pitt and Susan K. Buchanan. A biochemical and structural understanding of tom complex interactions and implications for human health and disease. Cells, 10:1164, May 2021. URL: https://doi.org/10.3390/cells10051164, doi:10.3390/cells10051164. This article has 46 citations.</p>
+</li>
+<li>
+<p>(pitt2021abiochemicaland media a23c1074): Ashley S. Pitt and Susan K. Buchanan. A biochemical and structural understanding of tom complex interactions and implications for human health and disease. Cells, 10:1164, May 2021. URL: https://doi.org/10.3390/cells10051164, doi:10.3390/cells10051164. This article has 46 citations.</p>
+</li>
+<li>
+<p>(pitt2021abiochemicaland media 096ec19a): Ashley S. Pitt and Susan K. Buchanan. A biochemical and structural understanding of tom complex interactions and implications for human health and disease. Cells, 10:1164, May 2021. URL: https://doi.org/10.3390/cells10051164, doi:10.3390/cells10051164. This article has 46 citations.</p>
+</li>
+<li>
+<p>(pitt2021abiochemicaland media 626e7aa4): Ashley S. Pitt and Susan K. Buchanan. A biochemical and structural understanding of tom complex interactions and implications for human health and disease. Cells, 10:1164, May 2021. URL: https://doi.org/10.3390/cells10051164, doi:10.3390/cells10051164. This article has 46 citations.</p>
+</li>
+<li>
+<p>(pitt2021abiochemicaland pages 23-24): Ashley S. Pitt and Susan K. Buchanan. A biochemical and structural understanding of tom complex interactions and implications for human health and disease. Cells, 10:1164, May 2021. URL: https://doi.org/10.3390/cells10051164, doi:10.3390/cells10051164. This article has 46 citations.</p>
+</li>
+</ol>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>su2024structureofthe pages 1-3</li>
+<li>pitt2021abiochemicaland pages 6-9</li>
+<li>pitt2021abiochemicaland pages 13-15</li>
+<li>pitt2021abiochemicaland pages 15-16</li>
+<li>lionaki2023mitochondrialproteinimport pages 1-2</li>
+<li>hu2018mitochondrialaccumulationof pages 1-2</li>
+<li>pitt2021abiochemicaland pages 11-12</li>
+<li>pitt2021abiochemicaland pages 23-24</li>
+<li>https://doi.org/10.1093/pnasnexus/pgae269</li>
+<li>https://doi.org/10.3390/cells10051164</li>
+<li>https://doi.org/10.1002/bies.202200160</li>
+<li>https://doi.org/10.1158/1541-7786.MCR-23-0138</li>
+<li>https://doi.org/10.1074/jbc.ra118.002713</li>
+<li>https://doi.org/10.3390/cells10051164,</li>
+<li>https://doi.org/10.1093/pnasnexus/pgae269,</li>
+<li>https://doi.org/10.1158/1541-7786.mcr-23-0138,</li>
+<li>https://doi.org/10.1002/bies.202200160,</li>
+<li>https://doi.org/10.1074/jbc.ra118.002713,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q9NS69
+gene_symbol: TOMM22
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: TOMM22 encodes hTom22, a single-pass mitochondrial outer membrane receptor and scaffold subunit of the TOM complex. TOMM22 recognizes mitochondrial precursor proteins, helps transfer them toward the TOMM40 pore, and supports TOM complex assembly and stability; its transporter annotation is best interpreted as contribution to TOM complex protein import rather than standalone pore activity.
+existing_annotations:
+- term:
+    id: GO:0030150
+    label: protein import into mitochondrial matrix
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: Correct as a TOM-complex entry step for matrix-destined mitochondrial preproteins. TOMM22 is a receptor/scaffold that recognizes precursors and transfers them toward the TOMM40 pore before downstream inner-membrane import.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM22/TOMM22-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: The **TOM complex** is the primary entry gate for most nucleus-encoded mitochondrial proteins into mitochondria.
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: TOMM22 functions as a **major preprotein-binding site** and **organizational scaffold** for the TOM complex, helping recognize mitochondrial precursor proteins and transfer them toward the **Tom40 import pore**.
+- term:
+    id: GO:0005742
+    label: mitochondrial outer membrane translocase complex
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: Correct. TOMM22 is a core receptor/scaffold subunit of the TOM complex / mitochondrial outer membrane translocase complex.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM22/TOMM22-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: Human **TOMM22 (Q9NS69)** encodes **hTom22**, a **single-pass outer mitochondrial membrane** subunit of the TOM complex that acts as the **central receptor** and an **assembly-organizing scaffold**.
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: 2) an **organizational scaffold** required for correct **TOM complex assembly** and stability.
+- term:
+    id: GO:0008320
+    label: protein transmembrane transporter activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: contributes_to
+  review:
+    summary: Accepted as contribution to TOM complex protein transmembrane transporter activity. TOMM22 is the receptor/scaffold that transfers precursors toward the TOMM40 pore, not the pore-forming subunit by itself.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM22/TOMM22-deep-research-falcon.md
+    reason: Retain only as complex contribution; TOMM40 is the conducting pore, whereas TOMM22 provides receptor/scaffold function needed for import.
+    supported_by:
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: TOMM22 functions as a **major preprotein-binding site** and **organizational scaffold** for the TOM complex, helping recognize mitochondrial precursor proteins and transfer them toward the **Tom40 import pore**.
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: The 2024 PNAS Nexus study (Su et al.) reports a **human TOM holo complex cryo-EM structure** including intact Tom20 at **~6 Å** and explicitly frames Tom22 as one of the TOM receptors that recognize targeting signals and collaborate in translocation.
+- term:
+    id: GO:0005741
+    label: mitochondrial outer membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  review:
+    summary: Correct. TOMM22 is a single-pass mitochondrial outer membrane component of the TOM complex.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM22/TOMM22-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: hTom22 is an **outer mitochondrial membrane (OMM)** component and is structurally a **single-pass amphipathic α-helical** protein.
+- term:
+    id: GO:0006886
+    label: intracellular protein transport
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  review:
+    summary: Correct pathway family but too broad. TOMM22 specifically functions in TOM-complex mitochondrial protein import.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/TOMM22/TOMM22-deep-research-falcon.md
+    reason: Use mitochondrial protein import/localization and TOM complex terms rather than generic intracellular protein transport.
+    supported_by:
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: The **TOM complex** is the primary entry gate for most nucleus-encoded mitochondrial proteins into mitochondria.
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: TOMM22 functions as a **major preprotein-binding site** and **organizational scaffold** for the TOM complex, helping recognize mitochondrial precursor proteins and transfer them toward the **Tom40 import pore**.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:12198123
+  review:
+    summary: Protein binding is too generic for TOMM22. The informative functions are precursor/targeting-sequence recognition and TOM complex scaffold membership.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/TOMM22/TOMM22-deep-research-falcon.md
+    reason: Documented interactions should be captured by TOM complex and targeting-sequence/preprotein receptor annotations rather than generic protein binding.
+    supported_by:
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: &#39;Within this machinery, **TOMM22/hTom22** is described as the **central receptor** of the TOM complex, functioning both as:&#39;
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: 1) a **major preprotein-binding site** and transfer platform, and
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:25556234
+  review:
+    summary: Protein binding is too generic for TOMM22. The informative functions are precursor/targeting-sequence recognition and TOM complex scaffold membership.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/TOMM22/TOMM22-deep-research-falcon.md
+    reason: Documented interactions should be captured by TOM complex and targeting-sequence/preprotein receptor annotations rather than generic protein binding.
+    supported_by:
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: &#39;Within this machinery, **TOMM22/hTom22** is described as the **central receptor** of the TOM complex, functioning both as:&#39;
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: 1) a **major preprotein-binding site** and transfer platform, and
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:32296183
+  review:
+    summary: Protein binding is too generic for TOMM22. The informative functions are precursor/targeting-sequence recognition and TOM complex scaffold membership.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/TOMM22/TOMM22-deep-research-falcon.md
+    reason: Documented interactions should be captured by TOM complex and targeting-sequence/preprotein receptor annotations rather than generic protein binding.
+    supported_by:
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: &#39;Within this machinery, **TOMM22/hTom22** is described as the **central receptor** of the TOM complex, functioning both as:&#39;
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: 1) a **major preprotein-binding site** and transfer platform, and
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:32814053
+  review:
+    summary: Protein binding is too generic for TOMM22. The informative functions are precursor/targeting-sequence recognition and TOM complex scaffold membership.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/TOMM22/TOMM22-deep-research-falcon.md
+    reason: Documented interactions should be captured by TOM complex and targeting-sequence/preprotein receptor annotations rather than generic protein binding.
+    supported_by:
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: &#39;Within this machinery, **TOMM22/hTom22** is described as the **central receptor** of the TOM complex, functioning both as:&#39;
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: 1) a **major preprotein-binding site** and transfer platform, and
+- term:
+    id: GO:0030150
+    label: protein import into mitochondrial matrix
+  evidence_type: TAS
+  original_reference_id: PMID:10982837
+  review:
+    summary: Correct as a TOM-complex entry step for matrix-destined mitochondrial preproteins. TOMM22 is a receptor/scaffold that recognizes precursors and transfers them toward the TOMM40 pore before downstream inner-membrane import.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM22/TOMM22-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: The **TOM complex** is the primary entry gate for most nucleus-encoded mitochondrial proteins into mitochondria.
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: TOMM22 functions as a **major preprotein-binding site** and **organizational scaffold** for the TOM complex, helping recognize mitochondrial precursor proteins and transfer them toward the **Tom40 import pore**.
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IDA
+  original_reference_id: GO_REF:0000052
+  review:
+    summary: Correct but broad. TOMM22 is specifically localized to the mitochondrial outer membrane/TOM complex.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/TOMM22/TOMM22-deep-research-falcon.md
+    reason: Prefer mitochondrial outer membrane and TOM complex annotations over generic mitochondrion.
+    supported_by:
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: hTom22 is an **outer mitochondrial membrane (OMM)** component and is structurally a **single-pass amphipathic α-helical** protein.
+- term:
+    id: GO:0005741
+    label: mitochondrial outer membrane
+  evidence_type: EXP
+  original_reference_id: PMID:10982837
+  review:
+    summary: Correct. TOMM22 is a single-pass mitochondrial outer membrane component of the TOM complex.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM22/TOMM22-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: hTom22 is an **outer mitochondrial membrane (OMM)** component and is structurally a **single-pass amphipathic α-helical** protein.
+- term:
+    id: GO:0030150
+    label: protein import into mitochondrial matrix
+  evidence_type: IDA
+  original_reference_id: PMID:15644312
+  review:
+    summary: Correct as a TOM-complex entry step for matrix-destined mitochondrial preproteins. TOMM22 is a receptor/scaffold that recognizes precursors and transfers them toward the TOMM40 pore before downstream inner-membrane import.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM22/TOMM22-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: The **TOM complex** is the primary entry gate for most nucleus-encoded mitochondrial proteins into mitochondria.
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: TOMM22 functions as a **major preprotein-binding site** and **organizational scaffold** for the TOM complex, helping recognize mitochondrial precursor proteins and transfer them toward the **Tom40 import pore**.
+- term:
+    id: GO:0005741
+    label: mitochondrial outer membrane
+  evidence_type: NAS
+  original_reference_id: PMID:18331822
+  review:
+    summary: Correct. TOMM22 is a single-pass mitochondrial outer membrane component of the TOM complex.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM22/TOMM22-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: hTom22 is an **outer mitochondrial membrane (OMM)** component and is structurally a **single-pass amphipathic α-helical** protein.
+- term:
+    id: GO:0045040
+    label: protein insertion into mitochondrial outer membrane
+  evidence_type: NAS
+  original_reference_id: PMID:18331822
+  review:
+    summary: Supported as a TOM-complex assembly/import pathway role, but TOMM22 is primarily the TOM receptor/scaffold rather than a general outer-membrane protein insertase.
+    action: KEEP_AS_NON_CORE
+    additional_reference_ids:
+    - file:human/TOMM22/TOMM22-deep-research-falcon.md
+    reason: Keep as non-core because TOMM22 affects TOM assembly and insertion of TOM-related substrates, while the core function is preprotein receptor/scaffold activity.
+    supported_by:
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: 2) an **organizational scaffold** required for correct **TOM complex assembly** and stability.
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: Functional perturbation evidence supports a role for Tom22 as an assembly determinant and, in some contexts, a rate-limiting factor for full TOM complex formation.
+- term:
+    id: GO:0140596
+    label: TOM complex
+  evidence_type: NAS
+  original_reference_id: PMID:18331822
+  review:
+    summary: Correct. TOMM22 is a core receptor/scaffold subunit of the TOM complex / mitochondrial outer membrane translocase complex.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM22/TOMM22-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: Human **TOMM22 (Q9NS69)** encodes **hTom22**, a **single-pass outer mitochondrial membrane** subunit of the TOM complex that acts as the **central receptor** and an **assembly-organizing scaffold**.
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: 2) an **organizational scaffold** required for correct **TOM complex assembly** and stability.
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: HTP
+  original_reference_id: PMID:34800366
+  review:
+    summary: Correct but broad. TOMM22 is specifically localized to the mitochondrial outer membrane/TOM complex.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/TOMM22/TOMM22-deep-research-falcon.md
+    reason: Prefer mitochondrial outer membrane and TOM complex annotations over generic mitochondrion.
+    supported_by:
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: hTom22 is an **outer mitochondrial membrane (OMM)** component and is structurally a **single-pass amphipathic α-helical** protein.
+- term:
+    id: GO:0030943
+    label: mitochondrion targeting sequence binding
+  evidence_type: IDA
+  original_reference_id: PMID:35733257
+  review:
+    summary: Correct and core. TOMM22 functions as a major mitochondrial preprotein/targeting-signal binding receptor in the TOM complex.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM22/TOMM22-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: 1) a **major preprotein-binding site** and transfer platform, and
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: TOMM22 functions as a **major preprotein-binding site** and **organizational scaffold** for the TOM complex, helping recognize mitochondrial precursor proteins and transfer them toward the **Tom40 import pore**.
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: The 2024 PNAS Nexus study (Su et al.) reports a **human TOM holo complex cryo-EM structure** including intact Tom20 at **~6 Å** and explicitly frames Tom22 as one of the TOM receptors that recognize targeting signals and collaborate in translocation.
+- term:
+    id: GO:0016020
+    label: membrane
+  evidence_type: HDA
+  original_reference_id: PMID:19946888
+  review:
+    summary: Correct but very broad. TOMM22 is specifically a mitochondrial outer membrane TOM complex subunit.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/TOMM22/TOMM22-deep-research-falcon.md
+    reason: Use mitochondrial outer membrane/TOM complex annotations instead of generic membrane.
+    supported_by:
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: hTom22 is an **outer mitochondrial membrane (OMM)** component and is structurally a **single-pass amphipathic α-helical** protein.
+- term:
+    id: GO:0005741
+    label: mitochondrial outer membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-5205661
+  review:
+    summary: Correct. TOMM22 is a single-pass mitochondrial outer membrane component of the TOM complex.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM22/TOMM22-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: hTom22 is an **outer mitochondrial membrane (OMM)** component and is structurally a **single-pass amphipathic α-helical** protein.
+- term:
+    id: GO:0016020
+    label: membrane
+  evidence_type: IDA
+  original_reference_id: PMID:15644312
+  review:
+    summary: Correct but very broad. TOMM22 is specifically a mitochondrial outer membrane TOM complex subunit.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/TOMM22/TOMM22-deep-research-falcon.md
+    reason: Use mitochondrial outer membrane/TOM complex annotations instead of generic membrane.
+    supported_by:
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: hTom22 is an **outer mitochondrial membrane (OMM)** component and is structurally a **single-pass amphipathic α-helical** protein.
+- term:
+    id: GO:0008320
+    label: protein transmembrane transporter activity
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  review:
+    summary: Accepted as contribution to TOM complex protein transmembrane transporter activity. TOMM22 is the receptor/scaffold that transfers precursors toward the TOMM40 pore, not the pore-forming subunit by itself.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM22/TOMM22-deep-research-falcon.md
+    reason: Retain only as complex contribution; TOMM40 is the conducting pore, whereas TOMM22 provides receptor/scaffold function needed for import.
+    supported_by:
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: TOMM22 functions as a **major preprotein-binding site** and **organizational scaffold** for the TOM complex, helping recognize mitochondrial precursor proteins and transfer them toward the **Tom40 import pore**.
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: The 2024 PNAS Nexus study (Su et al.) reports a **human TOM holo complex cryo-EM structure** including intact Tom20 at **~6 Å** and explicitly frames Tom22 as one of the TOM receptors that recognize targeting signals and collaborate in translocation.
+- term:
+    id: GO:0005742
+    label: mitochondrial outer membrane translocase complex
+  evidence_type: IDA
+  original_reference_id: PMID:12198123
+  review:
+    summary: Correct. TOMM22 is a core receptor/scaffold subunit of the TOM complex / mitochondrial outer membrane translocase complex.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM22/TOMM22-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: Human **TOMM22 (Q9NS69)** encodes **hTom22**, a **single-pass outer mitochondrial membrane** subunit of the TOM complex that acts as the **central receptor** and an **assembly-organizing scaffold**.
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: 2) an **organizational scaffold** required for correct **TOM complex assembly** and stability.
+- term:
+    id: GO:0005742
+    label: mitochondrial outer membrane translocase complex
+  evidence_type: IDA
+  original_reference_id: PMID:15644312
+  review:
+    summary: Correct. TOMM22 is a core receptor/scaffold subunit of the TOM complex / mitochondrial outer membrane translocase complex.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM22/TOMM22-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: Human **TOMM22 (Q9NS69)** encodes **hTom22**, a **single-pass outer mitochondrial membrane** subunit of the TOM complex that acts as the **central receptor** and an **assembly-organizing scaffold**.
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: 2) an **organizational scaffold** required for correct **TOM complex assembly** and stability.
+- term:
+    id: GO:0008320
+    label: protein transmembrane transporter activity
+  evidence_type: TAS
+  original_reference_id: PMID:15644312
+  review:
+    summary: Accepted as contribution to TOM complex protein transmembrane transporter activity. TOMM22 is the receptor/scaffold that transfers precursors toward the TOMM40 pore, not the pore-forming subunit by itself.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM22/TOMM22-deep-research-falcon.md
+    reason: Retain only as complex contribution; TOMM40 is the conducting pore, whereas TOMM22 provides receptor/scaffold function needed for import.
+    supported_by:
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: TOMM22 functions as a **major preprotein-binding site** and **organizational scaffold** for the TOM complex, helping recognize mitochondrial precursor proteins and transfer them toward the **Tom40 import pore**.
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: The 2024 PNAS Nexus study (Su et al.) reports a **human TOM holo complex cryo-EM structure** including intact Tom20 at **~6 Å** and explicitly frames Tom22 as one of the TOM receptors that recognize targeting signals and collaborate in translocation.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:14557246
+  review:
+    summary: Protein binding is too generic for TOMM22. The informative functions are precursor/targeting-sequence recognition and TOM complex scaffold membership.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/TOMM22/TOMM22-deep-research-falcon.md
+    reason: Documented interactions should be captured by TOM complex and targeting-sequence/preprotein receptor annotations rather than generic protein binding.
+    supported_by:
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: &#39;Within this machinery, **TOMM22/hTom22** is described as the **central receptor** of the TOM complex, functioning both as:&#39;
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: 1) a **major preprotein-binding site** and transfer platform, and
+- term:
+    id: GO:0070585
+    label: protein localization to mitochondrion
+  evidence_type: TAS
+  original_reference_id: PMID:14557246
+  review:
+    summary: Correct. TOMM22 is a central TOM-complex receptor/scaffold enabling localization/import of nuclear-encoded mitochondrial precursor proteins.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM22/TOMM22-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: The **TOM complex** is the primary entry gate for most nucleus-encoded mitochondrial proteins into mitochondria.
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: TOMM22 functions as a **major preprotein-binding site** and **organizational scaffold** for the TOM complex, helping recognize mitochondrial precursor proteins and transfer them toward the **Tom40 import pore**.
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO terms
+  findings: []
+- id: GO_REF:0000024
+  title: Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment of sequence similarity
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000052
+  title: Gene Ontology annotation based on curation of immunofluorescence data
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: PMID:10982837
+  title: Identification and functional analysis of human Tom22 for protein import into mitochondria.
+  findings: []
+- id: PMID:12198123
+  title: Insertion and assembly of human tom7 into the preprotein translocase complex of the outer mitochondrial membrane.
+  findings: []
+- id: PMID:14557246
+  title: AIP is a mitochondrial import mediator that binds to both import receptor Tom20 and preproteins.
+  findings: []
+- id: PMID:15644312
+  title: Dissection of the mitochondrial import and assembly pathway for human Tom40.
+  findings: []
+- id: PMID:18331822
+  title: Identification of Tom5 and Tom6 in the preprotein translocase complex of human mitochondrial outer membrane.
+  findings: []
+- id: PMID:19946888
+  title: Defining the membrane proteome of NK cells.
+  findings: []
+- id: PMID:25556234
+  title: New host factors important for respiratory syncytial virus (RSV) replication revealed by a novel microfluidics screen for interactors of matrix (M) protein.
+  findings: []
+- id: PMID:32296183
+  title: A reference map of the human binary protein interactome.
+  findings: []
+- id: PMID:32814053
+  title: Interactome Mapping Provides a Network of Neurodegenerative Disease Proteins and Uncovers Widespread Protein Aggregation in Affected Brains.
+  findings: []
+- id: PMID:34800366
+  title: Quantitative high-confidence human mitochondrial proteome and its dynamics in cellular context.
+  findings: []
+- id: PMID:35733257
+  title: Structural basis of Tom20 and Tom22 cytosolic domains as the human TOM complex receptors.
+  findings: []
+- id: Reactome:R-HSA-5205661
+  title: Pink1 is recruited from the cytoplasm to the mitochondria
+  findings: []
+- id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+  title: Falcon deep research report for human TOMM22
+  findings: []
+core_functions:
+- description: TOMM22 is the central receptor/scaffold subunit of the mitochondrial outer membrane TOM complex, binding mitochondrial precursor proteins and transferring them toward the TOMM40 pore while stabilizing TOM complex assembly.
+  supported_by:
+  - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+    supporting_text: Human **TOMM22 (Q9NS69)** encodes **hTom22**, a **single-pass outer mitochondrial membrane** subunit of the TOM complex that acts as the **central receptor** and an **assembly-organizing scaffold**.
+  - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+    supporting_text: TOMM22 functions as a **major preprotein-binding site** and **organizational scaffold** for the TOM complex, helping recognize mitochondrial precursor proteins and transfer them toward the **Tom40 import pore**.
+  - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+    supporting_text: 2) an **organizational scaffold** required for correct **TOM complex assembly** and stability.
+  - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+    supporting_text: hTom22 is an **outer mitochondrial membrane (OMM)** component and is structurally a **single-pass amphipathic α-helical** protein.
+  molecular_function:
+    id: GO:0030943
+    label: mitochondrion targeting sequence binding
+  directly_involved_in:
+  - id: GO:0070585
+    label: protein localization to mitochondrion
+  - id: GO:0030150
+    label: protein import into mitochondrial matrix
+  locations:
+  - id: GO:0005741
+    label: mitochondrial outer membrane
+  in_complex:
+    id: GO:0140596
+    label: TOM complex
+proposed_new_terms: []
+suggested_questions:
+- question: Which human mitochondrial precursor classes rely most directly on TOMM22 rather than TOMM20 or TOMM70 receptor engagement?
+  experts: []
+- question: How separable are TOMM22 precursor-receptor functions from its TOM complex assembly/stability role in human cells?
+  experts: []
+suggested_experiments:
+- hypothesis: TOMM22 targeting-sequence binding and TOM complex scaffold functions are separable.
+  description: Use TOMM22 cytosolic-domain and transmembrane/interface mutants in rescue cells, then compare precursor binding, TOM complex assembly by BN-PAGE, and import of presequence versus internal-signal substrates.
+- hypothesis: TOMM22 abundance can become rate-limiting for TOM complex assembly and mitochondrial protein import in high-biogenesis contexts.
+  description: Titrate TOMM22 expression in human cells and measure TOM assembly intermediates, Tom40/Tom7 incorporation, and import flux for representative matrix, inner-membrane, and outer-membrane substrates.
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/human/TOMM22/TOMM22-ai-review.yaml
+++ b/genes/human/TOMM22/TOMM22-ai-review.yaml
@@ -1,11 +1,11 @@
 id: Q9NS69
 gene_symbol: TOMM22
 product_type: PROTEIN
-status: INITIALIZED
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
-description: 'TODO: Add description for TOMM22'
+description: TOMM22 encodes hTom22, a single-pass mitochondrial outer membrane receptor and scaffold subunit of the TOM complex. TOMM22 recognizes mitochondrial precursor proteins, helps transfer them toward the TOMM40 pore, and supports TOM complex assembly and stability; its transporter annotation is best interpreted as contribution to TOM complex protein import rather than standalone pore activity.
 existing_annotations:
 - term:
     id: GO:0030150
@@ -13,16 +13,30 @@ existing_annotations:
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct as a TOM-complex entry step for matrix-destined mitochondrial preproteins. TOMM22 is a receptor/scaffold that recognizes precursors and transfers them toward the TOMM40 pore before downstream inner-membrane import.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM22/TOMM22-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: The **TOM complex** is the primary entry gate for most nucleus-encoded mitochondrial proteins into mitochondria.
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: TOMM22 functions as a **major preprotein-binding site** and **organizational scaffold** for the TOM complex, helping recognize mitochondrial precursor proteins and transfer them toward the **Tom40 import pore**.
 - term:
     id: GO:0005742
     label: mitochondrial outer membrane translocase complex
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct. TOMM22 is a core receptor/scaffold subunit of the TOM complex / mitochondrial outer membrane translocase complex.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM22/TOMM22-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: Human **TOMM22 (Q9NS69)** encodes **hTom22**, a **single-pass outer mitochondrial membrane** subunit of the TOM complex that acts as the **central receptor** and an **assembly-organizing scaffold**.
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: 2) an **organizational scaffold** required for correct **TOM complex assembly** and stability.
 - term:
     id: GO:0008320
     label: protein transmembrane transporter activity
@@ -30,208 +44,381 @@ existing_annotations:
   original_reference_id: GO_REF:0000033
   qualifier: contributes_to
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Accepted as contribution to TOM complex protein transmembrane transporter activity. TOMM22 is the receptor/scaffold that transfers precursors toward the TOMM40 pore, not the pore-forming subunit by itself.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM22/TOMM22-deep-research-falcon.md
+    reason: Retain only as complex contribution; TOMM40 is the conducting pore, whereas TOMM22 provides receptor/scaffold function needed for import.
+    supported_by:
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: TOMM22 functions as a **major preprotein-binding site** and **organizational scaffold** for the TOM complex, helping recognize mitochondrial precursor proteins and transfer them toward the **Tom40 import pore**.
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: The 2024 PNAS Nexus study (Su et al.) reports a **human TOM holo complex cryo-EM structure** including intact Tom20 at **~6 Å** and explicitly frames Tom22 as one of the TOM receptors that recognize targeting signals and collaborate in translocation.
 - term:
     id: GO:0005741
     label: mitochondrial outer membrane
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct. TOMM22 is a single-pass mitochondrial outer membrane component of the TOM complex.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM22/TOMM22-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: hTom22 is an **outer mitochondrial membrane (OMM)** component and is structurally a **single-pass amphipathic α-helical** protein.
 - term:
     id: GO:0006886
     label: intracellular protein transport
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct pathway family but too broad. TOMM22 specifically functions in TOM-complex mitochondrial protein import.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/TOMM22/TOMM22-deep-research-falcon.md
+    reason: Use mitochondrial protein import/localization and TOM complex terms rather than generic intracellular protein transport.
+    supported_by:
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: The **TOM complex** is the primary entry gate for most nucleus-encoded mitochondrial proteins into mitochondria.
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: TOMM22 functions as a **major preprotein-binding site** and **organizational scaffold** for the TOM complex, helping recognize mitochondrial precursor proteins and transfer them toward the **Tom40 import pore**.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:12198123
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Protein binding is too generic for TOMM22. The informative functions are precursor/targeting-sequence recognition and TOM complex scaffold membership.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/TOMM22/TOMM22-deep-research-falcon.md
+    reason: Documented interactions should be captured by TOM complex and targeting-sequence/preprotein receptor annotations rather than generic protein binding.
+    supported_by:
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: 'Within this machinery, **TOMM22/hTom22** is described as the **central receptor** of the TOM complex, functioning both as:'
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: 1) a **major preprotein-binding site** and transfer platform, and
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:25556234
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Protein binding is too generic for TOMM22. The informative functions are precursor/targeting-sequence recognition and TOM complex scaffold membership.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/TOMM22/TOMM22-deep-research-falcon.md
+    reason: Documented interactions should be captured by TOM complex and targeting-sequence/preprotein receptor annotations rather than generic protein binding.
+    supported_by:
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: 'Within this machinery, **TOMM22/hTom22** is described as the **central receptor** of the TOM complex, functioning both as:'
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: 1) a **major preprotein-binding site** and transfer platform, and
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:32296183
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Protein binding is too generic for TOMM22. The informative functions are precursor/targeting-sequence recognition and TOM complex scaffold membership.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/TOMM22/TOMM22-deep-research-falcon.md
+    reason: Documented interactions should be captured by TOM complex and targeting-sequence/preprotein receptor annotations rather than generic protein binding.
+    supported_by:
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: 'Within this machinery, **TOMM22/hTom22** is described as the **central receptor** of the TOM complex, functioning both as:'
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: 1) a **major preprotein-binding site** and transfer platform, and
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:32814053
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Protein binding is too generic for TOMM22. The informative functions are precursor/targeting-sequence recognition and TOM complex scaffold membership.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/TOMM22/TOMM22-deep-research-falcon.md
+    reason: Documented interactions should be captured by TOM complex and targeting-sequence/preprotein receptor annotations rather than generic protein binding.
+    supported_by:
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: 'Within this machinery, **TOMM22/hTom22** is described as the **central receptor** of the TOM complex, functioning both as:'
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: 1) a **major preprotein-binding site** and transfer platform, and
 - term:
     id: GO:0030150
     label: protein import into mitochondrial matrix
   evidence_type: TAS
   original_reference_id: PMID:10982837
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct as a TOM-complex entry step for matrix-destined mitochondrial preproteins. TOMM22 is a receptor/scaffold that recognizes precursors and transfers them toward the TOMM40 pore before downstream inner-membrane import.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM22/TOMM22-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: The **TOM complex** is the primary entry gate for most nucleus-encoded mitochondrial proteins into mitochondria.
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: TOMM22 functions as a **major preprotein-binding site** and **organizational scaffold** for the TOM complex, helping recognize mitochondrial precursor proteins and transfer them toward the **Tom40 import pore**.
 - term:
     id: GO:0005739
     label: mitochondrion
   evidence_type: IDA
   original_reference_id: GO_REF:0000052
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct but broad. TOMM22 is specifically localized to the mitochondrial outer membrane/TOM complex.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/TOMM22/TOMM22-deep-research-falcon.md
+    reason: Prefer mitochondrial outer membrane and TOM complex annotations over generic mitochondrion.
+    supported_by:
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: hTom22 is an **outer mitochondrial membrane (OMM)** component and is structurally a **single-pass amphipathic α-helical** protein.
 - term:
     id: GO:0005741
     label: mitochondrial outer membrane
   evidence_type: EXP
   original_reference_id: PMID:10982837
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct. TOMM22 is a single-pass mitochondrial outer membrane component of the TOM complex.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM22/TOMM22-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: hTom22 is an **outer mitochondrial membrane (OMM)** component and is structurally a **single-pass amphipathic α-helical** protein.
 - term:
     id: GO:0030150
     label: protein import into mitochondrial matrix
   evidence_type: IDA
   original_reference_id: PMID:15644312
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct as a TOM-complex entry step for matrix-destined mitochondrial preproteins. TOMM22 is a receptor/scaffold that recognizes precursors and transfers them toward the TOMM40 pore before downstream inner-membrane import.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM22/TOMM22-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: The **TOM complex** is the primary entry gate for most nucleus-encoded mitochondrial proteins into mitochondria.
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: TOMM22 functions as a **major preprotein-binding site** and **organizational scaffold** for the TOM complex, helping recognize mitochondrial precursor proteins and transfer them toward the **Tom40 import pore**.
 - term:
     id: GO:0005741
     label: mitochondrial outer membrane
   evidence_type: NAS
   original_reference_id: PMID:18331822
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct. TOMM22 is a single-pass mitochondrial outer membrane component of the TOM complex.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM22/TOMM22-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: hTom22 is an **outer mitochondrial membrane (OMM)** component and is structurally a **single-pass amphipathic α-helical** protein.
 - term:
     id: GO:0045040
     label: protein insertion into mitochondrial outer membrane
   evidence_type: NAS
   original_reference_id: PMID:18331822
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Supported as a TOM-complex assembly/import pathway role, but TOMM22 is primarily the TOM receptor/scaffold rather than a general outer-membrane protein insertase.
+    action: KEEP_AS_NON_CORE
+    additional_reference_ids:
+    - file:human/TOMM22/TOMM22-deep-research-falcon.md
+    reason: Keep as non-core because TOMM22 affects TOM assembly and insertion of TOM-related substrates, while the core function is preprotein receptor/scaffold activity.
+    supported_by:
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: 2) an **organizational scaffold** required for correct **TOM complex assembly** and stability.
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: Functional perturbation evidence supports a role for Tom22 as an assembly determinant and, in some contexts, a rate-limiting factor for full TOM complex formation.
 - term:
     id: GO:0140596
     label: TOM complex
   evidence_type: NAS
   original_reference_id: PMID:18331822
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct. TOMM22 is a core receptor/scaffold subunit of the TOM complex / mitochondrial outer membrane translocase complex.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM22/TOMM22-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: Human **TOMM22 (Q9NS69)** encodes **hTom22**, a **single-pass outer mitochondrial membrane** subunit of the TOM complex that acts as the **central receptor** and an **assembly-organizing scaffold**.
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: 2) an **organizational scaffold** required for correct **TOM complex assembly** and stability.
 - term:
     id: GO:0005739
     label: mitochondrion
   evidence_type: HTP
   original_reference_id: PMID:34800366
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct but broad. TOMM22 is specifically localized to the mitochondrial outer membrane/TOM complex.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/TOMM22/TOMM22-deep-research-falcon.md
+    reason: Prefer mitochondrial outer membrane and TOM complex annotations over generic mitochondrion.
+    supported_by:
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: hTom22 is an **outer mitochondrial membrane (OMM)** component and is structurally a **single-pass amphipathic α-helical** protein.
 - term:
     id: GO:0030943
     label: mitochondrion targeting sequence binding
   evidence_type: IDA
   original_reference_id: PMID:35733257
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct and core. TOMM22 functions as a major mitochondrial preprotein/targeting-signal binding receptor in the TOM complex.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM22/TOMM22-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: 1) a **major preprotein-binding site** and transfer platform, and
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: TOMM22 functions as a **major preprotein-binding site** and **organizational scaffold** for the TOM complex, helping recognize mitochondrial precursor proteins and transfer them toward the **Tom40 import pore**.
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: The 2024 PNAS Nexus study (Su et al.) reports a **human TOM holo complex cryo-EM structure** including intact Tom20 at **~6 Å** and explicitly frames Tom22 as one of the TOM receptors that recognize targeting signals and collaborate in translocation.
 - term:
     id: GO:0016020
     label: membrane
   evidence_type: HDA
   original_reference_id: PMID:19946888
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct but very broad. TOMM22 is specifically a mitochondrial outer membrane TOM complex subunit.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/TOMM22/TOMM22-deep-research-falcon.md
+    reason: Use mitochondrial outer membrane/TOM complex annotations instead of generic membrane.
+    supported_by:
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: hTom22 is an **outer mitochondrial membrane (OMM)** component and is structurally a **single-pass amphipathic α-helical** protein.
 - term:
     id: GO:0005741
     label: mitochondrial outer membrane
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-5205661
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct. TOMM22 is a single-pass mitochondrial outer membrane component of the TOM complex.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM22/TOMM22-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: hTom22 is an **outer mitochondrial membrane (OMM)** component and is structurally a **single-pass amphipathic α-helical** protein.
 - term:
     id: GO:0016020
     label: membrane
   evidence_type: IDA
   original_reference_id: PMID:15644312
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct but very broad. TOMM22 is specifically a mitochondrial outer membrane TOM complex subunit.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/TOMM22/TOMM22-deep-research-falcon.md
+    reason: Use mitochondrial outer membrane/TOM complex annotations instead of generic membrane.
+    supported_by:
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: hTom22 is an **outer mitochondrial membrane (OMM)** component and is structurally a **single-pass amphipathic α-helical** protein.
 - term:
     id: GO:0008320
     label: protein transmembrane transporter activity
   evidence_type: ISS
   original_reference_id: GO_REF:0000024
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Accepted as contribution to TOM complex protein transmembrane transporter activity. TOMM22 is the receptor/scaffold that transfers precursors toward the TOMM40 pore, not the pore-forming subunit by itself.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM22/TOMM22-deep-research-falcon.md
+    reason: Retain only as complex contribution; TOMM40 is the conducting pore, whereas TOMM22 provides receptor/scaffold function needed for import.
+    supported_by:
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: TOMM22 functions as a **major preprotein-binding site** and **organizational scaffold** for the TOM complex, helping recognize mitochondrial precursor proteins and transfer them toward the **Tom40 import pore**.
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: The 2024 PNAS Nexus study (Su et al.) reports a **human TOM holo complex cryo-EM structure** including intact Tom20 at **~6 Å** and explicitly frames Tom22 as one of the TOM receptors that recognize targeting signals and collaborate in translocation.
 - term:
     id: GO:0005742
     label: mitochondrial outer membrane translocase complex
   evidence_type: IDA
   original_reference_id: PMID:12198123
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct. TOMM22 is a core receptor/scaffold subunit of the TOM complex / mitochondrial outer membrane translocase complex.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM22/TOMM22-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: Human **TOMM22 (Q9NS69)** encodes **hTom22**, a **single-pass outer mitochondrial membrane** subunit of the TOM complex that acts as the **central receptor** and an **assembly-organizing scaffold**.
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: 2) an **organizational scaffold** required for correct **TOM complex assembly** and stability.
 - term:
     id: GO:0005742
     label: mitochondrial outer membrane translocase complex
   evidence_type: IDA
   original_reference_id: PMID:15644312
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct. TOMM22 is a core receptor/scaffold subunit of the TOM complex / mitochondrial outer membrane translocase complex.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM22/TOMM22-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: Human **TOMM22 (Q9NS69)** encodes **hTom22**, a **single-pass outer mitochondrial membrane** subunit of the TOM complex that acts as the **central receptor** and an **assembly-organizing scaffold**.
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: 2) an **organizational scaffold** required for correct **TOM complex assembly** and stability.
 - term:
     id: GO:0008320
     label: protein transmembrane transporter activity
   evidence_type: TAS
   original_reference_id: PMID:15644312
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Accepted as contribution to TOM complex protein transmembrane transporter activity. TOMM22 is the receptor/scaffold that transfers precursors toward the TOMM40 pore, not the pore-forming subunit by itself.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM22/TOMM22-deep-research-falcon.md
+    reason: Retain only as complex contribution; TOMM40 is the conducting pore, whereas TOMM22 provides receptor/scaffold function needed for import.
+    supported_by:
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: TOMM22 functions as a **major preprotein-binding site** and **organizational scaffold** for the TOM complex, helping recognize mitochondrial precursor proteins and transfer them toward the **Tom40 import pore**.
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: The 2024 PNAS Nexus study (Su et al.) reports a **human TOM holo complex cryo-EM structure** including intact Tom20 at **~6 Å** and explicitly frames Tom22 as one of the TOM receptors that recognize targeting signals and collaborate in translocation.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:14557246
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Protein binding is too generic for TOMM22. The informative functions are precursor/targeting-sequence recognition and TOM complex scaffold membership.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/TOMM22/TOMM22-deep-research-falcon.md
+    reason: Documented interactions should be captured by TOM complex and targeting-sequence/preprotein receptor annotations rather than generic protein binding.
+    supported_by:
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: 'Within this machinery, **TOMM22/hTom22** is described as the **central receptor** of the TOM complex, functioning both as:'
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: 1) a **major preprotein-binding site** and transfer platform, and
 - term:
     id: GO:0070585
     label: protein localization to mitochondrion
   evidence_type: TAS
   original_reference_id: PMID:14557246
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct. TOMM22 is a central TOM-complex receptor/scaffold enabling localization/import of nuclear-encoded mitochondrial precursor proteins.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/TOMM22/TOMM22-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: The **TOM complex** is the primary entry gate for most nucleus-encoded mitochondrial proteins into mitochondria.
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: TOMM22 functions as a **major preprotein-binding site** and **organizational scaffold** for the TOM complex, helping recognize mitochondrial precursor proteins and transfer them toward the **Tom40 import pore**.
 references:
 - id: GO_REF:0000002
-  title: Gene Ontology annotation through association of InterPro records with GO
-    terms
+  title: Gene Ontology annotation through association of InterPro records with GO terms
   findings: []
 - id: GO_REF:0000024
-  title: Manual transfer of experimentally-verified manual GO annotation data to orthologs
-    by curator judgment of sequence similarity
+  title: Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment of sequence similarity
   findings: []
 - id: GO_REF:0000033
   title: Annotation inferences using phylogenetic trees
@@ -243,46 +430,77 @@ references:
   title: Combined Automated Annotation using Multiple IEA Methods
   findings: []
 - id: PMID:10982837
-  title: Identification and functional analysis of human Tom22 for protein import
-    into mitochondria.
+  title: Identification and functional analysis of human Tom22 for protein import into mitochondria.
   findings: []
 - id: PMID:12198123
-  title: Insertion and assembly of human tom7 into the preprotein translocase complex
-    of the outer mitochondrial membrane.
+  title: Insertion and assembly of human tom7 into the preprotein translocase complex of the outer mitochondrial membrane.
   findings: []
 - id: PMID:14557246
-  title: AIP is a mitochondrial import mediator that binds to both import receptor
-    Tom20 and preproteins.
+  title: AIP is a mitochondrial import mediator that binds to both import receptor Tom20 and preproteins.
   findings: []
 - id: PMID:15644312
   title: Dissection of the mitochondrial import and assembly pathway for human Tom40.
   findings: []
 - id: PMID:18331822
-  title: Identification of Tom5 and Tom6 in the preprotein translocase complex of
-    human mitochondrial outer membrane.
+  title: Identification of Tom5 and Tom6 in the preprotein translocase complex of human mitochondrial outer membrane.
   findings: []
 - id: PMID:19946888
   title: Defining the membrane proteome of NK cells.
   findings: []
 - id: PMID:25556234
-  title: New host factors important for respiratory syncytial virus (RSV) replication
-    revealed by a novel microfluidics screen for interactors of matrix (M) protein.
+  title: New host factors important for respiratory syncytial virus (RSV) replication revealed by a novel microfluidics screen for interactors of matrix (M) protein.
   findings: []
 - id: PMID:32296183
   title: A reference map of the human binary protein interactome.
   findings: []
 - id: PMID:32814053
-  title: Interactome Mapping Provides a Network of Neurodegenerative Disease Proteins
-    and Uncovers Widespread Protein Aggregation in Affected Brains.
+  title: Interactome Mapping Provides a Network of Neurodegenerative Disease Proteins and Uncovers Widespread Protein Aggregation in Affected Brains.
   findings: []
 - id: PMID:34800366
-  title: Quantitative high-confidence human mitochondrial proteome and its dynamics
-    in cellular context.
+  title: Quantitative high-confidence human mitochondrial proteome and its dynamics in cellular context.
   findings: []
 - id: PMID:35733257
-  title: Structural basis of Tom20 and Tom22 cytosolic domains as the human TOM complex
-    receptors.
+  title: Structural basis of Tom20 and Tom22 cytosolic domains as the human TOM complex receptors.
   findings: []
 - id: Reactome:R-HSA-5205661
   title: Pink1 is recruited from the cytoplasm to the mitochondria
   findings: []
+- id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+  title: Falcon deep research report for human TOMM22
+  findings: []
+core_functions:
+- description: TOMM22 is the central receptor/scaffold subunit of the mitochondrial outer membrane TOM complex, binding mitochondrial precursor proteins and transferring them toward the TOMM40 pore while stabilizing TOM complex assembly.
+  supported_by:
+  - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+    supporting_text: Human **TOMM22 (Q9NS69)** encodes **hTom22**, a **single-pass outer mitochondrial membrane** subunit of the TOM complex that acts as the **central receptor** and an **assembly-organizing scaffold**.
+  - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+    supporting_text: TOMM22 functions as a **major preprotein-binding site** and **organizational scaffold** for the TOM complex, helping recognize mitochondrial precursor proteins and transfer them toward the **Tom40 import pore**.
+  - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+    supporting_text: 2) an **organizational scaffold** required for correct **TOM complex assembly** and stability.
+  - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+    supporting_text: hTom22 is an **outer mitochondrial membrane (OMM)** component and is structurally a **single-pass amphipathic α-helical** protein.
+  molecular_function:
+    id: GO:0030943
+    label: mitochondrion targeting sequence binding
+  directly_involved_in:
+  - id: GO:0070585
+    label: protein localization to mitochondrion
+  - id: GO:0030150
+    label: protein import into mitochondrial matrix
+  locations:
+  - id: GO:0005741
+    label: mitochondrial outer membrane
+  in_complex:
+    id: GO:0140596
+    label: TOM complex
+proposed_new_terms: []
+suggested_questions:
+- question: Which human mitochondrial precursor classes rely most directly on TOMM22 rather than TOMM20 or TOMM70 receptor engagement?
+  experts: []
+- question: How separable are TOMM22 precursor-receptor functions from its TOM complex assembly/stability role in human cells?
+  experts: []
+suggested_experiments:
+- hypothesis: TOMM22 targeting-sequence binding and TOM complex scaffold functions are separable.
+  description: Use TOMM22 cytosolic-domain and transmembrane/interface mutants in rescue cells, then compare precursor binding, TOM complex assembly by BN-PAGE, and import of presequence versus internal-signal substrates.
+- hypothesis: TOMM22 abundance can become rate-limiting for TOM complex assembly and mitochondrial protein import in high-biogenesis contexts.
+  description: Titrate TOMM22 expression in human cells and measure TOM assembly intermediates, Tom40/Tom7 incorporation, and import flux for representative matrix, inner-membrane, and outer-membrane substrates.

--- a/genes/human/TOMM22/TOMM22-deep-research-falcon.md
+++ b/genes/human/TOMM22/TOMM22-deep-research-falcon.md
@@ -1,0 +1,286 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-11T16:35:51.753780'
+end_time: '2026-05-11T16:43:40.301411'
+duration_seconds: 468.55
+template_file: templates/gene_research_go_focused.md
+template_variables:
+  organism: human
+  gene_id: TOMM22
+  gene_symbol: TOMM22
+  uniprot_accession: Q9NS69
+  protein_description: 'RecName: Full=Mitochondrial import receptor subunit TOM22
+    homolog; Short=hTom22; AltName: Full=1C9-2; AltName: Full=Translocase of outer
+    membrane 22 kDa subunit homolog;'
+  gene_info: Name=TOMM22; Synonyms=TOM22;
+  organism_full: Homo sapiens (Human).
+  protein_family: Belongs to the Tom22 family. .
+  protein_domains: Tom22. (IPR005683); Tom22 (PF04281)
+provider_config:
+  timeout: 600
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 18
+---
+
+## Question
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** Q9NS69
+- **Protein Description:** RecName: Full=Mitochondrial import receptor subunit TOM22 homolog; Short=hTom22; AltName: Full=1C9-2; AltName: Full=Translocase of outer membrane 22 kDa subunit homolog;
+- **Gene Information:** Name=TOMM22; Synonyms=TOM22;
+- **Organism (full):** Homo sapiens (Human).
+- **Protein Family:** Belongs to the Tom22 family. .
+- **Key Domains:** Tom22. (IPR005683); Tom22 (PF04281)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "TOMM22" matches the protein description above**
+2. **Verify the organism is correct:** Homo sapiens (Human).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'TOMM22' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **TOMM22** (gene ID: TOMM22, UniProt: Q9NS69) in human.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** Q9NS69
+- **Protein Description:** RecName: Full=Mitochondrial import receptor subunit TOM22 homolog; Short=hTom22; AltName: Full=1C9-2; AltName: Full=Translocase of outer membrane 22 kDa subunit homolog;
+- **Gene Information:** Name=TOMM22; Synonyms=TOM22;
+- **Organism (full):** Homo sapiens (Human).
+- **Protein Family:** Belongs to the Tom22 family. .
+- **Key Domains:** Tom22. (IPR005683); Tom22 (PF04281)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "TOMM22" matches the protein description above**
+2. **Verify the organism is correct:** Homo sapiens (Human).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'TOMM22' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **TOMM22** (gene ID: TOMM22, UniProt: Q9NS69) in human.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Research Report: Human **TOMM22** (UniProt Q9NS69) — Functional Annotation and Current Understanding
+
+### 1) Target verification (identity and disambiguation)
+The UniProt accession **Q9NS69** corresponds to **human TOMM22 (TOM22)**, annotated as the **mitochondrial import receptor subunit TOM22 homolog (hTom22)** and a member of the **Tom22 family**. Multiple independent human-mitochondria studies and reviews explicitly define **Tom22/TOMM22** as a receptor/core subunit of the **translocase of the outer mitochondrial membrane (TOM) complex**, consistent with the UniProt description and expected domain/family context (Tom22 family single-pass α-helical subunit). (pitt2021abiochemicaland pages 6-9, su2024structureofthe pages 1-3, haastrup2024mitochondrialtranslocasetomm22 pages 1-3)
+
+### 2) Key concepts and definitions (current understanding)
+
+#### 2.1 The TOM complex and why TOMM22 is central
+The **TOM complex** is the primary entry gate for most nucleus-encoded mitochondrial proteins into mitochondria. In the human system, precursor proteins (carrying **N-terminal presequences** or **internal targeting signals**) are recognized by TOM receptors **Tom20, Tom22, and Tom70**, and then translocated through the **Tom40** pore. (su2024structureofthe pages 1-3)
+
+Within this machinery, **TOMM22/hTom22** is described as the **central receptor** of the TOM complex, functioning both as:
+1) a **major preprotein-binding site** and transfer platform, and
+2) an **organizational scaffold** required for correct **TOM complex assembly** and stability. (pitt2021abiochemicaland pages 6-9)
+
+A quantitative estimate summarized in a structural/biochemical review is that **~1100 proteins out of ~1500 proteins imported by the TOM complex rely on hTom22 for import**—emphasizing its broad client range and centrality among TOM receptors. (pitt2021abiochemicaland pages 13-15)
+
+#### 2.2 Subcellular localization and topology
+hTom22 is an **outer mitochondrial membrane (OMM)** component and is structurally a **single-pass amphipathic α-helical** protein. Cryo-EM-based descriptions place Tom22 **between two Tom40 β-barrels**, where it forms a key part of the **dimeric interface** and provides **stabilizing support** to Tom40. (pitt2021abiochemicaland pages 6-9)
+
+The protein contains a **conserved proline** that introduces a **kink** in the transmembrane helix. In available human TOM structures, substantial portions of Tom22 are **not resolved** (notably residues **1–61** and **119–142** in the cited review’s summary of structural work), implying flexible/disordered regions that may contribute to receptor function and interactions. (pitt2021abiochemicaland pages 6-9)
+
+A major conceptual update in the current understanding is that the human Tom22 IMS-facing region appears **mechanistically distinct from fungal Tom22**: the review notes that human Tom22 **lacks** the **acidic patch** in the IMS region implicated in the fungal “acid chain hypothesis,” and instead contains a **glutamine-rich domain**. This is interpreted as evidence that some mechanistic features of mitochondrial targeting and translocation characterized in fungi may not directly translate to humans. (pitt2021abiochemicaland pages 6-9)
+
+#### 2.3 Complex composition and receptor cooperation
+A 2024 cryo-EM study focused on receptor positioning describes the TOM complex as comprising seven subunits (**Tom40, Tom20, Tom22, Tom70, Tom5, Tom6, Tom7**) and supports a model in which **different receptors can function simultaneously** to ensure efficient translocation of precursors. This work obtained a human TOM holo complex containing an intact Tom20 receptor at **~6 Å resolution**, in which Tom20 is stabilized by **extensive interactions with Tom22, Tom40, and Tom6**. (Su et al., 2024; published online 26 Jul 2024; https://doi.org/10.1093/pnasnexus/pgae269) (su2024structureofthe pages 1-3)
+
+### 3) Molecular function and pathways
+
+#### 3.1 Primary function: receptor/scaffold for mitochondrial protein import
+The best-supported primary function of TOMM22 is as a **central receptor/scaffold** enabling mitochondrial protein import via the TOM complex. Functional evidence summarized in the Cells review includes perturbation experiments showing that **hTom22 knockdown** increases levels of **stable hTOM assembly intermediates**, consistent with a requirement for Tom22 in Tom40/TOM assembly; conversely, **Tom22 overexpression** supports the interpretation that Tom22 can be **rate-limiting for assembly of complete TOM complexes** and can promote integration of other subunits (e.g., Tom7) in a human cell context. (Pitt & Buchanan, 2021; 11 May 2021; https://doi.org/10.3390/cells10051164) (pitt2021abiochemicaland pages 6-9)
+
+#### 3.2 Interaction partners (TOM complex and beyond)
+**Within TOM**, Tom22 is positioned to interact closely with Tom40 and other core subunits; receptor-level cooperation includes Tom22 interactions with Tom20 (supported by cross-linking mass spectrometry evidence reported in the review, although not fully resolved structurally). (pitt2021abiochemicaland pages 6-9)
+
+**Beyond canonical import**, Tom22 is repeatedly described as having a **broad interactome** that includes proteins involved in apoptosis, mitochondrial dynamics, and metabolic functions. The review highlights functional interactions relevant to:
+- **Apoptosis via Bax** (see below) (pitt2021abiochemicaland pages 13-15)
+- **Mitochondrial morphology/dynamics** (review summary of Tom22 perturbation phenotypes) (pitt2021abiochemicaland pages 15-16)
+- **Steroidogenesis** via a larger metabolic protein complex involving **3βHSD2** and other components (pitt2021abiochemicaland pages 13-15)
+
+These broader interactions are consistent with an emerging view of import machinery components as integration points for stress and signaling, as emphasized by a 2023 review essay describing mitochondrial protein import as a signaling hub connecting mitochondrial and cellular homeostasis. (Lionaki et al., 2023; accepted 2 Jan 2023; https://doi.org/10.1002/bies.202200160) (lionaki2023mitochondrialproteinimport pages 1-2)
+
+### 4) Recent developments (prioritizing 2023–2024)
+
+#### 4.1 Structural biology (2024): receptor organization within human TOM
+The 2024 PNAS Nexus study (Su et al.) reports a **human TOM holo complex cryo-EM structure** including intact Tom20 at **~6 Å** and explicitly frames Tom22 as one of the TOM receptors that recognize targeting signals and collaborate in translocation. This work strengthens a receptor-cooperation model in which Tom22 is physically positioned to stabilize receptor arrangement and facilitate precursor delivery to Tom40. (26 Jul 2024; https://doi.org/10.1093/pnasnexus/pgae269) (su2024structureofthe pages 1-3)
+
+#### 4.2 Cancer biology (2024): TOMM22 overexpression in pancreatic cancer
+A 2024 Molecular Cancer Research article reports that **TOMM22 mRNA/protein is overexpressed in pancreatic ductal adenocarcinoma (PDAC)** and is **inversely correlated with disease outcomes**. Functionally, in pancreatic cancer cell models, **TOMM22 silencing decreased** whereas **forced overexpression increased** growth and malignant potential. The authors further report that TOMM22 overexpression increased import of several mitochondrial proteins (including respiration-associated proteins) and was associated with increased **complex I (RCI) activity**, **NAD+/NADH ratio**, **oxygen consumption rate**, **mitochondrial membrane potential**, and **ATP production**; complex I inhibition reduced ATP and suppressed malignant phenotypes, linking TOMM22-driven import changes to bioenergetics and growth. (Haastrup et al., 1 Feb 2024 issue date; final article context indicates Feb 2024, with PMC availability noted Dec 2024; https://doi.org/10.1158/1541-7786.MCR-23-0138) (haastrup2024mitochondrialtranslocasetomm22 pages 1-3)
+
+Interpretation: this study supports the hypothesis that, in at least some tumors, increased TOMM22 can act as a **functional enabler** of mitochondrial biogenesis/respiratory capacity via increased import capacity, rather than being a passive marker of mitochondrial abundance. (haastrup2024mitochondrialtranslocasetomm22 pages 1-3)
+
+#### 4.3 Import machinery as a stress-signaling node (2023)
+A 2023 review essay frames mitochondrial protein import as a **regulatable signaling hub**, where impairment of import induces adaptive responses inside and outside mitochondria (proteostasis and metabolic responses). While not Tom22-specific, it supports an expert consensus that TOM components (including receptor subunits like Tom22) should be considered in a systems context where changes in import efficiency can engage broader stress/quality-control pathways. (Lionaki et al., 2023; https://doi.org/10.1002/bies.202200160) (lionaki2023mitochondrialproteinimport pages 1-2)
+
+### 5) Current applications and real-world implementations
+
+#### 5.1 Biomarker and therapeutic targeting concepts in oncology
+The pancreatic cancer study explicitly proposes **TOMM22** as having potential for **early diagnostic/prognostic biomarker development** and **therapeutic targeting** in PDAC, based on tumor overexpression, correlation with outcomes, and functional causality in cell models (gain- and loss-of-function) linked to mitochondrial import and OXPHOS-related readouts. (Haastrup et al., 2024; https://doi.org/10.1158/1541-7786.MCR-23-0138) (haastrup2024mitochondrialtranslocasetomm22 pages 1-3)
+
+Separately, a structural/biochemical review highlights that Tom22 participates in apoptosis-related interactions (notably with Bax), and discusses the concept that targeting TOM-complex components and their interactions could be a viable strategy in disease contexts where mitochondrial dysfunction is causal. (Pitt & Buchanan, 2021; https://doi.org/10.3390/cells10051164) (pitt2021abiochemicaland pages 13-15)
+
+#### 5.2 Mechanistic disease models (yeast) for noncanonical substrates
+A primary research study in yeast mitochondria provides direct evidence that Tom22 can act as a receptor for **amyloid-β (Aβ)**: Aβ binding is reported to be mediated mainly by Tom22 rather than Tom20, and Aβ residues **25–42** were identified as critical for interaction. The authors propose that cytosolic Aβ is recognized by Tom22 and then transferred to Tom40 for translocation. While this is a yeast model, it is frequently used as a tractable platform to dissect TOM-mediated uptake mechanisms relevant to Alzheimer’s-disease-associated mitochondrial Aβ accumulation. (Hu et al., 2018; https://doi.org/10.1074/jbc.ra118.002713) (hu2018mitochondrialaccumulationof pages 1-2)
+
+### 6) Expert opinions and analysis (authoritative synthesis)
+
+#### 6.1 Essentiality and assembly control
+The Cells review argues that the “structural reliance” of the core TOM complex on Tom22 is consistent with impaired viability observed when Tom22 is deficient (as discussed across model systems and mammalian contexts). The same review synthesizes perturbation evidence supporting Tom22 as an assembly organizer and potential rate-limiting component for complete TOM biogenesis under some conditions. (Pitt & Buchanan, 2021; https://doi.org/10.3390/cells10051164) (pitt2021abiochemicaland pages 13-15, pitt2021abiochemicaland pages 6-9)
+
+#### 6.2 Apoptosis interface (Bax)
+A key expert-level point emphasized in the review is that Tom22 is not merely an import receptor but also participates in **Bax-mediated apoptosis**: inhibition of Tom22–Bax interactions (e.g., via antibody blocking or Tom22 knockdown) is reported to inhibit Bax-mediated apoptosis, suggesting Tom22 can be an actionable node coupling mitochondrial surface machinery to apoptotic execution pathways. (Pitt & Buchanan, 2021; https://doi.org/10.3390/cells10051164) (pitt2021abiochemicaland pages 13-15)
+
+### 7) Relevant statistics and quantitative data (from recent/authoritative sources)
+- **Mitochondrial proteome scale (mammals):** mammalian mitochondria may contain up to **~1500 proteins**, and only about **~1%** are encoded by mitochondrial DNA, implying extensive reliance on nuclear-encoded precursor import. (Lionaki et al., 2023; https://doi.org/10.1002/bies.202200160) (lionaki2023mitochondrialproteinimport pages 1-2)
+- **Tom22-dependent import breadth:** **~1100 of ~1500 TOM-imported proteins** are summarized as relying on **hTom22** for import (review synthesis). (Pitt & Buchanan, 2021; https://doi.org/10.3390/cells10051164) (pitt2021abiochemicaland pages 13-15)
+- **Structural parameters:** human TOM structural work summarized in the Cells review includes a human TOM core at **~3.4 Å** (review summary) and an observed tetrameric form at **~8.5 Å** (review summary). (pitt2021abiochemicaland pages 11-12)
+- **2024 cryo-EM holo complex resolution:** the Tom20-containing human TOM holo complex was resolved at **~6 Å**. (Su et al., 2024; https://doi.org/10.1093/pnasnexus/pgae269) (su2024structureofthe pages 1-3)
+- **Noncanonical substrate determinant:** in the yeast Aβ study, Aβ residues **25–42** were implicated in Tom22-mediated interaction. (Hu et al., 2018; https://doi.org/10.1074/jbc.ra118.002713) (hu2018mitochondrialaccumulationof pages 1-2)
+
+### 8) Visual evidence (figures) supporting TOMM22 placement and features
+The following extracted figures visually summarize Tom22’s placement within the TOM complex and highlight its structural features/interactome in a review context. (pitt2021abiochemicaland media a23c1074, pitt2021abiochemicaland media 096ec19a, pitt2021abiochemicaland media 626e7aa4)
+
+### 9) Consolidated functional annotation (narrative conclusion)
+Human **TOMM22 (Q9NS69)** encodes **hTom22**, a **single-pass outer mitochondrial membrane** subunit of the TOM complex that acts as the **central receptor** and an **assembly-organizing scaffold**. Its core role is to coordinate **recognition/transfer of mitochondrial precursor proteins** from receptor engagement toward passage through the **Tom40** pore, and structural work positions Tom22 at the **Tom40 dimer interface** with a conserved kinked helix and flexible terminal regions. Functional perturbation evidence supports a role for Tom22 as an assembly determinant and, in some contexts, a rate-limiting factor for full TOM complex formation. Beyond canonical import, authoritative synthesis highlights Tom22 as an interaction hub relevant to apoptosis (e.g., Bax-related mechanisms) and metabolic processes (e.g., steroidogenic complexes), consistent with recent frameworks that mitochondrial protein import machinery participates in broader stress-signaling networks. Recent 2024 work advances receptor-level structural organization of the human TOM holo complex and provides disease-context evidence in which TOMM22 overexpression can enhance import-linked respiratory phenotypes and tumor aggressiveness in pancreatic cancer, supporting ongoing interest in TOMM22 as a biomarker and potential therapeutic target. (pitt2021abiochemicaland pages 6-9, pitt2021abiochemicaland pages 13-15, su2024structureofthe pages 1-3, haastrup2024mitochondrialtranslocasetomm22 pages 1-3, lionaki2023mitochondrialproteinimport pages 1-2)
+
+---
+
+## Summary Table
+| Category | Summary |
+|---|---|
+| Identity | **TOMM22** encodes the human **mitochondrial import receptor subunit TOM22 homolog** (hTom22), the **central receptor** of the TOM complex; this matches UniProt Q9NS69 and the Tom22 family assignment. It is a conserved TOM core component distinct from TOM20/TOM70 receptor subunits. (pitt2021abiochemicaland pages 6-9, su2024structureofthe pages 1-3, haastrup2024mitochondrialtranslocasetomm22 pages 1-3) |
+| Localization/topology | hTom22 localizes to the **outer mitochondrial membrane** as a **single-pass amphipathic α-helical** protein. Structural work places it **between the two Tom40 β-barrels**, forming the **dimeric interface** and stabilizing the complex. Human Tom22 contains a **conserved proline-induced kink**; the **N-terminal cytosolic** and **C-terminal IMS** regions are partly unresolved/flexible in structures, and the human IMS region is **glutamine-rich** rather than carrying the fungal acidic patch. (pitt2021abiochemicaland pages 6-9, pitt2021abiochemicaland pages 11-12) |
+| Molecular function | TOMM22 functions as a **major preprotein-binding site** and **organizational scaffold** for the TOM complex, helping recognize mitochondrial precursor proteins and transfer them toward the **Tom40 import pore**. It participates in import of precursors with **N-terminal presequences** or contributes to handling broader precursor classes together with Tom20/Tom70. (pitt2021abiochemicaland pages 6-9, su2024structureofthe pages 1-3, haastrup2024mitochondrialtranslocasetomm22 pages 1-3) |
+| Complex membership | Human TOM complex contains **Tom40, Tom20, Tom22, Tom70, Tom5, Tom6, and Tom7**. Tom22 is part of the **core TOM complex** with Tom40/Tom5/Tom6/Tom7; cryo-EM studies resolved human TOM core structures at **~3.4 Å** and a TOM holo complex containing intact Tom20 at **~6 Å**. Tom22 is important for assembly state organization, while Tom6 stabilizes and Tom7 destabilizes TOM partly through effects linked to Tom22. (pitt2021abiochemicaland pages 11-12, su2024structureofthe pages 1-3, pitt2021abiochemicaland pages 6-9) |
+| Interaction partners | Key partners include **Tom40**, **Tom20**, **Tom6**, **Tom7**, and likely **Tom70** within the import machinery. Outside canonical import, reported interactors include **Bax** (apoptosis), **PINK1/Parkin pathway components**, **Mfn1**, mito **BKCa** channel, **3βHSD2**, **P450C11AS**, and **StAR** in steroidogenic contexts. Cross-linked MS supports a Tom20–Tom22 interaction even where density is unresolved. (pitt2021abiochemicaland pages 23-24, pitt2021abiochemicaland pages 15-16, pitt2021abiochemicaland pages 13-15, pitt2021abiochemicaland pages 6-9) |
+| Regulation/quality control | Tom22 is a **rate-limiting factor for complete TOM assembly** in some cell systems; knockdown increases stable TOM assembly intermediates, whereas overexpression promotes assembly and **Tom7 integration**. Reviews also note regulation through **phosphorylation** and quality-control pathways including **Yme1-mediated degradation** and import-stress signaling/mitophagy links. (pitt2021abiochemicaland pages 6-9, pitt2021abiochemicaland pages 23-24) |
+| Disease/phenotypes | Reduced or defective Tom22 impairs viability and mitochondrial homeostasis; **zebrafish tom22 mutants** show hepatocyte apoptosis and abnormal liver organization. In human disease biology, Tom22 contributes to **Bax-mediated apoptosis**, has been implicated in **Parkinson’s disease-related import dysfunction**, and is discussed in mitochondrial stress, steroidogenesis, and metabolic disease contexts. HIV-1 protease has been reported to cleave Tom22 in apoptosis-related models. (pitt2021abiochemicaland pages 13-15, pitt2021abiochemicaland pages 23-24, pitt2021abiochemicaland pages 15-16, su2024structureofthe pages 1-3) |
+| Recent 2023-2024 developments/applications | **2024 cryo-EM** work further defined receptor organization in the **human TOM holo complex**, supporting simultaneous action of Tom20/Tom22/Tom70 during import. **2024 pancreatic cancer** data showed **TOMM22 overexpression** promotes aggressive growth by enhancing mitochondrial protein import, respiration-associated functions, membrane potential, and ATP production, highlighting **biomarker/therapeutic** potential. Reviews from **2023** emphasize TOM components, including Tom22, as signaling hubs in mitochondrial import stress responses. (su2024structureofthe pages 1-3, haastrup2024mitochondrialtranslocasetomm22 pages 1-3, lionaki2023mitochondrialproteinimport pages 1-2) |
+| Quantitative data | Mammalian mitochondria contain up to **~1500 proteins**, with only **~1% mtDNA-encoded**; a review estimates **~1100 of ~1500** TOM-imported proteins rely on **hTom22** for import. Structural resolutions cited for human TOM include **~3.4 Å** for the core complex and **~6 Å** for the Tom20-containing holo complex; lower-resolution tetrameric TOM has been observed at **~8.5 Å**. In the Aβ study, residues **25–42** were critical for Tom22-mediated recognition in yeast. (pitt2021abiochemicaland pages 13-15, pitt2021abiochemicaland pages 11-12, lionaki2023mitochondrialproteinimport pages 1-2, su2024structureofthe pages 1-3, hu2018mitochondrialaccumulationof pages 1-2) |
+
+
+*Table: This table summarizes the key functional annotation for human TOMM22/ hTom22, including its identity, topology, role in the mitochondrial TOM complex, major interaction partners, disease links, and recent 2023-2024 developments. It is useful as a compact evidence-backed reference for narrative gene annotation.*
+
+References
+
+1. (pitt2021abiochemicaland pages 6-9): Ashley S. Pitt and Susan K. Buchanan. A biochemical and structural understanding of tom complex interactions and implications for human health and disease. Cells, 10:1164, May 2021. URL: https://doi.org/10.3390/cells10051164, doi:10.3390/cells10051164. This article has 46 citations.
+
+2. (su2024structureofthe pages 1-3): Jiayue Su, Xuyang Tian, Ziyi Wang, Jiawen Yang, Shan Sun, and Sen-Fang Sui. Structure of the intact tom20 receptor in the human translocase of the outer membrane complex. PNAS Nexus, Jun 2024. URL: https://doi.org/10.1093/pnasnexus/pgae269, doi:10.1093/pnasnexus/pgae269. This article has 12 citations and is from a peer-reviewed journal.
+
+3. (haastrup2024mitochondrialtranslocasetomm22 pages 1-3): Mary Oluwadamilola Haastrup, Kunwar Somesh Vikramdeo, Shashi Anand, Mohammad Aslam Khan, James Elliot Carter, Seema Singh, Ajay Pratap Singh, and Santanu Dasgupta. Mitochondrial translocase tomm22 is overexpressed in pancreatic cancer and promotes aggressive growth by modulating mitochondrial protein import and function. Molecular cancer research : MCR, 22:197-208, Oct 2024. URL: https://doi.org/10.1158/1541-7786.mcr-23-0138, doi:10.1158/1541-7786.mcr-23-0138. This article has 10 citations.
+
+4. (pitt2021abiochemicaland pages 13-15): Ashley S. Pitt and Susan K. Buchanan. A biochemical and structural understanding of tom complex interactions and implications for human health and disease. Cells, 10:1164, May 2021. URL: https://doi.org/10.3390/cells10051164, doi:10.3390/cells10051164. This article has 46 citations.
+
+5. (pitt2021abiochemicaland pages 15-16): Ashley S. Pitt and Susan K. Buchanan. A biochemical and structural understanding of tom complex interactions and implications for human health and disease. Cells, 10:1164, May 2021. URL: https://doi.org/10.3390/cells10051164, doi:10.3390/cells10051164. This article has 46 citations.
+
+6. (lionaki2023mitochondrialproteinimport pages 1-2): Eirini Lionaki, Ilias Gkikas, and Nektarios Tavernarakis. Mitochondrial protein import machinery conveys stress signals to the cytosol and beyond. BioEssays, Jan 2023. URL: https://doi.org/10.1002/bies.202200160, doi:10.1002/bies.202200160. This article has 14 citations and is from a peer-reviewed journal.
+
+7. (hu2018mitochondrialaccumulationof pages 1-2): Wenxin Hu, Zhiming Wang, and Hongjin Zheng. Mitochondrial accumulation of amyloid β (aβ) peptides requires tomm22 as a main aβ receptor in yeast. Journal of Biological Chemistry, 293:12681-12689, Aug 2018. URL: https://doi.org/10.1074/jbc.ra118.002713, doi:10.1074/jbc.ra118.002713. This article has 51 citations and is from a domain leading peer-reviewed journal.
+
+8. (pitt2021abiochemicaland pages 11-12): Ashley S. Pitt and Susan K. Buchanan. A biochemical and structural understanding of tom complex interactions and implications for human health and disease. Cells, 10:1164, May 2021. URL: https://doi.org/10.3390/cells10051164, doi:10.3390/cells10051164. This article has 46 citations.
+
+9. (pitt2021abiochemicaland media a23c1074): Ashley S. Pitt and Susan K. Buchanan. A biochemical and structural understanding of tom complex interactions and implications for human health and disease. Cells, 10:1164, May 2021. URL: https://doi.org/10.3390/cells10051164, doi:10.3390/cells10051164. This article has 46 citations.
+
+10. (pitt2021abiochemicaland media 096ec19a): Ashley S. Pitt and Susan K. Buchanan. A biochemical and structural understanding of tom complex interactions and implications for human health and disease. Cells, 10:1164, May 2021. URL: https://doi.org/10.3390/cells10051164, doi:10.3390/cells10051164. This article has 46 citations.
+
+11. (pitt2021abiochemicaland media 626e7aa4): Ashley S. Pitt and Susan K. Buchanan. A biochemical and structural understanding of tom complex interactions and implications for human health and disease. Cells, 10:1164, May 2021. URL: https://doi.org/10.3390/cells10051164, doi:10.3390/cells10051164. This article has 46 citations.
+
+12. (pitt2021abiochemicaland pages 23-24): Ashley S. Pitt and Susan K. Buchanan. A biochemical and structural understanding of tom complex interactions and implications for human health and disease. Cells, 10:1164, May 2021. URL: https://doi.org/10.3390/cells10051164, doi:10.3390/cells10051164. This article has 46 citations.
+
+## Citations
+
+1. su2024structureofthe pages 1-3
+2. pitt2021abiochemicaland pages 6-9
+3. pitt2021abiochemicaland pages 13-15
+4. pitt2021abiochemicaland pages 15-16
+5. lionaki2023mitochondrialproteinimport pages 1-2
+6. hu2018mitochondrialaccumulationof pages 1-2
+7. pitt2021abiochemicaland pages 11-12
+8. pitt2021abiochemicaland pages 23-24
+9. https://doi.org/10.1093/pnasnexus/pgae269
+10. https://doi.org/10.3390/cells10051164
+11. https://doi.org/10.1002/bies.202200160
+12. https://doi.org/10.1158/1541-7786.MCR-23-0138
+13. https://doi.org/10.1074/jbc.ra118.002713
+14. https://doi.org/10.3390/cells10051164,
+15. https://doi.org/10.1093/pnasnexus/pgae269,
+16. https://doi.org/10.1158/1541-7786.mcr-23-0138,
+17. https://doi.org/10.1002/bies.202200160,
+18. https://doi.org/10.1074/jbc.ra118.002713,


### PR DESCRIPTION
## Summary

Adds Falcon deep-research reports and incorporated review updates for three human mitochondrial import genes:

- TIMM44
- TIMM50
- TOMM22

The YAML reviews now mark broad/generic annotations appropriately, add evidence-backed core functions, and include generated HTML pages for each gene.

## Validation

- `uv run python scripts/validate_deep_research.py genes/human/TIMM44/TIMM44-deep-research-falcon.md genes/human/TIMM50/TIMM50-deep-research-falcon.md genes/human/TOMM22/TOMM22-deep-research-falcon.md`
- `just validate human TIMM44`
- `just validate human TIMM50`
- `just validate human TOMM22`
- `just render human TIMM44`
- `just render human TIMM50`
- `just render human TOMM22`
- exact local `supporting_text` check across edited YAMLs: 179 entries matched
- `git diff --check` / `git diff --cached --check`