### PR TITLE
[codex] Add Falcon research reviews for PAM16 PMPCB GFER

### DIFF
--- a/genes/human/GFER/GFER-ai-review.html
+++ b/genes/human/GFER/GFER-ai-review.html
@@ -1,0 +1,5009 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>GFER - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>GFER</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/P55789" target="_blank" class="term-link">
+                        P55789
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "GFER";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="P55789" data-a="DESCRIPTION: GFER encodes ALR/Erv1, a FAD-dependent sulfhydryl ..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>GFER encodes ALR/Erv1, a FAD-dependent sulfhydryl oxidase in the mitochondrial intermembrane space. Its core role is to re-oxidize MIA40/CHCHD4 in the mitochondrial disulfide relay, enabling oxidative folding and import/retention of cysteine-rich IMS proteins.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016971" target="_blank" class="term-link">
+                                    GO:0016971
+                                </a>
+                            </span>
+                            <span class="term-label">flavin-dependent sulfhydryl oxidase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P55789" data-a="GO:0016971" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct and core. GFER/ALR is the FAD-linked sulfhydryl oxidase of the mitochondrial disulfide relay.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/GFER/GFER-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The literature retrieved consistently maps **human GFER** to **ALR (augmenter of liver regeneration)** and the mammalian homolog of **yeast Erv1**, a **FAD-linked sulfhydryl oxidase** functioning in the **mitochondrial IMS disulfide relay**. This matches the UniProt P55789 description (FAD-linked sulfhydryl oxidase ALR; EC 1.8.3.2; aliases ALR/HERV1/HPO). (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 16-19)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/GFER/GFER-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ALR/GFER is a **FAD-dependent sulfhydryl oxidase** whose direct physiological substrate is the **reduced CPC motif of MIA40/CHCHD4**. It accepts electrons from reduced MIA40, transfers them through its own redox-active cysteine motifs to FAD, and then reduces downstream electron acceptors (primarily cytochrome c), thereby enabling repeated rounds of oxidative folding and IMS protein biogenesis. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 25-31)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/GFER/GFER-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">| Enzymatic activity (EC 1.8.3.2) | GFER/ALR is a **sulfhydryl oxidase** that re-oxidizes **MIA40/CHCHD4** after MIA40 oxidizes incoming IMS substrates. Electron flow is **substrate thiols → MIA40 CPC → ALR shuttle motif → ALR core CXXC/CAAC-CEEC → FAD → terminal acceptor (primarily cytochrome c, alternatively O2)**, thereby enabling de novo disulfide formation and repeated oxidative folding cycles. | (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 25-31, finger2020proteinimportby pages 8-10) | 2024-06, https://doi.org/10.1002/2211-5463.13839 ; 2020-03, https://doi.org/10.1515/hsz-2020-0108 |</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001889" target="_blank" class="term-link">
+                                    GO:0001889
+                                </a>
+                            </span>
+                            <span class="term-label">liver development</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P55789" data-a="GO:0001889" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Keep as non-core. ALR has historical growth factor/liver-regeneration biology, but the primary mechanistically defined function of UniProt P55789 is IMS sulfhydryl oxidase activity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Liver development/regeneration is a downstream or isoform/context-associated phenotype, not the core molecular function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/GFER/GFER-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Older review literature notes reports of non-mitochondrial ALR forms (cytosolic/nuclear/secreted growth factor activities), but for **functional annotation of UniProt P55789**, the mechanistically defined and disease-linked role is the mitochondrial IMS sulfhydryl oxidase in the disulfide relay. (fischer2013themitochondrialdisulfide pages 6-7)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20593814" target="_blank" class="term-link">
+                                        PMID:20593814
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The short form (sfALR, 15 kDa; starting at M81 of the human long form, lfALR, sequence depicted in Figure 1A) is a circulating growth factor (11, 12, 15, 17, 18) and interacts with specific receptors on the cell surface (19, 20).</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
+                                    GO:0005576
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular region</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P55789" data-a="GO:0005576" data-r="GO_REF:0000044" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Keep as non-core. extracellular region is consistent with reports of short/non-mitochondrial ALR forms, but the core reviewed function is long ALR in the mitochondrial intermembrane space.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Retain as non-core because non-mitochondrial ALR forms are reported, while prioritizing IMS disulfide-relay function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/GFER/GFER-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A hepatology review summarizes **two principal ALR isoforms**, approximately **~15 kDa (short)** and **~22 kDa (long)**; the **long isoform** functions in the mitochondrial IMS as a core MIA/disulfide relay component. (nalesnik2017augmenterofliver pages 1-4)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/GFER/GFER-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Older review literature notes reports of non-mitochondrial ALR forms (cytosolic/nuclear/secreted growth factor activities), but for **functional annotation of UniProt P55789**, the mechanistically defined and disease-linked role is the mitochondrial IMS sulfhydryl oxidase in the disulfide relay. (fischer2013themitochondrialdisulfide pages 6-7)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                    GO:0005737
+                                </a>
+                            </span>
+                            <span class="term-label">cytoplasm</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P55789" data-a="GO:0005737" data-r="GO_REF:0000044" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Keep as non-core. cytoplasm is consistent with reports of short/non-mitochondrial ALR forms, but the core reviewed function is long ALR in the mitochondrial intermembrane space.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Retain as non-core because non-mitochondrial ALR forms are reported, while prioritizing IMS disulfide-relay function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/GFER/GFER-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A hepatology review summarizes **two principal ALR isoforms**, approximately **~15 kDa (short)** and **~22 kDa (long)**; the **long isoform** functions in the mitochondrial IMS as a core MIA/disulfide relay component. (nalesnik2017augmenterofliver pages 1-4)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/GFER/GFER-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Older review literature notes reports of non-mitochondrial ALR forms (cytosolic/nuclear/secreted growth factor activities), but for **functional annotation of UniProt P55789**, the mechanistically defined and disease-linked role is the mitochondrial IMS sulfhydryl oxidase in the disulfide relay. (fischer2013themitochondrialdisulfide pages 6-7)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P55789" data-a="GO:0005739" data-r="GO_REF:0000044" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct but broad. GFER/long ALR is specifically localized to the mitochondrial intermembrane space.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Prefer mitochondrial intermembrane space and mitochondrial disulfide relay system over generic mitochondrion.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/GFER/GFER-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The best-supported primary functional localization of long ALR is the **mitochondrial intermembrane space**, where it operates in oxidative folding/protein import with MIA40. (zarges2024oxidativeproteinfolding pages 8-9, nalesnik2017augmenterofliver pages 1-4)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005758" target="_blank" class="term-link">
+                                    GO:0005758
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial intermembrane space</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P55789" data-a="GO:0005758" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct and core. Long ALR/GFER functions in the mitochondrial intermembrane space.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/GFER/GFER-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The best-supported primary functional localization of long ALR is the **mitochondrial intermembrane space**, where it operates in oxidative folding/protein import with MIA40. (zarges2024oxidativeproteinfolding pages 8-9, nalesnik2017augmenterofliver pages 1-4)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/GFER/GFER-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A hepatology review summarizes **two principal ALR isoforms**, approximately **~15 kDa (short)** and **~22 kDa (long)**; the **long isoform** functions in the mitochondrial IMS as a core MIA/disulfide relay component. (nalesnik2017augmenterofliver pages 1-4)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015035" target="_blank" class="term-link">
+                                    GO:0015035
+                                </a>
+                            </span>
+                            <span class="term-label">protein-disulfide reductase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="P55789" data-a="GO:0015035" data-r="GO_REF:0000117" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> The disulfide-relay context is right, but reductase is the wrong direction for GFER. GFER oxidizes thiols/re-oxidizes MIA40 as a sulfhydryl oxidase.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Replace protein-disulfide reductase activity with sulfhydryl/thiol oxidase activity for GFER.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016971" target="_blank" class="term-link">
+                                    flavin-dependent sulfhydryl oxidase activity
+                                </a>
+                            </span>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016972" target="_blank" class="term-link">
+                                    thiol oxidase activity
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/GFER/GFER-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The IMS contains an oxidative folding/import pathway in which incoming cysteine-rich proteins are oxidized and trapped in the IMS by formation of disulfide bonds. In mammals, the core catalytic pair is **MIA40/CHCHD4 (oxidoreductase)** and **ALR/GFER (sulfhydryl oxidase)**. ALR’s central biochemical function is to **regenerate oxidized MIA40** after MIA40 transfers disulfides to substrates. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 8-10)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/GFER/GFER-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ALR/GFER is a **FAD-dependent sulfhydryl oxidase** whose direct physiological substrate is the **reduced CPC motif of MIA40/CHCHD4**. It accepts electrons from reduced MIA40, transfers them through its own redox-active cysteine motifs to FAD, and then reduces downstream electron acceptors (primarily cytochrome c), thereby enabling repeated rounds of oxidative folding and IMS protein biogenesis. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 25-31)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/GFER/GFER-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">| Enzymatic activity (EC 1.8.3.2) | GFER/ALR is a **sulfhydryl oxidase** that re-oxidizes **MIA40/CHCHD4** after MIA40 oxidizes incoming IMS substrates. Electron flow is **substrate thiols → MIA40 CPC → ALR shuttle motif → ALR core CXXC/CAAC-CEEC → FAD → terminal acceptor (primarily cytochrome c, alternatively O2)**, thereby enabling de novo disulfide formation and repeated oxidative folding cycles. | (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 25-31, finger2020proteinimportby pages 8-10) | 2024-06, https://doi.org/10.1002/2211-5463.13839 ; 2020-03, https://doi.org/10.1515/hsz-2020-0108 |</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016971" target="_blank" class="term-link">
+                                    GO:0016971
+                                </a>
+                            </span>
+                            <span class="term-label">flavin-dependent sulfhydryl oxidase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P55789" data-a="GO:0016971" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct and core. GFER/ALR is the FAD-linked sulfhydryl oxidase of the mitochondrial disulfide relay.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/GFER/GFER-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The literature retrieved consistently maps **human GFER** to **ALR (augmenter of liver regeneration)** and the mammalian homolog of **yeast Erv1**, a **FAD-linked sulfhydryl oxidase** functioning in the **mitochondrial IMS disulfide relay**. This matches the UniProt P55789 description (FAD-linked sulfhydryl oxidase ALR; EC 1.8.3.2; aliases ALR/HERV1/HPO). (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 16-19)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/GFER/GFER-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ALR/GFER is a **FAD-dependent sulfhydryl oxidase** whose direct physiological substrate is the **reduced CPC motif of MIA40/CHCHD4**. It accepts electrons from reduced MIA40, transfers them through its own redox-active cysteine motifs to FAD, and then reduces downstream electron acceptors (primarily cytochrome c), thereby enabling repeated rounds of oxidative folding and IMS protein biogenesis. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 25-31)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/GFER/GFER-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">| Enzymatic activity (EC 1.8.3.2) | GFER/ALR is a **sulfhydryl oxidase** that re-oxidizes **MIA40/CHCHD4** after MIA40 oxidizes incoming IMS substrates. Electron flow is **substrate thiols → MIA40 CPC → ALR shuttle motif → ALR core CXXC/CAAC-CEEC → FAD → terminal acceptor (primarily cytochrome c, alternatively O2)**, thereby enabling de novo disulfide formation and repeated oxidative folding cycles. | (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 25-31, finger2020proteinimportby pages 8-10) | 2024-06, https://doi.org/10.1002/2211-5463.13839 ; 2020-03, https://doi.org/10.1515/hsz-2020-0108 |</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016972" target="_blank" class="term-link">
+                                    GO:0016972
+                                </a>
+                            </span>
+                            <span class="term-label">thiol oxidase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P55789" data-a="GO:0016972" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct. Thiol oxidase activity captures the sulfhydryl oxidase chemistry of ALR/GFER.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/GFER/GFER-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ALR/GFER is a **FAD-dependent sulfhydryl oxidase** whose direct physiological substrate is the **reduced CPC motif of MIA40/CHCHD4**. It accepts electrons from reduced MIA40, transfers them through its own redox-active cysteine motifs to FAD, and then reduces downstream electron acceptors (primarily cytochrome c), thereby enabling repeated rounds of oxidative folding and IMS protein biogenesis. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 25-31)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/GFER/GFER-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">| Enzymatic activity (EC 1.8.3.2) | GFER/ALR is a **sulfhydryl oxidase** that re-oxidizes **MIA40/CHCHD4** after MIA40 oxidizes incoming IMS substrates. Electron flow is **substrate thiols → MIA40 CPC → ALR shuttle motif → ALR core CXXC/CAAC-CEEC → FAD → terminal acceptor (primarily cytochrome c, alternatively O2)**, thereby enabling de novo disulfide formation and repeated oxidative folding cycles. | (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 25-31, finger2020proteinimportby pages 8-10) | 2024-06, https://doi.org/10.1002/2211-5463.13839 ; 2020-03, https://doi.org/10.1515/hsz-2020-0108 |</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25416956" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25416956
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A proteome-scale map of the human interactome network.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P55789" data-a="GO:0005515" data-r="PMID:25416956" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Protein binding is too generic for GFER. The informative role is FAD-dependent sulfhydryl oxidase activity in the MIA40/CHCHD4 disulfide relay.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Replace generic interaction capture with sulfhydryl oxidase activity and mitochondrial disulfide relay system annotations.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/GFER/GFER-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The IMS contains an oxidative folding/import pathway in which incoming cysteine-rich proteins are oxidized and trapped in the IMS by formation of disulfide bonds. In mammals, the core catalytic pair is **MIA40/CHCHD4 (oxidoreductase)** and **ALR/GFER (sulfhydryl oxidase)**. ALR’s central biochemical function is to **regenerate oxidized MIA40** after MIA40 transfers disulfides to substrates. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 8-10)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/GFER/GFER-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ALR/GFER is a **FAD-dependent sulfhydryl oxidase** whose direct physiological substrate is the **reduced CPC motif of MIA40/CHCHD4**. It accepts electrons from reduced MIA40, transfers them through its own redox-active cysteine motifs to FAD, and then reduces downstream electron acceptors (primarily cytochrome c), thereby enabling repeated rounds of oxidative folding and IMS protein biogenesis. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 25-31)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/32353859" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:32353859
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A SARS-CoV-2 protein interaction map reveals targets for dru...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P55789" data-a="GO:0005515" data-r="PMID:32353859" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Protein binding is too generic for GFER. The informative role is FAD-dependent sulfhydryl oxidase activity in the MIA40/CHCHD4 disulfide relay.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Replace generic interaction capture with sulfhydryl oxidase activity and mitochondrial disulfide relay system annotations.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/GFER/GFER-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The IMS contains an oxidative folding/import pathway in which incoming cysteine-rich proteins are oxidized and trapped in the IMS by formation of disulfide bonds. In mammals, the core catalytic pair is **MIA40/CHCHD4 (oxidoreductase)** and **ALR/GFER (sulfhydryl oxidase)**. ALR’s central biochemical function is to **regenerate oxidized MIA40** after MIA40 transfers disulfides to substrates. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 8-10)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/GFER/GFER-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ALR/GFER is a **FAD-dependent sulfhydryl oxidase** whose direct physiological substrate is the **reduced CPC motif of MIA40/CHCHD4**. It accepts electrons from reduced MIA40, transfers them through its own redox-active cysteine motifs to FAD, and then reduces downstream electron acceptors (primarily cytochrome c), thereby enabling repeated rounds of oxidative folding and IMS protein biogenesis. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 25-31)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/33060197" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:33060197
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Comparative host-coronavirus protein interaction networks re...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P55789" data-a="GO:0005515" data-r="PMID:33060197" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Protein binding is too generic for GFER. The informative role is FAD-dependent sulfhydryl oxidase activity in the MIA40/CHCHD4 disulfide relay.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Replace generic interaction capture with sulfhydryl oxidase activity and mitochondrial disulfide relay system annotations.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/GFER/GFER-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The IMS contains an oxidative folding/import pathway in which incoming cysteine-rich proteins are oxidized and trapped in the IMS by formation of disulfide bonds. In mammals, the core catalytic pair is **MIA40/CHCHD4 (oxidoreductase)** and **ALR/GFER (sulfhydryl oxidase)**. ALR’s central biochemical function is to **regenerate oxidized MIA40** after MIA40 transfers disulfides to substrates. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 8-10)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/GFER/GFER-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ALR/GFER is a **FAD-dependent sulfhydryl oxidase** whose direct physiological substrate is the **reduced CPC motif of MIA40/CHCHD4**. It accepts electrons from reduced MIA40, transfers them through its own redox-active cysteine motifs to FAD, and then reduces downstream electron acceptors (primarily cytochrome c), thereby enabling repeated rounds of oxidative folding and IMS protein biogenesis. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 25-31)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/36217030" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:36217030
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A comprehensive SARS-CoV-2-human protein-protein interactome...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P55789" data-a="GO:0005515" data-r="PMID:36217030" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Protein binding is too generic for GFER. The informative role is FAD-dependent sulfhydryl oxidase activity in the MIA40/CHCHD4 disulfide relay.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Replace generic interaction capture with sulfhydryl oxidase activity and mitochondrial disulfide relay system annotations.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/GFER/GFER-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The IMS contains an oxidative folding/import pathway in which incoming cysteine-rich proteins are oxidized and trapped in the IMS by formation of disulfide bonds. In mammals, the core catalytic pair is **MIA40/CHCHD4 (oxidoreductase)** and **ALR/GFER (sulfhydryl oxidase)**. ALR’s central biochemical function is to **regenerate oxidized MIA40** after MIA40 transfers disulfides to substrates. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 8-10)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/GFER/GFER-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ALR/GFER is a **FAD-dependent sulfhydryl oxidase** whose direct physiological substrate is the **reduced CPC motif of MIA40/CHCHD4**. It accepts electrons from reduced MIA40, transfers them through its own redox-active cysteine motifs to FAD, and then reduces downstream electron acceptors (primarily cytochrome c), thereby enabling repeated rounds of oxidative folding and IMS protein biogenesis. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 25-31)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000052
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P55789" data-a="GO:0005739" data-r="GO_REF:0000052" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct but broad. GFER/long ALR is specifically localized to the mitochondrial intermembrane space.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Prefer mitochondrial intermembrane space and mitochondrial disulfide relay system over generic mitochondrion.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/GFER/GFER-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The best-supported primary functional localization of long ALR is the **mitochondrial intermembrane space**, where it operates in oxidative folding/protein import with MIA40. (zarges2024oxidativeproteinfolding pages 8-9, nalesnik2017augmenterofliver pages 1-4)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                    GO:0005829
+                                </a>
+                            </span>
+                            <span class="term-label">cytosol</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000052
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P55789" data-a="GO:0005829" data-r="GO_REF:0000052" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Keep as non-core. cytosol is consistent with reports of short/non-mitochondrial ALR forms, but the core reviewed function is long ALR in the mitochondrial intermembrane space.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Retain as non-core because non-mitochondrial ALR forms are reported, while prioritizing IMS disulfide-relay function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/GFER/GFER-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A hepatology review summarizes **two principal ALR isoforms**, approximately **~15 kDa (short)** and **~22 kDa (long)**; the **long isoform** functions in the mitochondrial IMS as a core MIA/disulfide relay component. (nalesnik2017augmenterofliver pages 1-4)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/GFER/GFER-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Older review literature notes reports of non-mitochondrial ALR forms (cytosolic/nuclear/secreted growth factor activities), but for **functional annotation of UniProt P55789**, the mechanistically defined and disease-linked role is the mitochondrial IMS sulfhydryl oxidase in the disulfide relay. (fischer2013themitochondrialdisulfide pages 6-7)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016971" target="_blank" class="term-link">
+                                    GO:0016971
+                                </a>
+                            </span>
+                            <span class="term-label">flavin-dependent sulfhydryl oxidase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20593814" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:20593814
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structure of the human sulfhydryl oxidase augmenter of liver...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P55789" data-a="GO:0016971" data-r="PMID:20593814" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct and core. GFER/ALR is the FAD-linked sulfhydryl oxidase of the mitochondrial disulfide relay.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/GFER/GFER-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The literature retrieved consistently maps **human GFER** to **ALR (augmenter of liver regeneration)** and the mammalian homolog of **yeast Erv1**, a **FAD-linked sulfhydryl oxidase** functioning in the **mitochondrial IMS disulfide relay**. This matches the UniProt P55789 description (FAD-linked sulfhydryl oxidase ALR; EC 1.8.3.2; aliases ALR/HERV1/HPO). (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 16-19)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/GFER/GFER-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ALR/GFER is a **FAD-dependent sulfhydryl oxidase** whose direct physiological substrate is the **reduced CPC motif of MIA40/CHCHD4**. It accepts electrons from reduced MIA40, transfers them through its own redox-active cysteine motifs to FAD, and then reduces downstream electron acceptors (primarily cytochrome c), thereby enabling repeated rounds of oxidative folding and IMS protein biogenesis. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 25-31)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/GFER/GFER-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">| Enzymatic activity (EC 1.8.3.2) | GFER/ALR is a **sulfhydryl oxidase** that re-oxidizes **MIA40/CHCHD4** after MIA40 oxidizes incoming IMS substrates. Electron flow is **substrate thiols → MIA40 CPC → ALR shuttle motif → ALR core CXXC/CAAC-CEEC → FAD → terminal acceptor (primarily cytochrome c, alternatively O2)**, thereby enabling de novo disulfide formation and repeated oxidative folding cycles. | (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 25-31, finger2020proteinimportby pages 8-10) | 2024-06, https://doi.org/10.1002/2211-5463.13839 ; 2020-03, https://doi.org/10.1515/hsz-2020-0108 |</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016971" target="_blank" class="term-link">
+                                    GO:0016971
+                                </a>
+                            </span>
+                            <span class="term-label">flavin-dependent sulfhydryl oxidase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/22224850" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:22224850
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    An electron-transfer path through an extended disulfide rela...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P55789" data-a="GO:0016971" data-r="PMID:22224850" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct and core. GFER/ALR is the FAD-linked sulfhydryl oxidase of the mitochondrial disulfide relay.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/GFER/GFER-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The literature retrieved consistently maps **human GFER** to **ALR (augmenter of liver regeneration)** and the mammalian homolog of **yeast Erv1**, a **FAD-linked sulfhydryl oxidase** functioning in the **mitochondrial IMS disulfide relay**. This matches the UniProt P55789 description (FAD-linked sulfhydryl oxidase ALR; EC 1.8.3.2; aliases ALR/HERV1/HPO). (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 16-19)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/GFER/GFER-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ALR/GFER is a **FAD-dependent sulfhydryl oxidase** whose direct physiological substrate is the **reduced CPC motif of MIA40/CHCHD4**. It accepts electrons from reduced MIA40, transfers them through its own redox-active cysteine motifs to FAD, and then reduces downstream electron acceptors (primarily cytochrome c), thereby enabling repeated rounds of oxidative folding and IMS protein biogenesis. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 25-31)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/GFER/GFER-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">| Enzymatic activity (EC 1.8.3.2) | GFER/ALR is a **sulfhydryl oxidase** that re-oxidizes **MIA40/CHCHD4** after MIA40 oxidizes incoming IMS substrates. Electron flow is **substrate thiols → MIA40 CPC → ALR shuttle motif → ALR core CXXC/CAAC-CEEC → FAD → terminal acceptor (primarily cytochrome c, alternatively O2)**, thereby enabling de novo disulfide formation and repeated oxidative folding cycles. | (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 25-31, finger2020proteinimportby pages 8-10) | 2024-06, https://doi.org/10.1002/2211-5463.13839 ; 2020-03, https://doi.org/10.1515/hsz-2020-0108 |</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016972" target="_blank" class="term-link">
+                                    GO:0016972
+                                </a>
+                            </span>
+                            <span class="term-label">thiol oxidase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20593814" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:20593814
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structure of the human sulfhydryl oxidase augmenter of liver...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P55789" data-a="GO:0016972" data-r="PMID:20593814" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct. Thiol oxidase activity captures the sulfhydryl oxidase chemistry of ALR/GFER.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/GFER/GFER-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ALR/GFER is a **FAD-dependent sulfhydryl oxidase** whose direct physiological substrate is the **reduced CPC motif of MIA40/CHCHD4**. It accepts electrons from reduced MIA40, transfers them through its own redox-active cysteine motifs to FAD, and then reduces downstream electron acceptors (primarily cytochrome c), thereby enabling repeated rounds of oxidative folding and IMS protein biogenesis. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 25-31)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/GFER/GFER-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">| Enzymatic activity (EC 1.8.3.2) | GFER/ALR is a **sulfhydryl oxidase** that re-oxidizes **MIA40/CHCHD4** after MIA40 oxidizes incoming IMS substrates. Electron flow is **substrate thiols → MIA40 CPC → ALR shuttle motif → ALR core CXXC/CAAC-CEEC → FAD → terminal acceptor (primarily cytochrome c, alternatively O2)**, thereby enabling de novo disulfide formation and repeated oxidative folding cycles. | (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 25-31, finger2020proteinimportby pages 8-10) | 2024-06, https://doi.org/10.1002/2211-5463.13839 ; 2020-03, https://doi.org/10.1515/hsz-2020-0108 |</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016972" target="_blank" class="term-link">
+                                    GO:0016972
+                                </a>
+                            </span>
+                            <span class="term-label">thiol oxidase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/22224850" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:22224850
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    An electron-transfer path through an extended disulfide rela...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P55789" data-a="GO:0016972" data-r="PMID:22224850" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct. Thiol oxidase activity captures the sulfhydryl oxidase chemistry of ALR/GFER.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/GFER/GFER-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ALR/GFER is a **FAD-dependent sulfhydryl oxidase** whose direct physiological substrate is the **reduced CPC motif of MIA40/CHCHD4**. It accepts electrons from reduced MIA40, transfers them through its own redox-active cysteine motifs to FAD, and then reduces downstream electron acceptors (primarily cytochrome c), thereby enabling repeated rounds of oxidative folding and IMS protein biogenesis. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 25-31)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/GFER/GFER-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">| Enzymatic activity (EC 1.8.3.2) | GFER/ALR is a **sulfhydryl oxidase** that re-oxidizes **MIA40/CHCHD4** after MIA40 oxidizes incoming IMS substrates. Electron flow is **substrate thiols → MIA40 CPC → ALR shuttle motif → ALR core CXXC/CAAC-CEEC → FAD → terminal acceptor (primarily cytochrome c, alternatively O2)**, thereby enabling de novo disulfide formation and repeated oxidative folding cycles. | (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 25-31, finger2020proteinimportby pages 8-10) | 2024-06, https://doi.org/10.1002/2211-5463.13839 ; 2020-03, https://doi.org/10.1515/hsz-2020-0108 |</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0160203" target="_blank" class="term-link">
+                                    GO:0160203
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial disulfide relay system</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/21383138" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:21383138
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Molecular recognition and substrate mimicry drive the electr...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P55789" data-a="GO:0160203" data-r="PMID:21383138" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct and core. GFER/ALR re-oxidizes MIA40/CHCHD4 in the mitochondrial disulfide relay system.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/GFER/GFER-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The IMS contains an oxidative folding/import pathway in which incoming cysteine-rich proteins are oxidized and trapped in the IMS by formation of disulfide bonds. In mammals, the core catalytic pair is **MIA40/CHCHD4 (oxidoreductase)** and **ALR/GFER (sulfhydryl oxidase)**. ALR’s central biochemical function is to **regenerate oxidized MIA40** after MIA40 transfers disulfides to substrates. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 8-10)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/GFER/GFER-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ALR/GFER is a **FAD-dependent sulfhydryl oxidase** whose direct physiological substrate is the **reduced CPC motif of MIA40/CHCHD4**. It accepts electrons from reduced MIA40, transfers them through its own redox-active cysteine motifs to FAD, and then reduces downstream electron acceptors (primarily cytochrome c), thereby enabling repeated rounds of oxidative folding and IMS protein biogenesis. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 25-31)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/GFER/GFER-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">| Enzymatic activity (EC 1.8.3.2) | GFER/ALR is a **sulfhydryl oxidase** that re-oxidizes **MIA40/CHCHD4** after MIA40 oxidizes incoming IMS substrates. Electron flow is **substrate thiols → MIA40 CPC → ALR shuttle motif → ALR core CXXC/CAAC-CEEC → FAD → terminal acceptor (primarily cytochrome c, alternatively O2)**, thereby enabling de novo disulfide formation and repeated oxidative folding cycles. | (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 25-31, finger2020proteinimportby pages 8-10) | 2024-06, https://doi.org/10.1002/2211-5463.13839 ; 2020-03, https://doi.org/10.1515/hsz-2020-0108 |</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HTP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:34800366
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Quantitative high-confidence human mitochondrial proteome an...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P55789" data-a="GO:0005739" data-r="PMID:34800366" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct but broad. GFER/long ALR is specifically localized to the mitochondrial intermembrane space.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Prefer mitochondrial intermembrane space and mitochondrial disulfide relay system over generic mitochondrion.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/GFER/GFER-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The best-supported primary functional localization of long ALR is the **mitochondrial intermembrane space**, where it operates in oxidative folding/protein import with MIA40. (zarges2024oxidativeproteinfolding pages 8-9, nalesnik2017augmenterofliver pages 1-4)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/23676665" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:23676665
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Protein import and oxidative folding in the mitochondrial in...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P55789" data-a="GO:0005515" data-r="PMID:23676665" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Protein binding is too generic for GFER. The informative role is FAD-dependent sulfhydryl oxidase activity in the MIA40/CHCHD4 disulfide relay.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Replace generic interaction capture with sulfhydryl oxidase activity and mitochondrial disulfide relay system annotations.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/GFER/GFER-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The IMS contains an oxidative folding/import pathway in which incoming cysteine-rich proteins are oxidized and trapped in the IMS by formation of disulfide bonds. In mammals, the core catalytic pair is **MIA40/CHCHD4 (oxidoreductase)** and **ALR/GFER (sulfhydryl oxidase)**. ALR’s central biochemical function is to **regenerate oxidized MIA40** after MIA40 transfers disulfides to substrates. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 8-10)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/GFER/GFER-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ALR/GFER is a **FAD-dependent sulfhydryl oxidase** whose direct physiological substrate is the **reduced CPC motif of MIA40/CHCHD4**. It accepts electrons from reduced MIA40, transfers them through its own redox-active cysteine motifs to FAD, and then reduces downstream electron acceptors (primarily cytochrome c), thereby enabling repeated rounds of oxidative folding and IMS protein biogenesis. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 25-31)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/23676665" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:23676665
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Protein import and oxidative folding in the mitochondrial in...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P55789" data-a="GO:0005739" data-r="PMID:23676665" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct but broad. GFER/long ALR is specifically localized to the mitochondrial intermembrane space.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Prefer mitochondrial intermembrane space and mitochondrial disulfide relay system over generic mitochondrion.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/GFER/GFER-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The best-supported primary functional localization of long ALR is the **mitochondrial intermembrane space**, where it operates in oxidative folding/protein import with MIA40. (zarges2024oxidativeproteinfolding pages 8-9, nalesnik2017augmenterofliver pages 1-4)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015035" target="_blank" class="term-link">
+                                    GO:0015035
+                                </a>
+                            </span>
+                            <span class="term-label">protein-disulfide reductase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/22224850" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:22224850
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    An electron-transfer path through an extended disulfide rela...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="P55789" data-a="GO:0015035" data-r="PMID:22224850" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> The disulfide-relay context is right, but reductase is the wrong direction for GFER. GFER oxidizes thiols/re-oxidizes MIA40 as a sulfhydryl oxidase.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Replace protein-disulfide reductase activity with sulfhydryl/thiol oxidase activity for GFER.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016971" target="_blank" class="term-link">
+                                    flavin-dependent sulfhydryl oxidase activity
+                                </a>
+                            </span>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016972" target="_blank" class="term-link">
+                                    thiol oxidase activity
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/GFER/GFER-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The IMS contains an oxidative folding/import pathway in which incoming cysteine-rich proteins are oxidized and trapped in the IMS by formation of disulfide bonds. In mammals, the core catalytic pair is **MIA40/CHCHD4 (oxidoreductase)** and **ALR/GFER (sulfhydryl oxidase)**. ALR’s central biochemical function is to **regenerate oxidized MIA40** after MIA40 transfers disulfides to substrates. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 8-10)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/GFER/GFER-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ALR/GFER is a **FAD-dependent sulfhydryl oxidase** whose direct physiological substrate is the **reduced CPC motif of MIA40/CHCHD4**. It accepts electrons from reduced MIA40, transfers them through its own redox-active cysteine motifs to FAD, and then reduces downstream electron acceptors (primarily cytochrome c), thereby enabling repeated rounds of oxidative folding and IMS protein biogenesis. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 25-31)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/GFER/GFER-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">| Enzymatic activity (EC 1.8.3.2) | GFER/ALR is a **sulfhydryl oxidase** that re-oxidizes **MIA40/CHCHD4** after MIA40 oxidizes incoming IMS substrates. Electron flow is **substrate thiols → MIA40 CPC → ALR shuttle motif → ALR core CXXC/CAAC-CEEC → FAD → terminal acceptor (primarily cytochrome c, alternatively O2)**, thereby enabling de novo disulfide formation and repeated oxidative folding cycles. | (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 25-31, finger2020proteinimportby pages 8-10) | 2024-06, https://doi.org/10.1002/2211-5463.13839 ; 2020-03, https://doi.org/10.1515/hsz-2020-0108 |</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050660" target="_blank" class="term-link">
+                                    GO:0050660
+                                </a>
+                            </span>
+                            <span class="term-label">flavin adenine dinucleotide binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/22224850" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:22224850
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    An electron-transfer path through an extended disulfide rela...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P55789" data-a="GO:0050660" data-r="PMID:22224850" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct. GFER/ALR is a FAD-linked sulfhydryl oxidase with a noncovalently bound FAD cofactor.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/GFER/GFER-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The literature retrieved consistently maps **human GFER** to **ALR (augmenter of liver regeneration)** and the mammalian homolog of **yeast Erv1**, a **FAD-linked sulfhydryl oxidase** functioning in the **mitochondrial IMS disulfide relay**. This matches the UniProt P55789 description (FAD-linked sulfhydryl oxidase ALR; EC 1.8.3.2; aliases ALR/HERV1/HPO). (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 16-19)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/GFER/GFER-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">- ALR contains an **N-terminal shuttle domain** with a redox-active **CRAC** motif and a **core domain** containing a redox-active **CAAC (CXXC-like)** motif and a **noncovalently bound FAD**. (zarges2024oxidativeproteinfolding pages 8-9)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12681488" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12681488
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The apoptosis-associated protein BNIPL interacts with two ce...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P55789" data-a="GO:0005515" data-r="PMID:12681488" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Protein binding is too generic for GFER. The informative role is FAD-dependent sulfhydryl oxidase activity in the MIA40/CHCHD4 disulfide relay.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Replace generic interaction capture with sulfhydryl oxidase activity and mitochondrial disulfide relay system annotations.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/GFER/GFER-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The IMS contains an oxidative folding/import pathway in which incoming cysteine-rich proteins are oxidized and trapped in the IMS by formation of disulfide bonds. In mammals, the core catalytic pair is **MIA40/CHCHD4 (oxidoreductase)** and **ALR/GFER (sulfhydryl oxidase)**. ALR’s central biochemical function is to **regenerate oxidized MIA40** after MIA40 transfers disulfides to substrates. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 8-10)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/GFER/GFER-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ALR/GFER is a **FAD-dependent sulfhydryl oxidase** whose direct physiological substrate is the **reduced CPC motif of MIA40/CHCHD4**. It accepts electrons from reduced MIA40, transfers them through its own redox-active cysteine motifs to FAD, and then reduces downstream electron acceptors (primarily cytochrome c), thereby enabling repeated rounds of oxidative folding and IMS protein biogenesis. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 25-31)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>GFER/ALR is the FAD-dependent sulfhydryl oxidase of the mitochondrial intermembrane-space disulfide relay. It re-oxidizes MIA40/CHCHD4 after substrate oxidation, passing electrons through ALR redox cysteine motifs to FAD and downstream acceptors to support oxidative folding and retention of cysteine-rich IMS proteins.</h3>
+                <span class="vote-buttons" data-g="P55789" data-a="FUNCTION: GFER/ALR is the FAD-dependent sulfhydryl oxidase o..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016971" target="_blank" class="term-link">
+                            flavin-dependent sulfhydryl oxidase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0160203" target="_blank" class="term-link">
+                                mitochondrial disulfide relay system
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005758" target="_blank" class="term-link">
+                                mitochondrial intermembrane space
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/GFER/GFER-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">The literature retrieved consistently maps **human GFER** to **ALR (augmenter of liver regeneration)** and the mammalian homolog of **yeast Erv1**, a **FAD-linked sulfhydryl oxidase** functioning in the **mitochondrial IMS disulfide relay**. This matches the UniProt P55789 description (FAD-linked sulfhydryl oxidase ALR; EC 1.8.3.2; aliases ALR/HERV1/HPO). (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 16-19)</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/GFER/GFER-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">The IMS contains an oxidative folding/import pathway in which incoming cysteine-rich proteins are oxidized and trapped in the IMS by formation of disulfide bonds. In mammals, the core catalytic pair is **MIA40/CHCHD4 (oxidoreductase)** and **ALR/GFER (sulfhydryl oxidase)**. ALR’s central biochemical function is to **regenerate oxidized MIA40** after MIA40 transfers disulfides to substrates. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 8-10)</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/GFER/GFER-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">ALR/GFER is a **FAD-dependent sulfhydryl oxidase** whose direct physiological substrate is the **reduced CPC motif of MIA40/CHCHD4**. It accepts electrons from reduced MIA40, transfers them through its own redox-active cysteine motifs to FAD, and then reduces downstream electron acceptors (primarily cytochrome c), thereby enabling repeated rounds of oxidative folding and IMS protein biogenesis. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 25-31)</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/GFER/GFER-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">The best-supported primary functional localization of long ALR is the **mitochondrial intermembrane space**, where it operates in oxidative folding/protein import with MIA40. (zarges2024oxidativeproteinfolding pages 8-9, nalesnik2017augmenterofliver pages 1-4)</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/GFER/GFER-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">| Enzymatic activity (EC 1.8.3.2) | GFER/ALR is a **sulfhydryl oxidase** that re-oxidizes **MIA40/CHCHD4** after MIA40 oxidizes incoming IMS substrates. Electron flow is **substrate thiols → MIA40 CPC → ALR shuttle motif → ALR core CXXC/CAAC-CEEC → FAD → terminal acceptor (primarily cytochrome c, alternatively O2)**, thereby enabling de novo disulfide formation and repeated oxidative folding cycles. | (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 25-31, finger2020proteinimportby pages 8-10) | 2024-06, https://doi.org/10.1002/2211-5463.13839 ; 2020-03, https://doi.org/10.1515/hsz-2020-0108 |</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000052.md" target="_blank" class="term-link">
+                            GO_REF:0000052
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on curation of immunofluorescence data</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
+                            GO_REF:0000117
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/12681488" target="_blank" class="term-link">
+                            PMID:12681488
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The apoptosis-associated protein BNIPL interacts with two cell proliferation-related proteins, MIF and GFER.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/20593814" target="_blank" class="term-link">
+                            PMID:20593814
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Structure of the human sulfhydryl oxidase augmenter of liver regeneration and characterization of a human mutation causing an autosomal recessive myopathy .</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/21383138" target="_blank" class="term-link">
+                            PMID:21383138
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Molecular recognition and substrate mimicry drive the electron-transfer process between MIA40 and ALR.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/22224850" target="_blank" class="term-link">
+                            PMID:22224850
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">An electron-transfer path through an extended disulfide relay system: the case of the redox protein ALR.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/23676665" target="_blank" class="term-link">
+                            PMID:23676665
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Protein import and oxidative folding in the mitochondrial intermembrane space of intact mammalian cells.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/25416956" target="_blank" class="term-link">
+                            PMID:25416956
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A proteome-scale map of the human interactome network.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/32353859" target="_blank" class="term-link">
+                            PMID:32353859
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A SARS-CoV-2 protein interaction map reveals targets for drug repurposing.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/33060197" target="_blank" class="term-link">
+                            PMID:33060197
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Comparative host-coronavirus protein interaction networks reveal pan-viral disease mechanisms.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link">
+                            PMID:34800366
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Quantitative high-confidence human mitochondrial proteome and its dynamics in cellular context.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/36217030" target="_blank" class="term-link">
+                            PMID:36217030
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A comprehensive SARS-CoV-2-human protein-protein interactome reveals COVID-19 pathobiology and potential host therapeutic targets.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/GFER/GFER-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research report for human GFER</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> How do short and long GFER/ALR isoforms divide mitochondrial IMS oxidase function from reported cytosolic or extracellular activities?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P55789" data-a="Q: How do short and long GFER/ALR isoforms divide mit..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Which ALR electron acceptor routes dominate in human cells under respiratory stress or MIA pathway inhibition?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P55789" data-a="Q: Which ALR electron acceptor routes dominate in hum..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Rescue GFER-deficient cells with wild-type and variant ALR, then quantify FAD retention, MIA40 redox state, import/oxidation of cysteine-rich IMS substrates, and respiratory complex assembly.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: Disease-associated GFER variants primarily impair IMS substrate biogenesis by destabilizing FAD-linked ALR rather than abolishing all residual catalytic chemistry.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="P55789" data-a="EXPERIMENT: Rescue GFER-deficient cells with wild-type and var..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Express isoform-specific GFER constructs with compartment-restricted tags and compare localization, secreted/cytosolic signaling readouts, and rescue of MIA pathway substrate import.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: Reported non-mitochondrial ALR activities are isoform-specific and separable from long-isoform IMS disulfide-relay function.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="P55789" data-a="EXPERIMENT: Express isoform-specific GFER constructs with comp..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Deep Research Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(GFER-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P55789" data-a="DOC: Deep Research Falcon" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <hr />
+<p>provider: falcon<br />
+model: Edison Scientific Literature<br />
+cached: true<br />
+start_time: '2026-05-11T18:36:03.813221'<br />
+end_time: '2026-05-11T18:36:03.815515'<br />
+duration_seconds: 0.0<br />
+template_file: templates/gene_research_go_focused.md<br />
+template_variables:<br />
+  organism: human<br />
+  gene_id: GFER<br />
+  gene_symbol: GFER<br />
+  uniprot_accession: P55789<br />
+  protein_description: 'RecName: Full=FAD-linked sulfhydryl oxidase ALR {ECO:0000305|PubMed:20593814};<br />
+    EC=1.8.3.2 {ECO:0000269|PubMed:20593814, ECO:0000269|PubMed:22224850}; AltName:<br />
+    Full=Augmenter of liver regeneration; Short=hERV1; AltName: Full=Hepatopoietin;'<br />
+  gene_info: Name=GFER {ECO:0000312|HGNC:HGNC:4236}; Synonyms=ALR, HERV1, HPO;<br />
+  organism_full: Homo sapiens (Human).<br />
+  protein_family: Not specified in UniProt<br />
+  protein_domains: ALR/ERV. (IPR039799); ERV/ALR_sulphydryl_oxid_sf. (IPR036774);<br />
+    ERV/ALR_sulphydryl_oxidase. (IPR017905); Evr1_Alr (PF04777)<br />
+provider_config:<br />
+  timeout: 600<br />
+  max_retries: 3<br />
+  parameters:<br />
+    allowed_domains: []<br />
+    temperature: 0.1<br />
+citation_count: 38</p>
+<hr />
+<h2 id="question">Question</h2>
+<h1 id="gene-research-for-functional-annotation">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> P55789</li>
+<li><strong>Protein Description:</strong> RecName: Full=FAD-linked sulfhydryl oxidase ALR {ECO:0000305|PubMed:20593814}; EC=1.8.3.2 {ECO:0000269|PubMed:20593814, ECO:0000269|PubMed:22224850}; AltName: Full=Augmenter of liver regeneration; Short=hERV1; AltName: Full=Hepatopoietin;</li>
+<li><strong>Gene Information:</strong> Name=GFER {ECO:0000312|HGNC:HGNC:4236}; Synonyms=ALR, HERV1, HPO;</li>
+<li><strong>Organism (full):</strong> Homo sapiens (Human).</li>
+<li><strong>Protein Family:</strong> Not specified in UniProt</li>
+<li><strong>Key Domains:</strong> ALR/ERV. (IPR039799); ERV/ALR_sulphydryl_oxid_sf. (IPR036774); ERV/ALR_sulphydryl_oxidase. (IPR017905); Evr1_Alr (PF04777)</li>
+</ul>
+<h3 id="mandatory-verification-steps">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "GFER" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Homo sapiens (Human).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'GFER' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>GFER</strong> (gene ID: GFER, UniProt: P55789) in human.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="output">Output</h2>
+<p>Question: You are an expert researcher providing comprehensive, well-cited information.</p>
+<p>Provide detailed information focusing on:<br />
+1. Key concepts and definitions with current understanding<br />
+2. Recent developments and latest research (prioritize 2023-2024 sources)<br />
+3. Current applications and real-world implementations<br />
+4. Expert opinions and analysis from authoritative sources<br />
+5. Relevant statistics and data from recent studies</p>
+<p>Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.<br />
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.</p>
+<h1 id="gene-research-for-functional-annotation_1">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context_1">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot_1">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> P55789</li>
+<li><strong>Protein Description:</strong> RecName: Full=FAD-linked sulfhydryl oxidase ALR {ECO:0000305|PubMed:20593814}; EC=1.8.3.2 {ECO:0000269|PubMed:20593814, ECO:0000269|PubMed:22224850}; AltName: Full=Augmenter of liver regeneration; Short=hERV1; AltName: Full=Hepatopoietin;</li>
+<li><strong>Gene Information:</strong> Name=GFER {ECO:0000312|HGNC:HGNC:4236}; Synonyms=ALR, HERV1, HPO;</li>
+<li><strong>Organism (full):</strong> Homo sapiens (Human).</li>
+<li><strong>Protein Family:</strong> Not specified in UniProt</li>
+<li><strong>Key Domains:</strong> ALR/ERV. (IPR039799); ERV/ALR_sulphydryl_oxid_sf. (IPR036774); ERV/ALR_sulphydryl_oxidase. (IPR017905); Evr1_Alr (PF04777)</li>
+</ul>
+<h3 id="mandatory-verification-steps_1">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "GFER" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Homo sapiens (Human).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature_1">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'GFER' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target_1">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>GFER</strong> (gene ID: GFER, UniProt: P55789) in human.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="comprehensive-research-report-human-gfer-uniprot-p55789-alr-augmenter-of-liver-regeneration">Comprehensive Research Report: Human <strong>GFER</strong> (UniProt P55789) / <strong>ALR</strong> (Augmenter of Liver Regeneration)</h2>
+<h3 id="executive-summary">Executive summary</h3>
+<p><strong>GFER</strong> encodes <strong>ALR/Erv1</strong>, a <strong>FAD-dependent sulfhydryl oxidase</strong> in the <strong>mitochondrial intermembrane space (IMS)</strong> that is essential for the <strong>mitochondrial disulfide relay</strong> (also called the <strong>MIA pathway</strong>). Its primary, best-supported role is to <strong>re-oxidize the oxidoreductase MIA40/CHCHD4</strong>, thereby enabling oxidative folding and import/retention of cysteine-rich IMS proteins. Mechanistically, ALR transfers electrons from reduced MIA40 to its <strong>FAD</strong> cofactor and then typically to <strong>cytochrome c</strong> (feeding into complex IV), with <strong>molecular oxygen</strong> as an alternative acceptor that yields <strong>H2O2</strong> as by-product and is reported to be much slower than cytochrome c transfer in the human system. Disruptive biallelic variants in GFER cause autosomal-recessive mitochondrial disease with myopathy and multi-system involvement; a well-studied example is <strong>R194H</strong>, which impairs ALR stability/cofactor handling and is associated with combined respiratory-chain deficiency. Recent (2024) advances include an updated mechanistic synthesis of human IMS oxidative folding and chemical-biology studies describing <strong>MitoBlock</strong> small-molecule inhibitors that bind near ALR’s CEEC/FAD region and modulate the import pathway.</p>
+<h3 id="mandatory-verification-correct-geneprotein-identity">Mandatory verification: correct gene/protein identity</h3>
+<p>The literature retrieved consistently maps <strong>human GFER</strong> to <strong>ALR (augmenter of liver regeneration)</strong> and the mammalian homolog of <strong>yeast Erv1</strong>, a <strong>FAD-linked sulfhydryl oxidase</strong> functioning in the <strong>mitochondrial IMS disulfide relay</strong>. This matches the UniProt P55789 description (FAD-linked sulfhydryl oxidase ALR; EC 1.8.3.2; aliases ALR/HERV1/HPO). (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 16-19)</p>
+<hr />
+<h2 id="1-key-concepts-and-definitions-current-understanding">1. Key concepts and definitions (current understanding)</h2>
+<h3 id="11-the-mitochondrial-disulfide-relay-mia-pathway">1.1 The mitochondrial disulfide relay (MIA pathway)</h3>
+<p>The IMS contains an oxidative folding/import pathway in which incoming cysteine-rich proteins are oxidized and trapped in the IMS by formation of disulfide bonds. In mammals, the core catalytic pair is <strong>MIA40/CHCHD4 (oxidoreductase)</strong> and <strong>ALR/GFER (sulfhydryl oxidase)</strong>. ALR’s central biochemical function is to <strong>regenerate oxidized MIA40</strong> after MIA40 transfers disulfides to substrates. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 8-10)</p>
+<h3 id="12-what-does-alrgfer-do-primary-function">1.2 What does ALR/GFER do (primary function)?</h3>
+<p>ALR/GFER is a <strong>FAD-dependent sulfhydryl oxidase</strong> whose direct physiological substrate is the <strong>reduced CPC motif of MIA40/CHCHD4</strong>. It accepts electrons from reduced MIA40, transfers them through its own redox-active cysteine motifs to FAD, and then reduces downstream electron acceptors (primarily cytochrome c), thereby enabling repeated rounds of oxidative folding and IMS protein biogenesis. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 25-31)</p>
+<hr />
+<h2 id="2-molecular-function-reaction-mechanism-and-substrateelectron-acceptor-specificity">2. Molecular function: reaction, mechanism, and substrate/electron acceptor specificity</h2>
+<h3 id="21-reaction-logic-and-electron-flow">2.1 Reaction logic and electron flow</h3>
+<p>In the human disulfide relay, ALR reoxidizes MIA40 via thiol–disulfide exchange, passing electrons onward to FAD and then to terminal acceptors.</p>
+<p><strong>Mechanistic steps (human ALR):</strong><br />
+- ALR contains an <strong>N-terminal shuttle domain</strong> with a redox-active <strong>CRAC</strong> motif and a <strong>core domain</strong> containing a redox-active <strong>CAAC (CXXC-like)</strong> motif and a <strong>noncovalently bound FAD</strong>. (zarges2024oxidativeproteinfolding pages 8-9)<br />
+- <strong>C55 of MIA40</strong> attacks ALR’s oxidized shuttle CXXC motif (CRAC) in a thiol–disulfide exchange, leaving <strong>MIA40 oxidized</strong> and reducing ALR’s shuttle motif. (zarges2024oxidativeproteinfolding pages 8-9)<br />
+- Electrons are transferred from the shuttle motif to the core motif and then to <strong>FAD → FADH2</strong>. (zarges2024oxidativeproteinfolding pages 8-9)<br />
+- <strong>FADH2</strong> is reoxidized mainly by <strong>electron transfer to cytochrome c</strong>, which then feeds electrons to <strong>complex IV (cytochrome c oxidase)</strong>; alternatively, FADH2 can reduce <strong>O2</strong>, generating <strong>H2O2</strong>. (zarges2024oxidativeproteinfolding pages 8-9)</p>
+<p>A mechanistic schematic of these steps (including motifs and acceptor routes) is shown in Figure 5 of Zarges &amp; Riemer 2024. (zarges2024oxidativeproteinfolding media 9e639530)</p>
+<h3 id="22-domain-architecture-and-catalytic-motifs-human">2.2 Domain architecture and catalytic motifs (human)</h3>
+<p>A complementary mechanistic description in higher eukaryotes specifies that ALR’s N-terminal <strong>CRAC</strong> motif is attacked by MIA40’s reduced <strong>CPC</strong> motif; ALR then transfers electrons via an <strong>intersubunit relay</strong> to a core motif (described as <strong>CEEC</strong> in that review) and into FAD, before reducing cytochrome c or O2. (finger2020proteinimportby pages 25-31, finger2020proteinimportby pages 8-10)</p>
+<h3 id="23-electron-acceptors-and-specificity-cytochrome-c-vs-oxygen">2.3 Electron acceptors and specificity: cytochrome c vs oxygen</h3>
+<p>In the human IMS relay, electron transfer to <strong>cytochrome c</strong> is described as the predominant route and direct reduction of O2 as an alternative that generates H2O2. (zarges2024oxidativeproteinfolding pages 8-9)</p>
+<p>Quantitatively, the 2024 review states that O2-dependent reoxidation is <strong>“up to a 100-fold slower”</strong> than electron transfer to cytochrome c. (zarges2024oxidativeproteinfolding pages 8-9)</p>
+<p>While the most detailed kinetic constants retrieved here are for <strong>yeast Erv1 (EC 1.8.3.2)</strong> rather than human ALR, they provide experimentally grounded context that Erv1-family enzymes generally favor cytochrome c as acceptor: cytochrome c was <strong>~7–15-fold more efficient</strong> than O2 as acceptor for yeast Erv1 under the tested conditions, with example catalytic efficiencies <strong>kcat/Km ~1.5×10^5 M−1 s−1</strong> (cytochrome c) vs <strong>~1.0×10^4 M−1 s−1</strong> (O2) in one comparison, and oxygen acting as a competitive inhibitor of cytochrome c reductase activity. (tang2020kineticcharacterisationof pages 1-2, tang2020kineticcharacterisationof pages 5-7)</p>
+<h3 id="24-ros-production">2.4 ROS production</h3>
+<p>Because ALR/Erv1 can use <strong>O2</strong> as terminal acceptor, it can generate <strong>H2O2</strong> as a by-product (in the human mechanistic synthesis), and Erv/ALR-family flavin oxidases have been reported to release <strong>superoxide</strong> during turnover. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 16-19)</p>
+<hr />
+<h2 id="3-subcellular-localization-isoforms-and-structural-context">3. Subcellular localization, isoforms, and structural context</h2>
+<h3 id="31-subcellular-site-of-action">3.1 Subcellular site of action</h3>
+<p>The best-supported primary functional localization of long ALR is the <strong>mitochondrial intermembrane space</strong>, where it operates in oxidative folding/protein import with MIA40. (zarges2024oxidativeproteinfolding pages 8-9, nalesnik2017augmenterofliver pages 1-4)</p>
+<h3 id="32-isoforms-long-vs-short-and-broader-context">3.2 Isoforms (long vs short) and broader context</h3>
+<p>A hepatology review summarizes <strong>two principal ALR isoforms</strong>, approximately <strong>~15 kDa (short)</strong> and <strong>~22 kDa (long)</strong>; the <strong>long isoform</strong> functions in the mitochondrial IMS as a core MIA/disulfide relay component. (nalesnik2017augmenterofliver pages 1-4)</p>
+<p>Older review literature notes reports of non-mitochondrial ALR forms (cytosolic/nuclear/secreted growth factor activities), but for <strong>functional annotation of UniProt P55789</strong>, the mechanistically defined and disease-linked role is the mitochondrial IMS sulfhydryl oxidase in the disulfide relay. (fischer2013themitochondrialdisulfide pages 6-7)</p>
+<h3 id="33-stoichiometryabundance-data-point">3.3 Stoichiometry/abundance (data point)</h3>
+<p>In mammalian tissues, ALR can be present in excess over MIA40, reported as <strong>~1:1 to 10:1 (ALR:MIA40)</strong>. This supports the view that ALR abundance can shape relay capacity and that “goldilocks” ALR concentrations may be physiologically important. (finger2020proteinimportby pages 8-10, zarges2024oxidativeproteinfolding pages 8-9)</p>
+<hr />
+<h2 id="4-recent-developments-and-latest-research-prioritizing-20232024">4. Recent developments and latest research (prioritizing 2023–2024)</h2>
+<h3 id="41-2024-mechanistic-synthesis-of-human-oxidative-folding-in-the-ims">4.1 2024 mechanistic synthesis of human oxidative folding in the IMS</h3>
+<p>Zarges &amp; Riemer (2024) provide a recent, mechanistically detailed review of human IMS oxidative folding, including explicit motif architecture (CRAC/CAAC), homodimerization, and acceptor routing (cytochrome c vs O2 → H2O2), and they summarize the disease mutation <strong>R194H</strong> and its biochemical effects. (zarges2024oxidativeproteinfolding pages 8-9, zarges2024oxidativeproteinfolding pages 11-12)</p>
+<h3 id="42-2024-chemical-biology-mitoblock-inhibitors-of-alr">4.2 2024 chemical-biology: MitoBlock inhibitors of ALR</h3>
+<p>Muzzioli &amp; Gallo (2024) describe a small <strong>MitoBlock</strong> library of ALR inhibitors/probes (MB-5 to MB-9 and MB-13) used to dissect ALR’s role in MIA pathway dynamics. A key result is that <strong>MB-6</strong> can “lock” a precursor in a <strong>MIA40-bound</strong> state by blocking <strong>MIA40 reoxidation by ALR</strong>, functionally arresting the relay. (muzzioli2024theinteractionand pages 1-2)</p>
+<p>They map inhibitor binding by NMR and docking to a pocket near the <strong>CEEC motif</strong> and adjacent to <strong>FAD</strong>, involving residues such as <strong>F91, L102, Y116, E144, C145, W195, R196, G197, W199, K200</strong> at/near the ALR dimer interface. (muzzioli2024theinteractionand pages 2-4, muzzioli2024theinteractionand pages 4-7)</p>
+<p>They also report biochemical potencies for several compounds in vitro: <strong>MB-8 IC50 = 9.02 µM; MB-9 IC50 = 2.15 µM; MB-13 IC50 = 10.7 µM</strong>, with limited cell-toxicity observations (e.g., MB-9 and MB-13 non-toxic in yeast and HeLa at tested high concentrations; MB-8 toxic in HeLa at 100 µM). (muzzioli2024theinteractionand pages 4-7)</p>
+<h3 id="43-limitation-of-the-present-retrieval-for-20232024-gfer-specific-primaries">4.3 Limitation of the present retrieval for 2023–2024 GFER-specific primaries</h3>
+<p>Within the current tool-retrieved corpus, the most directly GFER/ALR-focused 2023–2024 sources were the <strong>2024 FEBS Open Bio review</strong> and <strong>2024 IJMS inhibitor paper</strong>; additional 2023–2024 GFER-focused primary studies were not retrieved by the Scholar queries used here.</p>
+<hr />
+<h2 id="5-current-applications-and-real-world-implementations">5. Current applications and real-world implementations</h2>
+<h3 id="51-clinical-genetics-and-mitochondrial-medicine">5.1 Clinical genetics and mitochondrial medicine</h3>
+<p>GFER is established as a Mendelian mitochondrial disease gene. Reviews cite <strong>autosomal-recessive myopathy with congenital cataract and combined respiratory-chain deficiency</strong> (initially reported by Di Fonzo et al. 2009) and additional phenotypes including <strong>developmental delay</strong> and endocrine/neurologic presentations such as <strong>GFER-related mitochondrial encephalomyopathy with adrenal insufficiency</strong>. (alhabib2021chchd4(mia40)and pages 9-10, fischer2013themitochondrialdisulfide pages 6-7)</p>
+<p>A key mechanistic link between genotype and phenotype is that impaired ALR function disrupts MIA pathway substrate maturation/import, which in turn can impair respiratory chain biogenesis and activity. For the R194H syndrome specifically, patient mitochondria show decreased activities of respiratory complexes (reported as I, II, and IV in one review) and reduced levels of MIA40 substrates, consistent with combined respiratory chain deficiency secondary to IMS oxidative folding defects. (erdogan2017mitochondrialdisulfiderelay pages 6-9)</p>
+<h3 id="52-chemical-probes-and-early-stage-drug-discovery">5.2 Chemical probes and early-stage drug discovery</h3>
+<p>The 2024 MitoBlock study positions ALR as a tractable chemical-biology target to manipulate mitochondrial IMS import and oxidative folding. These compounds can be used as mechanistic probes to trap intermediates (e.g., precursor–MIA40 complex) and potentially as starting points for therapeutic development targeting mitochondrial import/redox pathways. (muzzioli2024theinteractionand pages 1-2, muzzioli2024theinteractionand pages 4-7)</p>
+<h3 id="53-cancer-relevance-reported-implementationsobservations">5.3 Cancer relevance (reported implementations/observations)</h3>
+<p>ALR upregulation is reported to be linked to cancers including <strong>hepatocellular carcinoma</strong>, and ALR inhibition is cited as causing “drastic cell growth reduction” alongside disruption of <strong>heme iron</strong> and decreased <strong>complex I</strong> function (as background cited in the 2024 inhibitor paper). (muzzioli2024theinteractionand pages 2-4, nalesnik2017augmenterofliver pages 8-10)</p>
+<hr />
+<h2 id="6-expert-opinions-and-authoritative-synthesis">6. Expert opinions and authoritative synthesis</h2>
+<p>A consistent expert interpretation across reviews is that ALR/GFER is a <strong>core component</strong> of the IMS oxidative folding machinery whose enzymatic activity couples protein import/oxidative folding to the respiratory chain via cytochrome c. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 8-10)</p>
+<p>Reviews also emphasize that disruption of the disulfide relay is disease-relevant, and that mutations in relay components (including ALR/GFER) produce mitochondrial pathology consistent with impaired IMS substrate biogenesis and consequent respiratory chain defects. (zarges2024oxidativeproteinfolding pages 11-12, alhabib2021chchd4(mia40)and pages 9-10)</p>
+<hr />
+<h2 id="7-statistics-and-quantitative-data-from-recent-studies">7. Statistics and quantitative data from recent studies</h2>
+<h3 id="71-human-system-quantitative-comparisons">7.1 Human-system quantitative comparisons</h3>
+<ul>
+<li>O2-dependent reoxidation of ALR’s FADH2 is described as <strong>up to ~100-fold slower</strong> than electron transfer to cytochrome c in the human oxidative folding context. (zarges2024oxidativeproteinfolding pages 8-9)</li>
+<li>ALR abundance can be <strong>~1:1 to 10:1</strong> relative to MIA40 in mammalian tissues (ALR:MIA40). (finger2020proteinimportby pages 8-10)</li>
+</ul>
+<h3 id="72-quantitative-inhibitor-data-2024">7.2 Quantitative inhibitor data (2024)</h3>
+<ul>
+<li>In vitro biochemical IC50 values: <strong>MB-8 9.02 µM; MB-9 2.15 µM; MB-13 10.7 µM</strong>. (muzzioli2024theinteractionand pages 4-7)</li>
+</ul>
+<h3 id="73-comparative-enzyme-kinetics-erv1-family-yeast-data">7.3 Comparative enzyme kinetics (Erv1-family; yeast data)</h3>
+<ul>
+<li>Yeast Erv1 (EC 1.8.3.2) shows cytochrome c as <strong>~7–15-fold</strong> more efficient acceptor than O2 under tested conditions, with representative kcat/Km values <strong>~1.5×10^5 M−1 s−1 (cytochrome c)</strong> vs <strong>~1.0×10^4 M−1 s−1 (O2)</strong> in one comparison. (tang2020kineticcharacterisationof pages 1-2, tang2020kineticcharacterisationof pages 5-7)</li>
+</ul>
+<p>These yeast data should be treated as <strong>comparative biochemical context</strong> rather than definitive human ALR kinetic constants.</p>
+<hr />
+<h2 id="evidence-map-table-summary">Evidence map table (summary)</h2>
+<p>The following table consolidates key functional, mechanistic, disease, and inhibitor findings with dates and URLs.</p>
+<table>
+<thead>
+<tr>
+<th>Aspect</th>
+<th>Key details</th>
+<th>Evidence (citation IDs)</th>
+<th>Publication date/URL</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Target identity / aliases</td>
+<td><strong>Human GFER</strong> (UniProt <strong>P55789</strong>) corresponds to <strong>augmenter of liver regeneration (ALR)</strong>, the mammalian <strong>Erv1</strong> homolog; also called <strong>hepatopoietin / hERV1 / HPO</strong>. Retrieved reviews consistently identify it as the <strong>FAD-dependent sulfhydryl oxidase</strong> of the mitochondrial disulfide relay.</td>
+<td>(zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 16-19)</td>
+<td>2024-06, https://doi.org/10.1002/2211-5463.13839 ; 2020-03, https://doi.org/10.1515/hsz-2020-0108</td>
+</tr>
+<tr>
+<td>Enzymatic activity (EC 1.8.3.2)</td>
+<td>GFER/ALR is a <strong>sulfhydryl oxidase</strong> that re-oxidizes <strong>MIA40/CHCHD4</strong> after MIA40 oxidizes incoming IMS substrates. Electron flow is <strong>substrate thiols → MIA40 CPC → ALR shuttle motif → ALR core CXXC/CAAC-CEEC → FAD → terminal acceptor (primarily cytochrome c, alternatively O2)</strong>, thereby enabling de novo disulfide formation and repeated oxidative folding cycles.</td>
+<td>(zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 25-31, finger2020proteinimportby pages 8-10)</td>
+<td>2024-06, https://doi.org/10.1002/2211-5463.13839 ; 2020-03, https://doi.org/10.1515/hsz-2020-0108</td>
+</tr>
+<tr>
+<td>Key motifs / domains / structural features</td>
+<td>Human ALR has an <strong>N-terminal shuttle domain</strong> with <strong>CRAC</strong> motif and a <strong>C-terminal FAD-binding core</strong> with a redox-active <strong>CAAC/CEEC-type CXXC</strong> motif. It forms a <strong>homodimer</strong> stabilized by hydrophobic contacts and <strong>two intersubunit disulfide bonds</strong>; FAD is bound <strong>noncovalently</strong> in a helical core bundle. Mechanistically, the reduced CRAC motif transfers electrons to the partner subunit core motif and then to FAD.</td>
+<td>(zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 8-10, finger2020proteinimportby pages 25-31)</td>
+<td>2024-06, https://doi.org/10.1002/2211-5463.13839 ; 2020-03, https://doi.org/10.1515/hsz-2020-0108</td>
+</tr>
+<tr>
+<td>Subcellular localization / isoforms</td>
+<td>The <strong>long ALR isoform (~22 kDa)</strong> functions in the <strong>mitochondrial intermembrane space (IMS)</strong> as part of the MIA/disulfide relay. Reviews also note a <strong>short isoform (~15 kDa)</strong> and physiological relevance of distinct ALR isoforms, including non-mitochondrial reports in older literature; for functional annotation of P55789, the best-supported primary role is the <strong>mitochondrial IMS oxidoreductase</strong>.</td>
+<td>(nalesnik2017augmenterofliver pages 1-4, finger2020proteinimportby pages 16-19, fischer2013themitochondrialdisulfide pages 6-7)</td>
+<td>2017-07, https://doi.org/10.1002/hep.29047 ; 2020-03, https://doi.org/10.1515/hsz-2020-0108 ; 2013-11, https://doi.org/10.1155/2013/742923</td>
+</tr>
+<tr>
+<td>Pathway role</td>
+<td>GFER/ALR is the <strong>reoxidizing enzyme for MIA40/CHCHD4</strong> in the <strong>mitochondrial disulfide relay / MIA pathway</strong>, which imports and oxidatively folds cysteine-rich IMS proteins. By transferring electrons to <strong>cytochrome c</strong> and then <strong>complex IV</strong>, ALR couples oxidative folding/protein import to the <strong>electron transport chain</strong>.</td>
+<td>(zarges2024oxidativeproteinfolding pages 8-9, dicksonmurray2021themia40chchd4oxidative pages 8-10, finger2020proteinimportby pages 8-10)</td>
+<td>2024-06, https://doi.org/10.1002/2211-5463.13839 ; 2021-04, https://doi.org/10.3390/antiox10040592 ; 2020-03, https://doi.org/10.1515/hsz-2020-0108</td>
+</tr>
+<tr>
+<td>Electron acceptors and relative efficiency</td>
+<td><strong>Human-focused reviews:</strong> cytochrome c is the preferred acceptor; direct reoxidation by <strong>O2</strong> produces <strong>H2O2</strong> and is reported as <strong>up to ~100-fold slower</strong> than cytochrome c reduction in the human pathway context. <strong>Yeast kinetic data (comparative, not human):</strong> cytochrome c is <strong>~7–15-fold more efficient</strong> than O2, with representative values <strong>kcat/Km ≈ 1.5 × 10^5 M^-1 s^-1 for cytochrome c vs 1.0 × 10^4 M^-1 s^-1 for O2</strong>; O2 can competitively inhibit cytochrome c reductase activity.</td>
+<td>(zarges2024oxidativeproteinfolding pages 8-9, tang2020kineticcharacterisationof pages 1-2, tang2020kineticcharacterisationof pages 5-7, tang2020kineticcharacterisationof pages 7-9)</td>
+<td>2024-06, https://doi.org/10.1002/2211-5463.13839 ; 2020-10, https://doi.org/10.1111/febs.15077</td>
+</tr>
+<tr>
+<td>Quantitative pathway / abundance notes</td>
+<td>In mammalian tissues, <strong>ALR is often present at ~1:1 to 10:1 excess over MIA40</strong>, suggesting ALR is not typically limiting for MIA40 reoxidation. Electron transfer from FADH2 to cytochrome c proceeds as <strong>one-electron steps</strong>, whereas thiol–disulfide exchange steps move <strong>two electrons</strong>.</td>
+<td>(finger2020proteinimportby pages 8-10, zarges2024oxidativeproteinfolding pages 8-9)</td>
+<td>2020-03, https://doi.org/10.1515/hsz-2020-0108 ; 2024-06, https://doi.org/10.1002/2211-5463.13839</td>
+</tr>
+<tr>
+<td>ROS / by-products</td>
+<td>Besides respiratory-chain coupling, ALR can pass electrons directly to <strong>molecular oxygen</strong>, generating <strong>H2O2</strong>; flavin-linked Erv/ALR enzymes have also been reported to release <strong>superoxide</strong> during turnover. This makes ALR a potential contributor to IMS redox signaling as well as oxidative folding.</td>
+<td>(zarges2024oxidativeproteinfolding pages 8-9, dicksonmurray2021themia40chchd4oxidative pages 8-10, finger2020proteinimportby pages 16-19)</td>
+<td>2024-06, https://doi.org/10.1002/2211-5463.13839 ; 2021-04, https://doi.org/10.3390/antiox10040592 ; 2020-03, https://doi.org/10.1515/hsz-2020-0108</td>
+</tr>
+<tr>
+<td>Disease associations</td>
+<td>Pathogenic <strong>GFER/ALR</strong> variants are linked to <strong>autosomal recessive mitochondrial disease</strong>, including <strong>myopathy</strong>, <strong>congenital cataract</strong>, <strong>sensorineural hearing loss</strong>, <strong>developmental delay</strong>, and <strong>combined respiratory-chain deficiency</strong>; additional literature reports <strong>GFER-related mitochondrial encephalomyopathy with adrenal insufficiency</strong>. Patient cells show reduced respiratory-chain function and reduced levels/import of MIA-pathway substrates, consistent with impaired IMS oxidative folding.</td>
+<td>(zarges2024oxidativeproteinfolding pages 11-12, alhabib2021chchd4(mia40)and pages 9-10, erdogan2017mitochondrialdisulfiderelay pages 6-9, sokol2014mitochondrialproteintranslocases pages 7-8, finger2020proteinimportby pages 16-19)</td>
+<td>2024-06, https://doi.org/10.1002/2211-5463.13839 ; 2021-02, https://doi.org/10.1042/bst20190232 ; 2017-08, https://doi.org/10.1007/s00441-016-2481-z ; 2020-03, https://doi.org/10.1515/hsz-2020-0108</td>
+</tr>
+<tr>
+<td>Mutation example: R194H</td>
+<td>The disease-associated <strong>R194H</strong> substitution lies at the <strong>ALR dimer interface</strong>. Reported mechanistic effects include impaired <strong>protein stability</strong>, reduced <strong>flavin/FAD binding or retention</strong>, and gradual enzyme inactivation during turnover; some studies note residual catalytic activity despite these defects. Clinically associated phenotypes include <strong>mitochondrial myopathy</strong>, <strong>cataract</strong>, <strong>hearing loss</strong>, <strong>developmental delay</strong>, and <strong>combined respiratory-chain deficiency</strong>.</td>
+<td>(zarges2024oxidativeproteinfolding pages 11-12, erdogan2017mitochondrialdisulfiderelay pages 6-9, sokol2014mitochondrialproteintranslocases pages 7-8)</td>
+<td>2024-06, https://doi.org/10.1002/2211-5463.13839 ; 2017-08, https://doi.org/10.1007/s00441-016-2481-z ; 2014-08, https://doi.org/10.1016/j.febslet.2014.05.028</td>
+</tr>
+<tr>
+<td>Inhibitors / mechanistic probes</td>
+<td><strong>MitoBlock</strong> compounds target ALR as chemical probes of the MIA pathway. <strong>MB-6</strong> binds a hydrophobic pocket near the <strong>CEEC motif/FAD</strong> region and can trap precursor protein in an ALR-inhibited, <strong>MIA40-bound</strong> state, blocking MIA40 reoxidation. Other compounds bind related sites at the ALR dimer interface; <strong>MB-7</strong> is described as highly specific in modeling/NMR analyses.</td>
+<td>(muzzioli2024theinteractionand pages 1-2, muzzioli2024theinteractionand pages 9-11, muzzioli2024theinteractionand pages 2-4)</td>
+<td>2024-01, https://doi.org/10.3390/ijms25021174</td>
+</tr>
+<tr>
+<td>Inhibitor potency / application data</td>
+<td>In purified-enzyme assays, reported <strong>IC50</strong> values were <strong>MB-8: 9.02 µM</strong>, <strong>MB-9: 2.15 µM</strong>, <strong>MB-13: 10.7 µM</strong>. NMR mapped binding to residues including <strong>F91, L102, Y116, E144, C145, W195, R196, G197, W199, K200</strong> at/near the dimer interface and FAD-proximal pocket. These compounds are proposed as <strong>starting points for ALR-targeted drug discovery</strong> and for dissecting import-pathway mechanism.</td>
+<td>(muzzioli2024theinteractionand pages 4-7, muzzioli2024theinteractionand pages 9-11, muzzioli2024theinteractionand pages 2-4)</td>
+<td>2024-01, https://doi.org/10.3390/ijms25021174</td>
+</tr>
+<tr>
+<td>Real-world relevance / cancer biology</td>
+<td>ALR upregulation has been linked to <strong>multiple cancers</strong>, especially <strong>hepatocellular carcinoma</strong>. Prior work cited in the 2024 inhibitor study reports that ALR inhibition causes <strong>drastic cell growth reduction</strong>, disruption of <strong>heme iron</strong>, and decreased <strong>complex I</strong> function, supporting interest in ALR as a metabolism- and mitochondrial-import-linked therapeutic target.</td>
+<td>(muzzioli2024theinteractionand pages 2-4, nalesnik2017augmenterofliver pages 8-10, fischer2013themitochondrialdisulfide pages 11-12)</td>
+<td>2024-01, https://doi.org/10.3390/ijms25021174 ; 2017-07, https://doi.org/10.1002/hep.29047 ; 2013-11, https://doi.org/10.1155/2013/742923</td>
+</tr>
+<tr>
+<td>Key recent reviews / source map</td>
+<td><strong>2024 review:</strong> Zarges &amp; Riemer, <em>FEBS Open Bio</em> — detailed human oxidative folding and ALR mechanism. <strong>2021 reviews:</strong> Al-Habib &amp; Ashcroft, <em>Biochem Soc Trans</em>; Dickson-Murray et al., <em>Antioxidants</em> — CHCHD4/MIA40 relay and redox regulation. <strong>2020 review:</strong> Finger &amp; Riemer, <em>Biological Chemistry</em> — higher-eukaryote disulfide relay and ALR architecture. <strong>2024 primary inhibitor study:</strong> Muzzioli &amp; Gallo, <em>IJMS</em> — MitoBlock interaction with ALR.</td>
+<td>(zarges2024oxidativeproteinfolding pages 8-9, dicksonmurray2021themia40chchd4oxidative pages 8-10, finger2020proteinimportby pages 8-10, muzzioli2024theinteractionand pages 2-4)</td>
+<td>2024-06, https://doi.org/10.1002/2211-5463.13839 ; 2021-02, https://doi.org/10.1042/bst20190232 ; 2021-04, https://doi.org/10.3390/antiox10040592 ; 2020-03, https://doi.org/10.1515/hsz-2020-0108 ; 2024-01, https://doi.org/10.3390/ijms25021174</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the core functional annotation of human GFER/ALR (UniProt P55789), including enzymatic mechanism, localization, pathway role, disease relevance, and 2024 inhibitor data. It is designed as a compact evidence map for downstream narrative reporting and citation.</em></p>
+<hr />
+<h2 id="figure-evidence-mechanism-overview">Figure evidence (mechanism overview)</h2>
+<p>A recent schematic of ALR-mediated MIA40 reoxidation and alternative FADH2 reoxidation routes (cytochrome c vs O2→H2O2; yeast Osm1 pathway) is provided in Zarges &amp; Riemer 2024 (Figure 5). (zarges2024oxidativeproteinfolding media 9e639530)</p>
+<hr />
+<h2 id="references-urls-and-publication-dates-key-sources-used">References (URLs and publication dates; key sources used)</h2>
+<ul>
+<li>Zarges C, Riemer J. <strong>Oxidative protein folding in the intermembrane space of human mitochondria</strong>. <em>FEBS Open Bio</em>. <strong>2024-06</strong>. https://doi.org/10.1002/2211-5463.13839 (zarges2024oxidativeproteinfolding pages 8-9, zarges2024oxidativeproteinfolding pages 11-12)</li>
+<li>Muzzioli R, Gallo A. <strong>The Interaction and Effect of a Small MitoBlock Library as Inhibitor of ALR Protein–Protein Interaction Pathway</strong>. <em>Int J Mol Sci</em>. <strong>2024-01</strong>. https://doi.org/10.3390/ijms25021174 (muzzioli2024theinteractionand pages 1-2, muzzioli2024theinteractionand pages 4-7)</li>
+<li>Finger Y, Riemer J. <strong>Protein import by the mitochondrial disulfide relay in higher eukaryotes</strong>. <em>Biological Chemistry</em>. <strong>2020-03</strong>. https://doi.org/10.1515/hsz-2020-0108 (finger2020proteinimportby pages 8-10)</li>
+<li>Al-Habib H, Ashcroft M. <strong>CHCHD4 (MIA40) and the mitochondrial disulfide relay system</strong>. <em>Biochem Soc Trans</em>. <strong>2021-02</strong>. https://doi.org/10.1042/bst20190232 (alhabib2021chchd4(mia40)and pages 9-10)</li>
+<li>Erdogan AJ, Riemer J. <strong>Mitochondrial disulfide relay and its substrates: mechanisms in health and disease</strong>. <em>Cell Tissue Res</em>. <strong>2017-08</strong>. https://doi.org/10.1007/s00441-016-2481-z (erdogan2017mitochondrialdisulfiderelay pages 6-9)</li>
+<li>Nalesnik MA, Gandhi CR, Starzl TE. <strong>Augmenter of liver regeneration: A fundamental life protein</strong>. <em>Hepatology</em>. <strong>2017-07</strong>. https://doi.org/10.1002/hep.29047 (nalesnik2017augmenterofliver pages 1-4)</li>
+<li>Tang X, Ang SK, Ceh-Pavia E, Heyes DJ, Lu H. <strong>Kinetic characterisation of Erv1</strong> (yeast; EC 1.8.3.2). <em>FEBS J</em>. <strong>2020-10</strong>. https://doi.org/10.1111/febs.15077 (tang2020kineticcharacterisationof pages 1-2, tang2020kineticcharacterisationof pages 5-7)</li>
+</ul>
+<p>References</p>
+<ol>
+<li>
+<p>(zarges2024oxidativeproteinfolding pages 8-9): Christine Zarges and Jan Riemer. Oxidative protein folding in the intermembrane space of human mitochondria. FEBS Open Bio, 14:1610-1626, Jun 2024. URL: https://doi.org/10.1002/2211-5463.13839, doi:10.1002/2211-5463.13839. This article has 24 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(finger2020proteinimportby pages 16-19): Yannik Finger and Jan Riemer. Protein import by the mitochondrial disulfide relay in higher eukaryotes. Biological Chemistry, 401:749-763, Mar 2020. URL: https://doi.org/10.1515/hsz-2020-0108, doi:10.1515/hsz-2020-0108. This article has 29 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(finger2020proteinimportby pages 8-10): Yannik Finger and Jan Riemer. Protein import by the mitochondrial disulfide relay in higher eukaryotes. Biological Chemistry, 401:749-763, Mar 2020. URL: https://doi.org/10.1515/hsz-2020-0108, doi:10.1515/hsz-2020-0108. This article has 29 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(finger2020proteinimportby pages 25-31): Yannik Finger and Jan Riemer. Protein import by the mitochondrial disulfide relay in higher eukaryotes. Biological Chemistry, 401:749-763, Mar 2020. URL: https://doi.org/10.1515/hsz-2020-0108, doi:10.1515/hsz-2020-0108. This article has 29 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(zarges2024oxidativeproteinfolding media 9e639530): Christine Zarges and Jan Riemer. Oxidative protein folding in the intermembrane space of human mitochondria. FEBS Open Bio, 14:1610-1626, Jun 2024. URL: https://doi.org/10.1002/2211-5463.13839, doi:10.1002/2211-5463.13839. This article has 24 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(tang2020kineticcharacterisationof pages 1-2): Xiaofan Tang, Swee Kim Ang, Efrain Ceh‐Pavia, Derren J. Heyes, and Hui Lu. Kinetic characterisation of erv1, a key component for protein import and folding in yeast mitochondria. The Febs Journal, 287:1220-1231, Oct 2020. URL: https://doi.org/10.1111/febs.15077, doi:10.1111/febs.15077. This article has 15 citations.</p>
+</li>
+<li>
+<p>(tang2020kineticcharacterisationof pages 5-7): Xiaofan Tang, Swee Kim Ang, Efrain Ceh‐Pavia, Derren J. Heyes, and Hui Lu. Kinetic characterisation of erv1, a key component for protein import and folding in yeast mitochondria. The Febs Journal, 287:1220-1231, Oct 2020. URL: https://doi.org/10.1111/febs.15077, doi:10.1111/febs.15077. This article has 15 citations.</p>
+</li>
+<li>
+<p>(nalesnik2017augmenterofliver pages 1-4): Michael A. Nalesnik, Chandrashekhar R. Gandhi, and Thomas E. Starzl. Augmenter of liver regeneration: a fundamental life protein. Hepatology, 66:266-270, Jul 2017. URL: https://doi.org/10.1002/hep.29047, doi:10.1002/hep.29047. This article has 43 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(fischer2013themitochondrialdisulfide pages 6-7): Manuel Fischer and Jan Riemer. The mitochondrial disulfide relay system: roles in oxidative protein folding and beyond. International Journal of Cell Biology, 2013:1-12, Nov 2013. URL: https://doi.org/10.1155/2013/742923, doi:10.1155/2013/742923. This article has 61 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(zarges2024oxidativeproteinfolding pages 11-12): Christine Zarges and Jan Riemer. Oxidative protein folding in the intermembrane space of human mitochondria. FEBS Open Bio, 14:1610-1626, Jun 2024. URL: https://doi.org/10.1002/2211-5463.13839, doi:10.1002/2211-5463.13839. This article has 24 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(muzzioli2024theinteractionand pages 1-2): Riccardo Muzzioli and Angelo Gallo. The interaction and effect of a small mitoblock library as inhibitor of alr protein–protein interaction pathway. International Journal of Molecular Sciences, 25:1174, Jan 2024. URL: https://doi.org/10.3390/ijms25021174, doi:10.3390/ijms25021174. This article has 3 citations.</p>
+</li>
+<li>
+<p>(muzzioli2024theinteractionand pages 2-4): Riccardo Muzzioli and Angelo Gallo. The interaction and effect of a small mitoblock library as inhibitor of alr protein–protein interaction pathway. International Journal of Molecular Sciences, 25:1174, Jan 2024. URL: https://doi.org/10.3390/ijms25021174, doi:10.3390/ijms25021174. This article has 3 citations.</p>
+</li>
+<li>
+<p>(muzzioli2024theinteractionand pages 4-7): Riccardo Muzzioli and Angelo Gallo. The interaction and effect of a small mitoblock library as inhibitor of alr protein–protein interaction pathway. International Journal of Molecular Sciences, 25:1174, Jan 2024. URL: https://doi.org/10.3390/ijms25021174, doi:10.3390/ijms25021174. This article has 3 citations.</p>
+</li>
+<li>
+<p>(alhabib2021chchd4(mia40)and pages 9-10): Hasan Al-Habib and Margaret Ashcroft. Chchd4 (mia40) and the mitochondrial disulfide relay system. Biochemical Society Transactions, 49:17-27, Feb 2021. URL: https://doi.org/10.1042/bst20190232, doi:10.1042/bst20190232. This article has 37 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(erdogan2017mitochondrialdisulfiderelay pages 6-9): Alican J. Erdogan and Jan Riemer. Mitochondrial disulfide relay and its substrates: mechanisms in health and disease. Cell and Tissue Research, 367:59-72, Aug 2017. URL: https://doi.org/10.1007/s00441-016-2481-z, doi:10.1007/s00441-016-2481-z. This article has 30 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(nalesnik2017augmenterofliver pages 8-10): Michael A. Nalesnik, Chandrashekhar R. Gandhi, and Thomas E. Starzl. Augmenter of liver regeneration: a fundamental life protein. Hepatology, 66:266-270, Jul 2017. URL: https://doi.org/10.1002/hep.29047, doi:10.1002/hep.29047. This article has 43 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(dicksonmurray2021themia40chchd4oxidative pages 8-10): Eleanor Dickson-Murray, Kenza Nedara, Nazanine Modjtahedi, and Kostas Tokatlidis. The mia40/chchd4 oxidative folding system: redox regulation and signaling in the mitochondrial intermembrane space. Antioxidants, 10:592, Apr 2021. URL: https://doi.org/10.3390/antiox10040592, doi:10.3390/antiox10040592. This article has 37 citations.</p>
+</li>
+<li>
+<p>(tang2020kineticcharacterisationof pages 7-9): Xiaofan Tang, Swee Kim Ang, Efrain Ceh‐Pavia, Derren J. Heyes, and Hui Lu. Kinetic characterisation of erv1, a key component for protein import and folding in yeast mitochondria. The Febs Journal, 287:1220-1231, Oct 2020. URL: https://doi.org/10.1111/febs.15077, doi:10.1111/febs.15077. This article has 15 citations.</p>
+</li>
+<li>
+<p>(sokol2014mitochondrialproteintranslocases pages 7-8): Anna Magdalena Sokol, Malgorzata Eliza Sztolsztener, Michal Wasilewski, Eva Heinz, and Agnieszka Chacinska. Mitochondrial protein translocases for survival and wellbeing. FEBS Letters, 588:2484-2495, Aug 2014. URL: https://doi.org/10.1016/j.febslet.2014.05.028, doi:10.1016/j.febslet.2014.05.028. This article has 126 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(muzzioli2024theinteractionand pages 9-11): Riccardo Muzzioli and Angelo Gallo. The interaction and effect of a small mitoblock library as inhibitor of alr protein–protein interaction pathway. International Journal of Molecular Sciences, 25:1174, Jan 2024. URL: https://doi.org/10.3390/ijms25021174, doi:10.3390/ijms25021174. This article has 3 citations.</p>
+</li>
+<li>
+<p>(fischer2013themitochondrialdisulfide pages 11-12): Manuel Fischer and Jan Riemer. The mitochondrial disulfide relay system: roles in oxidative protein folding and beyond. International Journal of Cell Biology, 2013:1-12, Nov 2013. URL: https://doi.org/10.1155/2013/742923, doi:10.1155/2013/742923. This article has 61 citations and is from a peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>zarges2024oxidativeproteinfolding pages 8-9</li>
+<li>nalesnik2017augmenterofliver pages 1-4</li>
+<li>fischer2013themitochondrialdisulfide pages 6-7</li>
+<li>muzzioli2024theinteractionand pages 1-2</li>
+<li>muzzioli2024theinteractionand pages 4-7</li>
+<li>erdogan2017mitochondrialdisulfiderelay pages 6-9</li>
+<li>finger2020proteinimportby pages 8-10</li>
+<li>finger2020proteinimportby pages 16-19</li>
+<li>finger2020proteinimportby pages 25-31</li>
+<li>tang2020kineticcharacterisationof pages 1-2</li>
+<li>tang2020kineticcharacterisationof pages 5-7</li>
+<li>zarges2024oxidativeproteinfolding pages 11-12</li>
+<li>muzzioli2024theinteractionand pages 2-4</li>
+<li>nalesnik2017augmenterofliver pages 8-10</li>
+<li>tang2020kineticcharacterisationof pages 7-9</li>
+<li>sokol2014mitochondrialproteintranslocases pages 7-8</li>
+<li>muzzioli2024theinteractionand pages 9-11</li>
+<li>fischer2013themitochondrialdisulfide pages 11-12</li>
+<li>https://doi.org/10.1002/2211-5463.13839</li>
+<li>https://doi.org/10.1515/hsz-2020-0108</li>
+<li>https://doi.org/10.1002/hep.29047</li>
+<li>https://doi.org/10.1155/2013/742923</li>
+<li>https://doi.org/10.3390/antiox10040592</li>
+<li>https://doi.org/10.1111/febs.15077</li>
+<li>https://doi.org/10.1042/bst20190232</li>
+<li>https://doi.org/10.1007/s00441-016-2481-z</li>
+<li>https://doi.org/10.1016/j.febslet.2014.05.028</li>
+<li>https://doi.org/10.3390/ijms25021174</li>
+<li>https://doi.org/10.1002/2211-5463.13839,</li>
+<li>https://doi.org/10.1515/hsz-2020-0108,</li>
+<li>https://doi.org/10.1111/febs.15077,</li>
+<li>https://doi.org/10.1002/hep.29047,</li>
+<li>https://doi.org/10.1155/2013/742923,</li>
+<li>https://doi.org/10.3390/ijms25021174,</li>
+<li>https://doi.org/10.1042/bst20190232,</li>
+<li>https://doi.org/10.1007/s00441-016-2481-z,</li>
+<li>https://doi.org/10.3390/antiox10040592,</li>
+<li>https://doi.org/10.1016/j.febslet.2014.05.028,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: P55789
+gene_symbol: GFER
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: &#39;GFER encodes ALR/Erv1, a FAD-dependent sulfhydryl oxidase in the mitochondrial intermembrane space.
+  Its core role is to re-oxidize MIA40/CHCHD4 in the mitochondrial disulfide relay, enabling oxidative folding and
+  import/retention of cysteine-rich IMS proteins.&#39;
+alternative_products:
+- name: 1 (HPO-205, lfALR)
+  id: P55789-1
+- name: 2 (HPO-125, sfALR)
+  id: P55789-2
+  sequence_note: VSP_040393
+existing_annotations:
+- term:
+    id: GO:0016971
+    label: flavin-dependent sulfhydryl oxidase activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: Correct and core. GFER/ALR is the FAD-linked sulfhydryl oxidase of the mitochondrial disulfide
+      relay.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/GFER/GFER-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: The literature retrieved consistently maps **human GFER** to **ALR (augmenter of liver
+        regeneration)** and the mammalian homolog of **yeast Erv1**, a **FAD-linked sulfhydryl oxidase**
+        functioning in the **mitochondrial IMS disulfide relay**. This matches the UniProt P55789 description
+        (FAD-linked sulfhydryl oxidase ALR; EC 1.8.3.2; aliases ALR/HERV1/HPO).
+        (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 16-19)
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: ALR/GFER is a **FAD-dependent sulfhydryl oxidase** whose direct physiological substrate
+        is the **reduced CPC motif of MIA40/CHCHD4**. It accepts electrons from reduced MIA40, transfers them
+        through its own redox-active cysteine motifs to FAD, and then reduces downstream electron acceptors
+        (primarily cytochrome c), thereby enabling repeated rounds of oxidative folding and IMS protein
+        biogenesis. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 25-31)
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: &#39;| Enzymatic activity (EC 1.8.3.2) | GFER/ALR is a **sulfhydryl oxidase** that re-oxidizes
+        **MIA40/CHCHD4** after MIA40 oxidizes incoming IMS substrates. Electron flow is **substrate thiols → MIA40
+        CPC → ALR shuttle motif → ALR core CXXC/CAAC-CEEC → FAD → terminal acceptor (primarily cytochrome c, alternatively
+        O2)**, thereby enabling de novo disulfide formation and repeated oxidative folding cycles. | (zarges2024oxidativeproteinfolding
+        pages 8-9, finger2020proteinimportby pages 25-31, finger2020proteinimportby pages 8-10) | 2024-06, https://doi.org/10.1002/2211-5463.13839
+        ; 2020-03, https://doi.org/10.1515/hsz-2020-0108 |&#39;
+- term:
+    id: GO:0001889
+    label: liver development
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: Keep as non-core. ALR has historical growth factor/liver-regeneration biology, but the primary
+      mechanistically defined function of UniProt P55789 is IMS sulfhydryl oxidase activity.
+    action: KEEP_AS_NON_CORE
+    additional_reference_ids:
+    - file:human/GFER/GFER-deep-research-falcon.md
+    - PMID:20593814
+    reason: Liver development/regeneration is a downstream or isoform/context-associated phenotype, not the
+      core molecular function.
+    supported_by:
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: Older review literature notes reports of non-mitochondrial ALR forms
+        (cytosolic/nuclear/secreted growth factor activities), but for **functional annotation of UniProt
+        P55789**, the mechanistically defined and disease-linked role is the mitochondrial IMS sulfhydryl
+        oxidase in the disulfide relay. (fischer2013themitochondrialdisulfide pages 6-7)
+    - reference_id: PMID:20593814
+      supporting_text: The short form (sfALR, 15 kDa; starting at M81 of the human long form, lfALR, sequence
+        depicted in Figure 1A) is a circulating growth factor (11, 12, 15, 17, 18) and interacts with specific
+        receptors on the cell surface (19, 20).
+- term:
+    id: GO:0005576
+    label: extracellular region
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  review:
+    summary: Keep as non-core. extracellular region is consistent with reports of short/non-mitochondrial ALR
+      forms, but the core reviewed function is long ALR in the mitochondrial intermembrane space.
+    action: KEEP_AS_NON_CORE
+    additional_reference_ids:
+    - file:human/GFER/GFER-deep-research-falcon.md
+    reason: Retain as non-core because non-mitochondrial ALR forms are reported, while prioritizing IMS
+      disulfide-relay function.
+    supported_by:
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: A hepatology review summarizes **two principal ALR isoforms**, approximately **~15 kDa
+        (short)** and **~22 kDa (long)**; the **long isoform** functions in the mitochondrial IMS as a core
+        MIA/disulfide relay component. (nalesnik2017augmenterofliver pages 1-4)
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: Older review literature notes reports of non-mitochondrial ALR forms
+        (cytosolic/nuclear/secreted growth factor activities), but for **functional annotation of UniProt
+        P55789**, the mechanistically defined and disease-linked role is the mitochondrial IMS sulfhydryl
+        oxidase in the disulfide relay. (fischer2013themitochondrialdisulfide pages 6-7)
+- term:
+    id: GO:0005737
+    label: cytoplasm
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  review:
+    summary: Keep as non-core. cytoplasm is consistent with reports of short/non-mitochondrial ALR forms, but
+      the core reviewed function is long ALR in the mitochondrial intermembrane space.
+    action: KEEP_AS_NON_CORE
+    additional_reference_ids:
+    - file:human/GFER/GFER-deep-research-falcon.md
+    reason: Retain as non-core because non-mitochondrial ALR forms are reported, while prioritizing IMS
+      disulfide-relay function.
+    supported_by:
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: A hepatology review summarizes **two principal ALR isoforms**, approximately **~15 kDa
+        (short)** and **~22 kDa (long)**; the **long isoform** functions in the mitochondrial IMS as a core
+        MIA/disulfide relay component. (nalesnik2017augmenterofliver pages 1-4)
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: Older review literature notes reports of non-mitochondrial ALR forms
+        (cytosolic/nuclear/secreted growth factor activities), but for **functional annotation of UniProt
+        P55789**, the mechanistically defined and disease-linked role is the mitochondrial IMS sulfhydryl
+        oxidase in the disulfide relay. (fischer2013themitochondrialdisulfide pages 6-7)
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  review:
+    summary: Correct but broad. GFER/long ALR is specifically localized to the mitochondrial intermembrane
+      space.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/GFER/GFER-deep-research-falcon.md
+    reason: Prefer mitochondrial intermembrane space and mitochondrial disulfide relay system over generic
+      mitochondrion.
+    supported_by:
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: The best-supported primary functional localization of long ALR is the **mitochondrial
+        intermembrane space**, where it operates in oxidative folding/protein import with MIA40.
+        (zarges2024oxidativeproteinfolding pages 8-9, nalesnik2017augmenterofliver pages 1-4)
+- term:
+    id: GO:0005758
+    label: mitochondrial intermembrane space
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  review:
+    summary: Correct and core. Long ALR/GFER functions in the mitochondrial intermembrane space.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/GFER/GFER-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: The best-supported primary functional localization of long ALR is the **mitochondrial
+        intermembrane space**, where it operates in oxidative folding/protein import with MIA40.
+        (zarges2024oxidativeproteinfolding pages 8-9, nalesnik2017augmenterofliver pages 1-4)
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: A hepatology review summarizes **two principal ALR isoforms**, approximately **~15 kDa
+        (short)** and **~22 kDa (long)**; the **long isoform** functions in the mitochondrial IMS as a core
+        MIA/disulfide relay component. (nalesnik2017augmenterofliver pages 1-4)
+- term:
+    id: GO:0015035
+    label: protein-disulfide reductase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  review:
+    summary: The disulfide-relay context is right, but reductase is the wrong direction for GFER. GFER
+      oxidizes thiols/re-oxidizes MIA40 as a sulfhydryl oxidase.
+    action: MODIFY
+    additional_reference_ids:
+    - file:human/GFER/GFER-deep-research-falcon.md
+    reason: Replace protein-disulfide reductase activity with sulfhydryl/thiol oxidase activity for GFER.
+    proposed_replacement_terms:
+    - id: GO:0016971
+      label: flavin-dependent sulfhydryl oxidase activity
+    - id: GO:0016972
+      label: thiol oxidase activity
+    supported_by:
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: The IMS contains an oxidative folding/import pathway in which incoming cysteine-rich
+        proteins are oxidized and trapped in the IMS by formation of disulfide bonds. In mammals, the core
+        catalytic pair is **MIA40/CHCHD4 (oxidoreductase)** and **ALR/GFER (sulfhydryl oxidase)**. ALR’s
+        central biochemical function is to **regenerate oxidized MIA40** after MIA40 transfers disulfides to
+        substrates. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 8-10)
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: ALR/GFER is a **FAD-dependent sulfhydryl oxidase** whose direct physiological substrate
+        is the **reduced CPC motif of MIA40/CHCHD4**. It accepts electrons from reduced MIA40, transfers them
+        through its own redox-active cysteine motifs to FAD, and then reduces downstream electron acceptors
+        (primarily cytochrome c), thereby enabling repeated rounds of oxidative folding and IMS protein
+        biogenesis. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 25-31)
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: &#39;| Enzymatic activity (EC 1.8.3.2) | GFER/ALR is a **sulfhydryl oxidase** that re-oxidizes
+        **MIA40/CHCHD4** after MIA40 oxidizes incoming IMS substrates. Electron flow is **substrate thiols → MIA40
+        CPC → ALR shuttle motif → ALR core CXXC/CAAC-CEEC → FAD → terminal acceptor (primarily cytochrome c, alternatively
+        O2)**, thereby enabling de novo disulfide formation and repeated oxidative folding cycles. | (zarges2024oxidativeproteinfolding
+        pages 8-9, finger2020proteinimportby pages 25-31, finger2020proteinimportby pages 8-10) | 2024-06, https://doi.org/10.1002/2211-5463.13839
+        ; 2020-03, https://doi.org/10.1515/hsz-2020-0108 |&#39;
+- term:
+    id: GO:0016971
+    label: flavin-dependent sulfhydryl oxidase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  review:
+    summary: Correct and core. GFER/ALR is the FAD-linked sulfhydryl oxidase of the mitochondrial disulfide
+      relay.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/GFER/GFER-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: The literature retrieved consistently maps **human GFER** to **ALR (augmenter of liver
+        regeneration)** and the mammalian homolog of **yeast Erv1**, a **FAD-linked sulfhydryl oxidase**
+        functioning in the **mitochondrial IMS disulfide relay**. This matches the UniProt P55789 description
+        (FAD-linked sulfhydryl oxidase ALR; EC 1.8.3.2; aliases ALR/HERV1/HPO).
+        (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 16-19)
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: ALR/GFER is a **FAD-dependent sulfhydryl oxidase** whose direct physiological substrate
+        is the **reduced CPC motif of MIA40/CHCHD4**. It accepts electrons from reduced MIA40, transfers them
+        through its own redox-active cysteine motifs to FAD, and then reduces downstream electron acceptors
+        (primarily cytochrome c), thereby enabling repeated rounds of oxidative folding and IMS protein
+        biogenesis. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 25-31)
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: &#39;| Enzymatic activity (EC 1.8.3.2) | GFER/ALR is a **sulfhydryl oxidase** that re-oxidizes
+        **MIA40/CHCHD4** after MIA40 oxidizes incoming IMS substrates. Electron flow is **substrate thiols → MIA40
+        CPC → ALR shuttle motif → ALR core CXXC/CAAC-CEEC → FAD → terminal acceptor (primarily cytochrome c, alternatively
+        O2)**, thereby enabling de novo disulfide formation and repeated oxidative folding cycles. | (zarges2024oxidativeproteinfolding
+        pages 8-9, finger2020proteinimportby pages 25-31, finger2020proteinimportby pages 8-10) | 2024-06, https://doi.org/10.1002/2211-5463.13839
+        ; 2020-03, https://doi.org/10.1515/hsz-2020-0108 |&#39;
+- term:
+    id: GO:0016972
+    label: thiol oxidase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  review:
+    summary: Correct. Thiol oxidase activity captures the sulfhydryl oxidase chemistry of ALR/GFER.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/GFER/GFER-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: ALR/GFER is a **FAD-dependent sulfhydryl oxidase** whose direct physiological substrate
+        is the **reduced CPC motif of MIA40/CHCHD4**. It accepts electrons from reduced MIA40, transfers them
+        through its own redox-active cysteine motifs to FAD, and then reduces downstream electron acceptors
+        (primarily cytochrome c), thereby enabling repeated rounds of oxidative folding and IMS protein
+        biogenesis. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 25-31)
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: &#39;| Enzymatic activity (EC 1.8.3.2) | GFER/ALR is a **sulfhydryl oxidase** that re-oxidizes
+        **MIA40/CHCHD4** after MIA40 oxidizes incoming IMS substrates. Electron flow is **substrate thiols → MIA40
+        CPC → ALR shuttle motif → ALR core CXXC/CAAC-CEEC → FAD → terminal acceptor (primarily cytochrome c, alternatively
+        O2)**, thereby enabling de novo disulfide formation and repeated oxidative folding cycles. | (zarges2024oxidativeproteinfolding
+        pages 8-9, finger2020proteinimportby pages 25-31, finger2020proteinimportby pages 8-10) | 2024-06, https://doi.org/10.1002/2211-5463.13839
+        ; 2020-03, https://doi.org/10.1515/hsz-2020-0108 |&#39;
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:25416956
+  review:
+    summary: Protein binding is too generic for GFER. The informative role is FAD-dependent sulfhydryl oxidase
+      activity in the MIA40/CHCHD4 disulfide relay.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/GFER/GFER-deep-research-falcon.md
+    reason: Replace generic interaction capture with sulfhydryl oxidase activity and mitochondrial disulfide
+      relay system annotations.
+    supported_by:
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: The IMS contains an oxidative folding/import pathway in which incoming cysteine-rich
+        proteins are oxidized and trapped in the IMS by formation of disulfide bonds. In mammals, the core
+        catalytic pair is **MIA40/CHCHD4 (oxidoreductase)** and **ALR/GFER (sulfhydryl oxidase)**. ALR’s
+        central biochemical function is to **regenerate oxidized MIA40** after MIA40 transfers disulfides to
+        substrates. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 8-10)
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: ALR/GFER is a **FAD-dependent sulfhydryl oxidase** whose direct physiological substrate
+        is the **reduced CPC motif of MIA40/CHCHD4**. It accepts electrons from reduced MIA40, transfers them
+        through its own redox-active cysteine motifs to FAD, and then reduces downstream electron acceptors
+        (primarily cytochrome c), thereby enabling repeated rounds of oxidative folding and IMS protein
+        biogenesis. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 25-31)
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:32353859
+  review:
+    summary: Protein binding is too generic for GFER. The informative role is FAD-dependent sulfhydryl oxidase
+      activity in the MIA40/CHCHD4 disulfide relay.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/GFER/GFER-deep-research-falcon.md
+    reason: Replace generic interaction capture with sulfhydryl oxidase activity and mitochondrial disulfide
+      relay system annotations.
+    supported_by:
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: The IMS contains an oxidative folding/import pathway in which incoming cysteine-rich
+        proteins are oxidized and trapped in the IMS by formation of disulfide bonds. In mammals, the core
+        catalytic pair is **MIA40/CHCHD4 (oxidoreductase)** and **ALR/GFER (sulfhydryl oxidase)**. ALR’s
+        central biochemical function is to **regenerate oxidized MIA40** after MIA40 transfers disulfides to
+        substrates. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 8-10)
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: ALR/GFER is a **FAD-dependent sulfhydryl oxidase** whose direct physiological substrate
+        is the **reduced CPC motif of MIA40/CHCHD4**. It accepts electrons from reduced MIA40, transfers them
+        through its own redox-active cysteine motifs to FAD, and then reduces downstream electron acceptors
+        (primarily cytochrome c), thereby enabling repeated rounds of oxidative folding and IMS protein
+        biogenesis. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 25-31)
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:33060197
+  review:
+    summary: Protein binding is too generic for GFER. The informative role is FAD-dependent sulfhydryl oxidase
+      activity in the MIA40/CHCHD4 disulfide relay.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/GFER/GFER-deep-research-falcon.md
+    reason: Replace generic interaction capture with sulfhydryl oxidase activity and mitochondrial disulfide
+      relay system annotations.
+    supported_by:
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: The IMS contains an oxidative folding/import pathway in which incoming cysteine-rich
+        proteins are oxidized and trapped in the IMS by formation of disulfide bonds. In mammals, the core
+        catalytic pair is **MIA40/CHCHD4 (oxidoreductase)** and **ALR/GFER (sulfhydryl oxidase)**. ALR’s
+        central biochemical function is to **regenerate oxidized MIA40** after MIA40 transfers disulfides to
+        substrates. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 8-10)
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: ALR/GFER is a **FAD-dependent sulfhydryl oxidase** whose direct physiological substrate
+        is the **reduced CPC motif of MIA40/CHCHD4**. It accepts electrons from reduced MIA40, transfers them
+        through its own redox-active cysteine motifs to FAD, and then reduces downstream electron acceptors
+        (primarily cytochrome c), thereby enabling repeated rounds of oxidative folding and IMS protein
+        biogenesis. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 25-31)
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:36217030
+  review:
+    summary: Protein binding is too generic for GFER. The informative role is FAD-dependent sulfhydryl oxidase
+      activity in the MIA40/CHCHD4 disulfide relay.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/GFER/GFER-deep-research-falcon.md
+    reason: Replace generic interaction capture with sulfhydryl oxidase activity and mitochondrial disulfide
+      relay system annotations.
+    supported_by:
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: The IMS contains an oxidative folding/import pathway in which incoming cysteine-rich
+        proteins are oxidized and trapped in the IMS by formation of disulfide bonds. In mammals, the core
+        catalytic pair is **MIA40/CHCHD4 (oxidoreductase)** and **ALR/GFER (sulfhydryl oxidase)**. ALR’s
+        central biochemical function is to **regenerate oxidized MIA40** after MIA40 transfers disulfides to
+        substrates. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 8-10)
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: ALR/GFER is a **FAD-dependent sulfhydryl oxidase** whose direct physiological substrate
+        is the **reduced CPC motif of MIA40/CHCHD4**. It accepts electrons from reduced MIA40, transfers them
+        through its own redox-active cysteine motifs to FAD, and then reduces downstream electron acceptors
+        (primarily cytochrome c), thereby enabling repeated rounds of oxidative folding and IMS protein
+        biogenesis. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 25-31)
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IDA
+  original_reference_id: GO_REF:0000052
+  review:
+    summary: Correct but broad. GFER/long ALR is specifically localized to the mitochondrial intermembrane
+      space.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/GFER/GFER-deep-research-falcon.md
+    reason: Prefer mitochondrial intermembrane space and mitochondrial disulfide relay system over generic
+      mitochondrion.
+    supported_by:
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: The best-supported primary functional localization of long ALR is the **mitochondrial
+        intermembrane space**, where it operates in oxidative folding/protein import with MIA40.
+        (zarges2024oxidativeproteinfolding pages 8-9, nalesnik2017augmenterofliver pages 1-4)
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: IDA
+  original_reference_id: GO_REF:0000052
+  review:
+    summary: Keep as non-core. cytosol is consistent with reports of short/non-mitochondrial ALR forms, but
+      the core reviewed function is long ALR in the mitochondrial intermembrane space.
+    action: KEEP_AS_NON_CORE
+    additional_reference_ids:
+    - file:human/GFER/GFER-deep-research-falcon.md
+    reason: Retain as non-core because non-mitochondrial ALR forms are reported, while prioritizing IMS
+      disulfide-relay function.
+    supported_by:
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: A hepatology review summarizes **two principal ALR isoforms**, approximately **~15 kDa
+        (short)** and **~22 kDa (long)**; the **long isoform** functions in the mitochondrial IMS as a core
+        MIA/disulfide relay component. (nalesnik2017augmenterofliver pages 1-4)
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: Older review literature notes reports of non-mitochondrial ALR forms
+        (cytosolic/nuclear/secreted growth factor activities), but for **functional annotation of UniProt
+        P55789**, the mechanistically defined and disease-linked role is the mitochondrial IMS sulfhydryl
+        oxidase in the disulfide relay. (fischer2013themitochondrialdisulfide pages 6-7)
+- term:
+    id: GO:0016971
+    label: flavin-dependent sulfhydryl oxidase activity
+  evidence_type: EXP
+  original_reference_id: PMID:20593814
+  review:
+    summary: Correct and core. GFER/ALR is the FAD-linked sulfhydryl oxidase of the mitochondrial disulfide
+      relay.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/GFER/GFER-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: The literature retrieved consistently maps **human GFER** to **ALR (augmenter of liver
+        regeneration)** and the mammalian homolog of **yeast Erv1**, a **FAD-linked sulfhydryl oxidase**
+        functioning in the **mitochondrial IMS disulfide relay**. This matches the UniProt P55789 description
+        (FAD-linked sulfhydryl oxidase ALR; EC 1.8.3.2; aliases ALR/HERV1/HPO).
+        (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 16-19)
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: ALR/GFER is a **FAD-dependent sulfhydryl oxidase** whose direct physiological substrate
+        is the **reduced CPC motif of MIA40/CHCHD4**. It accepts electrons from reduced MIA40, transfers them
+        through its own redox-active cysteine motifs to FAD, and then reduces downstream electron acceptors
+        (primarily cytochrome c), thereby enabling repeated rounds of oxidative folding and IMS protein
+        biogenesis. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 25-31)
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: &#39;| Enzymatic activity (EC 1.8.3.2) | GFER/ALR is a **sulfhydryl oxidase** that re-oxidizes
+        **MIA40/CHCHD4** after MIA40 oxidizes incoming IMS substrates. Electron flow is **substrate thiols → MIA40
+        CPC → ALR shuttle motif → ALR core CXXC/CAAC-CEEC → FAD → terminal acceptor (primarily cytochrome c, alternatively
+        O2)**, thereby enabling de novo disulfide formation and repeated oxidative folding cycles. | (zarges2024oxidativeproteinfolding
+        pages 8-9, finger2020proteinimportby pages 25-31, finger2020proteinimportby pages 8-10) | 2024-06, https://doi.org/10.1002/2211-5463.13839
+        ; 2020-03, https://doi.org/10.1515/hsz-2020-0108 |&#39;
+- term:
+    id: GO:0016971
+    label: flavin-dependent sulfhydryl oxidase activity
+  evidence_type: EXP
+  original_reference_id: PMID:22224850
+  review:
+    summary: Correct and core. GFER/ALR is the FAD-linked sulfhydryl oxidase of the mitochondrial disulfide
+      relay.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/GFER/GFER-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: The literature retrieved consistently maps **human GFER** to **ALR (augmenter of liver
+        regeneration)** and the mammalian homolog of **yeast Erv1**, a **FAD-linked sulfhydryl oxidase**
+        functioning in the **mitochondrial IMS disulfide relay**. This matches the UniProt P55789 description
+        (FAD-linked sulfhydryl oxidase ALR; EC 1.8.3.2; aliases ALR/HERV1/HPO).
+        (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 16-19)
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: ALR/GFER is a **FAD-dependent sulfhydryl oxidase** whose direct physiological substrate
+        is the **reduced CPC motif of MIA40/CHCHD4**. It accepts electrons from reduced MIA40, transfers them
+        through its own redox-active cysteine motifs to FAD, and then reduces downstream electron acceptors
+        (primarily cytochrome c), thereby enabling repeated rounds of oxidative folding and IMS protein
+        biogenesis. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 25-31)
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: &#39;| Enzymatic activity (EC 1.8.3.2) | GFER/ALR is a **sulfhydryl oxidase** that re-oxidizes
+        **MIA40/CHCHD4** after MIA40 oxidizes incoming IMS substrates. Electron flow is **substrate thiols → MIA40
+        CPC → ALR shuttle motif → ALR core CXXC/CAAC-CEEC → FAD → terminal acceptor (primarily cytochrome c, alternatively
+        O2)**, thereby enabling de novo disulfide formation and repeated oxidative folding cycles. | (zarges2024oxidativeproteinfolding
+        pages 8-9, finger2020proteinimportby pages 25-31, finger2020proteinimportby pages 8-10) | 2024-06, https://doi.org/10.1002/2211-5463.13839
+        ; 2020-03, https://doi.org/10.1515/hsz-2020-0108 |&#39;
+- term:
+    id: GO:0016972
+    label: thiol oxidase activity
+  evidence_type: EXP
+  original_reference_id: PMID:20593814
+  review:
+    summary: Correct. Thiol oxidase activity captures the sulfhydryl oxidase chemistry of ALR/GFER.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/GFER/GFER-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: ALR/GFER is a **FAD-dependent sulfhydryl oxidase** whose direct physiological substrate
+        is the **reduced CPC motif of MIA40/CHCHD4**. It accepts electrons from reduced MIA40, transfers them
+        through its own redox-active cysteine motifs to FAD, and then reduces downstream electron acceptors
+        (primarily cytochrome c), thereby enabling repeated rounds of oxidative folding and IMS protein
+        biogenesis. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 25-31)
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: &#39;| Enzymatic activity (EC 1.8.3.2) | GFER/ALR is a **sulfhydryl oxidase** that re-oxidizes
+        **MIA40/CHCHD4** after MIA40 oxidizes incoming IMS substrates. Electron flow is **substrate thiols → MIA40
+        CPC → ALR shuttle motif → ALR core CXXC/CAAC-CEEC → FAD → terminal acceptor (primarily cytochrome c, alternatively
+        O2)**, thereby enabling de novo disulfide formation and repeated oxidative folding cycles. | (zarges2024oxidativeproteinfolding
+        pages 8-9, finger2020proteinimportby pages 25-31, finger2020proteinimportby pages 8-10) | 2024-06, https://doi.org/10.1002/2211-5463.13839
+        ; 2020-03, https://doi.org/10.1515/hsz-2020-0108 |&#39;
+- term:
+    id: GO:0016972
+    label: thiol oxidase activity
+  evidence_type: EXP
+  original_reference_id: PMID:22224850
+  review:
+    summary: Correct. Thiol oxidase activity captures the sulfhydryl oxidase chemistry of ALR/GFER.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/GFER/GFER-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: ALR/GFER is a **FAD-dependent sulfhydryl oxidase** whose direct physiological substrate
+        is the **reduced CPC motif of MIA40/CHCHD4**. It accepts electrons from reduced MIA40, transfers them
+        through its own redox-active cysteine motifs to FAD, and then reduces downstream electron acceptors
+        (primarily cytochrome c), thereby enabling repeated rounds of oxidative folding and IMS protein
+        biogenesis. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 25-31)
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: &#39;| Enzymatic activity (EC 1.8.3.2) | GFER/ALR is a **sulfhydryl oxidase** that re-oxidizes
+        **MIA40/CHCHD4** after MIA40 oxidizes incoming IMS substrates. Electron flow is **substrate thiols → MIA40
+        CPC → ALR shuttle motif → ALR core CXXC/CAAC-CEEC → FAD → terminal acceptor (primarily cytochrome c, alternatively
+        O2)**, thereby enabling de novo disulfide formation and repeated oxidative folding cycles. | (zarges2024oxidativeproteinfolding
+        pages 8-9, finger2020proteinimportby pages 25-31, finger2020proteinimportby pages 8-10) | 2024-06, https://doi.org/10.1002/2211-5463.13839
+        ; 2020-03, https://doi.org/10.1515/hsz-2020-0108 |&#39;
+- term:
+    id: GO:0160203
+    label: mitochondrial disulfide relay system
+  evidence_type: IDA
+  original_reference_id: PMID:21383138
+  review:
+    summary: Correct and core. GFER/ALR re-oxidizes MIA40/CHCHD4 in the mitochondrial disulfide relay system.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/GFER/GFER-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: The IMS contains an oxidative folding/import pathway in which incoming cysteine-rich
+        proteins are oxidized and trapped in the IMS by formation of disulfide bonds. In mammals, the core
+        catalytic pair is **MIA40/CHCHD4 (oxidoreductase)** and **ALR/GFER (sulfhydryl oxidase)**. ALR’s
+        central biochemical function is to **regenerate oxidized MIA40** after MIA40 transfers disulfides to
+        substrates. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 8-10)
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: ALR/GFER is a **FAD-dependent sulfhydryl oxidase** whose direct physiological substrate
+        is the **reduced CPC motif of MIA40/CHCHD4**. It accepts electrons from reduced MIA40, transfers them
+        through its own redox-active cysteine motifs to FAD, and then reduces downstream electron acceptors
+        (primarily cytochrome c), thereby enabling repeated rounds of oxidative folding and IMS protein
+        biogenesis. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 25-31)
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: &#39;| Enzymatic activity (EC 1.8.3.2) | GFER/ALR is a **sulfhydryl oxidase** that re-oxidizes
+        **MIA40/CHCHD4** after MIA40 oxidizes incoming IMS substrates. Electron flow is **substrate thiols → MIA40
+        CPC → ALR shuttle motif → ALR core CXXC/CAAC-CEEC → FAD → terminal acceptor (primarily cytochrome c, alternatively
+        O2)**, thereby enabling de novo disulfide formation and repeated oxidative folding cycles. | (zarges2024oxidativeproteinfolding
+        pages 8-9, finger2020proteinimportby pages 25-31, finger2020proteinimportby pages 8-10) | 2024-06, https://doi.org/10.1002/2211-5463.13839
+        ; 2020-03, https://doi.org/10.1515/hsz-2020-0108 |&#39;
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: HTP
+  original_reference_id: PMID:34800366
+  review:
+    summary: Correct but broad. GFER/long ALR is specifically localized to the mitochondrial intermembrane
+      space.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/GFER/GFER-deep-research-falcon.md
+    reason: Prefer mitochondrial intermembrane space and mitochondrial disulfide relay system over generic
+      mitochondrion.
+    supported_by:
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: The best-supported primary functional localization of long ALR is the **mitochondrial
+        intermembrane space**, where it operates in oxidative folding/protein import with MIA40.
+        (zarges2024oxidativeproteinfolding pages 8-9, nalesnik2017augmenterofliver pages 1-4)
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:23676665
+  review:
+    summary: Protein binding is too generic for GFER. The informative role is FAD-dependent sulfhydryl oxidase
+      activity in the MIA40/CHCHD4 disulfide relay.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/GFER/GFER-deep-research-falcon.md
+    reason: Replace generic interaction capture with sulfhydryl oxidase activity and mitochondrial disulfide
+      relay system annotations.
+    supported_by:
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: The IMS contains an oxidative folding/import pathway in which incoming cysteine-rich
+        proteins are oxidized and trapped in the IMS by formation of disulfide bonds. In mammals, the core
+        catalytic pair is **MIA40/CHCHD4 (oxidoreductase)** and **ALR/GFER (sulfhydryl oxidase)**. ALR’s
+        central biochemical function is to **regenerate oxidized MIA40** after MIA40 transfers disulfides to
+        substrates. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 8-10)
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: ALR/GFER is a **FAD-dependent sulfhydryl oxidase** whose direct physiological substrate
+        is the **reduced CPC motif of MIA40/CHCHD4**. It accepts electrons from reduced MIA40, transfers them
+        through its own redox-active cysteine motifs to FAD, and then reduces downstream electron acceptors
+        (primarily cytochrome c), thereby enabling repeated rounds of oxidative folding and IMS protein
+        biogenesis. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 25-31)
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IDA
+  original_reference_id: PMID:23676665
+  review:
+    summary: Correct but broad. GFER/long ALR is specifically localized to the mitochondrial intermembrane
+      space.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/GFER/GFER-deep-research-falcon.md
+    reason: Prefer mitochondrial intermembrane space and mitochondrial disulfide relay system over generic
+      mitochondrion.
+    supported_by:
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: The best-supported primary functional localization of long ALR is the **mitochondrial
+        intermembrane space**, where it operates in oxidative folding/protein import with MIA40.
+        (zarges2024oxidativeproteinfolding pages 8-9, nalesnik2017augmenterofliver pages 1-4)
+- term:
+    id: GO:0015035
+    label: protein-disulfide reductase activity
+  evidence_type: IDA
+  original_reference_id: PMID:22224850
+  review:
+    summary: The disulfide-relay context is right, but reductase is the wrong direction for GFER. GFER
+      oxidizes thiols/re-oxidizes MIA40 as a sulfhydryl oxidase.
+    action: MODIFY
+    additional_reference_ids:
+    - file:human/GFER/GFER-deep-research-falcon.md
+    reason: Replace protein-disulfide reductase activity with sulfhydryl/thiol oxidase activity for GFER.
+    proposed_replacement_terms:
+    - id: GO:0016971
+      label: flavin-dependent sulfhydryl oxidase activity
+    - id: GO:0016972
+      label: thiol oxidase activity
+    supported_by:
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: The IMS contains an oxidative folding/import pathway in which incoming cysteine-rich
+        proteins are oxidized and trapped in the IMS by formation of disulfide bonds. In mammals, the core
+        catalytic pair is **MIA40/CHCHD4 (oxidoreductase)** and **ALR/GFER (sulfhydryl oxidase)**. ALR’s
+        central biochemical function is to **regenerate oxidized MIA40** after MIA40 transfers disulfides to
+        substrates. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 8-10)
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: ALR/GFER is a **FAD-dependent sulfhydryl oxidase** whose direct physiological substrate
+        is the **reduced CPC motif of MIA40/CHCHD4**. It accepts electrons from reduced MIA40, transfers them
+        through its own redox-active cysteine motifs to FAD, and then reduces downstream electron acceptors
+        (primarily cytochrome c), thereby enabling repeated rounds of oxidative folding and IMS protein
+        biogenesis. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 25-31)
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: &#39;| Enzymatic activity (EC 1.8.3.2) | GFER/ALR is a **sulfhydryl oxidase** that re-oxidizes
+        **MIA40/CHCHD4** after MIA40 oxidizes incoming IMS substrates. Electron flow is **substrate thiols → MIA40
+        CPC → ALR shuttle motif → ALR core CXXC/CAAC-CEEC → FAD → terminal acceptor (primarily cytochrome c, alternatively
+        O2)**, thereby enabling de novo disulfide formation and repeated oxidative folding cycles. | (zarges2024oxidativeproteinfolding
+        pages 8-9, finger2020proteinimportby pages 25-31, finger2020proteinimportby pages 8-10) | 2024-06, https://doi.org/10.1002/2211-5463.13839
+        ; 2020-03, https://doi.org/10.1515/hsz-2020-0108 |&#39;
+- term:
+    id: GO:0050660
+    label: flavin adenine dinucleotide binding
+  evidence_type: IDA
+  original_reference_id: PMID:22224850
+  review:
+    summary: Correct. GFER/ALR is a FAD-linked sulfhydryl oxidase with a noncovalently bound FAD cofactor.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/GFER/GFER-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: The literature retrieved consistently maps **human GFER** to **ALR (augmenter of liver
+        regeneration)** and the mammalian homolog of **yeast Erv1**, a **FAD-linked sulfhydryl oxidase**
+        functioning in the **mitochondrial IMS disulfide relay**. This matches the UniProt P55789 description
+        (FAD-linked sulfhydryl oxidase ALR; EC 1.8.3.2; aliases ALR/HERV1/HPO).
+        (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 16-19)
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: &#39;- ALR contains an **N-terminal shuttle domain** with a redox-active **CRAC** motif and a
+        **core domain** containing a redox-active **CAAC (CXXC-like)** motif and a **noncovalently bound FAD**.
+        (zarges2024oxidativeproteinfolding pages 8-9)&#39;
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:12681488
+  review:
+    summary: Protein binding is too generic for GFER. The informative role is FAD-dependent sulfhydryl oxidase
+      activity in the MIA40/CHCHD4 disulfide relay.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/GFER/GFER-deep-research-falcon.md
+    reason: Replace generic interaction capture with sulfhydryl oxidase activity and mitochondrial disulfide
+      relay system annotations.
+    supported_by:
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: The IMS contains an oxidative folding/import pathway in which incoming cysteine-rich
+        proteins are oxidized and trapped in the IMS by formation of disulfide bonds. In mammals, the core
+        catalytic pair is **MIA40/CHCHD4 (oxidoreductase)** and **ALR/GFER (sulfhydryl oxidase)**. ALR’s
+        central biochemical function is to **regenerate oxidized MIA40** after MIA40 transfers disulfides to
+        substrates. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 8-10)
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: ALR/GFER is a **FAD-dependent sulfhydryl oxidase** whose direct physiological substrate
+        is the **reduced CPC motif of MIA40/CHCHD4**. It accepts electrons from reduced MIA40, transfers them
+        through its own redox-active cysteine motifs to FAD, and then reduces downstream electron acceptors
+        (primarily cytochrome c), thereby enabling repeated rounds of oxidative folding and IMS protein
+        biogenesis. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 25-31)
+references:
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping,
+    accompanied by conservative changes to GO terms applied by UniProt
+  findings: []
+- id: GO_REF:0000052
+  title: Gene Ontology annotation based on curation of immunofluorescence data
+  findings: []
+- id: GO_REF:0000117
+  title: Electronic Gene Ontology annotations created by ARBA machine learning models
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: PMID:12681488
+  title: The apoptosis-associated protein BNIPL interacts with two cell proliferation-related proteins, MIF
+    and GFER.
+  findings: []
+- id: PMID:20593814
+  title: Structure of the human sulfhydryl oxidase augmenter of liver regeneration and characterization of a
+    human mutation causing an autosomal recessive myopathy .
+  findings: []
+- id: PMID:21383138
+  title: Molecular recognition and substrate mimicry drive the electron-transfer process between MIA40 and
+    ALR.
+  findings: []
+- id: PMID:22224850
+  title: &#39;An electron-transfer path through an extended disulfide relay system: the case of the redox protein ALR.&#39;
+  findings: []
+- id: PMID:23676665
+  title: Protein import and oxidative folding in the mitochondrial intermembrane space of intact mammalian
+    cells.
+  findings: []
+- id: PMID:25416956
+  title: A proteome-scale map of the human interactome network.
+  findings: []
+- id: PMID:32353859
+  title: A SARS-CoV-2 protein interaction map reveals targets for drug repurposing.
+  findings: []
+- id: PMID:33060197
+  title: Comparative host-coronavirus protein interaction networks reveal pan-viral disease mechanisms.
+  findings: []
+- id: PMID:34800366
+  title: Quantitative high-confidence human mitochondrial proteome and its dynamics in cellular context.
+  findings: []
+- id: PMID:36217030
+  title: A comprehensive SARS-CoV-2-human protein-protein interactome reveals COVID-19 pathobiology and
+    potential host therapeutic targets.
+  findings: []
+- id: file:human/GFER/GFER-deep-research-falcon.md
+  title: Falcon deep research report for human GFER
+  findings: []
+core_functions:
+- description: GFER/ALR is the FAD-dependent sulfhydryl oxidase of the mitochondrial intermembrane-space
+    disulfide relay. It re-oxidizes MIA40/CHCHD4 after substrate oxidation, passing electrons through ALR
+    redox cysteine motifs to FAD and downstream acceptors to support oxidative folding and retention of
+    cysteine-rich IMS proteins.
+  supported_by:
+  - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+    supporting_text: The literature retrieved consistently maps **human GFER** to **ALR (augmenter of liver
+      regeneration)** and the mammalian homolog of **yeast Erv1**, a **FAD-linked sulfhydryl oxidase**
+      functioning in the **mitochondrial IMS disulfide relay**. This matches the UniProt P55789 description
+      (FAD-linked sulfhydryl oxidase ALR; EC 1.8.3.2; aliases ALR/HERV1/HPO).
+      (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 16-19)
+  - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+    supporting_text: The IMS contains an oxidative folding/import pathway in which incoming cysteine-rich
+      proteins are oxidized and trapped in the IMS by formation of disulfide bonds. In mammals, the core
+      catalytic pair is **MIA40/CHCHD4 (oxidoreductase)** and **ALR/GFER (sulfhydryl oxidase)**. ALR’s central
+      biochemical function is to **regenerate oxidized MIA40** after MIA40 transfers disulfides to substrates.
+      (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 8-10)
+  - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+    supporting_text: ALR/GFER is a **FAD-dependent sulfhydryl oxidase** whose direct physiological substrate
+      is the **reduced CPC motif of MIA40/CHCHD4**. It accepts electrons from reduced MIA40, transfers them
+      through its own redox-active cysteine motifs to FAD, and then reduces downstream electron acceptors
+      (primarily cytochrome c), thereby enabling repeated rounds of oxidative folding and IMS protein
+      biogenesis. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 25-31)
+  - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+    supporting_text: The best-supported primary functional localization of long ALR is the **mitochondrial
+      intermembrane space**, where it operates in oxidative folding/protein import with MIA40.
+      (zarges2024oxidativeproteinfolding pages 8-9, nalesnik2017augmenterofliver pages 1-4)
+  - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+    supporting_text: &#39;| Enzymatic activity (EC 1.8.3.2) | GFER/ALR is a **sulfhydryl oxidase** that re-oxidizes
+      **MIA40/CHCHD4** after MIA40 oxidizes incoming IMS substrates. Electron flow is **substrate thiols → MIA40
+      CPC → ALR shuttle motif → ALR core CXXC/CAAC-CEEC → FAD → terminal acceptor (primarily cytochrome c, alternatively
+      O2)**, thereby enabling de novo disulfide formation and repeated oxidative folding cycles. | (zarges2024oxidativeproteinfolding
+      pages 8-9, finger2020proteinimportby pages 25-31, finger2020proteinimportby pages 8-10) | 2024-06, https://doi.org/10.1002/2211-5463.13839
+      ; 2020-03, https://doi.org/10.1515/hsz-2020-0108 |&#39;
+  molecular_function:
+    id: GO:0016971
+    label: flavin-dependent sulfhydryl oxidase activity
+  directly_involved_in:
+  - id: GO:0160203
+    label: mitochondrial disulfide relay system
+  locations:
+  - id: GO:0005758
+    label: mitochondrial intermembrane space
+proposed_new_terms: []
+suggested_questions:
+- question: How do short and long GFER/ALR isoforms divide mitochondrial IMS oxidase function from reported
+    cytosolic or extracellular activities?
+  experts: []
+- question: Which ALR electron acceptor routes dominate in human cells under respiratory stress or MIA pathway
+    inhibition?
+  experts: []
+suggested_experiments:
+- hypothesis: Disease-associated GFER variants primarily impair IMS substrate biogenesis by destabilizing
+    FAD-linked ALR rather than abolishing all residual catalytic chemistry.
+  description: Rescue GFER-deficient cells with wild-type and variant ALR, then quantify FAD retention, MIA40
+    redox state, import/oxidation of cysteine-rich IMS substrates, and respiratory complex assembly.
+- hypothesis: Reported non-mitochondrial ALR activities are isoform-specific and separable from long-isoform
+    IMS disulfide-relay function.
+  description: Express isoform-specific GFER constructs with compartment-restricted tags and compare
+    localization, secreted/cytosolic signaling readouts, and rescue of MIA pathway substrate import.
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/human/GFER/GFER-ai-review.yaml
+++ b/genes/human/GFER/GFER-ai-review.yaml
@@ -1,11 +1,13 @@
 id: P55789
 gene_symbol: GFER
 product_type: PROTEIN
-status: INITIALIZED
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
-description: 'TODO: Add description for GFER'
+description: 'GFER encodes ALR/Erv1, a FAD-dependent sulfhydryl oxidase in the mitochondrial intermembrane space.
+  Its core role is to re-oxidize MIA40/CHCHD4 in the mitochondrial disulfide relay, enabling oxidative folding and
+  import/retention of cysteine-rich IMS proteins.'
 alternative_products:
 - name: 1 (HPO-205, lfALR)
   id: P55789-1
@@ -19,216 +21,668 @@ existing_annotations:
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct and core. GFER/ALR is the FAD-linked sulfhydryl oxidase of the mitochondrial disulfide
+      relay.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/GFER/GFER-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: The literature retrieved consistently maps **human GFER** to **ALR (augmenter of liver
+        regeneration)** and the mammalian homolog of **yeast Erv1**, a **FAD-linked sulfhydryl oxidase**
+        functioning in the **mitochondrial IMS disulfide relay**. This matches the UniProt P55789 description
+        (FAD-linked sulfhydryl oxidase ALR; EC 1.8.3.2; aliases ALR/HERV1/HPO).
+        (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 16-19)
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: ALR/GFER is a **FAD-dependent sulfhydryl oxidase** whose direct physiological substrate
+        is the **reduced CPC motif of MIA40/CHCHD4**. It accepts electrons from reduced MIA40, transfers them
+        through its own redox-active cysteine motifs to FAD, and then reduces downstream electron acceptors
+        (primarily cytochrome c), thereby enabling repeated rounds of oxidative folding and IMS protein
+        biogenesis. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 25-31)
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: '| Enzymatic activity (EC 1.8.3.2) | GFER/ALR is a **sulfhydryl oxidase** that re-oxidizes
+        **MIA40/CHCHD4** after MIA40 oxidizes incoming IMS substrates. Electron flow is **substrate thiols → MIA40
+        CPC → ALR shuttle motif → ALR core CXXC/CAAC-CEEC → FAD → terminal acceptor (primarily cytochrome c, alternatively
+        O2)**, thereby enabling de novo disulfide formation and repeated oxidative folding cycles. | (zarges2024oxidativeproteinfolding
+        pages 8-9, finger2020proteinimportby pages 25-31, finger2020proteinimportby pages 8-10) | 2024-06, https://doi.org/10.1002/2211-5463.13839
+        ; 2020-03, https://doi.org/10.1515/hsz-2020-0108 |'
 - term:
     id: GO:0001889
     label: liver development
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Keep as non-core. ALR has historical growth factor/liver-regeneration biology, but the primary
+      mechanistically defined function of UniProt P55789 is IMS sulfhydryl oxidase activity.
+    action: KEEP_AS_NON_CORE
+    additional_reference_ids:
+    - file:human/GFER/GFER-deep-research-falcon.md
+    - PMID:20593814
+    reason: Liver development/regeneration is a downstream or isoform/context-associated phenotype, not the
+      core molecular function.
+    supported_by:
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: Older review literature notes reports of non-mitochondrial ALR forms
+        (cytosolic/nuclear/secreted growth factor activities), but for **functional annotation of UniProt
+        P55789**, the mechanistically defined and disease-linked role is the mitochondrial IMS sulfhydryl
+        oxidase in the disulfide relay. (fischer2013themitochondrialdisulfide pages 6-7)
+    - reference_id: PMID:20593814
+      supporting_text: The short form (sfALR, 15 kDa; starting at M81 of the human long form, lfALR, sequence
+        depicted in Figure 1A) is a circulating growth factor (11, 12, 15, 17, 18) and interacts with specific
+        receptors on the cell surface (19, 20).
 - term:
     id: GO:0005576
     label: extracellular region
   evidence_type: IEA
   original_reference_id: GO_REF:0000044
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Keep as non-core. extracellular region is consistent with reports of short/non-mitochondrial ALR
+      forms, but the core reviewed function is long ALR in the mitochondrial intermembrane space.
+    action: KEEP_AS_NON_CORE
+    additional_reference_ids:
+    - file:human/GFER/GFER-deep-research-falcon.md
+    reason: Retain as non-core because non-mitochondrial ALR forms are reported, while prioritizing IMS
+      disulfide-relay function.
+    supported_by:
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: A hepatology review summarizes **two principal ALR isoforms**, approximately **~15 kDa
+        (short)** and **~22 kDa (long)**; the **long isoform** functions in the mitochondrial IMS as a core
+        MIA/disulfide relay component. (nalesnik2017augmenterofliver pages 1-4)
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: Older review literature notes reports of non-mitochondrial ALR forms
+        (cytosolic/nuclear/secreted growth factor activities), but for **functional annotation of UniProt
+        P55789**, the mechanistically defined and disease-linked role is the mitochondrial IMS sulfhydryl
+        oxidase in the disulfide relay. (fischer2013themitochondrialdisulfide pages 6-7)
 - term:
     id: GO:0005737
     label: cytoplasm
   evidence_type: IEA
   original_reference_id: GO_REF:0000044
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Keep as non-core. cytoplasm is consistent with reports of short/non-mitochondrial ALR forms, but
+      the core reviewed function is long ALR in the mitochondrial intermembrane space.
+    action: KEEP_AS_NON_CORE
+    additional_reference_ids:
+    - file:human/GFER/GFER-deep-research-falcon.md
+    reason: Retain as non-core because non-mitochondrial ALR forms are reported, while prioritizing IMS
+      disulfide-relay function.
+    supported_by:
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: A hepatology review summarizes **two principal ALR isoforms**, approximately **~15 kDa
+        (short)** and **~22 kDa (long)**; the **long isoform** functions in the mitochondrial IMS as a core
+        MIA/disulfide relay component. (nalesnik2017augmenterofliver pages 1-4)
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: Older review literature notes reports of non-mitochondrial ALR forms
+        (cytosolic/nuclear/secreted growth factor activities), but for **functional annotation of UniProt
+        P55789**, the mechanistically defined and disease-linked role is the mitochondrial IMS sulfhydryl
+        oxidase in the disulfide relay. (fischer2013themitochondrialdisulfide pages 6-7)
 - term:
     id: GO:0005739
     label: mitochondrion
   evidence_type: IEA
   original_reference_id: GO_REF:0000044
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct but broad. GFER/long ALR is specifically localized to the mitochondrial intermembrane
+      space.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/GFER/GFER-deep-research-falcon.md
+    reason: Prefer mitochondrial intermembrane space and mitochondrial disulfide relay system over generic
+      mitochondrion.
+    supported_by:
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: The best-supported primary functional localization of long ALR is the **mitochondrial
+        intermembrane space**, where it operates in oxidative folding/protein import with MIA40.
+        (zarges2024oxidativeproteinfolding pages 8-9, nalesnik2017augmenterofliver pages 1-4)
 - term:
     id: GO:0005758
     label: mitochondrial intermembrane space
   evidence_type: IEA
   original_reference_id: GO_REF:0000044
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct and core. Long ALR/GFER functions in the mitochondrial intermembrane space.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/GFER/GFER-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: The best-supported primary functional localization of long ALR is the **mitochondrial
+        intermembrane space**, where it operates in oxidative folding/protein import with MIA40.
+        (zarges2024oxidativeproteinfolding pages 8-9, nalesnik2017augmenterofliver pages 1-4)
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: A hepatology review summarizes **two principal ALR isoforms**, approximately **~15 kDa
+        (short)** and **~22 kDa (long)**; the **long isoform** functions in the mitochondrial IMS as a core
+        MIA/disulfide relay component. (nalesnik2017augmenterofliver pages 1-4)
 - term:
     id: GO:0015035
     label: protein-disulfide reductase activity
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: The disulfide-relay context is right, but reductase is the wrong direction for GFER. GFER
+      oxidizes thiols/re-oxidizes MIA40 as a sulfhydryl oxidase.
+    action: MODIFY
+    additional_reference_ids:
+    - file:human/GFER/GFER-deep-research-falcon.md
+    reason: Replace protein-disulfide reductase activity with sulfhydryl/thiol oxidase activity for GFER.
+    proposed_replacement_terms:
+    - id: GO:0016971
+      label: flavin-dependent sulfhydryl oxidase activity
+    - id: GO:0016972
+      label: thiol oxidase activity
+    supported_by:
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: The IMS contains an oxidative folding/import pathway in which incoming cysteine-rich
+        proteins are oxidized and trapped in the IMS by formation of disulfide bonds. In mammals, the core
+        catalytic pair is **MIA40/CHCHD4 (oxidoreductase)** and **ALR/GFER (sulfhydryl oxidase)**. ALR’s
+        central biochemical function is to **regenerate oxidized MIA40** after MIA40 transfers disulfides to
+        substrates. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 8-10)
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: ALR/GFER is a **FAD-dependent sulfhydryl oxidase** whose direct physiological substrate
+        is the **reduced CPC motif of MIA40/CHCHD4**. It accepts electrons from reduced MIA40, transfers them
+        through its own redox-active cysteine motifs to FAD, and then reduces downstream electron acceptors
+        (primarily cytochrome c), thereby enabling repeated rounds of oxidative folding and IMS protein
+        biogenesis. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 25-31)
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: '| Enzymatic activity (EC 1.8.3.2) | GFER/ALR is a **sulfhydryl oxidase** that re-oxidizes
+        **MIA40/CHCHD4** after MIA40 oxidizes incoming IMS substrates. Electron flow is **substrate thiols → MIA40
+        CPC → ALR shuttle motif → ALR core CXXC/CAAC-CEEC → FAD → terminal acceptor (primarily cytochrome c, alternatively
+        O2)**, thereby enabling de novo disulfide formation and repeated oxidative folding cycles. | (zarges2024oxidativeproteinfolding
+        pages 8-9, finger2020proteinimportby pages 25-31, finger2020proteinimportby pages 8-10) | 2024-06, https://doi.org/10.1002/2211-5463.13839
+        ; 2020-03, https://doi.org/10.1515/hsz-2020-0108 |'
 - term:
     id: GO:0016971
     label: flavin-dependent sulfhydryl oxidase activity
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct and core. GFER/ALR is the FAD-linked sulfhydryl oxidase of the mitochondrial disulfide
+      relay.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/GFER/GFER-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: The literature retrieved consistently maps **human GFER** to **ALR (augmenter of liver
+        regeneration)** and the mammalian homolog of **yeast Erv1**, a **FAD-linked sulfhydryl oxidase**
+        functioning in the **mitochondrial IMS disulfide relay**. This matches the UniProt P55789 description
+        (FAD-linked sulfhydryl oxidase ALR; EC 1.8.3.2; aliases ALR/HERV1/HPO).
+        (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 16-19)
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: ALR/GFER is a **FAD-dependent sulfhydryl oxidase** whose direct physiological substrate
+        is the **reduced CPC motif of MIA40/CHCHD4**. It accepts electrons from reduced MIA40, transfers them
+        through its own redox-active cysteine motifs to FAD, and then reduces downstream electron acceptors
+        (primarily cytochrome c), thereby enabling repeated rounds of oxidative folding and IMS protein
+        biogenesis. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 25-31)
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: '| Enzymatic activity (EC 1.8.3.2) | GFER/ALR is a **sulfhydryl oxidase** that re-oxidizes
+        **MIA40/CHCHD4** after MIA40 oxidizes incoming IMS substrates. Electron flow is **substrate thiols → MIA40
+        CPC → ALR shuttle motif → ALR core CXXC/CAAC-CEEC → FAD → terminal acceptor (primarily cytochrome c, alternatively
+        O2)**, thereby enabling de novo disulfide formation and repeated oxidative folding cycles. | (zarges2024oxidativeproteinfolding
+        pages 8-9, finger2020proteinimportby pages 25-31, finger2020proteinimportby pages 8-10) | 2024-06, https://doi.org/10.1002/2211-5463.13839
+        ; 2020-03, https://doi.org/10.1515/hsz-2020-0108 |'
 - term:
     id: GO:0016972
     label: thiol oxidase activity
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct. Thiol oxidase activity captures the sulfhydryl oxidase chemistry of ALR/GFER.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/GFER/GFER-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: ALR/GFER is a **FAD-dependent sulfhydryl oxidase** whose direct physiological substrate
+        is the **reduced CPC motif of MIA40/CHCHD4**. It accepts electrons from reduced MIA40, transfers them
+        through its own redox-active cysteine motifs to FAD, and then reduces downstream electron acceptors
+        (primarily cytochrome c), thereby enabling repeated rounds of oxidative folding and IMS protein
+        biogenesis. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 25-31)
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: '| Enzymatic activity (EC 1.8.3.2) | GFER/ALR is a **sulfhydryl oxidase** that re-oxidizes
+        **MIA40/CHCHD4** after MIA40 oxidizes incoming IMS substrates. Electron flow is **substrate thiols → MIA40
+        CPC → ALR shuttle motif → ALR core CXXC/CAAC-CEEC → FAD → terminal acceptor (primarily cytochrome c, alternatively
+        O2)**, thereby enabling de novo disulfide formation and repeated oxidative folding cycles. | (zarges2024oxidativeproteinfolding
+        pages 8-9, finger2020proteinimportby pages 25-31, finger2020proteinimportby pages 8-10) | 2024-06, https://doi.org/10.1002/2211-5463.13839
+        ; 2020-03, https://doi.org/10.1515/hsz-2020-0108 |'
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:25416956
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Protein binding is too generic for GFER. The informative role is FAD-dependent sulfhydryl oxidase
+      activity in the MIA40/CHCHD4 disulfide relay.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/GFER/GFER-deep-research-falcon.md
+    reason: Replace generic interaction capture with sulfhydryl oxidase activity and mitochondrial disulfide
+      relay system annotations.
+    supported_by:
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: The IMS contains an oxidative folding/import pathway in which incoming cysteine-rich
+        proteins are oxidized and trapped in the IMS by formation of disulfide bonds. In mammals, the core
+        catalytic pair is **MIA40/CHCHD4 (oxidoreductase)** and **ALR/GFER (sulfhydryl oxidase)**. ALR’s
+        central biochemical function is to **regenerate oxidized MIA40** after MIA40 transfers disulfides to
+        substrates. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 8-10)
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: ALR/GFER is a **FAD-dependent sulfhydryl oxidase** whose direct physiological substrate
+        is the **reduced CPC motif of MIA40/CHCHD4**. It accepts electrons from reduced MIA40, transfers them
+        through its own redox-active cysteine motifs to FAD, and then reduces downstream electron acceptors
+        (primarily cytochrome c), thereby enabling repeated rounds of oxidative folding and IMS protein
+        biogenesis. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 25-31)
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:32353859
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Protein binding is too generic for GFER. The informative role is FAD-dependent sulfhydryl oxidase
+      activity in the MIA40/CHCHD4 disulfide relay.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/GFER/GFER-deep-research-falcon.md
+    reason: Replace generic interaction capture with sulfhydryl oxidase activity and mitochondrial disulfide
+      relay system annotations.
+    supported_by:
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: The IMS contains an oxidative folding/import pathway in which incoming cysteine-rich
+        proteins are oxidized and trapped in the IMS by formation of disulfide bonds. In mammals, the core
+        catalytic pair is **MIA40/CHCHD4 (oxidoreductase)** and **ALR/GFER (sulfhydryl oxidase)**. ALR’s
+        central biochemical function is to **regenerate oxidized MIA40** after MIA40 transfers disulfides to
+        substrates. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 8-10)
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: ALR/GFER is a **FAD-dependent sulfhydryl oxidase** whose direct physiological substrate
+        is the **reduced CPC motif of MIA40/CHCHD4**. It accepts electrons from reduced MIA40, transfers them
+        through its own redox-active cysteine motifs to FAD, and then reduces downstream electron acceptors
+        (primarily cytochrome c), thereby enabling repeated rounds of oxidative folding and IMS protein
+        biogenesis. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 25-31)
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:33060197
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Protein binding is too generic for GFER. The informative role is FAD-dependent sulfhydryl oxidase
+      activity in the MIA40/CHCHD4 disulfide relay.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/GFER/GFER-deep-research-falcon.md
+    reason: Replace generic interaction capture with sulfhydryl oxidase activity and mitochondrial disulfide
+      relay system annotations.
+    supported_by:
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: The IMS contains an oxidative folding/import pathway in which incoming cysteine-rich
+        proteins are oxidized and trapped in the IMS by formation of disulfide bonds. In mammals, the core
+        catalytic pair is **MIA40/CHCHD4 (oxidoreductase)** and **ALR/GFER (sulfhydryl oxidase)**. ALR’s
+        central biochemical function is to **regenerate oxidized MIA40** after MIA40 transfers disulfides to
+        substrates. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 8-10)
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: ALR/GFER is a **FAD-dependent sulfhydryl oxidase** whose direct physiological substrate
+        is the **reduced CPC motif of MIA40/CHCHD4**. It accepts electrons from reduced MIA40, transfers them
+        through its own redox-active cysteine motifs to FAD, and then reduces downstream electron acceptors
+        (primarily cytochrome c), thereby enabling repeated rounds of oxidative folding and IMS protein
+        biogenesis. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 25-31)
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:36217030
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Protein binding is too generic for GFER. The informative role is FAD-dependent sulfhydryl oxidase
+      activity in the MIA40/CHCHD4 disulfide relay.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/GFER/GFER-deep-research-falcon.md
+    reason: Replace generic interaction capture with sulfhydryl oxidase activity and mitochondrial disulfide
+      relay system annotations.
+    supported_by:
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: The IMS contains an oxidative folding/import pathway in which incoming cysteine-rich
+        proteins are oxidized and trapped in the IMS by formation of disulfide bonds. In mammals, the core
+        catalytic pair is **MIA40/CHCHD4 (oxidoreductase)** and **ALR/GFER (sulfhydryl oxidase)**. ALR’s
+        central biochemical function is to **regenerate oxidized MIA40** after MIA40 transfers disulfides to
+        substrates. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 8-10)
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: ALR/GFER is a **FAD-dependent sulfhydryl oxidase** whose direct physiological substrate
+        is the **reduced CPC motif of MIA40/CHCHD4**. It accepts electrons from reduced MIA40, transfers them
+        through its own redox-active cysteine motifs to FAD, and then reduces downstream electron acceptors
+        (primarily cytochrome c), thereby enabling repeated rounds of oxidative folding and IMS protein
+        biogenesis. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 25-31)
 - term:
     id: GO:0005739
     label: mitochondrion
   evidence_type: IDA
   original_reference_id: GO_REF:0000052
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct but broad. GFER/long ALR is specifically localized to the mitochondrial intermembrane
+      space.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/GFER/GFER-deep-research-falcon.md
+    reason: Prefer mitochondrial intermembrane space and mitochondrial disulfide relay system over generic
+      mitochondrion.
+    supported_by:
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: The best-supported primary functional localization of long ALR is the **mitochondrial
+        intermembrane space**, where it operates in oxidative folding/protein import with MIA40.
+        (zarges2024oxidativeproteinfolding pages 8-9, nalesnik2017augmenterofliver pages 1-4)
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: IDA
   original_reference_id: GO_REF:0000052
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Keep as non-core. cytosol is consistent with reports of short/non-mitochondrial ALR forms, but
+      the core reviewed function is long ALR in the mitochondrial intermembrane space.
+    action: KEEP_AS_NON_CORE
+    additional_reference_ids:
+    - file:human/GFER/GFER-deep-research-falcon.md
+    reason: Retain as non-core because non-mitochondrial ALR forms are reported, while prioritizing IMS
+      disulfide-relay function.
+    supported_by:
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: A hepatology review summarizes **two principal ALR isoforms**, approximately **~15 kDa
+        (short)** and **~22 kDa (long)**; the **long isoform** functions in the mitochondrial IMS as a core
+        MIA/disulfide relay component. (nalesnik2017augmenterofliver pages 1-4)
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: Older review literature notes reports of non-mitochondrial ALR forms
+        (cytosolic/nuclear/secreted growth factor activities), but for **functional annotation of UniProt
+        P55789**, the mechanistically defined and disease-linked role is the mitochondrial IMS sulfhydryl
+        oxidase in the disulfide relay. (fischer2013themitochondrialdisulfide pages 6-7)
 - term:
     id: GO:0016971
     label: flavin-dependent sulfhydryl oxidase activity
   evidence_type: EXP
   original_reference_id: PMID:20593814
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct and core. GFER/ALR is the FAD-linked sulfhydryl oxidase of the mitochondrial disulfide
+      relay.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/GFER/GFER-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: The literature retrieved consistently maps **human GFER** to **ALR (augmenter of liver
+        regeneration)** and the mammalian homolog of **yeast Erv1**, a **FAD-linked sulfhydryl oxidase**
+        functioning in the **mitochondrial IMS disulfide relay**. This matches the UniProt P55789 description
+        (FAD-linked sulfhydryl oxidase ALR; EC 1.8.3.2; aliases ALR/HERV1/HPO).
+        (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 16-19)
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: ALR/GFER is a **FAD-dependent sulfhydryl oxidase** whose direct physiological substrate
+        is the **reduced CPC motif of MIA40/CHCHD4**. It accepts electrons from reduced MIA40, transfers them
+        through its own redox-active cysteine motifs to FAD, and then reduces downstream electron acceptors
+        (primarily cytochrome c), thereby enabling repeated rounds of oxidative folding and IMS protein
+        biogenesis. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 25-31)
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: '| Enzymatic activity (EC 1.8.3.2) | GFER/ALR is a **sulfhydryl oxidase** that re-oxidizes
+        **MIA40/CHCHD4** after MIA40 oxidizes incoming IMS substrates. Electron flow is **substrate thiols → MIA40
+        CPC → ALR shuttle motif → ALR core CXXC/CAAC-CEEC → FAD → terminal acceptor (primarily cytochrome c, alternatively
+        O2)**, thereby enabling de novo disulfide formation and repeated oxidative folding cycles. | (zarges2024oxidativeproteinfolding
+        pages 8-9, finger2020proteinimportby pages 25-31, finger2020proteinimportby pages 8-10) | 2024-06, https://doi.org/10.1002/2211-5463.13839
+        ; 2020-03, https://doi.org/10.1515/hsz-2020-0108 |'
 - term:
     id: GO:0016971
     label: flavin-dependent sulfhydryl oxidase activity
   evidence_type: EXP
   original_reference_id: PMID:22224850
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct and core. GFER/ALR is the FAD-linked sulfhydryl oxidase of the mitochondrial disulfide
+      relay.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/GFER/GFER-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: The literature retrieved consistently maps **human GFER** to **ALR (augmenter of liver
+        regeneration)** and the mammalian homolog of **yeast Erv1**, a **FAD-linked sulfhydryl oxidase**
+        functioning in the **mitochondrial IMS disulfide relay**. This matches the UniProt P55789 description
+        (FAD-linked sulfhydryl oxidase ALR; EC 1.8.3.2; aliases ALR/HERV1/HPO).
+        (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 16-19)
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: ALR/GFER is a **FAD-dependent sulfhydryl oxidase** whose direct physiological substrate
+        is the **reduced CPC motif of MIA40/CHCHD4**. It accepts electrons from reduced MIA40, transfers them
+        through its own redox-active cysteine motifs to FAD, and then reduces downstream electron acceptors
+        (primarily cytochrome c), thereby enabling repeated rounds of oxidative folding and IMS protein
+        biogenesis. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 25-31)
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: '| Enzymatic activity (EC 1.8.3.2) | GFER/ALR is a **sulfhydryl oxidase** that re-oxidizes
+        **MIA40/CHCHD4** after MIA40 oxidizes incoming IMS substrates. Electron flow is **substrate thiols → MIA40
+        CPC → ALR shuttle motif → ALR core CXXC/CAAC-CEEC → FAD → terminal acceptor (primarily cytochrome c, alternatively
+        O2)**, thereby enabling de novo disulfide formation and repeated oxidative folding cycles. | (zarges2024oxidativeproteinfolding
+        pages 8-9, finger2020proteinimportby pages 25-31, finger2020proteinimportby pages 8-10) | 2024-06, https://doi.org/10.1002/2211-5463.13839
+        ; 2020-03, https://doi.org/10.1515/hsz-2020-0108 |'
 - term:
     id: GO:0016972
     label: thiol oxidase activity
   evidence_type: EXP
   original_reference_id: PMID:20593814
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct. Thiol oxidase activity captures the sulfhydryl oxidase chemistry of ALR/GFER.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/GFER/GFER-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: ALR/GFER is a **FAD-dependent sulfhydryl oxidase** whose direct physiological substrate
+        is the **reduced CPC motif of MIA40/CHCHD4**. It accepts electrons from reduced MIA40, transfers them
+        through its own redox-active cysteine motifs to FAD, and then reduces downstream electron acceptors
+        (primarily cytochrome c), thereby enabling repeated rounds of oxidative folding and IMS protein
+        biogenesis. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 25-31)
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: '| Enzymatic activity (EC 1.8.3.2) | GFER/ALR is a **sulfhydryl oxidase** that re-oxidizes
+        **MIA40/CHCHD4** after MIA40 oxidizes incoming IMS substrates. Electron flow is **substrate thiols → MIA40
+        CPC → ALR shuttle motif → ALR core CXXC/CAAC-CEEC → FAD → terminal acceptor (primarily cytochrome c, alternatively
+        O2)**, thereby enabling de novo disulfide formation and repeated oxidative folding cycles. | (zarges2024oxidativeproteinfolding
+        pages 8-9, finger2020proteinimportby pages 25-31, finger2020proteinimportby pages 8-10) | 2024-06, https://doi.org/10.1002/2211-5463.13839
+        ; 2020-03, https://doi.org/10.1515/hsz-2020-0108 |'
 - term:
     id: GO:0016972
     label: thiol oxidase activity
   evidence_type: EXP
   original_reference_id: PMID:22224850
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct. Thiol oxidase activity captures the sulfhydryl oxidase chemistry of ALR/GFER.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/GFER/GFER-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: ALR/GFER is a **FAD-dependent sulfhydryl oxidase** whose direct physiological substrate
+        is the **reduced CPC motif of MIA40/CHCHD4**. It accepts electrons from reduced MIA40, transfers them
+        through its own redox-active cysteine motifs to FAD, and then reduces downstream electron acceptors
+        (primarily cytochrome c), thereby enabling repeated rounds of oxidative folding and IMS protein
+        biogenesis. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 25-31)
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: '| Enzymatic activity (EC 1.8.3.2) | GFER/ALR is a **sulfhydryl oxidase** that re-oxidizes
+        **MIA40/CHCHD4** after MIA40 oxidizes incoming IMS substrates. Electron flow is **substrate thiols → MIA40
+        CPC → ALR shuttle motif → ALR core CXXC/CAAC-CEEC → FAD → terminal acceptor (primarily cytochrome c, alternatively
+        O2)**, thereby enabling de novo disulfide formation and repeated oxidative folding cycles. | (zarges2024oxidativeproteinfolding
+        pages 8-9, finger2020proteinimportby pages 25-31, finger2020proteinimportby pages 8-10) | 2024-06, https://doi.org/10.1002/2211-5463.13839
+        ; 2020-03, https://doi.org/10.1515/hsz-2020-0108 |'
 - term:
     id: GO:0160203
     label: mitochondrial disulfide relay system
   evidence_type: IDA
   original_reference_id: PMID:21383138
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct and core. GFER/ALR re-oxidizes MIA40/CHCHD4 in the mitochondrial disulfide relay system.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/GFER/GFER-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: The IMS contains an oxidative folding/import pathway in which incoming cysteine-rich
+        proteins are oxidized and trapped in the IMS by formation of disulfide bonds. In mammals, the core
+        catalytic pair is **MIA40/CHCHD4 (oxidoreductase)** and **ALR/GFER (sulfhydryl oxidase)**. ALR’s
+        central biochemical function is to **regenerate oxidized MIA40** after MIA40 transfers disulfides to
+        substrates. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 8-10)
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: ALR/GFER is a **FAD-dependent sulfhydryl oxidase** whose direct physiological substrate
+        is the **reduced CPC motif of MIA40/CHCHD4**. It accepts electrons from reduced MIA40, transfers them
+        through its own redox-active cysteine motifs to FAD, and then reduces downstream electron acceptors
+        (primarily cytochrome c), thereby enabling repeated rounds of oxidative folding and IMS protein
+        biogenesis. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 25-31)
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: '| Enzymatic activity (EC 1.8.3.2) | GFER/ALR is a **sulfhydryl oxidase** that re-oxidizes
+        **MIA40/CHCHD4** after MIA40 oxidizes incoming IMS substrates. Electron flow is **substrate thiols → MIA40
+        CPC → ALR shuttle motif → ALR core CXXC/CAAC-CEEC → FAD → terminal acceptor (primarily cytochrome c, alternatively
+        O2)**, thereby enabling de novo disulfide formation and repeated oxidative folding cycles. | (zarges2024oxidativeproteinfolding
+        pages 8-9, finger2020proteinimportby pages 25-31, finger2020proteinimportby pages 8-10) | 2024-06, https://doi.org/10.1002/2211-5463.13839
+        ; 2020-03, https://doi.org/10.1515/hsz-2020-0108 |'
 - term:
     id: GO:0005739
     label: mitochondrion
   evidence_type: HTP
   original_reference_id: PMID:34800366
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct but broad. GFER/long ALR is specifically localized to the mitochondrial intermembrane
+      space.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/GFER/GFER-deep-research-falcon.md
+    reason: Prefer mitochondrial intermembrane space and mitochondrial disulfide relay system over generic
+      mitochondrion.
+    supported_by:
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: The best-supported primary functional localization of long ALR is the **mitochondrial
+        intermembrane space**, where it operates in oxidative folding/protein import with MIA40.
+        (zarges2024oxidativeproteinfolding pages 8-9, nalesnik2017augmenterofliver pages 1-4)
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:23676665
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Protein binding is too generic for GFER. The informative role is FAD-dependent sulfhydryl oxidase
+      activity in the MIA40/CHCHD4 disulfide relay.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/GFER/GFER-deep-research-falcon.md
+    reason: Replace generic interaction capture with sulfhydryl oxidase activity and mitochondrial disulfide
+      relay system annotations.
+    supported_by:
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: The IMS contains an oxidative folding/import pathway in which incoming cysteine-rich
+        proteins are oxidized and trapped in the IMS by formation of disulfide bonds. In mammals, the core
+        catalytic pair is **MIA40/CHCHD4 (oxidoreductase)** and **ALR/GFER (sulfhydryl oxidase)**. ALR’s
+        central biochemical function is to **regenerate oxidized MIA40** after MIA40 transfers disulfides to
+        substrates. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 8-10)
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: ALR/GFER is a **FAD-dependent sulfhydryl oxidase** whose direct physiological substrate
+        is the **reduced CPC motif of MIA40/CHCHD4**. It accepts electrons from reduced MIA40, transfers them
+        through its own redox-active cysteine motifs to FAD, and then reduces downstream electron acceptors
+        (primarily cytochrome c), thereby enabling repeated rounds of oxidative folding and IMS protein
+        biogenesis. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 25-31)
 - term:
     id: GO:0005739
     label: mitochondrion
   evidence_type: IDA
   original_reference_id: PMID:23676665
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct but broad. GFER/long ALR is specifically localized to the mitochondrial intermembrane
+      space.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/GFER/GFER-deep-research-falcon.md
+    reason: Prefer mitochondrial intermembrane space and mitochondrial disulfide relay system over generic
+      mitochondrion.
+    supported_by:
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: The best-supported primary functional localization of long ALR is the **mitochondrial
+        intermembrane space**, where it operates in oxidative folding/protein import with MIA40.
+        (zarges2024oxidativeproteinfolding pages 8-9, nalesnik2017augmenterofliver pages 1-4)
 - term:
     id: GO:0015035
     label: protein-disulfide reductase activity
   evidence_type: IDA
   original_reference_id: PMID:22224850
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: The disulfide-relay context is right, but reductase is the wrong direction for GFER. GFER
+      oxidizes thiols/re-oxidizes MIA40 as a sulfhydryl oxidase.
+    action: MODIFY
+    additional_reference_ids:
+    - file:human/GFER/GFER-deep-research-falcon.md
+    reason: Replace protein-disulfide reductase activity with sulfhydryl/thiol oxidase activity for GFER.
+    proposed_replacement_terms:
+    - id: GO:0016971
+      label: flavin-dependent sulfhydryl oxidase activity
+    - id: GO:0016972
+      label: thiol oxidase activity
+    supported_by:
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: The IMS contains an oxidative folding/import pathway in which incoming cysteine-rich
+        proteins are oxidized and trapped in the IMS by formation of disulfide bonds. In mammals, the core
+        catalytic pair is **MIA40/CHCHD4 (oxidoreductase)** and **ALR/GFER (sulfhydryl oxidase)**. ALR’s
+        central biochemical function is to **regenerate oxidized MIA40** after MIA40 transfers disulfides to
+        substrates. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 8-10)
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: ALR/GFER is a **FAD-dependent sulfhydryl oxidase** whose direct physiological substrate
+        is the **reduced CPC motif of MIA40/CHCHD4**. It accepts electrons from reduced MIA40, transfers them
+        through its own redox-active cysteine motifs to FAD, and then reduces downstream electron acceptors
+        (primarily cytochrome c), thereby enabling repeated rounds of oxidative folding and IMS protein
+        biogenesis. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 25-31)
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: '| Enzymatic activity (EC 1.8.3.2) | GFER/ALR is a **sulfhydryl oxidase** that re-oxidizes
+        **MIA40/CHCHD4** after MIA40 oxidizes incoming IMS substrates. Electron flow is **substrate thiols → MIA40
+        CPC → ALR shuttle motif → ALR core CXXC/CAAC-CEEC → FAD → terminal acceptor (primarily cytochrome c, alternatively
+        O2)**, thereby enabling de novo disulfide formation and repeated oxidative folding cycles. | (zarges2024oxidativeproteinfolding
+        pages 8-9, finger2020proteinimportby pages 25-31, finger2020proteinimportby pages 8-10) | 2024-06, https://doi.org/10.1002/2211-5463.13839
+        ; 2020-03, https://doi.org/10.1515/hsz-2020-0108 |'
 - term:
     id: GO:0050660
     label: flavin adenine dinucleotide binding
   evidence_type: IDA
   original_reference_id: PMID:22224850
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct. GFER/ALR is a FAD-linked sulfhydryl oxidase with a noncovalently bound FAD cofactor.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/GFER/GFER-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: The literature retrieved consistently maps **human GFER** to **ALR (augmenter of liver
+        regeneration)** and the mammalian homolog of **yeast Erv1**, a **FAD-linked sulfhydryl oxidase**
+        functioning in the **mitochondrial IMS disulfide relay**. This matches the UniProt P55789 description
+        (FAD-linked sulfhydryl oxidase ALR; EC 1.8.3.2; aliases ALR/HERV1/HPO).
+        (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 16-19)
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: '- ALR contains an **N-terminal shuttle domain** with a redox-active **CRAC** motif and a
+        **core domain** containing a redox-active **CAAC (CXXC-like)** motif and a **noncovalently bound FAD**.
+        (zarges2024oxidativeproteinfolding pages 8-9)'
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:12681488
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Protein binding is too generic for GFER. The informative role is FAD-dependent sulfhydryl oxidase
+      activity in the MIA40/CHCHD4 disulfide relay.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/GFER/GFER-deep-research-falcon.md
+    reason: Replace generic interaction capture with sulfhydryl oxidase activity and mitochondrial disulfide
+      relay system annotations.
+    supported_by:
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: The IMS contains an oxidative folding/import pathway in which incoming cysteine-rich
+        proteins are oxidized and trapped in the IMS by formation of disulfide bonds. In mammals, the core
+        catalytic pair is **MIA40/CHCHD4 (oxidoreductase)** and **ALR/GFER (sulfhydryl oxidase)**. ALR’s
+        central biochemical function is to **regenerate oxidized MIA40** after MIA40 transfers disulfides to
+        substrates. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 8-10)
+    - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+      supporting_text: ALR/GFER is a **FAD-dependent sulfhydryl oxidase** whose direct physiological substrate
+        is the **reduced CPC motif of MIA40/CHCHD4**. It accepts electrons from reduced MIA40, transfers them
+        through its own redox-active cysteine motifs to FAD, and then reduces downstream electron acceptors
+        (primarily cytochrome c), thereby enabling repeated rounds of oxidative folding and IMS protein
+        biogenesis. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 25-31)
 references:
 - id: GO_REF:0000033
   title: Annotation inferences using phylogenetic trees
   findings: []
 - id: GO_REF:0000044
-  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
-    vocabulary mapping, accompanied by conservative changes to GO terms applied by
-    UniProt
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping,
+    accompanied by conservative changes to GO terms applied by UniProt
   findings: []
 - id: GO_REF:0000052
   title: Gene Ontology annotation based on curation of immunofluorescence data
@@ -240,25 +694,23 @@ references:
   title: Combined Automated Annotation using Multiple IEA Methods
   findings: []
 - id: PMID:12681488
-  title: The apoptosis-associated protein BNIPL interacts with two cell proliferation-related
-    proteins, MIF and GFER.
+  title: The apoptosis-associated protein BNIPL interacts with two cell proliferation-related proteins, MIF
+    and GFER.
   findings: []
 - id: PMID:20593814
-  title: Structure of the human sulfhydryl oxidase augmenter of liver regeneration
-    and characterization of a human mutation causing an autosomal recessive myopathy
-    .
+  title: Structure of the human sulfhydryl oxidase augmenter of liver regeneration and characterization of a
+    human mutation causing an autosomal recessive myopathy .
   findings: []
 - id: PMID:21383138
-  title: Molecular recognition and substrate mimicry drive the electron-transfer process
-    between MIA40 and ALR.
+  title: Molecular recognition and substrate mimicry drive the electron-transfer process between MIA40 and
+    ALR.
   findings: []
 - id: PMID:22224850
-  title: 'An electron-transfer path through an extended disulfide relay system: the
-    case of the redox protein ALR.'
+  title: 'An electron-transfer path through an extended disulfide relay system: the case of the redox protein ALR.'
   findings: []
 - id: PMID:23676665
-  title: Protein import and oxidative folding in the mitochondrial intermembrane space
-    of intact mammalian cells.
+  title: Protein import and oxidative folding in the mitochondrial intermembrane space of intact mammalian
+    cells.
   findings: []
 - id: PMID:25416956
   title: A proteome-scale map of the human interactome network.
@@ -267,14 +719,76 @@ references:
   title: A SARS-CoV-2 protein interaction map reveals targets for drug repurposing.
   findings: []
 - id: PMID:33060197
-  title: Comparative host-coronavirus protein interaction networks reveal pan-viral
-    disease mechanisms.
+  title: Comparative host-coronavirus protein interaction networks reveal pan-viral disease mechanisms.
   findings: []
 - id: PMID:34800366
-  title: Quantitative high-confidence human mitochondrial proteome and its dynamics
-    in cellular context.
+  title: Quantitative high-confidence human mitochondrial proteome and its dynamics in cellular context.
   findings: []
 - id: PMID:36217030
-  title: A comprehensive SARS-CoV-2-human protein-protein interactome reveals COVID-19
-    pathobiology and potential host therapeutic targets.
+  title: A comprehensive SARS-CoV-2-human protein-protein interactome reveals COVID-19 pathobiology and
+    potential host therapeutic targets.
   findings: []
+- id: file:human/GFER/GFER-deep-research-falcon.md
+  title: Falcon deep research report for human GFER
+  findings: []
+core_functions:
+- description: GFER/ALR is the FAD-dependent sulfhydryl oxidase of the mitochondrial intermembrane-space
+    disulfide relay. It re-oxidizes MIA40/CHCHD4 after substrate oxidation, passing electrons through ALR
+    redox cysteine motifs to FAD and downstream acceptors to support oxidative folding and retention of
+    cysteine-rich IMS proteins.
+  supported_by:
+  - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+    supporting_text: The literature retrieved consistently maps **human GFER** to **ALR (augmenter of liver
+      regeneration)** and the mammalian homolog of **yeast Erv1**, a **FAD-linked sulfhydryl oxidase**
+      functioning in the **mitochondrial IMS disulfide relay**. This matches the UniProt P55789 description
+      (FAD-linked sulfhydryl oxidase ALR; EC 1.8.3.2; aliases ALR/HERV1/HPO).
+      (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 16-19)
+  - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+    supporting_text: The IMS contains an oxidative folding/import pathway in which incoming cysteine-rich
+      proteins are oxidized and trapped in the IMS by formation of disulfide bonds. In mammals, the core
+      catalytic pair is **MIA40/CHCHD4 (oxidoreductase)** and **ALR/GFER (sulfhydryl oxidase)**. ALR’s central
+      biochemical function is to **regenerate oxidized MIA40** after MIA40 transfers disulfides to substrates.
+      (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 8-10)
+  - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+    supporting_text: ALR/GFER is a **FAD-dependent sulfhydryl oxidase** whose direct physiological substrate
+      is the **reduced CPC motif of MIA40/CHCHD4**. It accepts electrons from reduced MIA40, transfers them
+      through its own redox-active cysteine motifs to FAD, and then reduces downstream electron acceptors
+      (primarily cytochrome c), thereby enabling repeated rounds of oxidative folding and IMS protein
+      biogenesis. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 25-31)
+  - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+    supporting_text: The best-supported primary functional localization of long ALR is the **mitochondrial
+      intermembrane space**, where it operates in oxidative folding/protein import with MIA40.
+      (zarges2024oxidativeproteinfolding pages 8-9, nalesnik2017augmenterofliver pages 1-4)
+  - reference_id: file:human/GFER/GFER-deep-research-falcon.md
+    supporting_text: '| Enzymatic activity (EC 1.8.3.2) | GFER/ALR is a **sulfhydryl oxidase** that re-oxidizes
+      **MIA40/CHCHD4** after MIA40 oxidizes incoming IMS substrates. Electron flow is **substrate thiols → MIA40
+      CPC → ALR shuttle motif → ALR core CXXC/CAAC-CEEC → FAD → terminal acceptor (primarily cytochrome c, alternatively
+      O2)**, thereby enabling de novo disulfide formation and repeated oxidative folding cycles. | (zarges2024oxidativeproteinfolding
+      pages 8-9, finger2020proteinimportby pages 25-31, finger2020proteinimportby pages 8-10) | 2024-06, https://doi.org/10.1002/2211-5463.13839
+      ; 2020-03, https://doi.org/10.1515/hsz-2020-0108 |'
+  molecular_function:
+    id: GO:0016971
+    label: flavin-dependent sulfhydryl oxidase activity
+  directly_involved_in:
+  - id: GO:0160203
+    label: mitochondrial disulfide relay system
+  locations:
+  - id: GO:0005758
+    label: mitochondrial intermembrane space
+proposed_new_terms: []
+suggested_questions:
+- question: How do short and long GFER/ALR isoforms divide mitochondrial IMS oxidase function from reported
+    cytosolic or extracellular activities?
+  experts: []
+- question: Which ALR electron acceptor routes dominate in human cells under respiratory stress or MIA pathway
+    inhibition?
+  experts: []
+suggested_experiments:
+- hypothesis: Disease-associated GFER variants primarily impair IMS substrate biogenesis by destabilizing
+    FAD-linked ALR rather than abolishing all residual catalytic chemistry.
+  description: Rescue GFER-deficient cells with wild-type and variant ALR, then quantify FAD retention, MIA40
+    redox state, import/oxidation of cysteine-rich IMS substrates, and respiratory complex assembly.
+- hypothesis: Reported non-mitochondrial ALR activities are isoform-specific and separable from long-isoform
+    IMS disulfide-relay function.
+  description: Express isoform-specific GFER constructs with compartment-restricted tags and compare
+    localization, secreted/cytosolic signaling readouts, and rescue of MIA pathway substrate import.

--- a/genes/human/GFER/GFER-deep-research-falcon.md
+++ b/genes/human/GFER/GFER-deep-research-falcon.md
@@ -1,0 +1,381 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: true
+start_time: '2026-05-11T18:36:03.813221'
+end_time: '2026-05-11T18:36:03.815515'
+duration_seconds: 0.0
+template_file: templates/gene_research_go_focused.md
+template_variables:
+  organism: human
+  gene_id: GFER
+  gene_symbol: GFER
+  uniprot_accession: P55789
+  protein_description: 'RecName: Full=FAD-linked sulfhydryl oxidase ALR {ECO:0000305|PubMed:20593814};
+    EC=1.8.3.2 {ECO:0000269|PubMed:20593814, ECO:0000269|PubMed:22224850}; AltName:
+    Full=Augmenter of liver regeneration; Short=hERV1; AltName: Full=Hepatopoietin;'
+  gene_info: Name=GFER {ECO:0000312|HGNC:HGNC:4236}; Synonyms=ALR, HERV1, HPO;
+  organism_full: Homo sapiens (Human).
+  protein_family: Not specified in UniProt
+  protein_domains: ALR/ERV. (IPR039799); ERV/ALR_sulphydryl_oxid_sf. (IPR036774);
+    ERV/ALR_sulphydryl_oxidase. (IPR017905); Evr1_Alr (PF04777)
+provider_config:
+  timeout: 600
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 38
+---
+
+## Question
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** P55789
+- **Protein Description:** RecName: Full=FAD-linked sulfhydryl oxidase ALR {ECO:0000305|PubMed:20593814}; EC=1.8.3.2 {ECO:0000269|PubMed:20593814, ECO:0000269|PubMed:22224850}; AltName: Full=Augmenter of liver regeneration; Short=hERV1; AltName: Full=Hepatopoietin;
+- **Gene Information:** Name=GFER {ECO:0000312|HGNC:HGNC:4236}; Synonyms=ALR, HERV1, HPO;
+- **Organism (full):** Homo sapiens (Human).
+- **Protein Family:** Not specified in UniProt
+- **Key Domains:** ALR/ERV. (IPR039799); ERV/ALR_sulphydryl_oxid_sf. (IPR036774); ERV/ALR_sulphydryl_oxidase. (IPR017905); Evr1_Alr (PF04777)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "GFER" matches the protein description above**
+2. **Verify the organism is correct:** Homo sapiens (Human).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'GFER' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **GFER** (gene ID: GFER, UniProt: P55789) in human.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** P55789
+- **Protein Description:** RecName: Full=FAD-linked sulfhydryl oxidase ALR {ECO:0000305|PubMed:20593814}; EC=1.8.3.2 {ECO:0000269|PubMed:20593814, ECO:0000269|PubMed:22224850}; AltName: Full=Augmenter of liver regeneration; Short=hERV1; AltName: Full=Hepatopoietin;
+- **Gene Information:** Name=GFER {ECO:0000312|HGNC:HGNC:4236}; Synonyms=ALR, HERV1, HPO;
+- **Organism (full):** Homo sapiens (Human).
+- **Protein Family:** Not specified in UniProt
+- **Key Domains:** ALR/ERV. (IPR039799); ERV/ALR_sulphydryl_oxid_sf. (IPR036774); ERV/ALR_sulphydryl_oxidase. (IPR017905); Evr1_Alr (PF04777)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "GFER" matches the protein description above**
+2. **Verify the organism is correct:** Homo sapiens (Human).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'GFER' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **GFER** (gene ID: GFER, UniProt: P55789) in human.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Comprehensive Research Report: Human **GFER** (UniProt P55789) / **ALR** (Augmenter of Liver Regeneration)
+
+### Executive summary
+**GFER** encodes **ALR/Erv1**, a **FAD-dependent sulfhydryl oxidase** in the **mitochondrial intermembrane space (IMS)** that is essential for the **mitochondrial disulfide relay** (also called the **MIA pathway**). Its primary, best-supported role is to **re-oxidize the oxidoreductase MIA40/CHCHD4**, thereby enabling oxidative folding and import/retention of cysteine-rich IMS proteins. Mechanistically, ALR transfers electrons from reduced MIA40 to its **FAD** cofactor and then typically to **cytochrome c** (feeding into complex IV), with **molecular oxygen** as an alternative acceptor that yields **H2O2** as by-product and is reported to be much slower than cytochrome c transfer in the human system. Disruptive biallelic variants in GFER cause autosomal-recessive mitochondrial disease with myopathy and multi-system involvement; a well-studied example is **R194H**, which impairs ALR stability/cofactor handling and is associated with combined respiratory-chain deficiency. Recent (2024) advances include an updated mechanistic synthesis of human IMS oxidative folding and chemical-biology studies describing **MitoBlock** small-molecule inhibitors that bind near ALR’s CEEC/FAD region and modulate the import pathway.
+
+### Mandatory verification: correct gene/protein identity
+The literature retrieved consistently maps **human GFER** to **ALR (augmenter of liver regeneration)** and the mammalian homolog of **yeast Erv1**, a **FAD-linked sulfhydryl oxidase** functioning in the **mitochondrial IMS disulfide relay**. This matches the UniProt P55789 description (FAD-linked sulfhydryl oxidase ALR; EC 1.8.3.2; aliases ALR/HERV1/HPO). (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 16-19)
+
+---
+
+## 1. Key concepts and definitions (current understanding)
+
+### 1.1 The mitochondrial disulfide relay (MIA pathway)
+The IMS contains an oxidative folding/import pathway in which incoming cysteine-rich proteins are oxidized and trapped in the IMS by formation of disulfide bonds. In mammals, the core catalytic pair is **MIA40/CHCHD4 (oxidoreductase)** and **ALR/GFER (sulfhydryl oxidase)**. ALR’s central biochemical function is to **regenerate oxidized MIA40** after MIA40 transfers disulfides to substrates. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 8-10)
+
+### 1.2 What does ALR/GFER do (primary function)?
+ALR/GFER is a **FAD-dependent sulfhydryl oxidase** whose direct physiological substrate is the **reduced CPC motif of MIA40/CHCHD4**. It accepts electrons from reduced MIA40, transfers them through its own redox-active cysteine motifs to FAD, and then reduces downstream electron acceptors (primarily cytochrome c), thereby enabling repeated rounds of oxidative folding and IMS protein biogenesis. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 25-31)
+
+---
+
+## 2. Molecular function: reaction, mechanism, and substrate/electron acceptor specificity
+
+### 2.1 Reaction logic and electron flow
+In the human disulfide relay, ALR reoxidizes MIA40 via thiol–disulfide exchange, passing electrons onward to FAD and then to terminal acceptors.
+
+**Mechanistic steps (human ALR):**
+- ALR contains an **N-terminal shuttle domain** with a redox-active **CRAC** motif and a **core domain** containing a redox-active **CAAC (CXXC-like)** motif and a **noncovalently bound FAD**. (zarges2024oxidativeproteinfolding pages 8-9)
+- **C55 of MIA40** attacks ALR’s oxidized shuttle CXXC motif (CRAC) in a thiol–disulfide exchange, leaving **MIA40 oxidized** and reducing ALR’s shuttle motif. (zarges2024oxidativeproteinfolding pages 8-9)
+- Electrons are transferred from the shuttle motif to the core motif and then to **FAD → FADH2**. (zarges2024oxidativeproteinfolding pages 8-9)
+- **FADH2** is reoxidized mainly by **electron transfer to cytochrome c**, which then feeds electrons to **complex IV (cytochrome c oxidase)**; alternatively, FADH2 can reduce **O2**, generating **H2O2**. (zarges2024oxidativeproteinfolding pages 8-9)
+
+A mechanistic schematic of these steps (including motifs and acceptor routes) is shown in Figure 5 of Zarges & Riemer 2024. (zarges2024oxidativeproteinfolding media 9e639530)
+
+### 2.2 Domain architecture and catalytic motifs (human)
+A complementary mechanistic description in higher eukaryotes specifies that ALR’s N-terminal **CRAC** motif is attacked by MIA40’s reduced **CPC** motif; ALR then transfers electrons via an **intersubunit relay** to a core motif (described as **CEEC** in that review) and into FAD, before reducing cytochrome c or O2. (finger2020proteinimportby pages 25-31, finger2020proteinimportby pages 8-10)
+
+### 2.3 Electron acceptors and specificity: cytochrome c vs oxygen
+In the human IMS relay, electron transfer to **cytochrome c** is described as the predominant route and direct reduction of O2 as an alternative that generates H2O2. (zarges2024oxidativeproteinfolding pages 8-9)
+
+Quantitatively, the 2024 review states that O2-dependent reoxidation is **“up to a 100-fold slower”** than electron transfer to cytochrome c. (zarges2024oxidativeproteinfolding pages 8-9)
+
+While the most detailed kinetic constants retrieved here are for **yeast Erv1 (EC 1.8.3.2)** rather than human ALR, they provide experimentally grounded context that Erv1-family enzymes generally favor cytochrome c as acceptor: cytochrome c was **~7–15-fold more efficient** than O2 as acceptor for yeast Erv1 under the tested conditions, with example catalytic efficiencies **kcat/Km ~1.5×10^5 M−1 s−1** (cytochrome c) vs **~1.0×10^4 M−1 s−1** (O2) in one comparison, and oxygen acting as a competitive inhibitor of cytochrome c reductase activity. (tang2020kineticcharacterisationof pages 1-2, tang2020kineticcharacterisationof pages 5-7)
+
+### 2.4 ROS production
+Because ALR/Erv1 can use **O2** as terminal acceptor, it can generate **H2O2** as a by-product (in the human mechanistic synthesis), and Erv/ALR-family flavin oxidases have been reported to release **superoxide** during turnover. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 16-19)
+
+---
+
+## 3. Subcellular localization, isoforms, and structural context
+
+### 3.1 Subcellular site of action
+The best-supported primary functional localization of long ALR is the **mitochondrial intermembrane space**, where it operates in oxidative folding/protein import with MIA40. (zarges2024oxidativeproteinfolding pages 8-9, nalesnik2017augmenterofliver pages 1-4)
+
+### 3.2 Isoforms (long vs short) and broader context
+A hepatology review summarizes **two principal ALR isoforms**, approximately **~15 kDa (short)** and **~22 kDa (long)**; the **long isoform** functions in the mitochondrial IMS as a core MIA/disulfide relay component. (nalesnik2017augmenterofliver pages 1-4)
+
+Older review literature notes reports of non-mitochondrial ALR forms (cytosolic/nuclear/secreted growth factor activities), but for **functional annotation of UniProt P55789**, the mechanistically defined and disease-linked role is the mitochondrial IMS sulfhydryl oxidase in the disulfide relay. (fischer2013themitochondrialdisulfide pages 6-7)
+
+### 3.3 Stoichiometry/abundance (data point)
+In mammalian tissues, ALR can be present in excess over MIA40, reported as **~1:1 to 10:1 (ALR:MIA40)**. This supports the view that ALR abundance can shape relay capacity and that “goldilocks” ALR concentrations may be physiologically important. (finger2020proteinimportby pages 8-10, zarges2024oxidativeproteinfolding pages 8-9)
+
+---
+
+## 4. Recent developments and latest research (prioritizing 2023–2024)
+
+### 4.1 2024 mechanistic synthesis of human oxidative folding in the IMS
+Zarges & Riemer (2024) provide a recent, mechanistically detailed review of human IMS oxidative folding, including explicit motif architecture (CRAC/CAAC), homodimerization, and acceptor routing (cytochrome c vs O2 → H2O2), and they summarize the disease mutation **R194H** and its biochemical effects. (zarges2024oxidativeproteinfolding pages 8-9, zarges2024oxidativeproteinfolding pages 11-12)
+
+### 4.2 2024 chemical-biology: MitoBlock inhibitors of ALR
+Muzzioli & Gallo (2024) describe a small **MitoBlock** library of ALR inhibitors/probes (MB-5 to MB-9 and MB-13) used to dissect ALR’s role in MIA pathway dynamics. A key result is that **MB-6** can “lock” a precursor in a **MIA40-bound** state by blocking **MIA40 reoxidation by ALR**, functionally arresting the relay. (muzzioli2024theinteractionand pages 1-2)
+
+They map inhibitor binding by NMR and docking to a pocket near the **CEEC motif** and adjacent to **FAD**, involving residues such as **F91, L102, Y116, E144, C145, W195, R196, G197, W199, K200** at/near the ALR dimer interface. (muzzioli2024theinteractionand pages 2-4, muzzioli2024theinteractionand pages 4-7)
+
+They also report biochemical potencies for several compounds in vitro: **MB-8 IC50 = 9.02 µM; MB-9 IC50 = 2.15 µM; MB-13 IC50 = 10.7 µM**, with limited cell-toxicity observations (e.g., MB-9 and MB-13 non-toxic in yeast and HeLa at tested high concentrations; MB-8 toxic in HeLa at 100 µM). (muzzioli2024theinteractionand pages 4-7)
+
+### 4.3 Limitation of the present retrieval for 2023–2024 GFER-specific primaries
+Within the current tool-retrieved corpus, the most directly GFER/ALR-focused 2023–2024 sources were the **2024 FEBS Open Bio review** and **2024 IJMS inhibitor paper**; additional 2023–2024 GFER-focused primary studies were not retrieved by the Scholar queries used here.
+
+---
+
+## 5. Current applications and real-world implementations
+
+### 5.1 Clinical genetics and mitochondrial medicine
+GFER is established as a Mendelian mitochondrial disease gene. Reviews cite **autosomal-recessive myopathy with congenital cataract and combined respiratory-chain deficiency** (initially reported by Di Fonzo et al. 2009) and additional phenotypes including **developmental delay** and endocrine/neurologic presentations such as **GFER-related mitochondrial encephalomyopathy with adrenal insufficiency**. (alhabib2021chchd4(mia40)and pages 9-10, fischer2013themitochondrialdisulfide pages 6-7)
+
+A key mechanistic link between genotype and phenotype is that impaired ALR function disrupts MIA pathway substrate maturation/import, which in turn can impair respiratory chain biogenesis and activity. For the R194H syndrome specifically, patient mitochondria show decreased activities of respiratory complexes (reported as I, II, and IV in one review) and reduced levels of MIA40 substrates, consistent with combined respiratory chain deficiency secondary to IMS oxidative folding defects. (erdogan2017mitochondrialdisulfiderelay pages 6-9)
+
+### 5.2 Chemical probes and early-stage drug discovery
+The 2024 MitoBlock study positions ALR as a tractable chemical-biology target to manipulate mitochondrial IMS import and oxidative folding. These compounds can be used as mechanistic probes to trap intermediates (e.g., precursor–MIA40 complex) and potentially as starting points for therapeutic development targeting mitochondrial import/redox pathways. (muzzioli2024theinteractionand pages 1-2, muzzioli2024theinteractionand pages 4-7)
+
+### 5.3 Cancer relevance (reported implementations/observations)
+ALR upregulation is reported to be linked to cancers including **hepatocellular carcinoma**, and ALR inhibition is cited as causing “drastic cell growth reduction” alongside disruption of **heme iron** and decreased **complex I** function (as background cited in the 2024 inhibitor paper). (muzzioli2024theinteractionand pages 2-4, nalesnik2017augmenterofliver pages 8-10)
+
+---
+
+## 6. Expert opinions and authoritative synthesis
+
+A consistent expert interpretation across reviews is that ALR/GFER is a **core component** of the IMS oxidative folding machinery whose enzymatic activity couples protein import/oxidative folding to the respiratory chain via cytochrome c. (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 8-10)
+
+Reviews also emphasize that disruption of the disulfide relay is disease-relevant, and that mutations in relay components (including ALR/GFER) produce mitochondrial pathology consistent with impaired IMS substrate biogenesis and consequent respiratory chain defects. (zarges2024oxidativeproteinfolding pages 11-12, alhabib2021chchd4(mia40)and pages 9-10)
+
+---
+
+## 7. Statistics and quantitative data from recent studies
+
+### 7.1 Human-system quantitative comparisons
+- O2-dependent reoxidation of ALR’s FADH2 is described as **up to ~100-fold slower** than electron transfer to cytochrome c in the human oxidative folding context. (zarges2024oxidativeproteinfolding pages 8-9)
+- ALR abundance can be **~1:1 to 10:1** relative to MIA40 in mammalian tissues (ALR:MIA40). (finger2020proteinimportby pages 8-10)
+
+### 7.2 Quantitative inhibitor data (2024)
+- In vitro biochemical IC50 values: **MB-8 9.02 µM; MB-9 2.15 µM; MB-13 10.7 µM**. (muzzioli2024theinteractionand pages 4-7)
+
+### 7.3 Comparative enzyme kinetics (Erv1-family; yeast data)
+- Yeast Erv1 (EC 1.8.3.2) shows cytochrome c as **~7–15-fold** more efficient acceptor than O2 under tested conditions, with representative kcat/Km values **~1.5×10^5 M−1 s−1 (cytochrome c)** vs **~1.0×10^4 M−1 s−1 (O2)** in one comparison. (tang2020kineticcharacterisationof pages 1-2, tang2020kineticcharacterisationof pages 5-7)
+
+These yeast data should be treated as **comparative biochemical context** rather than definitive human ALR kinetic constants.
+
+---
+
+## Evidence map table (summary)
+The following table consolidates key functional, mechanistic, disease, and inhibitor findings with dates and URLs.
+
+| Aspect | Key details | Evidence (citation IDs) | Publication date/URL |
+|---|---|---|---|
+| Target identity / aliases | **Human GFER** (UniProt **P55789**) corresponds to **augmenter of liver regeneration (ALR)**, the mammalian **Erv1** homolog; also called **hepatopoietin / hERV1 / HPO**. Retrieved reviews consistently identify it as the **FAD-dependent sulfhydryl oxidase** of the mitochondrial disulfide relay. | (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 16-19) | 2024-06, https://doi.org/10.1002/2211-5463.13839 ; 2020-03, https://doi.org/10.1515/hsz-2020-0108 |
+| Enzymatic activity (EC 1.8.3.2) | GFER/ALR is a **sulfhydryl oxidase** that re-oxidizes **MIA40/CHCHD4** after MIA40 oxidizes incoming IMS substrates. Electron flow is **substrate thiols → MIA40 CPC → ALR shuttle motif → ALR core CXXC/CAAC-CEEC → FAD → terminal acceptor (primarily cytochrome c, alternatively O2)**, thereby enabling de novo disulfide formation and repeated oxidative folding cycles. | (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 25-31, finger2020proteinimportby pages 8-10) | 2024-06, https://doi.org/10.1002/2211-5463.13839 ; 2020-03, https://doi.org/10.1515/hsz-2020-0108 |
+| Key motifs / domains / structural features | Human ALR has an **N-terminal shuttle domain** with **CRAC** motif and a **C-terminal FAD-binding core** with a redox-active **CAAC/CEEC-type CXXC** motif. It forms a **homodimer** stabilized by hydrophobic contacts and **two intersubunit disulfide bonds**; FAD is bound **noncovalently** in a helical core bundle. Mechanistically, the reduced CRAC motif transfers electrons to the partner subunit core motif and then to FAD. | (zarges2024oxidativeproteinfolding pages 8-9, finger2020proteinimportby pages 8-10, finger2020proteinimportby pages 25-31) | 2024-06, https://doi.org/10.1002/2211-5463.13839 ; 2020-03, https://doi.org/10.1515/hsz-2020-0108 |
+| Subcellular localization / isoforms | The **long ALR isoform (~22 kDa)** functions in the **mitochondrial intermembrane space (IMS)** as part of the MIA/disulfide relay. Reviews also note a **short isoform (~15 kDa)** and physiological relevance of distinct ALR isoforms, including non-mitochondrial reports in older literature; for functional annotation of P55789, the best-supported primary role is the **mitochondrial IMS oxidoreductase**. | (nalesnik2017augmenterofliver pages 1-4, finger2020proteinimportby pages 16-19, fischer2013themitochondrialdisulfide pages 6-7) | 2017-07, https://doi.org/10.1002/hep.29047 ; 2020-03, https://doi.org/10.1515/hsz-2020-0108 ; 2013-11, https://doi.org/10.1155/2013/742923 |
+| Pathway role | GFER/ALR is the **reoxidizing enzyme for MIA40/CHCHD4** in the **mitochondrial disulfide relay / MIA pathway**, which imports and oxidatively folds cysteine-rich IMS proteins. By transferring electrons to **cytochrome c** and then **complex IV**, ALR couples oxidative folding/protein import to the **electron transport chain**. | (zarges2024oxidativeproteinfolding pages 8-9, dicksonmurray2021themia40chchd4oxidative pages 8-10, finger2020proteinimportby pages 8-10) | 2024-06, https://doi.org/10.1002/2211-5463.13839 ; 2021-04, https://doi.org/10.3390/antiox10040592 ; 2020-03, https://doi.org/10.1515/hsz-2020-0108 |
+| Electron acceptors and relative efficiency | **Human-focused reviews:** cytochrome c is the preferred acceptor; direct reoxidation by **O2** produces **H2O2** and is reported as **up to ~100-fold slower** than cytochrome c reduction in the human pathway context. **Yeast kinetic data (comparative, not human):** cytochrome c is **~7–15-fold more efficient** than O2, with representative values **kcat/Km ≈ 1.5 × 10^5 M^-1 s^-1 for cytochrome c vs 1.0 × 10^4 M^-1 s^-1 for O2**; O2 can competitively inhibit cytochrome c reductase activity. | (zarges2024oxidativeproteinfolding pages 8-9, tang2020kineticcharacterisationof pages 1-2, tang2020kineticcharacterisationof pages 5-7, tang2020kineticcharacterisationof pages 7-9) | 2024-06, https://doi.org/10.1002/2211-5463.13839 ; 2020-10, https://doi.org/10.1111/febs.15077 |
+| Quantitative pathway / abundance notes | In mammalian tissues, **ALR is often present at ~1:1 to 10:1 excess over MIA40**, suggesting ALR is not typically limiting for MIA40 reoxidation. Electron transfer from FADH2 to cytochrome c proceeds as **one-electron steps**, whereas thiol–disulfide exchange steps move **two electrons**. | (finger2020proteinimportby pages 8-10, zarges2024oxidativeproteinfolding pages 8-9) | 2020-03, https://doi.org/10.1515/hsz-2020-0108 ; 2024-06, https://doi.org/10.1002/2211-5463.13839 |
+| ROS / by-products | Besides respiratory-chain coupling, ALR can pass electrons directly to **molecular oxygen**, generating **H2O2**; flavin-linked Erv/ALR enzymes have also been reported to release **superoxide** during turnover. This makes ALR a potential contributor to IMS redox signaling as well as oxidative folding. | (zarges2024oxidativeproteinfolding pages 8-9, dicksonmurray2021themia40chchd4oxidative pages 8-10, finger2020proteinimportby pages 16-19) | 2024-06, https://doi.org/10.1002/2211-5463.13839 ; 2021-04, https://doi.org/10.3390/antiox10040592 ; 2020-03, https://doi.org/10.1515/hsz-2020-0108 |
+| Disease associations | Pathogenic **GFER/ALR** variants are linked to **autosomal recessive mitochondrial disease**, including **myopathy**, **congenital cataract**, **sensorineural hearing loss**, **developmental delay**, and **combined respiratory-chain deficiency**; additional literature reports **GFER-related mitochondrial encephalomyopathy with adrenal insufficiency**. Patient cells show reduced respiratory-chain function and reduced levels/import of MIA-pathway substrates, consistent with impaired IMS oxidative folding. | (zarges2024oxidativeproteinfolding pages 11-12, alhabib2021chchd4(mia40)and pages 9-10, erdogan2017mitochondrialdisulfiderelay pages 6-9, sokol2014mitochondrialproteintranslocases pages 7-8, finger2020proteinimportby pages 16-19) | 2024-06, https://doi.org/10.1002/2211-5463.13839 ; 2021-02, https://doi.org/10.1042/bst20190232 ; 2017-08, https://doi.org/10.1007/s00441-016-2481-z ; 2020-03, https://doi.org/10.1515/hsz-2020-0108 |
+| Mutation example: R194H | The disease-associated **R194H** substitution lies at the **ALR dimer interface**. Reported mechanistic effects include impaired **protein stability**, reduced **flavin/FAD binding or retention**, and gradual enzyme inactivation during turnover; some studies note residual catalytic activity despite these defects. Clinically associated phenotypes include **mitochondrial myopathy**, **cataract**, **hearing loss**, **developmental delay**, and **combined respiratory-chain deficiency**. | (zarges2024oxidativeproteinfolding pages 11-12, erdogan2017mitochondrialdisulfiderelay pages 6-9, sokol2014mitochondrialproteintranslocases pages 7-8) | 2024-06, https://doi.org/10.1002/2211-5463.13839 ; 2017-08, https://doi.org/10.1007/s00441-016-2481-z ; 2014-08, https://doi.org/10.1016/j.febslet.2014.05.028 |
+| Inhibitors / mechanistic probes | **MitoBlock** compounds target ALR as chemical probes of the MIA pathway. **MB-6** binds a hydrophobic pocket near the **CEEC motif/FAD** region and can trap precursor protein in an ALR-inhibited, **MIA40-bound** state, blocking MIA40 reoxidation. Other compounds bind related sites at the ALR dimer interface; **MB-7** is described as highly specific in modeling/NMR analyses. | (muzzioli2024theinteractionand pages 1-2, muzzioli2024theinteractionand pages 9-11, muzzioli2024theinteractionand pages 2-4) | 2024-01, https://doi.org/10.3390/ijms25021174 |
+| Inhibitor potency / application data | In purified-enzyme assays, reported **IC50** values were **MB-8: 9.02 µM**, **MB-9: 2.15 µM**, **MB-13: 10.7 µM**. NMR mapped binding to residues including **F91, L102, Y116, E144, C145, W195, R196, G197, W199, K200** at/near the dimer interface and FAD-proximal pocket. These compounds are proposed as **starting points for ALR-targeted drug discovery** and for dissecting import-pathway mechanism. | (muzzioli2024theinteractionand pages 4-7, muzzioli2024theinteractionand pages 9-11, muzzioli2024theinteractionand pages 2-4) | 2024-01, https://doi.org/10.3390/ijms25021174 |
+| Real-world relevance / cancer biology | ALR upregulation has been linked to **multiple cancers**, especially **hepatocellular carcinoma**. Prior work cited in the 2024 inhibitor study reports that ALR inhibition causes **drastic cell growth reduction**, disruption of **heme iron**, and decreased **complex I** function, supporting interest in ALR as a metabolism- and mitochondrial-import-linked therapeutic target. | (muzzioli2024theinteractionand pages 2-4, nalesnik2017augmenterofliver pages 8-10, fischer2013themitochondrialdisulfide pages 11-12) | 2024-01, https://doi.org/10.3390/ijms25021174 ; 2017-07, https://doi.org/10.1002/hep.29047 ; 2013-11, https://doi.org/10.1155/2013/742923 |
+| Key recent reviews / source map | **2024 review:** Zarges & Riemer, *FEBS Open Bio* — detailed human oxidative folding and ALR mechanism. **2021 reviews:** Al-Habib & Ashcroft, *Biochem Soc Trans*; Dickson-Murray et al., *Antioxidants* — CHCHD4/MIA40 relay and redox regulation. **2020 review:** Finger & Riemer, *Biological Chemistry* — higher-eukaryote disulfide relay and ALR architecture. **2024 primary inhibitor study:** Muzzioli & Gallo, *IJMS* — MitoBlock interaction with ALR. | (zarges2024oxidativeproteinfolding pages 8-9, dicksonmurray2021themia40chchd4oxidative pages 8-10, finger2020proteinimportby pages 8-10, muzzioli2024theinteractionand pages 2-4) | 2024-06, https://doi.org/10.1002/2211-5463.13839 ; 2021-02, https://doi.org/10.1042/bst20190232 ; 2021-04, https://doi.org/10.3390/antiox10040592 ; 2020-03, https://doi.org/10.1515/hsz-2020-0108 ; 2024-01, https://doi.org/10.3390/ijms25021174 |
+
+
+*Table: This table summarizes the core functional annotation of human GFER/ALR (UniProt P55789), including enzymatic mechanism, localization, pathway role, disease relevance, and 2024 inhibitor data. It is designed as a compact evidence map for downstream narrative reporting and citation.*
+
+---
+
+## Figure evidence (mechanism overview)
+A recent schematic of ALR-mediated MIA40 reoxidation and alternative FADH2 reoxidation routes (cytochrome c vs O2→H2O2; yeast Osm1 pathway) is provided in Zarges & Riemer 2024 (Figure 5). (zarges2024oxidativeproteinfolding media 9e639530)
+
+---
+
+## References (URLs and publication dates; key sources used)
+- Zarges C, Riemer J. **Oxidative protein folding in the intermembrane space of human mitochondria**. *FEBS Open Bio*. **2024-06**. https://doi.org/10.1002/2211-5463.13839 (zarges2024oxidativeproteinfolding pages 8-9, zarges2024oxidativeproteinfolding pages 11-12)
+- Muzzioli R, Gallo A. **The Interaction and Effect of a Small MitoBlock Library as Inhibitor of ALR Protein–Protein Interaction Pathway**. *Int J Mol Sci*. **2024-01**. https://doi.org/10.3390/ijms25021174 (muzzioli2024theinteractionand pages 1-2, muzzioli2024theinteractionand pages 4-7)
+- Finger Y, Riemer J. **Protein import by the mitochondrial disulfide relay in higher eukaryotes**. *Biological Chemistry*. **2020-03**. https://doi.org/10.1515/hsz-2020-0108 (finger2020proteinimportby pages 8-10)
+- Al-Habib H, Ashcroft M. **CHCHD4 (MIA40) and the mitochondrial disulfide relay system**. *Biochem Soc Trans*. **2021-02**. https://doi.org/10.1042/bst20190232 (alhabib2021chchd4(mia40)and pages 9-10)
+- Erdogan AJ, Riemer J. **Mitochondrial disulfide relay and its substrates: mechanisms in health and disease**. *Cell Tissue Res*. **2017-08**. https://doi.org/10.1007/s00441-016-2481-z (erdogan2017mitochondrialdisulfiderelay pages 6-9)
+- Nalesnik MA, Gandhi CR, Starzl TE. **Augmenter of liver regeneration: A fundamental life protein**. *Hepatology*. **2017-07**. https://doi.org/10.1002/hep.29047 (nalesnik2017augmenterofliver pages 1-4)
+- Tang X, Ang SK, Ceh-Pavia E, Heyes DJ, Lu H. **Kinetic characterisation of Erv1** (yeast; EC 1.8.3.2). *FEBS J*. **2020-10**. https://doi.org/10.1111/febs.15077 (tang2020kineticcharacterisationof pages 1-2, tang2020kineticcharacterisationof pages 5-7)
+
+
+References
+
+1. (zarges2024oxidativeproteinfolding pages 8-9): Christine Zarges and Jan Riemer. Oxidative protein folding in the intermembrane space of human mitochondria. FEBS Open Bio, 14:1610-1626, Jun 2024. URL: https://doi.org/10.1002/2211-5463.13839, doi:10.1002/2211-5463.13839. This article has 24 citations and is from a peer-reviewed journal.
+
+2. (finger2020proteinimportby pages 16-19): Yannik Finger and Jan Riemer. Protein import by the mitochondrial disulfide relay in higher eukaryotes. Biological Chemistry, 401:749-763, Mar 2020. URL: https://doi.org/10.1515/hsz-2020-0108, doi:10.1515/hsz-2020-0108. This article has 29 citations and is from a peer-reviewed journal.
+
+3. (finger2020proteinimportby pages 8-10): Yannik Finger and Jan Riemer. Protein import by the mitochondrial disulfide relay in higher eukaryotes. Biological Chemistry, 401:749-763, Mar 2020. URL: https://doi.org/10.1515/hsz-2020-0108, doi:10.1515/hsz-2020-0108. This article has 29 citations and is from a peer-reviewed journal.
+
+4. (finger2020proteinimportby pages 25-31): Yannik Finger and Jan Riemer. Protein import by the mitochondrial disulfide relay in higher eukaryotes. Biological Chemistry, 401:749-763, Mar 2020. URL: https://doi.org/10.1515/hsz-2020-0108, doi:10.1515/hsz-2020-0108. This article has 29 citations and is from a peer-reviewed journal.
+
+5. (zarges2024oxidativeproteinfolding media 9e639530): Christine Zarges and Jan Riemer. Oxidative protein folding in the intermembrane space of human mitochondria. FEBS Open Bio, 14:1610-1626, Jun 2024. URL: https://doi.org/10.1002/2211-5463.13839, doi:10.1002/2211-5463.13839. This article has 24 citations and is from a peer-reviewed journal.
+
+6. (tang2020kineticcharacterisationof pages 1-2): Xiaofan Tang, Swee Kim Ang, Efrain Ceh‐Pavia, Derren J. Heyes, and Hui Lu. Kinetic characterisation of erv1, a key component for protein import and folding in yeast mitochondria. The Febs Journal, 287:1220-1231, Oct 2020. URL: https://doi.org/10.1111/febs.15077, doi:10.1111/febs.15077. This article has 15 citations.
+
+7. (tang2020kineticcharacterisationof pages 5-7): Xiaofan Tang, Swee Kim Ang, Efrain Ceh‐Pavia, Derren J. Heyes, and Hui Lu. Kinetic characterisation of erv1, a key component for protein import and folding in yeast mitochondria. The Febs Journal, 287:1220-1231, Oct 2020. URL: https://doi.org/10.1111/febs.15077, doi:10.1111/febs.15077. This article has 15 citations.
+
+8. (nalesnik2017augmenterofliver pages 1-4): Michael A. Nalesnik, Chandrashekhar R. Gandhi, and Thomas E. Starzl. Augmenter of liver regeneration: a fundamental life protein. Hepatology, 66:266-270, Jul 2017. URL: https://doi.org/10.1002/hep.29047, doi:10.1002/hep.29047. This article has 43 citations and is from a highest quality peer-reviewed journal.
+
+9. (fischer2013themitochondrialdisulfide pages 6-7): Manuel Fischer and Jan Riemer. The mitochondrial disulfide relay system: roles in oxidative protein folding and beyond. International Journal of Cell Biology, 2013:1-12, Nov 2013. URL: https://doi.org/10.1155/2013/742923, doi:10.1155/2013/742923. This article has 61 citations and is from a peer-reviewed journal.
+
+10. (zarges2024oxidativeproteinfolding pages 11-12): Christine Zarges and Jan Riemer. Oxidative protein folding in the intermembrane space of human mitochondria. FEBS Open Bio, 14:1610-1626, Jun 2024. URL: https://doi.org/10.1002/2211-5463.13839, doi:10.1002/2211-5463.13839. This article has 24 citations and is from a peer-reviewed journal.
+
+11. (muzzioli2024theinteractionand pages 1-2): Riccardo Muzzioli and Angelo Gallo. The interaction and effect of a small mitoblock library as inhibitor of alr protein–protein interaction pathway. International Journal of Molecular Sciences, 25:1174, Jan 2024. URL: https://doi.org/10.3390/ijms25021174, doi:10.3390/ijms25021174. This article has 3 citations.
+
+12. (muzzioli2024theinteractionand pages 2-4): Riccardo Muzzioli and Angelo Gallo. The interaction and effect of a small mitoblock library as inhibitor of alr protein–protein interaction pathway. International Journal of Molecular Sciences, 25:1174, Jan 2024. URL: https://doi.org/10.3390/ijms25021174, doi:10.3390/ijms25021174. This article has 3 citations.
+
+13. (muzzioli2024theinteractionand pages 4-7): Riccardo Muzzioli and Angelo Gallo. The interaction and effect of a small mitoblock library as inhibitor of alr protein–protein interaction pathway. International Journal of Molecular Sciences, 25:1174, Jan 2024. URL: https://doi.org/10.3390/ijms25021174, doi:10.3390/ijms25021174. This article has 3 citations.
+
+14. (alhabib2021chchd4(mia40)and pages 9-10): Hasan Al-Habib and Margaret Ashcroft. Chchd4 (mia40) and the mitochondrial disulfide relay system. Biochemical Society Transactions, 49:17-27, Feb 2021. URL: https://doi.org/10.1042/bst20190232, doi:10.1042/bst20190232. This article has 37 citations and is from a peer-reviewed journal.
+
+15. (erdogan2017mitochondrialdisulfiderelay pages 6-9): Alican J. Erdogan and Jan Riemer. Mitochondrial disulfide relay and its substrates: mechanisms in health and disease. Cell and Tissue Research, 367:59-72, Aug 2017. URL: https://doi.org/10.1007/s00441-016-2481-z, doi:10.1007/s00441-016-2481-z. This article has 30 citations and is from a peer-reviewed journal.
+
+16. (nalesnik2017augmenterofliver pages 8-10): Michael A. Nalesnik, Chandrashekhar R. Gandhi, and Thomas E. Starzl. Augmenter of liver regeneration: a fundamental life protein. Hepatology, 66:266-270, Jul 2017. URL: https://doi.org/10.1002/hep.29047, doi:10.1002/hep.29047. This article has 43 citations and is from a highest quality peer-reviewed journal.
+
+17. (dicksonmurray2021themia40chchd4oxidative pages 8-10): Eleanor Dickson-Murray, Kenza Nedara, Nazanine Modjtahedi, and Kostas Tokatlidis. The mia40/chchd4 oxidative folding system: redox regulation and signaling in the mitochondrial intermembrane space. Antioxidants, 10:592, Apr 2021. URL: https://doi.org/10.3390/antiox10040592, doi:10.3390/antiox10040592. This article has 37 citations.
+
+18. (tang2020kineticcharacterisationof pages 7-9): Xiaofan Tang, Swee Kim Ang, Efrain Ceh‐Pavia, Derren J. Heyes, and Hui Lu. Kinetic characterisation of erv1, a key component for protein import and folding in yeast mitochondria. The Febs Journal, 287:1220-1231, Oct 2020. URL: https://doi.org/10.1111/febs.15077, doi:10.1111/febs.15077. This article has 15 citations.
+
+19. (sokol2014mitochondrialproteintranslocases pages 7-8): Anna Magdalena Sokol, Malgorzata Eliza Sztolsztener, Michal Wasilewski, Eva Heinz, and Agnieszka Chacinska. Mitochondrial protein translocases for survival and wellbeing. FEBS Letters, 588:2484-2495, Aug 2014. URL: https://doi.org/10.1016/j.febslet.2014.05.028, doi:10.1016/j.febslet.2014.05.028. This article has 126 citations and is from a peer-reviewed journal.
+
+20. (muzzioli2024theinteractionand pages 9-11): Riccardo Muzzioli and Angelo Gallo. The interaction and effect of a small mitoblock library as inhibitor of alr protein–protein interaction pathway. International Journal of Molecular Sciences, 25:1174, Jan 2024. URL: https://doi.org/10.3390/ijms25021174, doi:10.3390/ijms25021174. This article has 3 citations.
+
+21. (fischer2013themitochondrialdisulfide pages 11-12): Manuel Fischer and Jan Riemer. The mitochondrial disulfide relay system: roles in oxidative protein folding and beyond. International Journal of Cell Biology, 2013:1-12, Nov 2013. URL: https://doi.org/10.1155/2013/742923, doi:10.1155/2013/742923. This article has 61 citations and is from a peer-reviewed journal.
+
+## Citations
+
+1. zarges2024oxidativeproteinfolding pages 8-9
+2. nalesnik2017augmenterofliver pages 1-4
+3. fischer2013themitochondrialdisulfide pages 6-7
+4. muzzioli2024theinteractionand pages 1-2
+5. muzzioli2024theinteractionand pages 4-7
+6. erdogan2017mitochondrialdisulfiderelay pages 6-9
+7. finger2020proteinimportby pages 8-10
+8. finger2020proteinimportby pages 16-19
+9. finger2020proteinimportby pages 25-31
+10. tang2020kineticcharacterisationof pages 1-2
+11. tang2020kineticcharacterisationof pages 5-7
+12. zarges2024oxidativeproteinfolding pages 11-12
+13. muzzioli2024theinteractionand pages 2-4
+14. nalesnik2017augmenterofliver pages 8-10
+15. tang2020kineticcharacterisationof pages 7-9
+16. sokol2014mitochondrialproteintranslocases pages 7-8
+17. muzzioli2024theinteractionand pages 9-11
+18. fischer2013themitochondrialdisulfide pages 11-12
+19. https://doi.org/10.1002/2211-5463.13839
+20. https://doi.org/10.1515/hsz-2020-0108
+21. https://doi.org/10.1002/hep.29047
+22. https://doi.org/10.1155/2013/742923
+23. https://doi.org/10.3390/antiox10040592
+24. https://doi.org/10.1111/febs.15077
+25. https://doi.org/10.1042/bst20190232
+26. https://doi.org/10.1007/s00441-016-2481-z
+27. https://doi.org/10.1016/j.febslet.2014.05.028
+28. https://doi.org/10.3390/ijms25021174
+29. https://doi.org/10.1002/2211-5463.13839,
+30. https://doi.org/10.1515/hsz-2020-0108,
+31. https://doi.org/10.1111/febs.15077,
+32. https://doi.org/10.1002/hep.29047,
+33. https://doi.org/10.1155/2013/742923,
+34. https://doi.org/10.3390/ijms25021174,
+35. https://doi.org/10.1042/bst20190232,
+36. https://doi.org/10.1007/s00441-016-2481-z,
+37. https://doi.org/10.3390/antiox10040592,
+38. https://doi.org/10.1016/j.febslet.2014.05.028,

--- a/genes/human/PAM16/PAM16-ai-review.html
+++ b/genes/human/PAM16/PAM16-ai-review.html
@@ -3040,14 +3040,25 @@
                         </div>
                     </td>
                     <td>
-                        <span class="evidence-code">NAS</span>
+                        <span class="evidence-code">IDA</span>
 
 
 
                         <br>
                         <span style="font-size: 0.75rem;">
 
-                            file:human/PAM16/PAM16-deep-research-falcon.md
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20053669" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:20053669
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Role of Magmas in protein transport and human mitochondria b...
+                                </span>
+
+
 
                         </span>
 
@@ -3056,7 +3067,7 @@
                         <span class="action-badge action-new">
                             NEW
                         </span>
-                        <span class="vote-buttons" data-g="Q9Y3D7" data-a="GO:0030674" data-r="file:human/PAM16/PAM16-deep-research-falcon.md" data-act="NEW">
+                        <span class="vote-buttons" data-g="Q9Y3D7" data-a="GO:0030674" data-r="PMID:20053669" data-act="NEW">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -3064,7 +3075,7 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> New annotation. PAM16 functions as a regulatory adaptor/cochaperone that recruits and controls Pam18 at the import channel rather than acting as an enzyme or transporter.
+                            <strong>Summary:</strong> New annotation. PAM16 functions as a regulatory adaptor/cochaperone that forms a Magmas-DnaJC19/Pam18 subcomplex, tethers the J-protein component to the translocon, and restrains Pam18-stimulated mtHsp70 ATPase activity.
                         </div>
 
 
@@ -3080,11 +3091,39 @@
                             <div class="support-item">
                                 <span class="support-ref">
 
-                                    file:human/PAM16/PAM16-deep-research-falcon.md
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20053669" target="_blank" class="term-link">
+                                        PMID:20053669
+                                    </a>
 
                                 </span>
 
-                                <div class="support-text">**PAM16 is not an enzyme catalyzing a metabolic reaction nor a transporter substrate-binding channel.** Instead, it functions as a **regulatory cochaperone/adaptor** within the import motor. It is described as a **J-like** protein (Hsp40/J-domain superfamily-like) that regulates the activity and positioning of the true J-domain cochaperone **Pam18/Tim14** (metazoan functional ortholog often discussed as DNAJC19/Pam18 in the PAM motor context) which stimulates mtHsp70 ATPase activity. (sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5, riva2018ajourneythrough pages 11-15)</div>
+                                <div class="support-text">Moreover, Magmas interacts with yeast Pam18 as well as human DnaJC19 (ortholog of yeast Pam18) both in vivo and in vitro conditions to form a heterodimeric subcomplex.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20053669" target="_blank" class="term-link">
+                                        PMID:20053669
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Our results are consistent with the existence of stable interaction between Magmas and DnaJC19 that plays a crucial role in tethering of DnaJC19 at the translocon and perhaps regulating human import motor activity.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19564938" target="_blank" class="term-link">
+                                        PMID:19564938
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">A similar effect was observed using human Tim16/Pam16s, which inhibited the increase in the ATPase activity of mtHsp70 (obtained due to the presence of yTim14/Pam18) by almost 50%. The latter result indicates that hTim16/Pam16s can replace its yeast Tim16/Pam18s homologue, in vitro, and can act as a negative regulator of yTim14/Pam18.</div>
 
                             </div>
 
@@ -3096,17 +3135,6 @@
                                 </span>
 
                                 <div class="support-text">PAM16 (MAGMAS/TIM16/TIMM16) is an essential subunit of the **TIM23-associated PAM motor**. Mechanistically, it forms a stable subcomplex with Pam18/Tim14 and is described as (i) **recruiting Pam18** to the import channel and (ii) **controlling Pam18 activity**, thereby indirectly regulating mtHsp70’s ATP-driven pulling activity during translocation into the matrix. (sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5)</div>
-
-                            </div>
-
-                            <div class="support-item">
-                                <span class="support-ref">
-
-                                    file:human/PAM16/PAM16-deep-research-falcon.md
-
-                                </span>
-
-                                <div class="support-text">| Mechanistic role | PAM16 is primarily a **regulatory cochaperone/adaptor**, not an enzyme or transporter substrate-binding transporter itself. It forms a stable subcomplex with Pam18 and **recruits/controls Pam18 at the import channel**, thereby **modulating Pam18-driven stimulation of mtHsp70 ATPase activity** and fine-tuning the ATP-dependent import motor. It is described as a **negative regulator/antagonist** of Pam18’s stimulatory effect on mtHsp70. | (riva2018ajourneythrough pages 11-15, sinha2017thecomplexitiesofa pages 4-5, jain2025investigatingmitochondrialpresequence pages 15-17, sinha2017thecomplexitiesof pages 4-5) | Riva 2018; Sinha 2017; Jain 2025 thesis, https://doi.org/10.53846/goediss-11596 |</div>
 
                             </div>
 
@@ -4661,36 +4689,37 @@ existing_annotations:
 - term:
     id: GO:0030674
     label: protein-macromolecule adaptor activity
-  evidence_type: NAS
-  original_reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+  evidence_type: IDA
+  original_reference_id: PMID:20053669
   review:
-    summary: New annotation. PAM16 functions as a regulatory adaptor/cochaperone that recruits and controls
-      Pam18 at the import channel rather than acting as an enzyme or transporter.
+    summary: New annotation. PAM16 functions as a regulatory adaptor/cochaperone that forms a
+      Magmas-DnaJC19/Pam18 subcomplex, tethers the J-protein component to the translocon, and restrains
+      Pam18-stimulated mtHsp70 ATPase activity.
     action: NEW
     reason: PAM16 has a specific adaptor/cochaperone role in the PAM motor that is more informative than
       generic protein binding and is not present in GOA.
     supported_by:
-    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
-      supporting_text: &#39;**PAM16 is not an enzyme catalyzing a metabolic reaction nor a transporter substrate-binding
-        channel.** Instead, it functions as a **regulatory cochaperone/adaptor** within the import motor. It is
-        described as a **J-like** protein (Hsp40/J-domain superfamily-like) that regulates the activity and positioning
-        of the true J-domain cochaperone **Pam18/Tim14** (metazoan functional ortholog often discussed as DNAJC19/Pam18
-        in the PAM motor context) which stimulates mtHsp70 ATPase activity. (sinha2017thecomplexitiesofa pages 4-5,
-        sinha2017thecomplexitiesof pages 4-5, riva2018ajourneythrough pages 11-15)&#39;
+    - reference_id: PMID:20053669
+      supporting_text: Moreover, Magmas interacts with yeast Pam18 as well as human DnaJC19 (ortholog of yeast
+        Pam18) both in vivo and in vitro conditions to form a heterodimeric subcomplex.
+    - reference_id: PMID:20053669
+      supporting_text: Our results are consistent with the existence of stable interaction between Magmas and
+        DnaJC19 that plays a crucial role in tethering of DnaJC19 at the translocon and perhaps regulating
+        human import motor activity.
+    - reference_id: PMID:19564938
+      supporting_text: A similar effect was observed using human Tim16/Pam16s, which inhibited the increase in
+        the ATPase activity of mtHsp70 (obtained due to the presence of yTim14/Pam18) by almost 50%. The
+        latter result indicates that hTim16/Pam16s can replace its yeast Tim16/Pam18s homologue, in vitro, and
+        can act as a negative regulator of yTim14/Pam18.
     - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
       supporting_text: PAM16 (MAGMAS/TIM16/TIMM16) is an essential subunit of the **TIM23-associated PAM
         motor**. Mechanistically, it forms a stable subcomplex with Pam18/Tim14 and is described as (i)
         **recruiting Pam18** to the import channel and (ii) **controlling Pam18 activity**, thereby indirectly
         regulating mtHsp70’s ATP-driven pulling activity during translocation into the matrix.
         (sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5)
-    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
-      supporting_text: &#39;| Mechanistic role | PAM16 is primarily a **regulatory cochaperone/adaptor**, not an enzyme
-        or transporter substrate-binding transporter itself. It forms a stable subcomplex with Pam18 and **recruits/controls
-        Pam18 at the import channel**, thereby **modulating Pam18-driven stimulation of mtHsp70 ATPase activity**
-        and fine-tuning the ATP-dependent import motor. It is described as a **negative regulator/antagonist** of
-        Pam18’s stimulatory effect on mtHsp70. | (riva2018ajourneythrough pages 11-15, sinha2017thecomplexitiesofa
-        pages 4-5, jain2025investigatingmitochondrialpresequence pages 15-17, sinha2017thecomplexitiesof pages 4-5)
-        | Riva 2018; Sinha 2017; Jain 2025 thesis, https://doi.org/10.53846/goediss-11596 |&#39;
+    additional_reference_ids:
+    - file:human/PAM16/PAM16-deep-research-falcon.md
+    - PMID:19564938
 references:
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO terms

--- a/genes/human/PAM16/PAM16-ai-review.html
+++ b/genes/human/PAM16/PAM16-ai-review.html
@@ -1,0 +1,5125 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>PAM16 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>PAM16</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q9Y3D7" target="_blank" class="term-link">
+                        Q9Y3D7
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "PAM16";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q9Y3D7" data-a="DESCRIPTION: PAM16 encodes MAGMAS/TIM16, a matrix-facing regula..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>PAM16 encodes MAGMAS/TIM16, a matrix-facing regulatory J-like cochaperone/adaptor subunit of the TIM23-associated PAM import motor. It forms a Pam18/Tim14 subcomplex, recruits and restrains Pam18 activity, and tunes mtHsp70-driven import of presequence-containing proteins into the mitochondrial matrix.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005744" target="_blank" class="term-link">
+                                    GO:0005744
+                                </a>
+                            </span>
+                            <span class="term-label">TIM23 mitochondrial import inner membrane translocase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y3D7" data-a="GO:0005744" data-r="GO_REF:0000033" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> PAM16 is functionally coupled to TIM23, but its complex membership is more precisely the PAM import motor rather than the TIM23 channel/core translocase.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Use the PAM complex term for PAM16 complex membership; TIM23 is the coupled translocase.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001405" target="_blank" class="term-link">
+                                    PAM complex, Tim23 associated import motor
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PAM16/PAM16-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The literature and database evidence summarized here consistently refers to **human PAM16** as **MAGMAS/TIM16/TIMM16**, a small mitochondrial protein (~125 aa; ~13 kDa) that is part of the **TIM23-associated presequence import motor (PAM complex)**. This matches the UniProt description for Q9Y3D7 (mitochondrial import inner membrane translocase subunit TIM16 / PAM16 family), including the hallmark **J-like domain** and functional role in mitochondrial protein import. (riva2018ajourneythrough pages 11-15, riva2018ajourneythrough pages 8-11, sinha2017thecomplexitiesofa pages 4-5)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PAM16/PAM16-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Most mitochondrial matrix proteins are encoded in the nucleus, translated in the cytosol, and imported into mitochondria. The **TIM23 complex** (inner membrane presequence translocase) mediates import of presequence-containing proteins; for matrix translocation, TIM23 couples to the **PAM (presequence translocase-associated motor)**, which uses an **mtHsp70 ATPase cycle** to pull precursor polypeptides into the matrix. (sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PAM16/PAM16-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">PAM16 (MAGMAS/TIM16/TIMM16) is an essential subunit of the **TIM23-associated PAM motor**. Mechanistically, it forms a stable subcomplex with Pam18/Tim14 and is described as (i) **recruiting Pam18** to the import channel and (ii) **controlling Pam18 activity**, thereby indirectly regulating mtHsp70’s ATP-driven pulling activity during translocation into the matrix. (sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030150" target="_blank" class="term-link">
+                                    GO:0030150
+                                </a>
+                            </span>
+                            <span class="term-label">protein import into mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y3D7" data-a="GO:0030150" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct and core. PAM16 regulates the PAM motor that powers TIM23-mediated matrix import.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PAM16/PAM16-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Most mitochondrial matrix proteins are encoded in the nucleus, translated in the cytosol, and imported into mitochondria. The **TIM23 complex** (inner membrane presequence translocase) mediates import of presequence-containing proteins; for matrix translocation, TIM23 couples to the **PAM (presequence translocase-associated motor)**, which uses an **mtHsp70 ATPase cycle** to pull precursor polypeptides into the matrix. (sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PAM16/PAM16-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">PAM16 (MAGMAS/TIM16/TIMM16) is an essential subunit of the **TIM23-associated PAM motor**. Mechanistically, it forms a stable subcomplex with Pam18/Tim14 and is described as (i) **recruiting Pam18** to the import channel and (ii) **controlling Pam18 activity**, thereby indirectly regulating mtHsp70’s ATP-driven pulling activity during translocation into the matrix. (sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001405" target="_blank" class="term-link">
+                                    GO:0001405
+                                </a>
+                            </span>
+                            <span class="term-label">PAM complex, Tim23 associated import motor</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y3D7" data-a="GO:0001405" data-r="GO_REF:0000117" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct and core. PAM16/MAGMAS is a regulatory subunit of the TIM23-associated PAM motor.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PAM16/PAM16-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The literature and database evidence summarized here consistently refers to **human PAM16** as **MAGMAS/TIM16/TIMM16**, a small mitochondrial protein (~125 aa; ~13 kDa) that is part of the **TIM23-associated presequence import motor (PAM complex)**. This matches the UniProt description for Q9Y3D7 (mitochondrial import inner membrane translocase subunit TIM16 / PAM16 family), including the hallmark **J-like domain** and functional role in mitochondrial protein import. (riva2018ajourneythrough pages 11-15, riva2018ajourneythrough pages 8-11, sinha2017thecomplexitiesofa pages 4-5)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PAM16/PAM16-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">PAM16 (MAGMAS/TIM16/TIMM16) is an essential subunit of the **TIM23-associated PAM motor**. Mechanistically, it forms a stable subcomplex with Pam18/Tim14 and is described as (i) **recruiting Pam18** to the import channel and (ii) **controlling Pam18 activity**, thereby indirectly regulating mtHsp70’s ATP-driven pulling activity during translocation into the matrix. (sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005743" target="_blank" class="term-link">
+                                    GO:0005743
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial inner membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y3D7" data-a="GO:0005743" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct. PAM16 is a peripheral component associated with the matrix side of the mitochondrial inner membrane.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PAM16/PAM16-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">PAM16/MAGMAS is localized to **mitochondria** and described as a **peripheral membrane protein** associated with the TIM23/PAM machinery at the **inner membrane, matrix-facing side**. One source explicitly notes that it does **not extend into the intermembrane space (IMS)**, consistent with a matrix-side role in regulating the mtHsp70 motor. (riva2018ajourneythrough pages 11-15, sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005744" target="_blank" class="term-link">
+                                    GO:0005744
+                                </a>
+                            </span>
+                            <span class="term-label">TIM23 mitochondrial import inner membrane translocase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y3D7" data-a="GO:0005744" data-r="GO_REF:0000002" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> PAM16 is functionally coupled to TIM23, but its complex membership is more precisely the PAM import motor rather than the TIM23 channel/core translocase.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Use the PAM complex term for PAM16 complex membership; TIM23 is the coupled translocase.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001405" target="_blank" class="term-link">
+                                    PAM complex, Tim23 associated import motor
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PAM16/PAM16-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The literature and database evidence summarized here consistently refers to **human PAM16** as **MAGMAS/TIM16/TIMM16**, a small mitochondrial protein (~125 aa; ~13 kDa) that is part of the **TIM23-associated presequence import motor (PAM complex)**. This matches the UniProt description for Q9Y3D7 (mitochondrial import inner membrane translocase subunit TIM16 / PAM16 family), including the hallmark **J-like domain** and functional role in mitochondrial protein import. (riva2018ajourneythrough pages 11-15, riva2018ajourneythrough pages 8-11, sinha2017thecomplexitiesofa pages 4-5)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PAM16/PAM16-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Most mitochondrial matrix proteins are encoded in the nucleus, translated in the cytosol, and imported into mitochondria. The **TIM23 complex** (inner membrane presequence translocase) mediates import of presequence-containing proteins; for matrix translocation, TIM23 couples to the **PAM (presequence translocase-associated motor)**, which uses an **mtHsp70 ATPase cycle** to pull precursor polypeptides into the matrix. (sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PAM16/PAM16-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">PAM16 (MAGMAS/TIM16/TIMM16) is an essential subunit of the **TIM23-associated PAM motor**. Mechanistically, it forms a stable subcomplex with Pam18/Tim14 and is described as (i) **recruiting Pam18** to the import channel and (ii) **controlling Pam18 activity**, thereby indirectly regulating mtHsp70’s ATP-driven pulling activity during translocation into the matrix. (sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030150" target="_blank" class="term-link">
+                                    GO:0030150
+                                </a>
+                            </span>
+                            <span class="term-label">protein import into mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y3D7" data-a="GO:0030150" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct and core. PAM16 regulates the PAM motor that powers TIM23-mediated matrix import.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PAM16/PAM16-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Most mitochondrial matrix proteins are encoded in the nucleus, translated in the cytosol, and imported into mitochondria. The **TIM23 complex** (inner membrane presequence translocase) mediates import of presequence-containing proteins; for matrix translocation, TIM23 couples to the **PAM (presequence translocase-associated motor)**, which uses an **mtHsp70 ATPase cycle** to pull precursor polypeptides into the matrix. (sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PAM16/PAM16-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">PAM16 (MAGMAS/TIM16/TIMM16) is an essential subunit of the **TIM23-associated PAM motor**. Mechanistically, it forms a stable subcomplex with Pam18/Tim14 and is described as (i) **recruiting Pam18** to the import channel and (ii) **controlling Pam18 activity**, thereby indirectly regulating mtHsp70’s ATP-driven pulling activity during translocation into the matrix. (sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/23263864" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:23263864
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Methylation-controlled J-protein MCJ acts in the import of p...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y3D7" data-a="GO:0005515" data-r="PMID:23263864" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Protein binding is too generic for PAM16. The informative role is a regulatory adaptor/cochaperone function within the Pam16-Pam18/PAM import motor.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Replace generic protein-binding capture with PAM complex membership and adaptor/regulatory cochaperone activity where supported.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PAM16/PAM16-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**PAM16 is not an enzyme catalyzing a metabolic reaction nor a transporter substrate-binding channel.** Instead, it functions as a **regulatory cochaperone/adaptor** within the import motor. It is described as a **J-like** protein (Hsp40/J-domain superfamily-like) that regulates the activity and positioning of the true J-domain cochaperone **Pam18/Tim14** (metazoan functional ortholog often discussed as DNAJC19/Pam18 in the PAM motor context) which stimulates mtHsp70 ATPase activity. (sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5, riva2018ajourneythrough pages 11-15)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PAM16/PAM16-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">| Mechanistic role | PAM16 is primarily a **regulatory cochaperone/adaptor**, not an enzyme or transporter substrate-binding transporter itself. It forms a stable subcomplex with Pam18 and **recruits/controls Pam18 at the import channel**, thereby **modulating Pam18-driven stimulation of mtHsp70 ATPase activity** and fine-tuning the ATP-dependent import motor. It is described as a **negative regulator/antagonist** of Pam18’s stimulatory effect on mtHsp70. | (riva2018ajourneythrough pages 11-15, sinha2017thecomplexitiesofa pages 4-5, jain2025investigatingmitochondrialpresequence pages 15-17, sinha2017thecomplexitiesof pages 4-5) | Riva 2018; Sinha 2017; Jain 2025 thesis, https://doi.org/10.53846/goediss-11596 |</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25416956" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25416956
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A proteome-scale map of the human interactome network.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y3D7" data-a="GO:0005515" data-r="PMID:25416956" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Protein binding is too generic for PAM16. The informative role is a regulatory adaptor/cochaperone function within the Pam16-Pam18/PAM import motor.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Replace generic protein-binding capture with PAM complex membership and adaptor/regulatory cochaperone activity where supported.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PAM16/PAM16-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**PAM16 is not an enzyme catalyzing a metabolic reaction nor a transporter substrate-binding channel.** Instead, it functions as a **regulatory cochaperone/adaptor** within the import motor. It is described as a **J-like** protein (Hsp40/J-domain superfamily-like) that regulates the activity and positioning of the true J-domain cochaperone **Pam18/Tim14** (metazoan functional ortholog often discussed as DNAJC19/Pam18 in the PAM motor context) which stimulates mtHsp70 ATPase activity. (sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5, riva2018ajourneythrough pages 11-15)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PAM16/PAM16-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">| Mechanistic role | PAM16 is primarily a **regulatory cochaperone/adaptor**, not an enzyme or transporter substrate-binding transporter itself. It forms a stable subcomplex with Pam18 and **recruits/controls Pam18 at the import channel**, thereby **modulating Pam18-driven stimulation of mtHsp70 ATPase activity** and fine-tuning the ATP-dependent import motor. It is described as a **negative regulator/antagonist** of Pam18’s stimulatory effect on mtHsp70. | (riva2018ajourneythrough pages 11-15, sinha2017thecomplexitiesofa pages 4-5, jain2025investigatingmitochondrialpresequence pages 15-17, sinha2017thecomplexitiesof pages 4-5) | Riva 2018; Sinha 2017; Jain 2025 thesis, https://doi.org/10.53846/goediss-11596 |</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:32296183
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A reference map of the human binary protein interactome.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y3D7" data-a="GO:0005515" data-r="PMID:32296183" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Protein binding is too generic for PAM16. The informative role is a regulatory adaptor/cochaperone function within the Pam16-Pam18/PAM import motor.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Replace generic protein-binding capture with PAM complex membership and adaptor/regulatory cochaperone activity where supported.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PAM16/PAM16-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**PAM16 is not an enzyme catalyzing a metabolic reaction nor a transporter substrate-binding channel.** Instead, it functions as a **regulatory cochaperone/adaptor** within the import motor. It is described as a **J-like** protein (Hsp40/J-domain superfamily-like) that regulates the activity and positioning of the true J-domain cochaperone **Pam18/Tim14** (metazoan functional ortholog often discussed as DNAJC19/Pam18 in the PAM motor context) which stimulates mtHsp70 ATPase activity. (sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5, riva2018ajourneythrough pages 11-15)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PAM16/PAM16-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">| Mechanistic role | PAM16 is primarily a **regulatory cochaperone/adaptor**, not an enzyme or transporter substrate-binding transporter itself. It forms a stable subcomplex with Pam18 and **recruits/controls Pam18 at the import channel**, thereby **modulating Pam18-driven stimulation of mtHsp70 ATPase activity** and fine-tuning the ATP-dependent import motor. It is described as a **negative regulator/antagonist** of Pam18’s stimulatory effect on mtHsp70. | (riva2018ajourneythrough pages 11-15, sinha2017thecomplexitiesofa pages 4-5, jain2025investigatingmitochondrialpresequence pages 15-17, sinha2017thecomplexitiesof pages 4-5) | Riva 2018; Sinha 2017; Jain 2025 thesis, https://doi.org/10.53846/goediss-11596 |</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:33961781
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dual proteome-scale networks reveal cell-specific remodeling...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y3D7" data-a="GO:0005515" data-r="PMID:33961781" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Protein binding is too generic for PAM16. The informative role is a regulatory adaptor/cochaperone function within the Pam16-Pam18/PAM import motor.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Replace generic protein-binding capture with PAM complex membership and adaptor/regulatory cochaperone activity where supported.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PAM16/PAM16-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**PAM16 is not an enzyme catalyzing a metabolic reaction nor a transporter substrate-binding channel.** Instead, it functions as a **regulatory cochaperone/adaptor** within the import motor. It is described as a **J-like** protein (Hsp40/J-domain superfamily-like) that regulates the activity and positioning of the true J-domain cochaperone **Pam18/Tim14** (metazoan functional ortholog often discussed as DNAJC19/Pam18 in the PAM motor context) which stimulates mtHsp70 ATPase activity. (sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5, riva2018ajourneythrough pages 11-15)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PAM16/PAM16-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">| Mechanistic role | PAM16 is primarily a **regulatory cochaperone/adaptor**, not an enzyme or transporter substrate-binding transporter itself. It forms a stable subcomplex with Pam18 and **recruits/controls Pam18 at the import channel**, thereby **modulating Pam18-driven stimulation of mtHsp70 ATPase activity** and fine-tuning the ATP-dependent import motor. It is described as a **negative regulator/antagonist** of Pam18’s stimulatory effect on mtHsp70. | (riva2018ajourneythrough pages 11-15, sinha2017thecomplexitiesofa pages 4-5, jain2025investigatingmitochondrialpresequence pages 15-17, sinha2017thecomplexitiesof pages 4-5) | Riva 2018; Sinha 2017; Jain 2025 thesis, https://doi.org/10.53846/goediss-11596 |</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005743" target="_blank" class="term-link">
+                                    GO:0005743
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial inner membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10339406" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10339406
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Genetic and structural characterization of the human mitocho...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y3D7" data-a="GO:0005743" data-r="PMID:10339406" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct. PAM16 is a peripheral component associated with the matrix side of the mitochondrial inner membrane.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PAM16/PAM16-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">PAM16/MAGMAS is localized to **mitochondria** and described as a **peripheral membrane protein** associated with the TIM23/PAM machinery at the **inner membrane, matrix-facing side**. One source explicitly notes that it does **not extend into the intermembrane space (IMS)**, consistent with a matrix-side role in regulating the mtHsp70 motor. (riva2018ajourneythrough pages 11-15, sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005744" target="_blank" class="term-link">
+                                    GO:0005744
+                                </a>
+                            </span>
+                            <span class="term-label">TIM23 mitochondrial import inner membrane translocase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10339406" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10339406
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Genetic and structural characterization of the human mitocho...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y3D7" data-a="GO:0005744" data-r="PMID:10339406" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> PAM16 is functionally coupled to TIM23, but its complex membership is more precisely the PAM import motor rather than the TIM23 channel/core translocase.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Use the PAM complex term for PAM16 complex membership; TIM23 is the coupled translocase.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001405" target="_blank" class="term-link">
+                                    PAM complex, Tim23 associated import motor
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PAM16/PAM16-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The literature and database evidence summarized here consistently refers to **human PAM16** as **MAGMAS/TIM16/TIMM16**, a small mitochondrial protein (~125 aa; ~13 kDa) that is part of the **TIM23-associated presequence import motor (PAM complex)**. This matches the UniProt description for Q9Y3D7 (mitochondrial import inner membrane translocase subunit TIM16 / PAM16 family), including the hallmark **J-like domain** and functional role in mitochondrial protein import. (riva2018ajourneythrough pages 11-15, riva2018ajourneythrough pages 8-11, sinha2017thecomplexitiesofa pages 4-5)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PAM16/PAM16-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Most mitochondrial matrix proteins are encoded in the nucleus, translated in the cytosol, and imported into mitochondria. The **TIM23 complex** (inner membrane presequence translocase) mediates import of presequence-containing proteins; for matrix translocation, TIM23 couples to the **PAM (presequence translocase-associated motor)**, which uses an **mtHsp70 ATPase cycle** to pull precursor polypeptides into the matrix. (sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PAM16/PAM16-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">PAM16 (MAGMAS/TIM16/TIMM16) is an essential subunit of the **TIM23-associated PAM motor**. Mechanistically, it forms a stable subcomplex with Pam18/Tim14 and is described as (i) **recruiting Pam18** to the import channel and (ii) **controlling Pam18 activity**, thereby indirectly regulating mtHsp70’s ATP-driven pulling activity during translocation into the matrix. (sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006886" target="_blank" class="term-link">
+                                    GO:0006886
+                                </a>
+                            </span>
+                            <span class="term-label">intracellular protein transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10339406" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10339406
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Genetic and structural characterization of the human mitocho...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y3D7" data-a="GO:0006886" data-r="PMID:10339406" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct pathway family but too broad. PAM16 specifically supports TIM23/PAM-mediated mitochondrial matrix protein import.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Prefer protein import into mitochondrial matrix and PAM complex terms over generic intracellular protein transport.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PAM16/PAM16-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Most mitochondrial matrix proteins are encoded in the nucleus, translated in the cytosol, and imported into mitochondria. The **TIM23 complex** (inner membrane presequence translocase) mediates import of presequence-containing proteins; for matrix translocation, TIM23 couples to the **PAM (presequence translocase-associated motor)**, which uses an **mtHsp70 ATPase cycle** to pull precursor polypeptides into the matrix. (sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PAM16/PAM16-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">PAM16 (MAGMAS/TIM16/TIMM16) is an essential subunit of the **TIM23-associated PAM motor**. Mechanistically, it forms a stable subcomplex with Pam18/Tim14 and is described as (i) **recruiting Pam18** to the import channel and (ii) **controlling Pam18 activity**, thereby indirectly regulating mtHsp70’s ATP-driven pulling activity during translocation into the matrix. (sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000052
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y3D7" data-a="GO:0005739" data-r="GO_REF:0000052" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct but broad. PAM16 is specifically associated with the matrix-facing side of the mitochondrial inner membrane in the PAM import motor.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Prefer matrix side of mitochondrial inner membrane and PAM complex annotations over generic mitochondrion.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PAM16/PAM16-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">PAM16/MAGMAS is localized to **mitochondria** and described as a **peripheral membrane protein** associated with the TIM23/PAM machinery at the **inner membrane, matrix-facing side**. One source explicitly notes that it does **not extend into the intermembrane space (IMS)**, consistent with a matrix-side role in regulating the mtHsp70 motor. (riva2018ajourneythrough pages 11-15, sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HTP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:34800366
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Quantitative high-confidence human mitochondrial proteome an...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y3D7" data-a="GO:0005739" data-r="PMID:34800366" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct but broad. PAM16 is specifically associated with the matrix-facing side of the mitochondrial inner membrane in the PAM import motor.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Prefer matrix side of mitochondrial inner membrane and PAM complex annotations over generic mitochondrion.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PAM16/PAM16-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">PAM16/MAGMAS is localized to **mitochondria** and described as a **peripheral membrane protein** associated with the TIM23/PAM machinery at the **inner membrane, matrix-facing side**. One source explicitly notes that it does **not extend into the intermembrane space (IMS)**, consistent with a matrix-side role in regulating the mtHsp70 motor. (riva2018ajourneythrough pages 11-15, sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0099617" target="_blank" class="term-link">
+                                    GO:0099617
+                                </a>
+                            </span>
+                            <span class="term-label">matrix side of mitochondrial inner membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20053669" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:20053669
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Role of Magmas in protein transport and human mitochondria b...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y3D7" data-a="GO:0099617" data-r="PMID:20053669" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct. PAM16 localizes to the matrix-facing side of the mitochondrial inner membrane.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PAM16/PAM16-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">PAM16/MAGMAS is localized to **mitochondria** and described as a **peripheral membrane protein** associated with the TIM23/PAM machinery at the **inner membrane, matrix-facing side**. One source explicitly notes that it does **not extend into the intermembrane space (IMS)**, consistent with a matrix-side role in regulating the mtHsp70 motor. (riva2018ajourneythrough pages 11-15, sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001405" target="_blank" class="term-link">
+                                    GO:0001405
+                                </a>
+                            </span>
+                            <span class="term-label">PAM complex, Tim23 associated import motor</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y3D7" data-a="GO:0001405" data-r="GO_REF:0000024" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct and core. PAM16/MAGMAS is a regulatory subunit of the TIM23-associated PAM motor.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PAM16/PAM16-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The literature and database evidence summarized here consistently refers to **human PAM16** as **MAGMAS/TIM16/TIMM16**, a small mitochondrial protein (~125 aa; ~13 kDa) that is part of the **TIM23-associated presequence import motor (PAM complex)**. This matches the UniProt description for Q9Y3D7 (mitochondrial import inner membrane translocase subunit TIM16 / PAM16 family), including the hallmark **J-like domain** and functional role in mitochondrial protein import. (riva2018ajourneythrough pages 11-15, riva2018ajourneythrough pages 8-11, sinha2017thecomplexitiesofa pages 4-5)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PAM16/PAM16-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">PAM16 (MAGMAS/TIM16/TIMM16) is an essential subunit of the **TIM23-associated PAM motor**. Mechanistically, it forms a stable subcomplex with Pam18/Tim14 and is described as (i) **recruiting Pam18** to the import channel and (ii) **controlling Pam18 activity**, thereby indirectly regulating mtHsp70’s ATP-driven pulling activity during translocation into the matrix. (sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001503" target="_blank" class="term-link">
+                                    GO:0001503
+                                </a>
+                            </span>
+                            <span class="term-label">ossification</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/24786642" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:24786642
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The impairment of MAGMAS function in human is responsible fo...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y3D7" data-a="GO:0001503" data-r="PMID:24786642" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Keep as non-core. Human PAM16/MAGMAS disease data support a skeletal dysplasia/ossification phenotype, but the evolved core function is mitochondrial protein import motor regulation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Ossification is a downstream organismal phenotype of MAGMAS impairment, not the core molecular function of PAM16.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PAM16/PAM16-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">| Disease/phenotype links | PAM16 has recognized disease links, including **autosomal recessive spondylometaphyseal dysplasia, Megarbane type** in disease databases. Literature summarized in retrieved sources also links **MAGMAS overexpression** to neoplasia, including **prostate cancer**, **pituitary adenomas**, and anti-apoptotic/chemoresistance phenotypes. Open Targets also lists associations to neurodegenerative disease/Parkinson disease, but these are weaker database associations than the skeletal dysplasia link. | (riva2018ajourneythrough pages 11-15, sinha2017thecomplexitiesof pages 12-14, zhao2023mitochondrialskeletaldisorders pages 8-11, OpenTargets Search: -PAM16,TIMM16,MAGMAS) | Open Targets platform search context; Zhao 2023 dissertation; Riva 2018 |</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PAM16/PAM16-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**PAM16 (Q9Y3D7; MAGMAS/TIM16/TIMM16)** is a mitochondrial, inner-membrane-associated (matrix-facing) **regulatory subunit of the TIM23 presequence import motor (PAM complex)**. Its defining molecular feature is a **degenerate J-like domain lacking the HPD motif**, consistent with a function in **forming a heterodimer with Pam18 and modulating Pam18’s stimulation of mtHsp70 ATPase activity**, thereby tuning ATP-dependent protein translocation into the mitochondrial matrix. Disease relevance includes database-supported association with **autosomal recessive spondylometaphyseal dysplasia (Megarbane type)** and literature-supported roles in tumor cell survival/chemoresistance with reported overexpression frequencies in prostate cancer and pituitary adenomas. (riva2018ajourneythrough pages 11-15, sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5, OpenTargets Search: -PAM16,TIMM16,MAGMAS)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001405" target="_blank" class="term-link">
+                                    GO:0001405
+                                </a>
+                            </span>
+                            <span class="term-label">PAM complex, Tim23 associated import motor</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IGI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20053669" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:20053669
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Role of Magmas in protein transport and human mitochondria b...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y3D7" data-a="GO:0001405" data-r="PMID:20053669" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct and core. PAM16/MAGMAS is a regulatory subunit of the TIM23-associated PAM motor.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PAM16/PAM16-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The literature and database evidence summarized here consistently refers to **human PAM16** as **MAGMAS/TIM16/TIMM16**, a small mitochondrial protein (~125 aa; ~13 kDa) that is part of the **TIM23-associated presequence import motor (PAM complex)**. This matches the UniProt description for Q9Y3D7 (mitochondrial import inner membrane translocase subunit TIM16 / PAM16 family), including the hallmark **J-like domain** and functional role in mitochondrial protein import. (riva2018ajourneythrough pages 11-15, riva2018ajourneythrough pages 8-11, sinha2017thecomplexitiesofa pages 4-5)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PAM16/PAM16-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">PAM16 (MAGMAS/TIM16/TIMM16) is an essential subunit of the **TIM23-associated PAM motor**. Mechanistically, it forms a stable subcomplex with Pam18/Tim14 and is described as (i) **recruiting Pam18** to the import channel and (ii) **controlling Pam18 activity**, thereby indirectly regulating mtHsp70’s ATP-driven pulling activity during translocation into the matrix. (sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19564938" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19564938
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The mitochondrial protein translocation motor: structural co...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y3D7" data-a="GO:0005515" data-r="PMID:19564938" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Protein binding is too generic for PAM16. The informative role is a regulatory adaptor/cochaperone function within the Pam16-Pam18/PAM import motor.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Replace generic protein-binding capture with PAM complex membership and adaptor/regulatory cochaperone activity where supported.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PAM16/PAM16-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**PAM16 is not an enzyme catalyzing a metabolic reaction nor a transporter substrate-binding channel.** Instead, it functions as a **regulatory cochaperone/adaptor** within the import motor. It is described as a **J-like** protein (Hsp40/J-domain superfamily-like) that regulates the activity and positioning of the true J-domain cochaperone **Pam18/Tim14** (metazoan functional ortholog often discussed as DNAJC19/Pam18 in the PAM motor context) which stimulates mtHsp70 ATPase activity. (sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5, riva2018ajourneythrough pages 11-15)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PAM16/PAM16-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">| Mechanistic role | PAM16 is primarily a **regulatory cochaperone/adaptor**, not an enzyme or transporter substrate-binding transporter itself. It forms a stable subcomplex with Pam18 and **recruits/controls Pam18 at the import channel**, thereby **modulating Pam18-driven stimulation of mtHsp70 ATPase activity** and fine-tuning the ATP-dependent import motor. It is described as a **negative regulator/antagonist** of Pam18’s stimulatory effect on mtHsp70. | (riva2018ajourneythrough pages 11-15, sinha2017thecomplexitiesofa pages 4-5, jain2025investigatingmitochondrialpresequence pages 15-17, sinha2017thecomplexitiesof pages 4-5) | Riva 2018; Sinha 2017; Jain 2025 thesis, https://doi.org/10.53846/goediss-11596 |</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20053669" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:20053669
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Role of Magmas in protein transport and human mitochondria b...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y3D7" data-a="GO:0005515" data-r="PMID:20053669" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Protein binding is too generic for PAM16. The informative role is a regulatory adaptor/cochaperone function within the Pam16-Pam18/PAM import motor.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Replace generic protein-binding capture with PAM complex membership and adaptor/regulatory cochaperone activity where supported.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PAM16/PAM16-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**PAM16 is not an enzyme catalyzing a metabolic reaction nor a transporter substrate-binding channel.** Instead, it functions as a **regulatory cochaperone/adaptor** within the import motor. It is described as a **J-like** protein (Hsp40/J-domain superfamily-like) that regulates the activity and positioning of the true J-domain cochaperone **Pam18/Tim14** (metazoan functional ortholog often discussed as DNAJC19/Pam18 in the PAM motor context) which stimulates mtHsp70 ATPase activity. (sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5, riva2018ajourneythrough pages 11-15)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PAM16/PAM16-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">| Mechanistic role | PAM16 is primarily a **regulatory cochaperone/adaptor**, not an enzyme or transporter substrate-binding transporter itself. It forms a stable subcomplex with Pam18 and **recruits/controls Pam18 at the import channel**, thereby **modulating Pam18-driven stimulation of mtHsp70 ATPase activity** and fine-tuning the ATP-dependent import motor. It is described as a **negative regulator/antagonist** of Pam18’s stimulatory effect on mtHsp70. | (riva2018ajourneythrough pages 11-15, sinha2017thecomplexitiesofa pages 4-5, jain2025investigatingmitochondrialpresequence pages 15-17, sinha2017thecomplexitiesof pages 4-5) | Riva 2018; Sinha 2017; Jain 2025 thesis, https://doi.org/10.53846/goediss-11596 |</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20053669" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:20053669
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Role of Magmas in protein transport and human mitochondria b...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y3D7" data-a="GO:0005759" data-r="PMID:20053669" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct. PAM16 acts at the matrix-facing side of the inner membrane and does not extend into the IMS.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PAM16/PAM16-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">PAM16/MAGMAS is localized to **mitochondria** and described as a **peripheral membrane protein** associated with the TIM23/PAM machinery at the **inner membrane, matrix-facing side**. One source explicitly notes that it does **not extend into the intermembrane space (IMS)**, consistent with a matrix-side role in regulating the mtHsp70 motor. (riva2018ajourneythrough pages 11-15, sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030150" target="_blank" class="term-link">
+                                    GO:0030150
+                                </a>
+                            </span>
+                            <span class="term-label">protein import into mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IGI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20053669" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:20053669
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Role of Magmas in protein transport and human mitochondria b...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y3D7" data-a="GO:0030150" data-r="PMID:20053669" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct and core. PAM16 regulates the PAM motor that powers TIM23-mediated matrix import.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PAM16/PAM16-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Most mitochondrial matrix proteins are encoded in the nucleus, translated in the cytosol, and imported into mitochondria. The **TIM23 complex** (inner membrane presequence translocase) mediates import of presequence-containing proteins; for matrix translocation, TIM23 couples to the **PAM (presequence translocase-associated motor)**, which uses an **mtHsp70 ATPase cycle** to pull precursor polypeptides into the matrix. (sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PAM16/PAM16-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">PAM16 (MAGMAS/TIM16/TIMM16) is an essential subunit of the **TIM23-associated PAM motor**. Mechanistically, it forms a stable subcomplex with Pam18/Tim14 and is described as (i) **recruiting Pam18** to the import channel and (ii) **controlling Pam18 activity**, thereby indirectly regulating mtHsp70’s ATP-driven pulling activity during translocation into the matrix. (sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032780" target="_blank" class="term-link">
+                                    GO:0032780
+                                </a>
+                            </span>
+                            <span class="term-label">negative regulation of ATP-dependent activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19564938" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19564938
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The mitochondrial protein translocation motor: structural co...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y3D7" data-a="GO:0032780" data-r="PMID:19564938" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct and mechanistically informative. PAM16 restrains Pam18-mediated stimulation of mtHsp70 ATPase activity in the import motor.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PAM16/PAM16-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A recurring mechanistic interpretation is that Pam16/MAGMAS functions antagonistically to Pam18: it is required for correct association of the motor with the translocon and **inhibits Pam18-mediated stimulation of mtHsp70 ATPase activity**, thus tuning the import motor’s activity. (riva2018ajourneythrough pages 11-15, jain2025investigatingmitochondrialpresequence pages 15-17)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PAM16/PAM16-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">| Mechanistic role | PAM16 is primarily a **regulatory cochaperone/adaptor**, not an enzyme or transporter substrate-binding transporter itself. It forms a stable subcomplex with Pam18 and **recruits/controls Pam18 at the import channel**, thereby **modulating Pam18-driven stimulation of mtHsp70 ATPase activity** and fine-tuning the ATP-dependent import motor. It is described as a **negative regulator/antagonist** of Pam18’s stimulatory effect on mtHsp70. | (riva2018ajourneythrough pages 11-15, sinha2017thecomplexitiesofa pages 4-5, jain2025investigatingmitochondrialpresequence pages 15-17, sinha2017thecomplexitiesof pages 4-5) | Riva 2018; Sinha 2017; Jain 2025 thesis, https://doi.org/10.53846/goediss-11596 |</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032780" target="_blank" class="term-link">
+                                    GO:0032780
+                                </a>
+                            </span>
+                            <span class="term-label">negative regulation of ATP-dependent activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20053669" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:20053669
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Role of Magmas in protein transport and human mitochondria b...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y3D7" data-a="GO:0032780" data-r="PMID:20053669" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct and mechanistically informative. PAM16 restrains Pam18-mediated stimulation of mtHsp70 ATPase activity in the import motor.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PAM16/PAM16-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A recurring mechanistic interpretation is that Pam16/MAGMAS functions antagonistically to Pam18: it is required for correct association of the motor with the translocon and **inhibits Pam18-mediated stimulation of mtHsp70 ATPase activity**, thus tuning the import motor’s activity. (riva2018ajourneythrough pages 11-15, jain2025investigatingmitochondrialpresequence pages 15-17)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PAM16/PAM16-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">| Mechanistic role | PAM16 is primarily a **regulatory cochaperone/adaptor**, not an enzyme or transporter substrate-binding transporter itself. It forms a stable subcomplex with Pam18 and **recruits/controls Pam18 at the import channel**, thereby **modulating Pam18-driven stimulation of mtHsp70 ATPase activity** and fine-tuning the ATP-dependent import motor. It is described as a **negative regulator/antagonist** of Pam18’s stimulatory effect on mtHsp70. | (riva2018ajourneythrough pages 11-15, sinha2017thecomplexitiesofa pages 4-5, jain2025investigatingmitochondrialpresequence pages 15-17, sinha2017thecomplexitiesof pages 4-5) | Riva 2018; Sinha 2017; Jain 2025 thesis, https://doi.org/10.53846/goediss-11596 |</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032991" target="_blank" class="term-link">
+                                    GO:0032991
+                                </a>
+                            </span>
+                            <span class="term-label">protein-containing complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19564938" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19564938
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The mitochondrial protein translocation motor: structural co...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y3D7" data-a="GO:0032991" data-r="PMID:19564938" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct but too generic. The specific protein-containing complex is the TIM23-associated PAM motor.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Use PAM complex rather than the generic protein-containing complex term.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PAM16/PAM16-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The literature and database evidence summarized here consistently refers to **human PAM16** as **MAGMAS/TIM16/TIMM16**, a small mitochondrial protein (~125 aa; ~13 kDa) that is part of the **TIM23-associated presequence import motor (PAM complex)**. This matches the UniProt description for Q9Y3D7 (mitochondrial import inner membrane translocase subunit TIM16 / PAM16 family), including the hallmark **J-like domain** and functional role in mitochondrial protein import. (riva2018ajourneythrough pages 11-15, riva2018ajourneythrough pages 8-11, sinha2017thecomplexitiesofa pages 4-5)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PAM16/PAM16-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">PAM16 (MAGMAS/TIM16/TIMM16) is an essential subunit of the **TIM23-associated PAM motor**. Mechanistically, it forms a stable subcomplex with Pam18/Tim14 and is described as (i) **recruiting Pam18** to the import channel and (ii) **controlling Pam18 activity**, thereby indirectly regulating mtHsp70’s ATP-driven pulling activity during translocation into the matrix. (sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032991" target="_blank" class="term-link">
+                                    GO:0032991
+                                </a>
+                            </span>
+                            <span class="term-label">protein-containing complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20053669" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:20053669
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Role of Magmas in protein transport and human mitochondria b...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y3D7" data-a="GO:0032991" data-r="PMID:20053669" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct but too generic. The specific protein-containing complex is the TIM23-associated PAM motor.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Use PAM complex rather than the generic protein-containing complex term.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PAM16/PAM16-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The literature and database evidence summarized here consistently refers to **human PAM16** as **MAGMAS/TIM16/TIMM16**, a small mitochondrial protein (~125 aa; ~13 kDa) that is part of the **TIM23-associated presequence import motor (PAM complex)**. This matches the UniProt description for Q9Y3D7 (mitochondrial import inner membrane translocase subunit TIM16 / PAM16 family), including the hallmark **J-like domain** and functional role in mitochondrial protein import. (riva2018ajourneythrough pages 11-15, riva2018ajourneythrough pages 8-11, sinha2017thecomplexitiesofa pages 4-5)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PAM16/PAM16-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">PAM16 (MAGMAS/TIM16/TIMM16) is an essential subunit of the **TIM23-associated PAM motor**. Mechanistically, it forms a stable subcomplex with Pam18/Tim14 and is described as (i) **recruiting Pam18** to the import channel and (ii) **controlling Pam18 activity**, thereby indirectly regulating mtHsp70’s ATP-driven pulling activity during translocation into the matrix. (sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030674" target="_blank" class="term-link">
+                                    GO:0030674
+                                </a>
+                            </span>
+                            <span class="term-label">protein-macromolecule adaptor activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            file:human/PAM16/PAM16-deep-research-falcon.md
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y3D7" data-a="GO:0030674" data-r="file:human/PAM16/PAM16-deep-research-falcon.md" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> New annotation. PAM16 functions as a regulatory adaptor/cochaperone that recruits and controls Pam18 at the import channel rather than acting as an enzyme or transporter.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> PAM16 has a specific adaptor/cochaperone role in the PAM motor that is more informative than generic protein binding and is not present in GOA.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PAM16/PAM16-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**PAM16 is not an enzyme catalyzing a metabolic reaction nor a transporter substrate-binding channel.** Instead, it functions as a **regulatory cochaperone/adaptor** within the import motor. It is described as a **J-like** protein (Hsp40/J-domain superfamily-like) that regulates the activity and positioning of the true J-domain cochaperone **Pam18/Tim14** (metazoan functional ortholog often discussed as DNAJC19/Pam18 in the PAM motor context) which stimulates mtHsp70 ATPase activity. (sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5, riva2018ajourneythrough pages 11-15)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PAM16/PAM16-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">PAM16 (MAGMAS/TIM16/TIMM16) is an essential subunit of the **TIM23-associated PAM motor**. Mechanistically, it forms a stable subcomplex with Pam18/Tim14 and is described as (i) **recruiting Pam18** to the import channel and (ii) **controlling Pam18 activity**, thereby indirectly regulating mtHsp70’s ATP-driven pulling activity during translocation into the matrix. (sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PAM16/PAM16-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">| Mechanistic role | PAM16 is primarily a **regulatory cochaperone/adaptor**, not an enzyme or transporter substrate-binding transporter itself. It forms a stable subcomplex with Pam18 and **recruits/controls Pam18 at the import channel**, thereby **modulating Pam18-driven stimulation of mtHsp70 ATPase activity** and fine-tuning the ATP-dependent import motor. It is described as a **negative regulator/antagonist** of Pam18’s stimulatory effect on mtHsp70. | (riva2018ajourneythrough pages 11-15, sinha2017thecomplexitiesofa pages 4-5, jain2025investigatingmitochondrialpresequence pages 15-17, sinha2017thecomplexitiesof pages 4-5) | Riva 2018; Sinha 2017; Jain 2025 thesis, https://doi.org/10.53846/goediss-11596 |</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>PAM16 is the matrix-facing regulatory J-like cochaperone/adaptor subunit of the PAM complex that forms a subcomplex with Pam18/Tim14, recruits and restrains Pam18 activity, and tunes mtHsp70-powered import of presequence-containing proteins into the mitochondrial matrix.</h3>
+                <span class="vote-buttons" data-g="Q9Y3D7" data-a="FUNCTION: PAM16 is the matrix-facing regulatory J-like cocha..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030674" target="_blank" class="term-link">
+                            protein-macromolecule adaptor activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030150" target="_blank" class="term-link">
+                                protein import into mitochondrial matrix
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0099617" target="_blank" class="term-link">
+                                matrix side of mitochondrial inner membrane
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005743" target="_blank" class="term-link">
+                                mitochondrial inner membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001405" target="_blank" class="term-link">
+                            PAM complex, Tim23 associated import motor
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/PAM16/PAM16-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">Most mitochondrial matrix proteins are encoded in the nucleus, translated in the cytosol, and imported into mitochondria. The **TIM23 complex** (inner membrane presequence translocase) mediates import of presequence-containing proteins; for matrix translocation, TIM23 couples to the **PAM (presequence translocase-associated motor)**, which uses an **mtHsp70 ATPase cycle** to pull precursor polypeptides into the matrix. (sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5)</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/PAM16/PAM16-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">PAM16 (MAGMAS/TIM16/TIMM16) is an essential subunit of the **TIM23-associated PAM motor**. Mechanistically, it forms a stable subcomplex with Pam18/Tim14 and is described as (i) **recruiting Pam18** to the import channel and (ii) **controlling Pam18 activity**, thereby indirectly regulating mtHsp70’s ATP-driven pulling activity during translocation into the matrix. (sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5)</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/PAM16/PAM16-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">A recurring mechanistic interpretation is that Pam16/MAGMAS functions antagonistically to Pam18: it is required for correct association of the motor with the translocon and **inhibits Pam18-mediated stimulation of mtHsp70 ATPase activity**, thus tuning the import motor’s activity. (riva2018ajourneythrough pages 11-15, jain2025investigatingmitochondrialpresequence pages 15-17)</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/PAM16/PAM16-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">**PAM16 (Q9Y3D7; MAGMAS/TIM16/TIMM16)** is a mitochondrial, inner-membrane-associated (matrix-facing) **regulatory subunit of the TIM23 presequence import motor (PAM complex)**. Its defining molecular feature is a **degenerate J-like domain lacking the HPD motif**, consistent with a function in **forming a heterodimer with Pam18 and modulating Pam18’s stimulation of mtHsp70 ATPase activity**, thereby tuning ATP-dependent protein translocation into the mitochondrial matrix. Disease relevance includes database-supported association with **autosomal recessive spondylometaphyseal dysplasia (Megarbane type)** and literature-supported roles in tumor cell survival/chemoresistance with reported overexpression frequencies in prostate cancer and pituitary adenomas. (riva2018ajourneythrough pages 11-15, sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5, OpenTargets Search: -PAM16,TIMM16,MAGMAS)</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000024.md" target="_blank" class="term-link">
+                            GO_REF:0000024
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment of sequence similarity</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000052.md" target="_blank" class="term-link">
+                            GO_REF:0000052
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on curation of immunofluorescence data</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
+                            GO_REF:0000117
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/10339406" target="_blank" class="term-link">
+                            PMID:10339406
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Genetic and structural characterization of the human mitochondrial inner membrane translocase.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/19564938" target="_blank" class="term-link">
+                            PMID:19564938
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The mitochondrial protein translocation motor: structural conservation between the human and yeast Tim14/Pam18-Tim16/Pam16 co-chaperones.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/20053669" target="_blank" class="term-link">
+                            PMID:20053669
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Role of Magmas in protein transport and human mitochondria biogenesis.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/23263864" target="_blank" class="term-link">
+                            PMID:23263864
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Methylation-controlled J-protein MCJ acts in the import of proteins into human mitochondria.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/24786642" target="_blank" class="term-link">
+                            PMID:24786642
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The impairment of MAGMAS function in human is responsible for a severe skeletal dysplasia.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/25416956" target="_blank" class="term-link">
+                            PMID:25416956
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A proteome-scale map of the human interactome network.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
+                            PMID:32296183
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A reference map of the human binary protein interactome.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
+                            PMID:33961781
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link">
+                            PMID:34800366
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Quantitative high-confidence human mitochondrial proteome and its dynamics in cellular context.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/PAM16/PAM16-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research report for human PAM16</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Which human PAM16 surfaces are required for Pam18 recruitment versus inhibition of Pam18-stimulated mtHsp70 ATPase activity?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q9Y3D7" data-a="Q: Which human PAM16 surfaces are required for Pam18 ..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> How do skeletal dysplasia variants alter PAM16 stability, Pam18 binding, and matrix import flux in patient-relevant cells?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q9Y3D7" data-a="Q: How do skeletal dysplasia variants alter PAM16 sta..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Measure Pam18 binding, PAM/TIM23 association, mtHsp70 ATPase regulation, and matrix-import reporter flux after rescue of PAM16-null human cells with wild-type and disease-variant PAM16.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: PAM16 disease variants impair matrix import by destabilizing the Pam16-Pam18 regulatory subcomplex.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="Q9Y3D7" data-a="EXPERIMENT: Measure Pam18 binding, PAM/TIM23 association, mtHs..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Compare acute PAM16 knockdown or overexpression with Pam18-interface mutants for precursor import, mitochondrial proteostasis, apoptosis sensitivity, and respiratory function.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: PAM16 overexpression phenotypes in cancer models derive from altered PAM motor activity rather than a separate enzymatic function.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="Q9Y3D7" data-a="EXPERIMENT: Compare acute PAM16 knockdown or overexpression wi..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Deep Research Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(PAM16-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q9Y3D7" data-a="DOC: Deep Research Falcon" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <hr />
+<p>provider: falcon<br />
+model: Edison Scientific Literature<br />
+cached: false<br />
+start_time: '2026-05-11T18:16:43.304197'<br />
+end_time: '2026-05-11T18:24:57.634760'<br />
+duration_seconds: 494.33<br />
+template_file: templates/gene_research_go_focused.md<br />
+template_variables:<br />
+  organism: human<br />
+  gene_id: PAM16<br />
+  gene_symbol: PAM16<br />
+  uniprot_accession: Q9Y3D7<br />
+  protein_description: 'RecName: Full=Mitochondrial import inner membrane translocase<br />
+    subunit TIM16; AltName: Full=Mitochondria-associated granulocyte macrophage CSF-signaling<br />
+    molecule; AltName: Full=Presequence translocated-associated motor subunit PAM16;'<br />
+  gene_info: Name=PAM16; Synonyms=MAGMAS, TIM16, TIMM16; ORFNames=CGI-136;<br />
+  organism_full: Homo sapiens (Human).<br />
+  protein_family: Belongs to the TIM16/PAM16 family. .<br />
+  protein_domains: J_dom_sf. (IPR036869); Tim16. (IPR005341); Pam16 (PF03656)<br />
+provider_config:<br />
+  timeout: 600<br />
+  max_retries: 3<br />
+  parameters:<br />
+    allowed_domains: []<br />
+    temperature: 0.1<br />
+citation_count: 18</p>
+<hr />
+<h2 id="question">Question</h2>
+<h1 id="gene-research-for-functional-annotation">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> Q9Y3D7</li>
+<li><strong>Protein Description:</strong> RecName: Full=Mitochondrial import inner membrane translocase subunit TIM16; AltName: Full=Mitochondria-associated granulocyte macrophage CSF-signaling molecule; AltName: Full=Presequence translocated-associated motor subunit PAM16;</li>
+<li><strong>Gene Information:</strong> Name=PAM16; Synonyms=MAGMAS, TIM16, TIMM16; ORFNames=CGI-136;</li>
+<li><strong>Organism (full):</strong> Homo sapiens (Human).</li>
+<li><strong>Protein Family:</strong> Belongs to the TIM16/PAM16 family. .</li>
+<li><strong>Key Domains:</strong> J_dom_sf. (IPR036869); Tim16. (IPR005341); Pam16 (PF03656)</li>
+</ul>
+<h3 id="mandatory-verification-steps">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "PAM16" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Homo sapiens (Human).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'PAM16' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>PAM16</strong> (gene ID: PAM16, UniProt: Q9Y3D7) in human.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="output">Output</h2>
+<p>Question: You are an expert researcher providing comprehensive, well-cited information.</p>
+<p>Provide detailed information focusing on:<br />
+1. Key concepts and definitions with current understanding<br />
+2. Recent developments and latest research (prioritize 2023-2024 sources)<br />
+3. Current applications and real-world implementations<br />
+4. Expert opinions and analysis from authoritative sources<br />
+5. Relevant statistics and data from recent studies</p>
+<p>Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.<br />
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.</p>
+<h1 id="gene-research-for-functional-annotation_1">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context_1">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot_1">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> Q9Y3D7</li>
+<li><strong>Protein Description:</strong> RecName: Full=Mitochondrial import inner membrane translocase subunit TIM16; AltName: Full=Mitochondria-associated granulocyte macrophage CSF-signaling molecule; AltName: Full=Presequence translocated-associated motor subunit PAM16;</li>
+<li><strong>Gene Information:</strong> Name=PAM16; Synonyms=MAGMAS, TIM16, TIMM16; ORFNames=CGI-136;</li>
+<li><strong>Organism (full):</strong> Homo sapiens (Human).</li>
+<li><strong>Protein Family:</strong> Belongs to the TIM16/PAM16 family. .</li>
+<li><strong>Key Domains:</strong> J_dom_sf. (IPR036869); Tim16. (IPR005341); Pam16 (PF03656)</li>
+</ul>
+<h3 id="mandatory-verification-steps_1">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "PAM16" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Homo sapiens (Human).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature_1">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'PAM16' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target_1">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>PAM16</strong> (gene ID: PAM16, UniProt: Q9Y3D7) in human.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="comprehensive-research-report-human-pam16-uniprot-q9y3d7-synonyms-magmastim16timm16">Comprehensive Research Report: Human <strong>PAM16</strong> (UniProt <strong>Q9Y3D7</strong>; synonyms <strong>MAGMAS/TIM16/TIMM16</strong>)</h1>
+<h2 id="0-scope-and-geneprotein-verification-mandatory">0) Scope and gene/protein verification (mandatory)</h2>
+<p>The literature and database evidence summarized here consistently refers to <strong>human PAM16</strong> as <strong>MAGMAS/TIM16/TIMM16</strong>, a small mitochondrial protein (~125 aa; ~13 kDa) that is part of the <strong>TIM23-associated presequence import motor (PAM complex)</strong>. This matches the UniProt description for Q9Y3D7 (mitochondrial import inner membrane translocase subunit TIM16 / PAM16 family), including the hallmark <strong>J-like domain</strong> and functional role in mitochondrial protein import. (riva2018ajourneythrough pages 11-15, riva2018ajourneythrough pages 8-11, sinha2017thecomplexitiesofa pages 4-5)</p>
+<h2 id="1-key-concepts-and-definitions-current-understanding">1) Key concepts and definitions (current understanding)</h2>
+<h3 id="11-mitochondrial-presequence-import-tim23-and-the-pam-motor">1.1 Mitochondrial presequence import (TIM23) and the PAM motor</h3>
+<p>Most mitochondrial matrix proteins are encoded in the nucleus, translated in the cytosol, and imported into mitochondria. The <strong>TIM23 complex</strong> (inner membrane presequence translocase) mediates import of presequence-containing proteins; for matrix translocation, TIM23 couples to the <strong>PAM (presequence translocase-associated motor)</strong>, which uses an <strong>mtHsp70 ATPase cycle</strong> to pull precursor polypeptides into the matrix. (sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5)</p>
+<h3 id="12-what-pam16-is-and-is-not">1.2 What PAM16 is (and is not)</h3>
+<p><strong>PAM16 is not an enzyme catalyzing a metabolic reaction nor a transporter substrate-binding channel.</strong> Instead, it functions as a <strong>regulatory cochaperone/adaptor</strong> within the import motor. It is described as a <strong>J-like</strong> protein (Hsp40/J-domain superfamily-like) that regulates the activity and positioning of the true J-domain cochaperone <strong>Pam18/Tim14</strong> (metazoan functional ortholog often discussed as DNAJC19/Pam18 in the PAM motor context) which stimulates mtHsp70 ATPase activity. (sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5, riva2018ajourneythrough pages 11-15)</p>
+<h3 id="13-domain-architecture-j-like-domain-lacking-the-canonical-hpd-motif">1.3 Domain architecture: J-like domain lacking the canonical HPD motif</h3>
+<p>A key defining concept for PAM16 family proteins is that they contain a <strong>degenerate J-like domain</strong> that resembles a J-domain fold but lacks the invariant <strong>HPD</strong> tripeptide required for canonical J-domain stimulation of Hsp70 ATPase activity. In the retrieved human MAGMAS/PAM16-focused review, the J-like domain is placed at <strong>aa 54–117</strong> and is reported to contain <strong>DKE</strong> in place of HPD, consistent with an <strong>inhibitory/regulatory</strong> (rather than stimulatory) role. (riva2018ajourneythrough pages 11-15, jain2025investigatingmitochondrialpresequence pages 15-17, riva2018ajourneythrough pages 79-82)</p>
+<h2 id="2-core-biological-function-and-mechanism-functional-annotation">2) Core biological function and mechanism (functional annotation)</h2>
+<h3 id="21-primary-function-regulation-of-the-tim23-pam-import-motor">2.1 Primary function: regulation of the TIM23-PAM import motor</h3>
+<p>PAM16 (MAGMAS/TIM16/TIMM16) is an essential subunit of the <strong>TIM23-associated PAM motor</strong>. Mechanistically, it forms a stable subcomplex with Pam18/Tim14 and is described as (i) <strong>recruiting Pam18</strong> to the import channel and (ii) <strong>controlling Pam18 activity</strong>, thereby indirectly regulating mtHsp70’s ATP-driven pulling activity during translocation into the matrix. (sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5)</p>
+<h3 id="22-antagonismnegative-regulation-of-pam18-stimulated-mthsp70-atpase">2.2 Antagonism/negative regulation of Pam18-stimulated mtHsp70 ATPase</h3>
+<p>A recurring mechanistic interpretation is that Pam16/MAGMAS functions antagonistically to Pam18: it is required for correct association of the motor with the translocon and <strong>inhibits Pam18-mediated stimulation of mtHsp70 ATPase activity</strong>, thus tuning the import motor’s activity. (riva2018ajourneythrough pages 11-15, jain2025investigatingmitochondrialpresequence pages 15-17)</p>
+<h3 id="23-interacting-partners-and-complex-membership">2.3 Interacting partners and complex membership</h3>
+<p>Across the retrieved reviews, PAM16 is placed within the PAM motor with the following canonical partners:<br />
+- <strong>Pam18/Tim14</strong> (J-domain protein that stimulates mtHsp70 ATPase; PAM16 forms a stable complex with it)<br />
+- <strong>Tim44</strong> (inner membrane-associated scaffold/adaptor that recruits mtHsp70 at the channel outlet)<br />
+- <strong>mtHsp70</strong> (central ATP-driven motor/chaperone)<br />
+- <strong>Mge1/GrpE-like nucleotide exchange factor</strong> (facilitates ADP/ATP exchange on mtHsp70; metazoan homologs include GRPEL family)<br />
+- <strong>Pam17</strong> (organization factor; deletion disrupts association of Pam16/Pam18 with translocase in yeast-centric mechanistic discussions)<br />
+These interactions are discussed as part of the motor architecture that couples the TIM23 channel to mtHsp70-driven translocation. (sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 5-6, sinha2017thecomplexitiesof pages 4-5, riva2018ajourneythrough pages 11-15)</p>
+<p>A specific interaction detail reported in the MAGMAS review is the Pam16–Pam18 heterodimer interface involving <strong>L97 of Pam16</strong> and <strong>L150 of Pam18</strong>. (riva2018ajourneythrough pages 11-15)</p>
+<h2 id="3-cellular-and-sub-mitochondrial-localization">3) Cellular and sub-mitochondrial localization</h2>
+<p>PAM16/MAGMAS is localized to <strong>mitochondria</strong> and described as a <strong>peripheral membrane protein</strong> associated with the TIM23/PAM machinery at the <strong>inner membrane, matrix-facing side</strong>. One source explicitly notes that it does <strong>not extend into the intermembrane space (IMS)</strong>, consistent with a matrix-side role in regulating the mtHsp70 motor. (riva2018ajourneythrough pages 11-15, sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5)</p>
+<h2 id="4-disease-relevance-and-phenotypic-associations">4) Disease relevance and phenotypic associations</h2>
+<h3 id="41-mendelian-disease-association-database-level-evidence">4.1 Mendelian disease association (database-level evidence)</h3>
+<p>Open Targets returns PAM16 disease associations including <strong>autosomal recessive spondylometaphyseal dysplasia, Megarbane type</strong>, with a reported association score around <strong>0.58</strong> and <strong>evidence size = 5</strong> in the displayed summary, alongside other weaker associations (e.g., neurodegenerative disease, Parkinson disease, nephronophthisis) with evidence size = 5 in this snapshot. (OpenTargets Search: -PAM16,TIMM16,MAGMAS)</p>
+<h3 id="42-pam16magmas-in-cancer-biology-quantitative-observations">4.2 PAM16/MAGMAS in cancer biology (quantitative observations)</h3>
+<p>A MAGMAS-focused review summarizing experimental literature reports overexpression of MAGMAS in malignancy contexts, including:<br />
+- <strong>~50% of prostate cancers</strong> with MAGMAS overexpression<br />
+- <strong>~72% of human pituitary adenomas</strong> with MAGMAS overexpression<br />
+The same source summarizes functional phenotypes: MAGMAS overexpression is associated with <strong>reduced apoptosis</strong> (e.g., reduced cytochrome c release; altered BAX/Bcl2 balance; reduced ROS), whereas silencing reduces DNA synthesis and causes <strong>G0/G1 accumulation</strong>, consistent with a pro-survival/proliferative role in some tumor models. (riva2018ajourneythrough pages 11-15, sinha2017thecomplexitiesof pages 5-6)</p>
+<h2 id="5-recent-developments-and-latest-research-prioritize-20232024">5) Recent developments and latest research (prioritize 2023–2024)</h2>
+<h3 id="51-2023-reinforcement-of-tim23pam-module-connectivity-around-mthsp70">5.1 2023: reinforcement of TIM23/PAM module connectivity around mtHsp70</h3>
+<p>Although not centered on PAM16 specifically, <strong>Song et al. (Nature Communications, publication year 2023; DOI URL below)</strong> reports biochemical association/co-purification behavior in yeast mitochondria in which <strong>TIM23 and PAM subunits</strong> are discussed together, and explicitly lists <strong>Tim17, Tim44, Pam16 and Pam18</strong> as co-associated components in the mtHsp70-centered context (TIM23/PAM module). This supports the continued relevance of the canonical import-motor composition and connectivity in contemporary mitochondrial protein biogenesis research.<br />
+- URL: https://doi.org/10.1038/s41467-022-35720-5 (published in 2023; article metadata in the retrieved text) (song2023themitochondrialhsp70 pages 6-7, song2023themitochondrialhsp70 pages 7-9)</p>
+<h3 id="52-2024-evolutionary-repurposing-of-pam16pam18-outside-canonical-import">5.2 2024: evolutionary repurposing of Pam16/Pam18 outside canonical import</h3>
+<p><strong>von Känel et al. (PLOS Biology; Aug 2024)</strong> shows that in <em>Trypanosoma brucei</em> the Pam16/Pam18 module has been evolutionarily repurposed away from canonical TIM23-mediated import toward regulation of <strong>mitochondrial DNA (maxicircle) replication</strong>, while still retaining features such as essentiality and apparent Pam16–Pam18 functional linkage (TbPam16 stability depending on TbPam18). Although this is not human biology, it is a high-quality 2024 study reinforcing that Pam16/Pam18 are ancient and adaptable regulatory modules normally tied to mitochondrial biogenesis.<br />
+- Publication date: Aug 2024<br />
+- URL: https://doi.org/10.1371/journal.pbio.3002449 (kanel2024pam16andpam18 pages 1-2, kanel2024pam16andpam18 pages 2-3)</p>
+<h3 id="53-evidence-limitations-for-20232024-human-specific-pam16-mechanistic-advances">5.3 Evidence limitations for 2023–2024 human-specific PAM16 mechanistic advances</h3>
+<p>Within the retrieved and accessible full text in this run, <strong>direct 2023–2024 human-specific PAM16 mechanistic/structural studies were limited</strong>; therefore, the “latest research” section relies on (i) 2023–2024 peer-reviewed work that contextualizes the PAM module and (ii) database-level disease association evidence, while the most explicit molecular mechanism statements come from earlier but focused reviews. (sinha2017thecomplexitiesofa pages 4-5, riva2018ajourneythrough pages 11-15, OpenTargets Search: -PAM16,TIMM16,MAGMAS)</p>
+<h2 id="6-current-applications-and-real-world-implementations">6) Current applications and real-world implementations</h2>
+<h3 id="61-functional-annotation-use-cases">6.1 Functional annotation use-cases</h3>
+<p>In practice, PAM16 is used as a <strong>marker/component</strong> of the TIM23 presequence import motor in studies of:<br />
+- mitochondrial protein import capacity and proteostasis<br />
+- mtHsp70 cochaperone regulation<br />
+- mitochondrial stress phenotypes linked to import machinery perturbation<br />
+These applications follow directly from its described role as a regulator of Pam18/mtHsp70 at the TIM23 outlet. (sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5, riva2018ajourneythrough pages 11-15)</p>
+<h3 id="62-translational-relevance">6.2 Translational relevance</h3>
+<p>The strongest “real-world” relevance in the retrieved corpus is twofold:<br />
+- <strong>Rare disease genetics</strong>: association to Megarbane-type spondylometaphyseal dysplasia in disease-target resources (OpenTargets Search: -PAM16,TIMM16,MAGMAS).<br />
+- <strong>Cancer biology</strong>: summarized overexpression frequencies and anti-apoptotic phenotypes in prostate cancer and pituitary adenomas, suggesting potential biomarker or vulnerability hypotheses. (riva2018ajourneythrough pages 11-15)</p>
+<h2 id="7-expert-opinions-authoritative-synthesis">7) Expert opinions / authoritative synthesis</h2>
+<p>Two review-style sources in this evidence set frame PAM16 as a <strong>regulatory, membrane-associated J-like cochaperone</strong> whose main purpose is to <strong>position and restrain Pam18</strong>, thereby tuning mtHsp70-driven import:<br />
+- A review on human inner membrane translocases emphasizes Pam16’s role in recruiting and controlling Pam18, and placing Pam16 within the TIM23-associated Hsp70-based motor. (sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5)<br />
+- A MAGMAS-focused review integrates the import-motor role with disease/cancer phenotypes, emphasizing the degenerate J-like domain and antagonism of Pam18 stimulation of mtHsp70. (riva2018ajourneythrough pages 11-15)</p>
+<h2 id="8-summary-table-evidence-map">8) Summary table (evidence map)</h2>
+<table>
+<thead>
+<tr>
+<th>Category</th>
+<th>Key points</th>
+<th>Best supporting citations (by context IDs)</th>
+<th>Key sources with year/URL when available</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Identity/synonyms</td>
+<td>Human <strong>PAM16</strong> matches UniProt <strong>Q9Y3D7</strong> and is also referred to as <strong>MAGMAS</strong>, <strong>TIM16</strong>, and <strong>TIMM16</strong>; it encodes a small mitochondrial protein (~125 aa, ~13 kDa) that is part of the presequence translocase-associated motor linked to TIM23.</td>
+<td>(riva2018ajourneythrough pages 11-15, riva2018ajourneythrough pages 8-11, sinha2017thecomplexitiesofa pages 4-5)</td>
+<td>Riva 2018, <em>A journey through in vitro and in vivo models to understand the role of Magmas in cancer chemoresistance</em>; Sinha 2017, <em>The complexities of human mitochondrial inner-membrane protein translocases in maintenance of organeller function</em></td>
+</tr>
+<tr>
+<td>Domain features</td>
+<td>PAM16/MAGMAS contains a <strong>degenerate J-like domain</strong> (reported aa 54-117) related to Hsp40/J-domains but lacking the canonical <strong>HPD</strong> motif required for ATPase stimulation; reported substitution is <strong>DKE</strong> instead. This fits UniProt/InterPro family assignment to TIM16/PAM16 and a J-domain superfamily-like fold.</td>
+<td>(riva2018ajourneythrough pages 11-15, riva2018ajourneythrough pages 79-82, jain2025investigatingmitochondrialpresequence pages 15-17)</td>
+<td>Riva 2018; Jain 2025 thesis, https://doi.org/10.53846/goediss-11596</td>
+</tr>
+<tr>
+<td>Complex/pathway</td>
+<td>PAM16 is a component of the <strong>mitochondrial TIM23 presequence import pathway</strong>, specifically the <strong>PAM (presequence translocase-associated motor)</strong> that acts on matrix-destined precursor proteins after passage through TOM/TIM23. PAM motor subunits described with PAM16 include <strong>Pam18/Tim14 (human ortholog DNAJC19/Pam18)</strong>, <strong>Tim44</strong>, <strong>mtHsp70</strong>, and <strong>Mge1/GRPEL1-like nucleotide exchange factor</strong>.</td>
+<td>(riva2018ajourneythrough pages 11-15, sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 5-6, sinha2017thecomplexitiesof pages 4-5)</td>
+<td>Sinha 2017; Zhao &amp; Zou 2021, <em>Front Cardiovasc Med</em>, https://doi.org/10.3389/fcvm.2021.749756</td>
+</tr>
+<tr>
+<td>Mechanistic role</td>
+<td>PAM16 is primarily a <strong>regulatory cochaperone/adaptor</strong>, not an enzyme or transporter substrate-binding transporter itself. It forms a stable subcomplex with Pam18 and <strong>recruits/controls Pam18 at the import channel</strong>, thereby <strong>modulating Pam18-driven stimulation of mtHsp70 ATPase activity</strong> and fine-tuning the ATP-dependent import motor. It is described as a <strong>negative regulator/antagonist</strong> of Pam18’s stimulatory effect on mtHsp70.</td>
+<td>(riva2018ajourneythrough pages 11-15, sinha2017thecomplexitiesofa pages 4-5, jain2025investigatingmitochondrialpresequence pages 15-17, sinha2017thecomplexitiesof pages 4-5)</td>
+<td>Riva 2018; Sinha 2017; Jain 2025 thesis, https://doi.org/10.53846/goediss-11596</td>
+</tr>
+<tr>
+<td>Interacting partners</td>
+<td>Best-supported partners are <strong>Pam18/Tim14 (DNAJC19 orthologous role in metazoan TIM23 motor)</strong>, <strong>Tim44</strong>, <strong>mtHsp70</strong>, <strong>Mge1</strong>, and the <strong>TIM23 core translocase</strong>. Reported interaction details include a tight Pam16-Pam18 heterodimer and cited residue contacts such as <strong>L97 of Pam16</strong> with <strong>L150 of Pam18</strong>. Pam17 is reported to help maintain the Pam16-Pam18 module at the translocase.</td>
+<td>(riva2018ajourneythrough pages 11-15, sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 5-6, sinha2017thecomplexitiesof pages 4-5)</td>
+<td>Riva 2018; Sinha 2017; Song et al. 2023, <em>Nat Commun</em>, https://doi.org/10.1038/s41467-022-35720-5</td>
+</tr>
+<tr>
+<td>Localization</td>
+<td>PAM16/MAGMAS is a <strong>mitochondrial</strong> protein associated with the <strong>inner membrane on the matrix side</strong> as a <strong>peripheral membrane-associated</strong> component of the TIM23/PAM machinery; reports note it does <strong>not extend into the IMS</strong>. Function is therefore carried out at the <strong>matrix-facing exit of the TIM23 channel</strong> where precursor pulling/folding occurs.</td>
+<td>(riva2018ajourneythrough pages 11-15, sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5)</td>
+<td>Riva 2018; Sinha 2017</td>
+</tr>
+<tr>
+<td>Disease/phenotype links</td>
+<td>PAM16 has recognized disease links, including <strong>autosomal recessive spondylometaphyseal dysplasia, Megarbane type</strong> in disease databases. Literature summarized in retrieved sources also links <strong>MAGMAS overexpression</strong> to neoplasia, including <strong>prostate cancer</strong>, <strong>pituitary adenomas</strong>, and anti-apoptotic/chemoresistance phenotypes. Open Targets also lists associations to neurodegenerative disease/Parkinson disease, but these are weaker database associations than the skeletal dysplasia link.</td>
+<td>(riva2018ajourneythrough pages 11-15, sinha2017thecomplexitiesof pages 12-14, zhao2023mitochondrialskeletaldisorders pages 8-11, OpenTargets Search: -PAM16,TIMM16,MAGMAS)</td>
+<td>Open Targets platform search context; Zhao 2023 dissertation; Riva 2018</td>
+</tr>
+<tr>
+<td>Quantitative data</td>
+<td>Reported quantitative observations include <strong>overexpression in ~50% of prostate cancers</strong> and <strong>~72% of human pituitary adenomas</strong>; MAGMAS silencing reduced DNA synthesis and caused <strong>G0/G1 accumulation</strong> in cited cancer models. Open Targets evidence summaries show disease-association evidence counts of <strong>5</strong> for several PAM16-linked diseases and highest listed score here for <strong>autosomal recessive spondylometaphyseal dysplasia, Megarbane type</strong> (<strong>0.5824</strong>).</td>
+<td>(riva2018ajourneythrough pages 11-15, OpenTargets Search: -PAM16,TIMM16,MAGMAS)</td>
+<td>Riva 2018; Open Targets platform context</td>
+</tr>
+<tr>
+<td>Recent (2023-2024) updates/related work</td>
+<td>Direct human PAM16-specific 2023-2024 mechanistic advances were limited in retrieved material, but related recent work reinforces the <strong>mtHsp70-centered PAM/TIM23 framework</strong>. <strong>Song et al. 2023</strong> showed mtHsp70 remains physically associated with <strong>Tim17, Tim44, Pam16, and Pam18</strong> in mitochondrial interactome/co-purification analyses, supporting persistent linkage of PAM16 to mtHsp70-centered protein biogenesis networks. <strong>von Känel et al. 2024</strong> provided evolutionary evidence that Pam16/Pam18 are ancient regulatory modules normally tied to import, though repurposed in <em>T. brucei</em> for mitochondrial DNA replication rather than canonical import.</td>
+<td>(kanel2024pam16andpam18 pages 2-3, kanel2024pam16andpam18 pages 1-2, song2023themitochondrialhsp70 pages 6-7, song2023themitochondrialhsp70 pages 9-11, song2023themitochondrialhsp70 pages 7-9)</td>
+<td>Song et al. 2023, <em>Nature Communications</em>, 2023-01, https://doi.org/10.1038/s41467-022-35720-5; von Känel et al. 2024, <em>PLOS Biology</em>, 2024-08, https://doi.org/10.1371/journal.pbio.3002449</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes verified identity, domain architecture, TIM23/PAM role, localization, disease relevance, quantitative findings, and recent literature context for human PAM16 (UniProt Q9Y3D7). It is useful as a concise evidence map for functional annotation with direct context-ID citations.</em></p>
+<h2 id="9-key-urls-from-retrieved-sources">9) Key URLs (from retrieved sources)</h2>
+<ul>
+<li>Song J et al. <em>Nature Communications</em> (2023). “The mitochondrial Hsp70 controls the assembly of the F1FO-ATP synthase.” https://doi.org/10.1038/s41467-022-35720-5 (song2023themitochondrialhsp70 pages 6-7, song2023themitochondrialhsp70 pages 7-9)</li>
+<li>von Känel C et al. <em>PLOS Biology</em> (Aug 2024). “Pam16 and Pam18 were repurposed during Trypanosoma brucei evolution to regulate the replication of mitochondrial DNA.” https://doi.org/10.1371/journal.pbio.3002449 (kanel2024pam16andpam18 pages 1-2)</li>
+<li>Zhao F, Zou M-H. <em>Frontiers in Cardiovascular Medicine</em> (Sep 2021). “Role of the Mitochondrial Protein Import Machinery and Protein Processing in Heart Disease.” https://doi.org/10.3389/fcvm.2021.749756 (sinha2017thecomplexitiesofa pages 4-5)</li>
+</ul>
+<h2 id="10-conclusion-functional-annotation-statement">10) Conclusion (functional annotation statement)</h2>
+<p><strong>PAM16 (Q9Y3D7; MAGMAS/TIM16/TIMM16)</strong> is a mitochondrial, inner-membrane-associated (matrix-facing) <strong>regulatory subunit of the TIM23 presequence import motor (PAM complex)</strong>. Its defining molecular feature is a <strong>degenerate J-like domain lacking the HPD motif</strong>, consistent with a function in <strong>forming a heterodimer with Pam18 and modulating Pam18’s stimulation of mtHsp70 ATPase activity</strong>, thereby tuning ATP-dependent protein translocation into the mitochondrial matrix. Disease relevance includes database-supported association with <strong>autosomal recessive spondylometaphyseal dysplasia (Megarbane type)</strong> and literature-supported roles in tumor cell survival/chemoresistance with reported overexpression frequencies in prostate cancer and pituitary adenomas. (riva2018ajourneythrough pages 11-15, sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5, OpenTargets Search: -PAM16,TIMM16,MAGMAS)</p>
+<p>References</p>
+<ol>
+<li>
+<p>(riva2018ajourneythrough pages 11-15): E Riva. A journey through in vitro and in vivo models to understand the role of magmas in cancer chemoresistance. Unknown journal, 2018.</p>
+</li>
+<li>
+<p>(riva2018ajourneythrough pages 8-11): E Riva. A journey through in vitro and in vivo models to understand the role of magmas in cancer chemoresistance. Unknown journal, 2018.</p>
+</li>
+<li>
+<p>(sinha2017thecomplexitiesofa pages 4-5): D Sinha. The complexities of human mitochondrial inner-membrane protein translocases in maintenance of organeller function. Unknown journal, 2017.</p>
+</li>
+<li>
+<p>(sinha2017thecomplexitiesof pages 4-5): D Sinha. The complexities of human mitochondrial inner-membrane protein translocases in maintenance of organeller function. Unknown journal, 2017.</p>
+</li>
+<li>
+<p>(jain2025investigatingmitochondrialpresequence pages 15-17): Naintara Jain. Investigating Mitochondrial Presequence Import. PhD thesis, University Goettingen, 2025. URL: https://doi.org/10.53846/goediss-11596, doi:10.53846/goediss-11596.</p>
+</li>
+<li>
+<p>(riva2018ajourneythrough pages 79-82): E Riva. A journey through in vitro and in vivo models to understand the role of magmas in cancer chemoresistance. Unknown journal, 2018.</p>
+</li>
+<li>
+<p>(sinha2017thecomplexitiesof pages 5-6): D Sinha. The complexities of human mitochondrial inner-membrane protein translocases in maintenance of organeller function. Unknown journal, 2017.</p>
+</li>
+<li>
+<p>(OpenTargets Search: -PAM16,TIMM16,MAGMAS): Open Targets Query (-PAM16,TIMM16,MAGMAS, 5 results). Buniello, A. et al. (2025). Open Targets Platform: facilitating therapeutic hypotheses building in drug discovery. Nucleic Acids Research.</p>
+</li>
+<li>
+<p>(song2023themitochondrialhsp70 pages 6-7): Jiyao Song, Liesa Steidle, Isabelle Steymans, Jasjot Singh, Anne Sanner, Lena Böttinger, Dominic Winter, and Thomas Becker. The mitochondrial hsp70 controls the assembly of the f1fo-atp synthase. Nature Communications, Jan 2023. URL: https://doi.org/10.1038/s41467-022-35720-5, doi:10.1038/s41467-022-35720-5. This article has 25 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(song2023themitochondrialhsp70 pages 7-9): Jiyao Song, Liesa Steidle, Isabelle Steymans, Jasjot Singh, Anne Sanner, Lena Böttinger, Dominic Winter, and Thomas Becker. The mitochondrial hsp70 controls the assembly of the f1fo-atp synthase. Nature Communications, Jan 2023. URL: https://doi.org/10.1038/s41467-022-35720-5, doi:10.1038/s41467-022-35720-5. This article has 25 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(kanel2024pam16andpam18 pages 1-2): Corinne von Känel, Philip Stettler, Carmela Esposito, Stephan Berger, Simona Amodeo, Silke Oeljeklaus, Salvatore Calderaro, Ignacio M. Durante, Vendula Rašková, Bettina Warscheid, and André Schneider. Pam16 and pam18 were repurposed during trypanosoma brucei evolution to regulate the replication of mitochondrial dna. PLOS Biology, 22:e3002449, Aug 2024. URL: https://doi.org/10.1371/journal.pbio.3002449, doi:10.1371/journal.pbio.3002449. This article has 3 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(kanel2024pam16andpam18 pages 2-3): Corinne von Känel, Philip Stettler, Carmela Esposito, Stephan Berger, Simona Amodeo, Silke Oeljeklaus, Salvatore Calderaro, Ignacio M. Durante, Vendula Rašková, Bettina Warscheid, and André Schneider. Pam16 and pam18 were repurposed during trypanosoma brucei evolution to regulate the replication of mitochondrial dna. PLOS Biology, 22:e3002449, Aug 2024. URL: https://doi.org/10.1371/journal.pbio.3002449, doi:10.1371/journal.pbio.3002449. This article has 3 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(sinha2017thecomplexitiesof pages 12-14): D Sinha. The complexities of human mitochondrial inner-membrane protein translocases in maintenance of organeller function. Unknown journal, 2017.</p>
+</li>
+<li>
+<p>(zhao2023mitochondrialskeletaldisorders pages 8-11): Tian Rui Zhao. Mitochondrial skeletal disorders provide insight into the effect of mitochondrial proteostatic stress on steroidogenesis. Other, Sep 2023. URL: https://doi.org/10.11575/prism/42113, doi:10.11575/prism/42113. This article has 0 citations.</p>
+</li>
+<li>
+<p>(song2023themitochondrialhsp70 pages 9-11): Jiyao Song, Liesa Steidle, Isabelle Steymans, Jasjot Singh, Anne Sanner, Lena Böttinger, Dominic Winter, and Thomas Becker. The mitochondrial hsp70 controls the assembly of the f1fo-atp synthase. Nature Communications, Jan 2023. URL: https://doi.org/10.1038/s41467-022-35720-5, doi:10.1038/s41467-022-35720-5. This article has 25 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>riva2018ajourneythrough pages 11-15</li>
+<li>sinha2017thecomplexitiesofa pages 4-5</li>
+<li>riva2018ajourneythrough pages 8-11</li>
+<li>sinha2017thecomplexitiesof pages 4-5</li>
+<li>jain2025investigatingmitochondrialpresequence pages 15-17</li>
+<li>riva2018ajourneythrough pages 79-82</li>
+<li>sinha2017thecomplexitiesof pages 5-6</li>
+<li>sinha2017thecomplexitiesof pages 12-14</li>
+<li>zhao2023mitochondrialskeletaldisorders pages 8-11</li>
+<li>https://doi.org/10.1038/s41467-022-35720-5</li>
+<li>https://doi.org/10.1371/journal.pbio.3002449</li>
+<li>https://doi.org/10.53846/goediss-11596</li>
+<li>https://doi.org/10.3389/fcvm.2021.749756</li>
+<li>https://doi.org/10.1038/s41467-022-35720-5;</li>
+<li>https://doi.org/10.53846/goediss-11596,</li>
+<li>https://doi.org/10.1038/s41467-022-35720-5,</li>
+<li>https://doi.org/10.1371/journal.pbio.3002449,</li>
+<li>https://doi.org/10.11575/prism/42113,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q9Y3D7
+gene_symbol: PAM16
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: &#39;PAM16 encodes MAGMAS/TIM16, a matrix-facing regulatory J-like cochaperone/adaptor subunit of the TIM23-associated
+  PAM import motor. It forms a Pam18/Tim14 subcomplex, recruits and restrains Pam18 activity, and tunes mtHsp70-driven
+  import of presequence-containing proteins into the mitochondrial matrix.&#39;
+existing_annotations:
+- term:
+    id: GO:0005744
+    label: TIM23 mitochondrial import inner membrane translocase complex
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: PAM16 is functionally coupled to TIM23, but its complex membership is more precisely the PAM
+      import motor rather than the TIM23 channel/core translocase.
+    action: MODIFY
+    additional_reference_ids:
+    - file:human/PAM16/PAM16-deep-research-falcon.md
+    reason: Use the PAM complex term for PAM16 complex membership; TIM23 is the coupled translocase.
+    proposed_replacement_terms:
+    - id: GO:0001405
+      label: PAM complex, Tim23 associated import motor
+    supported_by:
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: The literature and database evidence summarized here consistently refers to **human
+        PAM16** as **MAGMAS/TIM16/TIMM16**, a small mitochondrial protein (~125 aa; ~13 kDa) that is part of
+        the **TIM23-associated presequence import motor (PAM complex)**. This matches the UniProt description
+        for Q9Y3D7 (mitochondrial import inner membrane translocase subunit TIM16 / PAM16 family), including
+        the hallmark **J-like domain** and functional role in mitochondrial protein import.
+        (riva2018ajourneythrough pages 11-15, riva2018ajourneythrough pages 8-11, sinha2017thecomplexitiesofa
+        pages 4-5)
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: Most mitochondrial matrix proteins are encoded in the nucleus, translated in the
+        cytosol, and imported into mitochondria. The **TIM23 complex** (inner membrane presequence
+        translocase) mediates import of presequence-containing proteins; for matrix translocation, TIM23
+        couples to the **PAM (presequence translocase-associated motor)**, which uses an **mtHsp70 ATPase
+        cycle** to pull precursor polypeptides into the matrix. (sinha2017thecomplexitiesofa pages 4-5,
+        sinha2017thecomplexitiesof pages 4-5)
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: PAM16 (MAGMAS/TIM16/TIMM16) is an essential subunit of the **TIM23-associated PAM
+        motor**. Mechanistically, it forms a stable subcomplex with Pam18/Tim14 and is described as (i)
+        **recruiting Pam18** to the import channel and (ii) **controlling Pam18 activity**, thereby indirectly
+        regulating mtHsp70’s ATP-driven pulling activity during translocation into the matrix.
+        (sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5)
+- term:
+    id: GO:0030150
+    label: protein import into mitochondrial matrix
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: Correct and core. PAM16 regulates the PAM motor that powers TIM23-mediated matrix import.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/PAM16/PAM16-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: Most mitochondrial matrix proteins are encoded in the nucleus, translated in the
+        cytosol, and imported into mitochondria. The **TIM23 complex** (inner membrane presequence
+        translocase) mediates import of presequence-containing proteins; for matrix translocation, TIM23
+        couples to the **PAM (presequence translocase-associated motor)**, which uses an **mtHsp70 ATPase
+        cycle** to pull precursor polypeptides into the matrix. (sinha2017thecomplexitiesofa pages 4-5,
+        sinha2017thecomplexitiesof pages 4-5)
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: PAM16 (MAGMAS/TIM16/TIMM16) is an essential subunit of the **TIM23-associated PAM
+        motor**. Mechanistically, it forms a stable subcomplex with Pam18/Tim14 and is described as (i)
+        **recruiting Pam18** to the import channel and (ii) **controlling Pam18 activity**, thereby indirectly
+        regulating mtHsp70’s ATP-driven pulling activity during translocation into the matrix.
+        (sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5)
+- term:
+    id: GO:0001405
+    label: PAM complex, Tim23 associated import motor
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  review:
+    summary: Correct and core. PAM16/MAGMAS is a regulatory subunit of the TIM23-associated PAM motor.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/PAM16/PAM16-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: The literature and database evidence summarized here consistently refers to **human
+        PAM16** as **MAGMAS/TIM16/TIMM16**, a small mitochondrial protein (~125 aa; ~13 kDa) that is part of
+        the **TIM23-associated presequence import motor (PAM complex)**. This matches the UniProt description
+        for Q9Y3D7 (mitochondrial import inner membrane translocase subunit TIM16 / PAM16 family), including
+        the hallmark **J-like domain** and functional role in mitochondrial protein import.
+        (riva2018ajourneythrough pages 11-15, riva2018ajourneythrough pages 8-11, sinha2017thecomplexitiesofa
+        pages 4-5)
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: PAM16 (MAGMAS/TIM16/TIMM16) is an essential subunit of the **TIM23-associated PAM
+        motor**. Mechanistically, it forms a stable subcomplex with Pam18/Tim14 and is described as (i)
+        **recruiting Pam18** to the import channel and (ii) **controlling Pam18 activity**, thereby indirectly
+        regulating mtHsp70’s ATP-driven pulling activity during translocation into the matrix.
+        (sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5)
+- term:
+    id: GO:0005743
+    label: mitochondrial inner membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  review:
+    summary: Correct. PAM16 is a peripheral component associated with the matrix side of the mitochondrial
+      inner membrane.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/PAM16/PAM16-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: PAM16/MAGMAS is localized to **mitochondria** and described as a **peripheral membrane
+        protein** associated with the TIM23/PAM machinery at the **inner membrane, matrix-facing side**. One
+        source explicitly notes that it does **not extend into the intermembrane space (IMS)**, consistent
+        with a matrix-side role in regulating the mtHsp70 motor. (riva2018ajourneythrough pages 11-15,
+        sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5)
+- term:
+    id: GO:0005744
+    label: TIM23 mitochondrial import inner membrane translocase complex
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  review:
+    summary: PAM16 is functionally coupled to TIM23, but its complex membership is more precisely the PAM
+      import motor rather than the TIM23 channel/core translocase.
+    action: MODIFY
+    additional_reference_ids:
+    - file:human/PAM16/PAM16-deep-research-falcon.md
+    reason: Use the PAM complex term for PAM16 complex membership; TIM23 is the coupled translocase.
+    proposed_replacement_terms:
+    - id: GO:0001405
+      label: PAM complex, Tim23 associated import motor
+    supported_by:
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: The literature and database evidence summarized here consistently refers to **human
+        PAM16** as **MAGMAS/TIM16/TIMM16**, a small mitochondrial protein (~125 aa; ~13 kDa) that is part of
+        the **TIM23-associated presequence import motor (PAM complex)**. This matches the UniProt description
+        for Q9Y3D7 (mitochondrial import inner membrane translocase subunit TIM16 / PAM16 family), including
+        the hallmark **J-like domain** and functional role in mitochondrial protein import.
+        (riva2018ajourneythrough pages 11-15, riva2018ajourneythrough pages 8-11, sinha2017thecomplexitiesofa
+        pages 4-5)
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: Most mitochondrial matrix proteins are encoded in the nucleus, translated in the
+        cytosol, and imported into mitochondria. The **TIM23 complex** (inner membrane presequence
+        translocase) mediates import of presequence-containing proteins; for matrix translocation, TIM23
+        couples to the **PAM (presequence translocase-associated motor)**, which uses an **mtHsp70 ATPase
+        cycle** to pull precursor polypeptides into the matrix. (sinha2017thecomplexitiesofa pages 4-5,
+        sinha2017thecomplexitiesof pages 4-5)
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: PAM16 (MAGMAS/TIM16/TIMM16) is an essential subunit of the **TIM23-associated PAM
+        motor**. Mechanistically, it forms a stable subcomplex with Pam18/Tim14 and is described as (i)
+        **recruiting Pam18** to the import channel and (ii) **controlling Pam18 activity**, thereby indirectly
+        regulating mtHsp70’s ATP-driven pulling activity during translocation into the matrix.
+        (sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5)
+- term:
+    id: GO:0030150
+    label: protein import into mitochondrial matrix
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  review:
+    summary: Correct and core. PAM16 regulates the PAM motor that powers TIM23-mediated matrix import.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/PAM16/PAM16-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: Most mitochondrial matrix proteins are encoded in the nucleus, translated in the
+        cytosol, and imported into mitochondria. The **TIM23 complex** (inner membrane presequence
+        translocase) mediates import of presequence-containing proteins; for matrix translocation, TIM23
+        couples to the **PAM (presequence translocase-associated motor)**, which uses an **mtHsp70 ATPase
+        cycle** to pull precursor polypeptides into the matrix. (sinha2017thecomplexitiesofa pages 4-5,
+        sinha2017thecomplexitiesof pages 4-5)
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: PAM16 (MAGMAS/TIM16/TIMM16) is an essential subunit of the **TIM23-associated PAM
+        motor**. Mechanistically, it forms a stable subcomplex with Pam18/Tim14 and is described as (i)
+        **recruiting Pam18** to the import channel and (ii) **controlling Pam18 activity**, thereby indirectly
+        regulating mtHsp70’s ATP-driven pulling activity during translocation into the matrix.
+        (sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5)
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:23263864
+  review:
+    summary: Protein binding is too generic for PAM16. The informative role is a regulatory
+      adaptor/cochaperone function within the Pam16-Pam18/PAM import motor.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/PAM16/PAM16-deep-research-falcon.md
+    reason: Replace generic protein-binding capture with PAM complex membership and adaptor/regulatory
+      cochaperone activity where supported.
+    supported_by:
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: &#39;**PAM16 is not an enzyme catalyzing a metabolic reaction nor a transporter substrate-binding
+        channel.** Instead, it functions as a **regulatory cochaperone/adaptor** within the import motor. It is
+        described as a **J-like** protein (Hsp40/J-domain superfamily-like) that regulates the activity and positioning
+        of the true J-domain cochaperone **Pam18/Tim14** (metazoan functional ortholog often discussed as DNAJC19/Pam18
+        in the PAM motor context) which stimulates mtHsp70 ATPase activity. (sinha2017thecomplexitiesofa pages 4-5,
+        sinha2017thecomplexitiesof pages 4-5, riva2018ajourneythrough pages 11-15)&#39;
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: &#39;| Mechanistic role | PAM16 is primarily a **regulatory cochaperone/adaptor**, not an enzyme
+        or transporter substrate-binding transporter itself. It forms a stable subcomplex with Pam18 and **recruits/controls
+        Pam18 at the import channel**, thereby **modulating Pam18-driven stimulation of mtHsp70 ATPase activity**
+        and fine-tuning the ATP-dependent import motor. It is described as a **negative regulator/antagonist** of
+        Pam18’s stimulatory effect on mtHsp70. | (riva2018ajourneythrough pages 11-15, sinha2017thecomplexitiesofa
+        pages 4-5, jain2025investigatingmitochondrialpresequence pages 15-17, sinha2017thecomplexitiesof pages 4-5)
+        | Riva 2018; Sinha 2017; Jain 2025 thesis, https://doi.org/10.53846/goediss-11596 |&#39;
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:25416956
+  review:
+    summary: Protein binding is too generic for PAM16. The informative role is a regulatory
+      adaptor/cochaperone function within the Pam16-Pam18/PAM import motor.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/PAM16/PAM16-deep-research-falcon.md
+    reason: Replace generic protein-binding capture with PAM complex membership and adaptor/regulatory
+      cochaperone activity where supported.
+    supported_by:
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: &#39;**PAM16 is not an enzyme catalyzing a metabolic reaction nor a transporter substrate-binding
+        channel.** Instead, it functions as a **regulatory cochaperone/adaptor** within the import motor. It is
+        described as a **J-like** protein (Hsp40/J-domain superfamily-like) that regulates the activity and positioning
+        of the true J-domain cochaperone **Pam18/Tim14** (metazoan functional ortholog often discussed as DNAJC19/Pam18
+        in the PAM motor context) which stimulates mtHsp70 ATPase activity. (sinha2017thecomplexitiesofa pages 4-5,
+        sinha2017thecomplexitiesof pages 4-5, riva2018ajourneythrough pages 11-15)&#39;
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: &#39;| Mechanistic role | PAM16 is primarily a **regulatory cochaperone/adaptor**, not an enzyme
+        or transporter substrate-binding transporter itself. It forms a stable subcomplex with Pam18 and **recruits/controls
+        Pam18 at the import channel**, thereby **modulating Pam18-driven stimulation of mtHsp70 ATPase activity**
+        and fine-tuning the ATP-dependent import motor. It is described as a **negative regulator/antagonist** of
+        Pam18’s stimulatory effect on mtHsp70. | (riva2018ajourneythrough pages 11-15, sinha2017thecomplexitiesofa
+        pages 4-5, jain2025investigatingmitochondrialpresequence pages 15-17, sinha2017thecomplexitiesof pages 4-5)
+        | Riva 2018; Sinha 2017; Jain 2025 thesis, https://doi.org/10.53846/goediss-11596 |&#39;
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:32296183
+  review:
+    summary: Protein binding is too generic for PAM16. The informative role is a regulatory
+      adaptor/cochaperone function within the Pam16-Pam18/PAM import motor.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/PAM16/PAM16-deep-research-falcon.md
+    reason: Replace generic protein-binding capture with PAM complex membership and adaptor/regulatory
+      cochaperone activity where supported.
+    supported_by:
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: &#39;**PAM16 is not an enzyme catalyzing a metabolic reaction nor a transporter substrate-binding
+        channel.** Instead, it functions as a **regulatory cochaperone/adaptor** within the import motor. It is
+        described as a **J-like** protein (Hsp40/J-domain superfamily-like) that regulates the activity and positioning
+        of the true J-domain cochaperone **Pam18/Tim14** (metazoan functional ortholog often discussed as DNAJC19/Pam18
+        in the PAM motor context) which stimulates mtHsp70 ATPase activity. (sinha2017thecomplexitiesofa pages 4-5,
+        sinha2017thecomplexitiesof pages 4-5, riva2018ajourneythrough pages 11-15)&#39;
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: &#39;| Mechanistic role | PAM16 is primarily a **regulatory cochaperone/adaptor**, not an enzyme
+        or transporter substrate-binding transporter itself. It forms a stable subcomplex with Pam18 and **recruits/controls
+        Pam18 at the import channel**, thereby **modulating Pam18-driven stimulation of mtHsp70 ATPase activity**
+        and fine-tuning the ATP-dependent import motor. It is described as a **negative regulator/antagonist** of
+        Pam18’s stimulatory effect on mtHsp70. | (riva2018ajourneythrough pages 11-15, sinha2017thecomplexitiesofa
+        pages 4-5, jain2025investigatingmitochondrialpresequence pages 15-17, sinha2017thecomplexitiesof pages 4-5)
+        | Riva 2018; Sinha 2017; Jain 2025 thesis, https://doi.org/10.53846/goediss-11596 |&#39;
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:33961781
+  review:
+    summary: Protein binding is too generic for PAM16. The informative role is a regulatory
+      adaptor/cochaperone function within the Pam16-Pam18/PAM import motor.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/PAM16/PAM16-deep-research-falcon.md
+    reason: Replace generic protein-binding capture with PAM complex membership and adaptor/regulatory
+      cochaperone activity where supported.
+    supported_by:
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: &#39;**PAM16 is not an enzyme catalyzing a metabolic reaction nor a transporter substrate-binding
+        channel.** Instead, it functions as a **regulatory cochaperone/adaptor** within the import motor. It is
+        described as a **J-like** protein (Hsp40/J-domain superfamily-like) that regulates the activity and positioning
+        of the true J-domain cochaperone **Pam18/Tim14** (metazoan functional ortholog often discussed as DNAJC19/Pam18
+        in the PAM motor context) which stimulates mtHsp70 ATPase activity. (sinha2017thecomplexitiesofa pages 4-5,
+        sinha2017thecomplexitiesof pages 4-5, riva2018ajourneythrough pages 11-15)&#39;
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: &#39;| Mechanistic role | PAM16 is primarily a **regulatory cochaperone/adaptor**, not an enzyme
+        or transporter substrate-binding transporter itself. It forms a stable subcomplex with Pam18 and **recruits/controls
+        Pam18 at the import channel**, thereby **modulating Pam18-driven stimulation of mtHsp70 ATPase activity**
+        and fine-tuning the ATP-dependent import motor. It is described as a **negative regulator/antagonist** of
+        Pam18’s stimulatory effect on mtHsp70. | (riva2018ajourneythrough pages 11-15, sinha2017thecomplexitiesofa
+        pages 4-5, jain2025investigatingmitochondrialpresequence pages 15-17, sinha2017thecomplexitiesof pages 4-5)
+        | Riva 2018; Sinha 2017; Jain 2025 thesis, https://doi.org/10.53846/goediss-11596 |&#39;
+- term:
+    id: GO:0005743
+    label: mitochondrial inner membrane
+  evidence_type: NAS
+  original_reference_id: PMID:10339406
+  review:
+    summary: Correct. PAM16 is a peripheral component associated with the matrix side of the mitochondrial
+      inner membrane.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/PAM16/PAM16-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: PAM16/MAGMAS is localized to **mitochondria** and described as a **peripheral membrane
+        protein** associated with the TIM23/PAM machinery at the **inner membrane, matrix-facing side**. One
+        source explicitly notes that it does **not extend into the intermembrane space (IMS)**, consistent
+        with a matrix-side role in regulating the mtHsp70 motor. (riva2018ajourneythrough pages 11-15,
+        sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5)
+- term:
+    id: GO:0005744
+    label: TIM23 mitochondrial import inner membrane translocase complex
+  evidence_type: NAS
+  original_reference_id: PMID:10339406
+  review:
+    summary: PAM16 is functionally coupled to TIM23, but its complex membership is more precisely the PAM
+      import motor rather than the TIM23 channel/core translocase.
+    action: MODIFY
+    additional_reference_ids:
+    - file:human/PAM16/PAM16-deep-research-falcon.md
+    reason: Use the PAM complex term for PAM16 complex membership; TIM23 is the coupled translocase.
+    proposed_replacement_terms:
+    - id: GO:0001405
+      label: PAM complex, Tim23 associated import motor
+    supported_by:
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: The literature and database evidence summarized here consistently refers to **human
+        PAM16** as **MAGMAS/TIM16/TIMM16**, a small mitochondrial protein (~125 aa; ~13 kDa) that is part of
+        the **TIM23-associated presequence import motor (PAM complex)**. This matches the UniProt description
+        for Q9Y3D7 (mitochondrial import inner membrane translocase subunit TIM16 / PAM16 family), including
+        the hallmark **J-like domain** and functional role in mitochondrial protein import.
+        (riva2018ajourneythrough pages 11-15, riva2018ajourneythrough pages 8-11, sinha2017thecomplexitiesofa
+        pages 4-5)
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: Most mitochondrial matrix proteins are encoded in the nucleus, translated in the
+        cytosol, and imported into mitochondria. The **TIM23 complex** (inner membrane presequence
+        translocase) mediates import of presequence-containing proteins; for matrix translocation, TIM23
+        couples to the **PAM (presequence translocase-associated motor)**, which uses an **mtHsp70 ATPase
+        cycle** to pull precursor polypeptides into the matrix. (sinha2017thecomplexitiesofa pages 4-5,
+        sinha2017thecomplexitiesof pages 4-5)
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: PAM16 (MAGMAS/TIM16/TIMM16) is an essential subunit of the **TIM23-associated PAM
+        motor**. Mechanistically, it forms a stable subcomplex with Pam18/Tim14 and is described as (i)
+        **recruiting Pam18** to the import channel and (ii) **controlling Pam18 activity**, thereby indirectly
+        regulating mtHsp70’s ATP-driven pulling activity during translocation into the matrix.
+        (sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5)
+- term:
+    id: GO:0006886
+    label: intracellular protein transport
+  evidence_type: NAS
+  original_reference_id: PMID:10339406
+  review:
+    summary: Correct pathway family but too broad. PAM16 specifically supports TIM23/PAM-mediated
+      mitochondrial matrix protein import.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/PAM16/PAM16-deep-research-falcon.md
+    reason: Prefer protein import into mitochondrial matrix and PAM complex terms over generic intracellular
+      protein transport.
+    supported_by:
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: Most mitochondrial matrix proteins are encoded in the nucleus, translated in the
+        cytosol, and imported into mitochondria. The **TIM23 complex** (inner membrane presequence
+        translocase) mediates import of presequence-containing proteins; for matrix translocation, TIM23
+        couples to the **PAM (presequence translocase-associated motor)**, which uses an **mtHsp70 ATPase
+        cycle** to pull precursor polypeptides into the matrix. (sinha2017thecomplexitiesofa pages 4-5,
+        sinha2017thecomplexitiesof pages 4-5)
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: PAM16 (MAGMAS/TIM16/TIMM16) is an essential subunit of the **TIM23-associated PAM
+        motor**. Mechanistically, it forms a stable subcomplex with Pam18/Tim14 and is described as (i)
+        **recruiting Pam18** to the import channel and (ii) **controlling Pam18 activity**, thereby indirectly
+        regulating mtHsp70’s ATP-driven pulling activity during translocation into the matrix.
+        (sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5)
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IDA
+  original_reference_id: GO_REF:0000052
+  review:
+    summary: Correct but broad. PAM16 is specifically associated with the matrix-facing side of the
+      mitochondrial inner membrane in the PAM import motor.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/PAM16/PAM16-deep-research-falcon.md
+    reason: Prefer matrix side of mitochondrial inner membrane and PAM complex annotations over generic
+      mitochondrion.
+    supported_by:
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: PAM16/MAGMAS is localized to **mitochondria** and described as a **peripheral membrane
+        protein** associated with the TIM23/PAM machinery at the **inner membrane, matrix-facing side**. One
+        source explicitly notes that it does **not extend into the intermembrane space (IMS)**, consistent
+        with a matrix-side role in regulating the mtHsp70 motor. (riva2018ajourneythrough pages 11-15,
+        sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5)
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: HTP
+  original_reference_id: PMID:34800366
+  review:
+    summary: Correct but broad. PAM16 is specifically associated with the matrix-facing side of the
+      mitochondrial inner membrane in the PAM import motor.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/PAM16/PAM16-deep-research-falcon.md
+    reason: Prefer matrix side of mitochondrial inner membrane and PAM complex annotations over generic
+      mitochondrion.
+    supported_by:
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: PAM16/MAGMAS is localized to **mitochondria** and described as a **peripheral membrane
+        protein** associated with the TIM23/PAM machinery at the **inner membrane, matrix-facing side**. One
+        source explicitly notes that it does **not extend into the intermembrane space (IMS)**, consistent
+        with a matrix-side role in regulating the mtHsp70 motor. (riva2018ajourneythrough pages 11-15,
+        sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5)
+- term:
+    id: GO:0099617
+    label: matrix side of mitochondrial inner membrane
+  evidence_type: IDA
+  original_reference_id: PMID:20053669
+  review:
+    summary: Correct. PAM16 localizes to the matrix-facing side of the mitochondrial inner membrane.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/PAM16/PAM16-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: PAM16/MAGMAS is localized to **mitochondria** and described as a **peripheral membrane
+        protein** associated with the TIM23/PAM machinery at the **inner membrane, matrix-facing side**. One
+        source explicitly notes that it does **not extend into the intermembrane space (IMS)**, consistent
+        with a matrix-side role in regulating the mtHsp70 motor. (riva2018ajourneythrough pages 11-15,
+        sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5)
+- term:
+    id: GO:0001405
+    label: PAM complex, Tim23 associated import motor
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  review:
+    summary: Correct and core. PAM16/MAGMAS is a regulatory subunit of the TIM23-associated PAM motor.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/PAM16/PAM16-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: The literature and database evidence summarized here consistently refers to **human
+        PAM16** as **MAGMAS/TIM16/TIMM16**, a small mitochondrial protein (~125 aa; ~13 kDa) that is part of
+        the **TIM23-associated presequence import motor (PAM complex)**. This matches the UniProt description
+        for Q9Y3D7 (mitochondrial import inner membrane translocase subunit TIM16 / PAM16 family), including
+        the hallmark **J-like domain** and functional role in mitochondrial protein import.
+        (riva2018ajourneythrough pages 11-15, riva2018ajourneythrough pages 8-11, sinha2017thecomplexitiesofa
+        pages 4-5)
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: PAM16 (MAGMAS/TIM16/TIMM16) is an essential subunit of the **TIM23-associated PAM
+        motor**. Mechanistically, it forms a stable subcomplex with Pam18/Tim14 and is described as (i)
+        **recruiting Pam18** to the import channel and (ii) **controlling Pam18 activity**, thereby indirectly
+        regulating mtHsp70’s ATP-driven pulling activity during translocation into the matrix.
+        (sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5)
+- term:
+    id: GO:0001503
+    label: ossification
+  evidence_type: IMP
+  original_reference_id: PMID:24786642
+  review:
+    summary: Keep as non-core. Human PAM16/MAGMAS disease data support a skeletal dysplasia/ossification
+      phenotype, but the evolved core function is mitochondrial protein import motor regulation.
+    action: KEEP_AS_NON_CORE
+    additional_reference_ids:
+    - file:human/PAM16/PAM16-deep-research-falcon.md
+    reason: Ossification is a downstream organismal phenotype of MAGMAS impairment, not the core molecular
+      function of PAM16.
+    supported_by:
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: &#39;| Disease/phenotype links | PAM16 has recognized disease links, including **autosomal recessive
+        spondylometaphyseal dysplasia, Megarbane type** in disease databases. Literature summarized in retrieved
+        sources also links **MAGMAS overexpression** to neoplasia, including **prostate cancer**, **pituitary adenomas**,
+        and anti-apoptotic/chemoresistance phenotypes. Open Targets also lists associations to neurodegenerative
+        disease/Parkinson disease, but these are weaker database associations than the skeletal dysplasia link.
+        | (riva2018ajourneythrough pages 11-15, sinha2017thecomplexitiesof pages 12-14, zhao2023mitochondrialskeletaldisorders
+        pages 8-11, OpenTargets Search: -PAM16,TIMM16,MAGMAS) | Open Targets platform search context; Zhao 2023
+        dissertation; Riva 2018 |&#39;
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: &#39;**PAM16 (Q9Y3D7; MAGMAS/TIM16/TIMM16)** is a mitochondrial, inner-membrane-associated (matrix-facing)
+        **regulatory subunit of the TIM23 presequence import motor (PAM complex)**. Its defining molecular feature
+        is a **degenerate J-like domain lacking the HPD motif**, consistent with a function in **forming a heterodimer
+        with Pam18 and modulating Pam18’s stimulation of mtHsp70 ATPase activity**, thereby tuning ATP-dependent
+        protein translocation into the mitochondrial matrix. Disease relevance includes database-supported association
+        with **autosomal recessive spondylometaphyseal dysplasia (Megarbane type)** and literature-supported roles
+        in tumor cell survival/chemoresistance with reported overexpression frequencies in prostate cancer and pituitary
+        adenomas. (riva2018ajourneythrough pages 11-15, sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof
+        pages 4-5, OpenTargets Search: -PAM16,TIMM16,MAGMAS)&#39;
+- term:
+    id: GO:0001405
+    label: PAM complex, Tim23 associated import motor
+  evidence_type: IGI
+  original_reference_id: PMID:20053669
+  review:
+    summary: Correct and core. PAM16/MAGMAS is a regulatory subunit of the TIM23-associated PAM motor.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/PAM16/PAM16-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: The literature and database evidence summarized here consistently refers to **human
+        PAM16** as **MAGMAS/TIM16/TIMM16**, a small mitochondrial protein (~125 aa; ~13 kDa) that is part of
+        the **TIM23-associated presequence import motor (PAM complex)**. This matches the UniProt description
+        for Q9Y3D7 (mitochondrial import inner membrane translocase subunit TIM16 / PAM16 family), including
+        the hallmark **J-like domain** and functional role in mitochondrial protein import.
+        (riva2018ajourneythrough pages 11-15, riva2018ajourneythrough pages 8-11, sinha2017thecomplexitiesofa
+        pages 4-5)
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: PAM16 (MAGMAS/TIM16/TIMM16) is an essential subunit of the **TIM23-associated PAM
+        motor**. Mechanistically, it forms a stable subcomplex with Pam18/Tim14 and is described as (i)
+        **recruiting Pam18** to the import channel and (ii) **controlling Pam18 activity**, thereby indirectly
+        regulating mtHsp70’s ATP-driven pulling activity during translocation into the matrix.
+        (sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5)
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:19564938
+  review:
+    summary: Protein binding is too generic for PAM16. The informative role is a regulatory
+      adaptor/cochaperone function within the Pam16-Pam18/PAM import motor.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/PAM16/PAM16-deep-research-falcon.md
+    reason: Replace generic protein-binding capture with PAM complex membership and adaptor/regulatory
+      cochaperone activity where supported.
+    supported_by:
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: &#39;**PAM16 is not an enzyme catalyzing a metabolic reaction nor a transporter substrate-binding
+        channel.** Instead, it functions as a **regulatory cochaperone/adaptor** within the import motor. It is
+        described as a **J-like** protein (Hsp40/J-domain superfamily-like) that regulates the activity and positioning
+        of the true J-domain cochaperone **Pam18/Tim14** (metazoan functional ortholog often discussed as DNAJC19/Pam18
+        in the PAM motor context) which stimulates mtHsp70 ATPase activity. (sinha2017thecomplexitiesofa pages 4-5,
+        sinha2017thecomplexitiesof pages 4-5, riva2018ajourneythrough pages 11-15)&#39;
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: &#39;| Mechanistic role | PAM16 is primarily a **regulatory cochaperone/adaptor**, not an enzyme
+        or transporter substrate-binding transporter itself. It forms a stable subcomplex with Pam18 and **recruits/controls
+        Pam18 at the import channel**, thereby **modulating Pam18-driven stimulation of mtHsp70 ATPase activity**
+        and fine-tuning the ATP-dependent import motor. It is described as a **negative regulator/antagonist** of
+        Pam18’s stimulatory effect on mtHsp70. | (riva2018ajourneythrough pages 11-15, sinha2017thecomplexitiesofa
+        pages 4-5, jain2025investigatingmitochondrialpresequence pages 15-17, sinha2017thecomplexitiesof pages 4-5)
+        | Riva 2018; Sinha 2017; Jain 2025 thesis, https://doi.org/10.53846/goediss-11596 |&#39;
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:20053669
+  review:
+    summary: Protein binding is too generic for PAM16. The informative role is a regulatory
+      adaptor/cochaperone function within the Pam16-Pam18/PAM import motor.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/PAM16/PAM16-deep-research-falcon.md
+    reason: Replace generic protein-binding capture with PAM complex membership and adaptor/regulatory
+      cochaperone activity where supported.
+    supported_by:
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: &#39;**PAM16 is not an enzyme catalyzing a metabolic reaction nor a transporter substrate-binding
+        channel.** Instead, it functions as a **regulatory cochaperone/adaptor** within the import motor. It is
+        described as a **J-like** protein (Hsp40/J-domain superfamily-like) that regulates the activity and positioning
+        of the true J-domain cochaperone **Pam18/Tim14** (metazoan functional ortholog often discussed as DNAJC19/Pam18
+        in the PAM motor context) which stimulates mtHsp70 ATPase activity. (sinha2017thecomplexitiesofa pages 4-5,
+        sinha2017thecomplexitiesof pages 4-5, riva2018ajourneythrough pages 11-15)&#39;
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: &#39;| Mechanistic role | PAM16 is primarily a **regulatory cochaperone/adaptor**, not an enzyme
+        or transporter substrate-binding transporter itself. It forms a stable subcomplex with Pam18 and **recruits/controls
+        Pam18 at the import channel**, thereby **modulating Pam18-driven stimulation of mtHsp70 ATPase activity**
+        and fine-tuning the ATP-dependent import motor. It is described as a **negative regulator/antagonist** of
+        Pam18’s stimulatory effect on mtHsp70. | (riva2018ajourneythrough pages 11-15, sinha2017thecomplexitiesofa
+        pages 4-5, jain2025investigatingmitochondrialpresequence pages 15-17, sinha2017thecomplexitiesof pages 4-5)
+        | Riva 2018; Sinha 2017; Jain 2025 thesis, https://doi.org/10.53846/goediss-11596 |&#39;
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: IDA
+  original_reference_id: PMID:20053669
+  review:
+    summary: Correct. PAM16 acts at the matrix-facing side of the inner membrane and does not extend into the
+      IMS.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/PAM16/PAM16-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: PAM16/MAGMAS is localized to **mitochondria** and described as a **peripheral membrane
+        protein** associated with the TIM23/PAM machinery at the **inner membrane, matrix-facing side**. One
+        source explicitly notes that it does **not extend into the intermembrane space (IMS)**, consistent
+        with a matrix-side role in regulating the mtHsp70 motor. (riva2018ajourneythrough pages 11-15,
+        sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5)
+- term:
+    id: GO:0030150
+    label: protein import into mitochondrial matrix
+  evidence_type: IGI
+  original_reference_id: PMID:20053669
+  review:
+    summary: Correct and core. PAM16 regulates the PAM motor that powers TIM23-mediated matrix import.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/PAM16/PAM16-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: Most mitochondrial matrix proteins are encoded in the nucleus, translated in the
+        cytosol, and imported into mitochondria. The **TIM23 complex** (inner membrane presequence
+        translocase) mediates import of presequence-containing proteins; for matrix translocation, TIM23
+        couples to the **PAM (presequence translocase-associated motor)**, which uses an **mtHsp70 ATPase
+        cycle** to pull precursor polypeptides into the matrix. (sinha2017thecomplexitiesofa pages 4-5,
+        sinha2017thecomplexitiesof pages 4-5)
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: PAM16 (MAGMAS/TIM16/TIMM16) is an essential subunit of the **TIM23-associated PAM
+        motor**. Mechanistically, it forms a stable subcomplex with Pam18/Tim14 and is described as (i)
+        **recruiting Pam18** to the import channel and (ii) **controlling Pam18 activity**, thereby indirectly
+        regulating mtHsp70’s ATP-driven pulling activity during translocation into the matrix.
+        (sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5)
+- term:
+    id: GO:0032780
+    label: negative regulation of ATP-dependent activity
+  evidence_type: IDA
+  original_reference_id: PMID:19564938
+  review:
+    summary: Correct and mechanistically informative. PAM16 restrains Pam18-mediated stimulation of mtHsp70
+      ATPase activity in the import motor.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/PAM16/PAM16-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: &#39;A recurring mechanistic interpretation is that Pam16/MAGMAS functions antagonistically to
+        Pam18: it is required for correct association of the motor with the translocon and **inhibits Pam18-mediated
+        stimulation of mtHsp70 ATPase activity**, thus tuning the import motor’s activity. (riva2018ajourneythrough
+        pages 11-15, jain2025investigatingmitochondrialpresequence pages 15-17)&#39;
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: &#39;| Mechanistic role | PAM16 is primarily a **regulatory cochaperone/adaptor**, not an enzyme
+        or transporter substrate-binding transporter itself. It forms a stable subcomplex with Pam18 and **recruits/controls
+        Pam18 at the import channel**, thereby **modulating Pam18-driven stimulation of mtHsp70 ATPase activity**
+        and fine-tuning the ATP-dependent import motor. It is described as a **negative regulator/antagonist** of
+        Pam18’s stimulatory effect on mtHsp70. | (riva2018ajourneythrough pages 11-15, sinha2017thecomplexitiesofa
+        pages 4-5, jain2025investigatingmitochondrialpresequence pages 15-17, sinha2017thecomplexitiesof pages 4-5)
+        | Riva 2018; Sinha 2017; Jain 2025 thesis, https://doi.org/10.53846/goediss-11596 |&#39;
+- term:
+    id: GO:0032780
+    label: negative regulation of ATP-dependent activity
+  evidence_type: IDA
+  original_reference_id: PMID:20053669
+  review:
+    summary: Correct and mechanistically informative. PAM16 restrains Pam18-mediated stimulation of mtHsp70
+      ATPase activity in the import motor.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/PAM16/PAM16-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: &#39;A recurring mechanistic interpretation is that Pam16/MAGMAS functions antagonistically to
+        Pam18: it is required for correct association of the motor with the translocon and **inhibits Pam18-mediated
+        stimulation of mtHsp70 ATPase activity**, thus tuning the import motor’s activity. (riva2018ajourneythrough
+        pages 11-15, jain2025investigatingmitochondrialpresequence pages 15-17)&#39;
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: &#39;| Mechanistic role | PAM16 is primarily a **regulatory cochaperone/adaptor**, not an enzyme
+        or transporter substrate-binding transporter itself. It forms a stable subcomplex with Pam18 and **recruits/controls
+        Pam18 at the import channel**, thereby **modulating Pam18-driven stimulation of mtHsp70 ATPase activity**
+        and fine-tuning the ATP-dependent import motor. It is described as a **negative regulator/antagonist** of
+        Pam18’s stimulatory effect on mtHsp70. | (riva2018ajourneythrough pages 11-15, sinha2017thecomplexitiesofa
+        pages 4-5, jain2025investigatingmitochondrialpresequence pages 15-17, sinha2017thecomplexitiesof pages 4-5)
+        | Riva 2018; Sinha 2017; Jain 2025 thesis, https://doi.org/10.53846/goediss-11596 |&#39;
+- term:
+    id: GO:0032991
+    label: protein-containing complex
+  evidence_type: IDA
+  original_reference_id: PMID:19564938
+  review:
+    summary: Correct but too generic. The specific protein-containing complex is the TIM23-associated PAM
+      motor.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/PAM16/PAM16-deep-research-falcon.md
+    reason: Use PAM complex rather than the generic protein-containing complex term.
+    supported_by:
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: The literature and database evidence summarized here consistently refers to **human
+        PAM16** as **MAGMAS/TIM16/TIMM16**, a small mitochondrial protein (~125 aa; ~13 kDa) that is part of
+        the **TIM23-associated presequence import motor (PAM complex)**. This matches the UniProt description
+        for Q9Y3D7 (mitochondrial import inner membrane translocase subunit TIM16 / PAM16 family), including
+        the hallmark **J-like domain** and functional role in mitochondrial protein import.
+        (riva2018ajourneythrough pages 11-15, riva2018ajourneythrough pages 8-11, sinha2017thecomplexitiesofa
+        pages 4-5)
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: PAM16 (MAGMAS/TIM16/TIMM16) is an essential subunit of the **TIM23-associated PAM
+        motor**. Mechanistically, it forms a stable subcomplex with Pam18/Tim14 and is described as (i)
+        **recruiting Pam18** to the import channel and (ii) **controlling Pam18 activity**, thereby indirectly
+        regulating mtHsp70’s ATP-driven pulling activity during translocation into the matrix.
+        (sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5)
+- term:
+    id: GO:0032991
+    label: protein-containing complex
+  evidence_type: IDA
+  original_reference_id: PMID:20053669
+  review:
+    summary: Correct but too generic. The specific protein-containing complex is the TIM23-associated PAM
+      motor.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/PAM16/PAM16-deep-research-falcon.md
+    reason: Use PAM complex rather than the generic protein-containing complex term.
+    supported_by:
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: The literature and database evidence summarized here consistently refers to **human
+        PAM16** as **MAGMAS/TIM16/TIMM16**, a small mitochondrial protein (~125 aa; ~13 kDa) that is part of
+        the **TIM23-associated presequence import motor (PAM complex)**. This matches the UniProt description
+        for Q9Y3D7 (mitochondrial import inner membrane translocase subunit TIM16 / PAM16 family), including
+        the hallmark **J-like domain** and functional role in mitochondrial protein import.
+        (riva2018ajourneythrough pages 11-15, riva2018ajourneythrough pages 8-11, sinha2017thecomplexitiesofa
+        pages 4-5)
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: PAM16 (MAGMAS/TIM16/TIMM16) is an essential subunit of the **TIM23-associated PAM
+        motor**. Mechanistically, it forms a stable subcomplex with Pam18/Tim14 and is described as (i)
+        **recruiting Pam18** to the import channel and (ii) **controlling Pam18 activity**, thereby indirectly
+        regulating mtHsp70’s ATP-driven pulling activity during translocation into the matrix.
+        (sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5)
+- term:
+    id: GO:0030674
+    label: protein-macromolecule adaptor activity
+  evidence_type: NAS
+  original_reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+  review:
+    summary: New annotation. PAM16 functions as a regulatory adaptor/cochaperone that recruits and controls
+      Pam18 at the import channel rather than acting as an enzyme or transporter.
+    action: NEW
+    reason: PAM16 has a specific adaptor/cochaperone role in the PAM motor that is more informative than
+      generic protein binding and is not present in GOA.
+    supported_by:
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: &#39;**PAM16 is not an enzyme catalyzing a metabolic reaction nor a transporter substrate-binding
+        channel.** Instead, it functions as a **regulatory cochaperone/adaptor** within the import motor. It is
+        described as a **J-like** protein (Hsp40/J-domain superfamily-like) that regulates the activity and positioning
+        of the true J-domain cochaperone **Pam18/Tim14** (metazoan functional ortholog often discussed as DNAJC19/Pam18
+        in the PAM motor context) which stimulates mtHsp70 ATPase activity. (sinha2017thecomplexitiesofa pages 4-5,
+        sinha2017thecomplexitiesof pages 4-5, riva2018ajourneythrough pages 11-15)&#39;
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: PAM16 (MAGMAS/TIM16/TIMM16) is an essential subunit of the **TIM23-associated PAM
+        motor**. Mechanistically, it forms a stable subcomplex with Pam18/Tim14 and is described as (i)
+        **recruiting Pam18** to the import channel and (ii) **controlling Pam18 activity**, thereby indirectly
+        regulating mtHsp70’s ATP-driven pulling activity during translocation into the matrix.
+        (sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5)
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: &#39;| Mechanistic role | PAM16 is primarily a **regulatory cochaperone/adaptor**, not an enzyme
+        or transporter substrate-binding transporter itself. It forms a stable subcomplex with Pam18 and **recruits/controls
+        Pam18 at the import channel**, thereby **modulating Pam18-driven stimulation of mtHsp70 ATPase activity**
+        and fine-tuning the ATP-dependent import motor. It is described as a **negative regulator/antagonist** of
+        Pam18’s stimulatory effect on mtHsp70. | (riva2018ajourneythrough pages 11-15, sinha2017thecomplexitiesofa
+        pages 4-5, jain2025investigatingmitochondrialpresequence pages 15-17, sinha2017thecomplexitiesof pages 4-5)
+        | Riva 2018; Sinha 2017; Jain 2025 thesis, https://doi.org/10.53846/goediss-11596 |&#39;
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO terms
+  findings: []
+- id: GO_REF:0000024
+  title: Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment
+    of sequence similarity
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping,
+    accompanied by conservative changes to GO terms applied by UniProt
+  findings: []
+- id: GO_REF:0000052
+  title: Gene Ontology annotation based on curation of immunofluorescence data
+  findings: []
+- id: GO_REF:0000117
+  title: Electronic Gene Ontology annotations created by ARBA machine learning models
+  findings: []
+- id: PMID:10339406
+  title: Genetic and structural characterization of the human mitochondrial inner membrane translocase.
+  findings: []
+- id: PMID:19564938
+  title: &#39;The mitochondrial protein translocation motor: structural conservation between the human and yeast Tim14/Pam18-Tim16/Pam16
+    co-chaperones.&#39;
+  findings: []
+- id: PMID:20053669
+  title: Role of Magmas in protein transport and human mitochondria biogenesis.
+  findings: []
+- id: PMID:23263864
+  title: Methylation-controlled J-protein MCJ acts in the import of proteins into human mitochondria.
+  findings: []
+- id: PMID:24786642
+  title: The impairment of MAGMAS function in human is responsible for a severe skeletal dysplasia.
+  findings: []
+- id: PMID:25416956
+  title: A proteome-scale map of the human interactome network.
+  findings: []
+- id: PMID:32296183
+  title: A reference map of the human binary protein interactome.
+  findings: []
+- id: PMID:33961781
+  title: Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.
+  findings: []
+- id: PMID:34800366
+  title: Quantitative high-confidence human mitochondrial proteome and its dynamics in cellular context.
+  findings: []
+- id: file:human/PAM16/PAM16-deep-research-falcon.md
+  title: Falcon deep research report for human PAM16
+  findings: []
+core_functions:
+- description: PAM16 is the matrix-facing regulatory J-like cochaperone/adaptor subunit of the PAM complex
+    that forms a subcomplex with Pam18/Tim14, recruits and restrains Pam18 activity, and tunes mtHsp70-powered
+    import of presequence-containing proteins into the mitochondrial matrix.
+  supported_by:
+  - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+    supporting_text: Most mitochondrial matrix proteins are encoded in the nucleus, translated in the cytosol,
+      and imported into mitochondria. The **TIM23 complex** (inner membrane presequence translocase) mediates
+      import of presequence-containing proteins; for matrix translocation, TIM23 couples to the **PAM
+      (presequence translocase-associated motor)**, which uses an **mtHsp70 ATPase cycle** to pull precursor
+      polypeptides into the matrix. (sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages
+      4-5)
+  - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+    supporting_text: PAM16 (MAGMAS/TIM16/TIMM16) is an essential subunit of the **TIM23-associated PAM
+      motor**. Mechanistically, it forms a stable subcomplex with Pam18/Tim14 and is described as (i)
+      **recruiting Pam18** to the import channel and (ii) **controlling Pam18 activity**, thereby indirectly
+      regulating mtHsp70’s ATP-driven pulling activity during translocation into the matrix.
+      (sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5)
+  - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+    supporting_text: &#39;A recurring mechanistic interpretation is that Pam16/MAGMAS functions antagonistically to
+      Pam18: it is required for correct association of the motor with the translocon and **inhibits Pam18-mediated
+      stimulation of mtHsp70 ATPase activity**, thus tuning the import motor’s activity. (riva2018ajourneythrough
+      pages 11-15, jain2025investigatingmitochondrialpresequence pages 15-17)&#39;
+  - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+    supporting_text: &#39;**PAM16 (Q9Y3D7; MAGMAS/TIM16/TIMM16)** is a mitochondrial, inner-membrane-associated (matrix-facing)
+      **regulatory subunit of the TIM23 presequence import motor (PAM complex)**. Its defining molecular feature
+      is a **degenerate J-like domain lacking the HPD motif**, consistent with a function in **forming a heterodimer
+      with Pam18 and modulating Pam18’s stimulation of mtHsp70 ATPase activity**, thereby tuning ATP-dependent protein
+      translocation into the mitochondrial matrix. Disease relevance includes database-supported association with
+      **autosomal recessive spondylometaphyseal dysplasia (Megarbane type)** and literature-supported roles in tumor
+      cell survival/chemoresistance with reported overexpression frequencies in prostate cancer and pituitary adenomas.
+      (riva2018ajourneythrough pages 11-15, sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages
+      4-5, OpenTargets Search: -PAM16,TIMM16,MAGMAS)&#39;
+  molecular_function:
+    id: GO:0030674
+    label: protein-macromolecule adaptor activity
+  directly_involved_in:
+  - id: GO:0030150
+    label: protein import into mitochondrial matrix
+  locations:
+  - id: GO:0099617
+    label: matrix side of mitochondrial inner membrane
+  - id: GO:0005743
+    label: mitochondrial inner membrane
+  in_complex:
+    id: GO:0001405
+    label: PAM complex, Tim23 associated import motor
+proposed_new_terms: []
+suggested_questions:
+- question: Which human PAM16 surfaces are required for Pam18 recruitment versus inhibition of
+    Pam18-stimulated mtHsp70 ATPase activity?
+  experts: []
+- question: How do skeletal dysplasia variants alter PAM16 stability, Pam18 binding, and matrix import flux in
+    patient-relevant cells?
+  experts: []
+suggested_experiments:
+- hypothesis: PAM16 disease variants impair matrix import by destabilizing the Pam16-Pam18 regulatory
+    subcomplex.
+  description: Measure Pam18 binding, PAM/TIM23 association, mtHsp70 ATPase regulation, and matrix-import
+    reporter flux after rescue of PAM16-null human cells with wild-type and disease-variant PAM16.
+- hypothesis: PAM16 overexpression phenotypes in cancer models derive from altered PAM motor activity rather
+    than a separate enzymatic function.
+  description: Compare acute PAM16 knockdown or overexpression with Pam18-interface mutants for precursor
+    import, mitochondrial proteostasis, apoptosis sensitivity, and respiratory function.
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/human/PAM16/PAM16-ai-review.yaml
+++ b/genes/human/PAM16/PAM16-ai-review.yaml
@@ -1,11 +1,13 @@
 id: Q9Y3D7
 gene_symbol: PAM16
 product_type: PROTEIN
-status: INITIALIZED
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
-description: 'TODO: Add description for PAM16'
+description: 'PAM16 encodes MAGMAS/TIM16, a matrix-facing regulatory J-like cochaperone/adaptor subunit of the TIM23-associated
+  PAM import motor. It forms a Pam18/Tim14 subcomplex, recruits and restrains Pam18 activity, and tunes mtHsp70-driven
+  import of presequence-containing proteins into the mitochondrial matrix.'
 existing_annotations:
 - term:
     id: GO:0005744
@@ -13,232 +15,754 @@ existing_annotations:
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: PAM16 is functionally coupled to TIM23, but its complex membership is more precisely the PAM
+      import motor rather than the TIM23 channel/core translocase.
+    action: MODIFY
+    additional_reference_ids:
+    - file:human/PAM16/PAM16-deep-research-falcon.md
+    reason: Use the PAM complex term for PAM16 complex membership; TIM23 is the coupled translocase.
+    proposed_replacement_terms:
+    - id: GO:0001405
+      label: PAM complex, Tim23 associated import motor
+    supported_by:
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: The literature and database evidence summarized here consistently refers to **human
+        PAM16** as **MAGMAS/TIM16/TIMM16**, a small mitochondrial protein (~125 aa; ~13 kDa) that is part of
+        the **TIM23-associated presequence import motor (PAM complex)**. This matches the UniProt description
+        for Q9Y3D7 (mitochondrial import inner membrane translocase subunit TIM16 / PAM16 family), including
+        the hallmark **J-like domain** and functional role in mitochondrial protein import.
+        (riva2018ajourneythrough pages 11-15, riva2018ajourneythrough pages 8-11, sinha2017thecomplexitiesofa
+        pages 4-5)
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: Most mitochondrial matrix proteins are encoded in the nucleus, translated in the
+        cytosol, and imported into mitochondria. The **TIM23 complex** (inner membrane presequence
+        translocase) mediates import of presequence-containing proteins; for matrix translocation, TIM23
+        couples to the **PAM (presequence translocase-associated motor)**, which uses an **mtHsp70 ATPase
+        cycle** to pull precursor polypeptides into the matrix. (sinha2017thecomplexitiesofa pages 4-5,
+        sinha2017thecomplexitiesof pages 4-5)
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: PAM16 (MAGMAS/TIM16/TIMM16) is an essential subunit of the **TIM23-associated PAM
+        motor**. Mechanistically, it forms a stable subcomplex with Pam18/Tim14 and is described as (i)
+        **recruiting Pam18** to the import channel and (ii) **controlling Pam18 activity**, thereby indirectly
+        regulating mtHsp70’s ATP-driven pulling activity during translocation into the matrix.
+        (sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5)
 - term:
     id: GO:0030150
     label: protein import into mitochondrial matrix
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct and core. PAM16 regulates the PAM motor that powers TIM23-mediated matrix import.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/PAM16/PAM16-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: Most mitochondrial matrix proteins are encoded in the nucleus, translated in the
+        cytosol, and imported into mitochondria. The **TIM23 complex** (inner membrane presequence
+        translocase) mediates import of presequence-containing proteins; for matrix translocation, TIM23
+        couples to the **PAM (presequence translocase-associated motor)**, which uses an **mtHsp70 ATPase
+        cycle** to pull precursor polypeptides into the matrix. (sinha2017thecomplexitiesofa pages 4-5,
+        sinha2017thecomplexitiesof pages 4-5)
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: PAM16 (MAGMAS/TIM16/TIMM16) is an essential subunit of the **TIM23-associated PAM
+        motor**. Mechanistically, it forms a stable subcomplex with Pam18/Tim14 and is described as (i)
+        **recruiting Pam18** to the import channel and (ii) **controlling Pam18 activity**, thereby indirectly
+        regulating mtHsp70’s ATP-driven pulling activity during translocation into the matrix.
+        (sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5)
 - term:
     id: GO:0001405
     label: PAM complex, Tim23 associated import motor
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct and core. PAM16/MAGMAS is a regulatory subunit of the TIM23-associated PAM motor.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/PAM16/PAM16-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: The literature and database evidence summarized here consistently refers to **human
+        PAM16** as **MAGMAS/TIM16/TIMM16**, a small mitochondrial protein (~125 aa; ~13 kDa) that is part of
+        the **TIM23-associated presequence import motor (PAM complex)**. This matches the UniProt description
+        for Q9Y3D7 (mitochondrial import inner membrane translocase subunit TIM16 / PAM16 family), including
+        the hallmark **J-like domain** and functional role in mitochondrial protein import.
+        (riva2018ajourneythrough pages 11-15, riva2018ajourneythrough pages 8-11, sinha2017thecomplexitiesofa
+        pages 4-5)
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: PAM16 (MAGMAS/TIM16/TIMM16) is an essential subunit of the **TIM23-associated PAM
+        motor**. Mechanistically, it forms a stable subcomplex with Pam18/Tim14 and is described as (i)
+        **recruiting Pam18** to the import channel and (ii) **controlling Pam18 activity**, thereby indirectly
+        regulating mtHsp70’s ATP-driven pulling activity during translocation into the matrix.
+        (sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5)
 - term:
     id: GO:0005743
     label: mitochondrial inner membrane
   evidence_type: IEA
   original_reference_id: GO_REF:0000044
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct. PAM16 is a peripheral component associated with the matrix side of the mitochondrial
+      inner membrane.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/PAM16/PAM16-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: PAM16/MAGMAS is localized to **mitochondria** and described as a **peripheral membrane
+        protein** associated with the TIM23/PAM machinery at the **inner membrane, matrix-facing side**. One
+        source explicitly notes that it does **not extend into the intermembrane space (IMS)**, consistent
+        with a matrix-side role in regulating the mtHsp70 motor. (riva2018ajourneythrough pages 11-15,
+        sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5)
 - term:
     id: GO:0005744
     label: TIM23 mitochondrial import inner membrane translocase complex
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: PAM16 is functionally coupled to TIM23, but its complex membership is more precisely the PAM
+      import motor rather than the TIM23 channel/core translocase.
+    action: MODIFY
+    additional_reference_ids:
+    - file:human/PAM16/PAM16-deep-research-falcon.md
+    reason: Use the PAM complex term for PAM16 complex membership; TIM23 is the coupled translocase.
+    proposed_replacement_terms:
+    - id: GO:0001405
+      label: PAM complex, Tim23 associated import motor
+    supported_by:
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: The literature and database evidence summarized here consistently refers to **human
+        PAM16** as **MAGMAS/TIM16/TIMM16**, a small mitochondrial protein (~125 aa; ~13 kDa) that is part of
+        the **TIM23-associated presequence import motor (PAM complex)**. This matches the UniProt description
+        for Q9Y3D7 (mitochondrial import inner membrane translocase subunit TIM16 / PAM16 family), including
+        the hallmark **J-like domain** and functional role in mitochondrial protein import.
+        (riva2018ajourneythrough pages 11-15, riva2018ajourneythrough pages 8-11, sinha2017thecomplexitiesofa
+        pages 4-5)
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: Most mitochondrial matrix proteins are encoded in the nucleus, translated in the
+        cytosol, and imported into mitochondria. The **TIM23 complex** (inner membrane presequence
+        translocase) mediates import of presequence-containing proteins; for matrix translocation, TIM23
+        couples to the **PAM (presequence translocase-associated motor)**, which uses an **mtHsp70 ATPase
+        cycle** to pull precursor polypeptides into the matrix. (sinha2017thecomplexitiesofa pages 4-5,
+        sinha2017thecomplexitiesof pages 4-5)
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: PAM16 (MAGMAS/TIM16/TIMM16) is an essential subunit of the **TIM23-associated PAM
+        motor**. Mechanistically, it forms a stable subcomplex with Pam18/Tim14 and is described as (i)
+        **recruiting Pam18** to the import channel and (ii) **controlling Pam18 activity**, thereby indirectly
+        regulating mtHsp70’s ATP-driven pulling activity during translocation into the matrix.
+        (sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5)
 - term:
     id: GO:0030150
     label: protein import into mitochondrial matrix
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct and core. PAM16 regulates the PAM motor that powers TIM23-mediated matrix import.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/PAM16/PAM16-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: Most mitochondrial matrix proteins are encoded in the nucleus, translated in the
+        cytosol, and imported into mitochondria. The **TIM23 complex** (inner membrane presequence
+        translocase) mediates import of presequence-containing proteins; for matrix translocation, TIM23
+        couples to the **PAM (presequence translocase-associated motor)**, which uses an **mtHsp70 ATPase
+        cycle** to pull precursor polypeptides into the matrix. (sinha2017thecomplexitiesofa pages 4-5,
+        sinha2017thecomplexitiesof pages 4-5)
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: PAM16 (MAGMAS/TIM16/TIMM16) is an essential subunit of the **TIM23-associated PAM
+        motor**. Mechanistically, it forms a stable subcomplex with Pam18/Tim14 and is described as (i)
+        **recruiting Pam18** to the import channel and (ii) **controlling Pam18 activity**, thereby indirectly
+        regulating mtHsp70’s ATP-driven pulling activity during translocation into the matrix.
+        (sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5)
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:23263864
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Protein binding is too generic for PAM16. The informative role is a regulatory
+      adaptor/cochaperone function within the Pam16-Pam18/PAM import motor.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/PAM16/PAM16-deep-research-falcon.md
+    reason: Replace generic protein-binding capture with PAM complex membership and adaptor/regulatory
+      cochaperone activity where supported.
+    supported_by:
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: '**PAM16 is not an enzyme catalyzing a metabolic reaction nor a transporter substrate-binding
+        channel.** Instead, it functions as a **regulatory cochaperone/adaptor** within the import motor. It is
+        described as a **J-like** protein (Hsp40/J-domain superfamily-like) that regulates the activity and positioning
+        of the true J-domain cochaperone **Pam18/Tim14** (metazoan functional ortholog often discussed as DNAJC19/Pam18
+        in the PAM motor context) which stimulates mtHsp70 ATPase activity. (sinha2017thecomplexitiesofa pages 4-5,
+        sinha2017thecomplexitiesof pages 4-5, riva2018ajourneythrough pages 11-15)'
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: '| Mechanistic role | PAM16 is primarily a **regulatory cochaperone/adaptor**, not an enzyme
+        or transporter substrate-binding transporter itself. It forms a stable subcomplex with Pam18 and **recruits/controls
+        Pam18 at the import channel**, thereby **modulating Pam18-driven stimulation of mtHsp70 ATPase activity**
+        and fine-tuning the ATP-dependent import motor. It is described as a **negative regulator/antagonist** of
+        Pam18’s stimulatory effect on mtHsp70. | (riva2018ajourneythrough pages 11-15, sinha2017thecomplexitiesofa
+        pages 4-5, jain2025investigatingmitochondrialpresequence pages 15-17, sinha2017thecomplexitiesof pages 4-5)
+        | Riva 2018; Sinha 2017; Jain 2025 thesis, https://doi.org/10.53846/goediss-11596 |'
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:25416956
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Protein binding is too generic for PAM16. The informative role is a regulatory
+      adaptor/cochaperone function within the Pam16-Pam18/PAM import motor.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/PAM16/PAM16-deep-research-falcon.md
+    reason: Replace generic protein-binding capture with PAM complex membership and adaptor/regulatory
+      cochaperone activity where supported.
+    supported_by:
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: '**PAM16 is not an enzyme catalyzing a metabolic reaction nor a transporter substrate-binding
+        channel.** Instead, it functions as a **regulatory cochaperone/adaptor** within the import motor. It is
+        described as a **J-like** protein (Hsp40/J-domain superfamily-like) that regulates the activity and positioning
+        of the true J-domain cochaperone **Pam18/Tim14** (metazoan functional ortholog often discussed as DNAJC19/Pam18
+        in the PAM motor context) which stimulates mtHsp70 ATPase activity. (sinha2017thecomplexitiesofa pages 4-5,
+        sinha2017thecomplexitiesof pages 4-5, riva2018ajourneythrough pages 11-15)'
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: '| Mechanistic role | PAM16 is primarily a **regulatory cochaperone/adaptor**, not an enzyme
+        or transporter substrate-binding transporter itself. It forms a stable subcomplex with Pam18 and **recruits/controls
+        Pam18 at the import channel**, thereby **modulating Pam18-driven stimulation of mtHsp70 ATPase activity**
+        and fine-tuning the ATP-dependent import motor. It is described as a **negative regulator/antagonist** of
+        Pam18’s stimulatory effect on mtHsp70. | (riva2018ajourneythrough pages 11-15, sinha2017thecomplexitiesofa
+        pages 4-5, jain2025investigatingmitochondrialpresequence pages 15-17, sinha2017thecomplexitiesof pages 4-5)
+        | Riva 2018; Sinha 2017; Jain 2025 thesis, https://doi.org/10.53846/goediss-11596 |'
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:32296183
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Protein binding is too generic for PAM16. The informative role is a regulatory
+      adaptor/cochaperone function within the Pam16-Pam18/PAM import motor.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/PAM16/PAM16-deep-research-falcon.md
+    reason: Replace generic protein-binding capture with PAM complex membership and adaptor/regulatory
+      cochaperone activity where supported.
+    supported_by:
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: '**PAM16 is not an enzyme catalyzing a metabolic reaction nor a transporter substrate-binding
+        channel.** Instead, it functions as a **regulatory cochaperone/adaptor** within the import motor. It is
+        described as a **J-like** protein (Hsp40/J-domain superfamily-like) that regulates the activity and positioning
+        of the true J-domain cochaperone **Pam18/Tim14** (metazoan functional ortholog often discussed as DNAJC19/Pam18
+        in the PAM motor context) which stimulates mtHsp70 ATPase activity. (sinha2017thecomplexitiesofa pages 4-5,
+        sinha2017thecomplexitiesof pages 4-5, riva2018ajourneythrough pages 11-15)'
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: '| Mechanistic role | PAM16 is primarily a **regulatory cochaperone/adaptor**, not an enzyme
+        or transporter substrate-binding transporter itself. It forms a stable subcomplex with Pam18 and **recruits/controls
+        Pam18 at the import channel**, thereby **modulating Pam18-driven stimulation of mtHsp70 ATPase activity**
+        and fine-tuning the ATP-dependent import motor. It is described as a **negative regulator/antagonist** of
+        Pam18’s stimulatory effect on mtHsp70. | (riva2018ajourneythrough pages 11-15, sinha2017thecomplexitiesofa
+        pages 4-5, jain2025investigatingmitochondrialpresequence pages 15-17, sinha2017thecomplexitiesof pages 4-5)
+        | Riva 2018; Sinha 2017; Jain 2025 thesis, https://doi.org/10.53846/goediss-11596 |'
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:33961781
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Protein binding is too generic for PAM16. The informative role is a regulatory
+      adaptor/cochaperone function within the Pam16-Pam18/PAM import motor.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/PAM16/PAM16-deep-research-falcon.md
+    reason: Replace generic protein-binding capture with PAM complex membership and adaptor/regulatory
+      cochaperone activity where supported.
+    supported_by:
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: '**PAM16 is not an enzyme catalyzing a metabolic reaction nor a transporter substrate-binding
+        channel.** Instead, it functions as a **regulatory cochaperone/adaptor** within the import motor. It is
+        described as a **J-like** protein (Hsp40/J-domain superfamily-like) that regulates the activity and positioning
+        of the true J-domain cochaperone **Pam18/Tim14** (metazoan functional ortholog often discussed as DNAJC19/Pam18
+        in the PAM motor context) which stimulates mtHsp70 ATPase activity. (sinha2017thecomplexitiesofa pages 4-5,
+        sinha2017thecomplexitiesof pages 4-5, riva2018ajourneythrough pages 11-15)'
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: '| Mechanistic role | PAM16 is primarily a **regulatory cochaperone/adaptor**, not an enzyme
+        or transporter substrate-binding transporter itself. It forms a stable subcomplex with Pam18 and **recruits/controls
+        Pam18 at the import channel**, thereby **modulating Pam18-driven stimulation of mtHsp70 ATPase activity**
+        and fine-tuning the ATP-dependent import motor. It is described as a **negative regulator/antagonist** of
+        Pam18’s stimulatory effect on mtHsp70. | (riva2018ajourneythrough pages 11-15, sinha2017thecomplexitiesofa
+        pages 4-5, jain2025investigatingmitochondrialpresequence pages 15-17, sinha2017thecomplexitiesof pages 4-5)
+        | Riva 2018; Sinha 2017; Jain 2025 thesis, https://doi.org/10.53846/goediss-11596 |'
 - term:
     id: GO:0005743
     label: mitochondrial inner membrane
   evidence_type: NAS
   original_reference_id: PMID:10339406
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct. PAM16 is a peripheral component associated with the matrix side of the mitochondrial
+      inner membrane.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/PAM16/PAM16-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: PAM16/MAGMAS is localized to **mitochondria** and described as a **peripheral membrane
+        protein** associated with the TIM23/PAM machinery at the **inner membrane, matrix-facing side**. One
+        source explicitly notes that it does **not extend into the intermembrane space (IMS)**, consistent
+        with a matrix-side role in regulating the mtHsp70 motor. (riva2018ajourneythrough pages 11-15,
+        sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5)
 - term:
     id: GO:0005744
     label: TIM23 mitochondrial import inner membrane translocase complex
   evidence_type: NAS
   original_reference_id: PMID:10339406
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: PAM16 is functionally coupled to TIM23, but its complex membership is more precisely the PAM
+      import motor rather than the TIM23 channel/core translocase.
+    action: MODIFY
+    additional_reference_ids:
+    - file:human/PAM16/PAM16-deep-research-falcon.md
+    reason: Use the PAM complex term for PAM16 complex membership; TIM23 is the coupled translocase.
+    proposed_replacement_terms:
+    - id: GO:0001405
+      label: PAM complex, Tim23 associated import motor
+    supported_by:
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: The literature and database evidence summarized here consistently refers to **human
+        PAM16** as **MAGMAS/TIM16/TIMM16**, a small mitochondrial protein (~125 aa; ~13 kDa) that is part of
+        the **TIM23-associated presequence import motor (PAM complex)**. This matches the UniProt description
+        for Q9Y3D7 (mitochondrial import inner membrane translocase subunit TIM16 / PAM16 family), including
+        the hallmark **J-like domain** and functional role in mitochondrial protein import.
+        (riva2018ajourneythrough pages 11-15, riva2018ajourneythrough pages 8-11, sinha2017thecomplexitiesofa
+        pages 4-5)
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: Most mitochondrial matrix proteins are encoded in the nucleus, translated in the
+        cytosol, and imported into mitochondria. The **TIM23 complex** (inner membrane presequence
+        translocase) mediates import of presequence-containing proteins; for matrix translocation, TIM23
+        couples to the **PAM (presequence translocase-associated motor)**, which uses an **mtHsp70 ATPase
+        cycle** to pull precursor polypeptides into the matrix. (sinha2017thecomplexitiesofa pages 4-5,
+        sinha2017thecomplexitiesof pages 4-5)
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: PAM16 (MAGMAS/TIM16/TIMM16) is an essential subunit of the **TIM23-associated PAM
+        motor**. Mechanistically, it forms a stable subcomplex with Pam18/Tim14 and is described as (i)
+        **recruiting Pam18** to the import channel and (ii) **controlling Pam18 activity**, thereby indirectly
+        regulating mtHsp70’s ATP-driven pulling activity during translocation into the matrix.
+        (sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5)
 - term:
     id: GO:0006886
     label: intracellular protein transport
   evidence_type: NAS
   original_reference_id: PMID:10339406
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct pathway family but too broad. PAM16 specifically supports TIM23/PAM-mediated
+      mitochondrial matrix protein import.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/PAM16/PAM16-deep-research-falcon.md
+    reason: Prefer protein import into mitochondrial matrix and PAM complex terms over generic intracellular
+      protein transport.
+    supported_by:
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: Most mitochondrial matrix proteins are encoded in the nucleus, translated in the
+        cytosol, and imported into mitochondria. The **TIM23 complex** (inner membrane presequence
+        translocase) mediates import of presequence-containing proteins; for matrix translocation, TIM23
+        couples to the **PAM (presequence translocase-associated motor)**, which uses an **mtHsp70 ATPase
+        cycle** to pull precursor polypeptides into the matrix. (sinha2017thecomplexitiesofa pages 4-5,
+        sinha2017thecomplexitiesof pages 4-5)
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: PAM16 (MAGMAS/TIM16/TIMM16) is an essential subunit of the **TIM23-associated PAM
+        motor**. Mechanistically, it forms a stable subcomplex with Pam18/Tim14 and is described as (i)
+        **recruiting Pam18** to the import channel and (ii) **controlling Pam18 activity**, thereby indirectly
+        regulating mtHsp70’s ATP-driven pulling activity during translocation into the matrix.
+        (sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5)
 - term:
     id: GO:0005739
     label: mitochondrion
   evidence_type: IDA
   original_reference_id: GO_REF:0000052
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct but broad. PAM16 is specifically associated with the matrix-facing side of the
+      mitochondrial inner membrane in the PAM import motor.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/PAM16/PAM16-deep-research-falcon.md
+    reason: Prefer matrix side of mitochondrial inner membrane and PAM complex annotations over generic
+      mitochondrion.
+    supported_by:
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: PAM16/MAGMAS is localized to **mitochondria** and described as a **peripheral membrane
+        protein** associated with the TIM23/PAM machinery at the **inner membrane, matrix-facing side**. One
+        source explicitly notes that it does **not extend into the intermembrane space (IMS)**, consistent
+        with a matrix-side role in regulating the mtHsp70 motor. (riva2018ajourneythrough pages 11-15,
+        sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5)
 - term:
     id: GO:0005739
     label: mitochondrion
   evidence_type: HTP
   original_reference_id: PMID:34800366
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct but broad. PAM16 is specifically associated with the matrix-facing side of the
+      mitochondrial inner membrane in the PAM import motor.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/PAM16/PAM16-deep-research-falcon.md
+    reason: Prefer matrix side of mitochondrial inner membrane and PAM complex annotations over generic
+      mitochondrion.
+    supported_by:
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: PAM16/MAGMAS is localized to **mitochondria** and described as a **peripheral membrane
+        protein** associated with the TIM23/PAM machinery at the **inner membrane, matrix-facing side**. One
+        source explicitly notes that it does **not extend into the intermembrane space (IMS)**, consistent
+        with a matrix-side role in regulating the mtHsp70 motor. (riva2018ajourneythrough pages 11-15,
+        sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5)
 - term:
     id: GO:0099617
     label: matrix side of mitochondrial inner membrane
   evidence_type: IDA
   original_reference_id: PMID:20053669
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct. PAM16 localizes to the matrix-facing side of the mitochondrial inner membrane.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/PAM16/PAM16-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: PAM16/MAGMAS is localized to **mitochondria** and described as a **peripheral membrane
+        protein** associated with the TIM23/PAM machinery at the **inner membrane, matrix-facing side**. One
+        source explicitly notes that it does **not extend into the intermembrane space (IMS)**, consistent
+        with a matrix-side role in regulating the mtHsp70 motor. (riva2018ajourneythrough pages 11-15,
+        sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5)
 - term:
     id: GO:0001405
     label: PAM complex, Tim23 associated import motor
   evidence_type: ISS
   original_reference_id: GO_REF:0000024
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct and core. PAM16/MAGMAS is a regulatory subunit of the TIM23-associated PAM motor.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/PAM16/PAM16-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: The literature and database evidence summarized here consistently refers to **human
+        PAM16** as **MAGMAS/TIM16/TIMM16**, a small mitochondrial protein (~125 aa; ~13 kDa) that is part of
+        the **TIM23-associated presequence import motor (PAM complex)**. This matches the UniProt description
+        for Q9Y3D7 (mitochondrial import inner membrane translocase subunit TIM16 / PAM16 family), including
+        the hallmark **J-like domain** and functional role in mitochondrial protein import.
+        (riva2018ajourneythrough pages 11-15, riva2018ajourneythrough pages 8-11, sinha2017thecomplexitiesofa
+        pages 4-5)
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: PAM16 (MAGMAS/TIM16/TIMM16) is an essential subunit of the **TIM23-associated PAM
+        motor**. Mechanistically, it forms a stable subcomplex with Pam18/Tim14 and is described as (i)
+        **recruiting Pam18** to the import channel and (ii) **controlling Pam18 activity**, thereby indirectly
+        regulating mtHsp70’s ATP-driven pulling activity during translocation into the matrix.
+        (sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5)
 - term:
     id: GO:0001503
     label: ossification
   evidence_type: IMP
   original_reference_id: PMID:24786642
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Keep as non-core. Human PAM16/MAGMAS disease data support a skeletal dysplasia/ossification
+      phenotype, but the evolved core function is mitochondrial protein import motor regulation.
+    action: KEEP_AS_NON_CORE
+    additional_reference_ids:
+    - file:human/PAM16/PAM16-deep-research-falcon.md
+    reason: Ossification is a downstream organismal phenotype of MAGMAS impairment, not the core molecular
+      function of PAM16.
+    supported_by:
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: '| Disease/phenotype links | PAM16 has recognized disease links, including **autosomal recessive
+        spondylometaphyseal dysplasia, Megarbane type** in disease databases. Literature summarized in retrieved
+        sources also links **MAGMAS overexpression** to neoplasia, including **prostate cancer**, **pituitary adenomas**,
+        and anti-apoptotic/chemoresistance phenotypes. Open Targets also lists associations to neurodegenerative
+        disease/Parkinson disease, but these are weaker database associations than the skeletal dysplasia link.
+        | (riva2018ajourneythrough pages 11-15, sinha2017thecomplexitiesof pages 12-14, zhao2023mitochondrialskeletaldisorders
+        pages 8-11, OpenTargets Search: -PAM16,TIMM16,MAGMAS) | Open Targets platform search context; Zhao 2023
+        dissertation; Riva 2018 |'
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: '**PAM16 (Q9Y3D7; MAGMAS/TIM16/TIMM16)** is a mitochondrial, inner-membrane-associated (matrix-facing)
+        **regulatory subunit of the TIM23 presequence import motor (PAM complex)**. Its defining molecular feature
+        is a **degenerate J-like domain lacking the HPD motif**, consistent with a function in **forming a heterodimer
+        with Pam18 and modulating Pam18’s stimulation of mtHsp70 ATPase activity**, thereby tuning ATP-dependent
+        protein translocation into the mitochondrial matrix. Disease relevance includes database-supported association
+        with **autosomal recessive spondylometaphyseal dysplasia (Megarbane type)** and literature-supported roles
+        in tumor cell survival/chemoresistance with reported overexpression frequencies in prostate cancer and pituitary
+        adenomas. (riva2018ajourneythrough pages 11-15, sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof
+        pages 4-5, OpenTargets Search: -PAM16,TIMM16,MAGMAS)'
 - term:
     id: GO:0001405
     label: PAM complex, Tim23 associated import motor
   evidence_type: IGI
   original_reference_id: PMID:20053669
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct and core. PAM16/MAGMAS is a regulatory subunit of the TIM23-associated PAM motor.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/PAM16/PAM16-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: The literature and database evidence summarized here consistently refers to **human
+        PAM16** as **MAGMAS/TIM16/TIMM16**, a small mitochondrial protein (~125 aa; ~13 kDa) that is part of
+        the **TIM23-associated presequence import motor (PAM complex)**. This matches the UniProt description
+        for Q9Y3D7 (mitochondrial import inner membrane translocase subunit TIM16 / PAM16 family), including
+        the hallmark **J-like domain** and functional role in mitochondrial protein import.
+        (riva2018ajourneythrough pages 11-15, riva2018ajourneythrough pages 8-11, sinha2017thecomplexitiesofa
+        pages 4-5)
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: PAM16 (MAGMAS/TIM16/TIMM16) is an essential subunit of the **TIM23-associated PAM
+        motor**. Mechanistically, it forms a stable subcomplex with Pam18/Tim14 and is described as (i)
+        **recruiting Pam18** to the import channel and (ii) **controlling Pam18 activity**, thereby indirectly
+        regulating mtHsp70’s ATP-driven pulling activity during translocation into the matrix.
+        (sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5)
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:19564938
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Protein binding is too generic for PAM16. The informative role is a regulatory
+      adaptor/cochaperone function within the Pam16-Pam18/PAM import motor.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/PAM16/PAM16-deep-research-falcon.md
+    reason: Replace generic protein-binding capture with PAM complex membership and adaptor/regulatory
+      cochaperone activity where supported.
+    supported_by:
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: '**PAM16 is not an enzyme catalyzing a metabolic reaction nor a transporter substrate-binding
+        channel.** Instead, it functions as a **regulatory cochaperone/adaptor** within the import motor. It is
+        described as a **J-like** protein (Hsp40/J-domain superfamily-like) that regulates the activity and positioning
+        of the true J-domain cochaperone **Pam18/Tim14** (metazoan functional ortholog often discussed as DNAJC19/Pam18
+        in the PAM motor context) which stimulates mtHsp70 ATPase activity. (sinha2017thecomplexitiesofa pages 4-5,
+        sinha2017thecomplexitiesof pages 4-5, riva2018ajourneythrough pages 11-15)'
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: '| Mechanistic role | PAM16 is primarily a **regulatory cochaperone/adaptor**, not an enzyme
+        or transporter substrate-binding transporter itself. It forms a stable subcomplex with Pam18 and **recruits/controls
+        Pam18 at the import channel**, thereby **modulating Pam18-driven stimulation of mtHsp70 ATPase activity**
+        and fine-tuning the ATP-dependent import motor. It is described as a **negative regulator/antagonist** of
+        Pam18’s stimulatory effect on mtHsp70. | (riva2018ajourneythrough pages 11-15, sinha2017thecomplexitiesofa
+        pages 4-5, jain2025investigatingmitochondrialpresequence pages 15-17, sinha2017thecomplexitiesof pages 4-5)
+        | Riva 2018; Sinha 2017; Jain 2025 thesis, https://doi.org/10.53846/goediss-11596 |'
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:20053669
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Protein binding is too generic for PAM16. The informative role is a regulatory
+      adaptor/cochaperone function within the Pam16-Pam18/PAM import motor.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/PAM16/PAM16-deep-research-falcon.md
+    reason: Replace generic protein-binding capture with PAM complex membership and adaptor/regulatory
+      cochaperone activity where supported.
+    supported_by:
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: '**PAM16 is not an enzyme catalyzing a metabolic reaction nor a transporter substrate-binding
+        channel.** Instead, it functions as a **regulatory cochaperone/adaptor** within the import motor. It is
+        described as a **J-like** protein (Hsp40/J-domain superfamily-like) that regulates the activity and positioning
+        of the true J-domain cochaperone **Pam18/Tim14** (metazoan functional ortholog often discussed as DNAJC19/Pam18
+        in the PAM motor context) which stimulates mtHsp70 ATPase activity. (sinha2017thecomplexitiesofa pages 4-5,
+        sinha2017thecomplexitiesof pages 4-5, riva2018ajourneythrough pages 11-15)'
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: '| Mechanistic role | PAM16 is primarily a **regulatory cochaperone/adaptor**, not an enzyme
+        or transporter substrate-binding transporter itself. It forms a stable subcomplex with Pam18 and **recruits/controls
+        Pam18 at the import channel**, thereby **modulating Pam18-driven stimulation of mtHsp70 ATPase activity**
+        and fine-tuning the ATP-dependent import motor. It is described as a **negative regulator/antagonist** of
+        Pam18’s stimulatory effect on mtHsp70. | (riva2018ajourneythrough pages 11-15, sinha2017thecomplexitiesofa
+        pages 4-5, jain2025investigatingmitochondrialpresequence pages 15-17, sinha2017thecomplexitiesof pages 4-5)
+        | Riva 2018; Sinha 2017; Jain 2025 thesis, https://doi.org/10.53846/goediss-11596 |'
 - term:
     id: GO:0005759
     label: mitochondrial matrix
   evidence_type: IDA
   original_reference_id: PMID:20053669
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct. PAM16 acts at the matrix-facing side of the inner membrane and does not extend into the
+      IMS.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/PAM16/PAM16-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: PAM16/MAGMAS is localized to **mitochondria** and described as a **peripheral membrane
+        protein** associated with the TIM23/PAM machinery at the **inner membrane, matrix-facing side**. One
+        source explicitly notes that it does **not extend into the intermembrane space (IMS)**, consistent
+        with a matrix-side role in regulating the mtHsp70 motor. (riva2018ajourneythrough pages 11-15,
+        sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5)
 - term:
     id: GO:0030150
     label: protein import into mitochondrial matrix
   evidence_type: IGI
   original_reference_id: PMID:20053669
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct and core. PAM16 regulates the PAM motor that powers TIM23-mediated matrix import.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/PAM16/PAM16-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: Most mitochondrial matrix proteins are encoded in the nucleus, translated in the
+        cytosol, and imported into mitochondria. The **TIM23 complex** (inner membrane presequence
+        translocase) mediates import of presequence-containing proteins; for matrix translocation, TIM23
+        couples to the **PAM (presequence translocase-associated motor)**, which uses an **mtHsp70 ATPase
+        cycle** to pull precursor polypeptides into the matrix. (sinha2017thecomplexitiesofa pages 4-5,
+        sinha2017thecomplexitiesof pages 4-5)
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: PAM16 (MAGMAS/TIM16/TIMM16) is an essential subunit of the **TIM23-associated PAM
+        motor**. Mechanistically, it forms a stable subcomplex with Pam18/Tim14 and is described as (i)
+        **recruiting Pam18** to the import channel and (ii) **controlling Pam18 activity**, thereby indirectly
+        regulating mtHsp70’s ATP-driven pulling activity during translocation into the matrix.
+        (sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5)
 - term:
     id: GO:0032780
     label: negative regulation of ATP-dependent activity
   evidence_type: IDA
   original_reference_id: PMID:19564938
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct and mechanistically informative. PAM16 restrains Pam18-mediated stimulation of mtHsp70
+      ATPase activity in the import motor.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/PAM16/PAM16-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: 'A recurring mechanistic interpretation is that Pam16/MAGMAS functions antagonistically to
+        Pam18: it is required for correct association of the motor with the translocon and **inhibits Pam18-mediated
+        stimulation of mtHsp70 ATPase activity**, thus tuning the import motor’s activity. (riva2018ajourneythrough
+        pages 11-15, jain2025investigatingmitochondrialpresequence pages 15-17)'
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: '| Mechanistic role | PAM16 is primarily a **regulatory cochaperone/adaptor**, not an enzyme
+        or transporter substrate-binding transporter itself. It forms a stable subcomplex with Pam18 and **recruits/controls
+        Pam18 at the import channel**, thereby **modulating Pam18-driven stimulation of mtHsp70 ATPase activity**
+        and fine-tuning the ATP-dependent import motor. It is described as a **negative regulator/antagonist** of
+        Pam18’s stimulatory effect on mtHsp70. | (riva2018ajourneythrough pages 11-15, sinha2017thecomplexitiesofa
+        pages 4-5, jain2025investigatingmitochondrialpresequence pages 15-17, sinha2017thecomplexitiesof pages 4-5)
+        | Riva 2018; Sinha 2017; Jain 2025 thesis, https://doi.org/10.53846/goediss-11596 |'
 - term:
     id: GO:0032780
     label: negative regulation of ATP-dependent activity
   evidence_type: IDA
   original_reference_id: PMID:20053669
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct and mechanistically informative. PAM16 restrains Pam18-mediated stimulation of mtHsp70
+      ATPase activity in the import motor.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/PAM16/PAM16-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: 'A recurring mechanistic interpretation is that Pam16/MAGMAS functions antagonistically to
+        Pam18: it is required for correct association of the motor with the translocon and **inhibits Pam18-mediated
+        stimulation of mtHsp70 ATPase activity**, thus tuning the import motor’s activity. (riva2018ajourneythrough
+        pages 11-15, jain2025investigatingmitochondrialpresequence pages 15-17)'
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: '| Mechanistic role | PAM16 is primarily a **regulatory cochaperone/adaptor**, not an enzyme
+        or transporter substrate-binding transporter itself. It forms a stable subcomplex with Pam18 and **recruits/controls
+        Pam18 at the import channel**, thereby **modulating Pam18-driven stimulation of mtHsp70 ATPase activity**
+        and fine-tuning the ATP-dependent import motor. It is described as a **negative regulator/antagonist** of
+        Pam18’s stimulatory effect on mtHsp70. | (riva2018ajourneythrough pages 11-15, sinha2017thecomplexitiesofa
+        pages 4-5, jain2025investigatingmitochondrialpresequence pages 15-17, sinha2017thecomplexitiesof pages 4-5)
+        | Riva 2018; Sinha 2017; Jain 2025 thesis, https://doi.org/10.53846/goediss-11596 |'
 - term:
     id: GO:0032991
     label: protein-containing complex
   evidence_type: IDA
   original_reference_id: PMID:19564938
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct but too generic. The specific protein-containing complex is the TIM23-associated PAM
+      motor.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/PAM16/PAM16-deep-research-falcon.md
+    reason: Use PAM complex rather than the generic protein-containing complex term.
+    supported_by:
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: The literature and database evidence summarized here consistently refers to **human
+        PAM16** as **MAGMAS/TIM16/TIMM16**, a small mitochondrial protein (~125 aa; ~13 kDa) that is part of
+        the **TIM23-associated presequence import motor (PAM complex)**. This matches the UniProt description
+        for Q9Y3D7 (mitochondrial import inner membrane translocase subunit TIM16 / PAM16 family), including
+        the hallmark **J-like domain** and functional role in mitochondrial protein import.
+        (riva2018ajourneythrough pages 11-15, riva2018ajourneythrough pages 8-11, sinha2017thecomplexitiesofa
+        pages 4-5)
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: PAM16 (MAGMAS/TIM16/TIMM16) is an essential subunit of the **TIM23-associated PAM
+        motor**. Mechanistically, it forms a stable subcomplex with Pam18/Tim14 and is described as (i)
+        **recruiting Pam18** to the import channel and (ii) **controlling Pam18 activity**, thereby indirectly
+        regulating mtHsp70’s ATP-driven pulling activity during translocation into the matrix.
+        (sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5)
 - term:
     id: GO:0032991
     label: protein-containing complex
   evidence_type: IDA
   original_reference_id: PMID:20053669
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct but too generic. The specific protein-containing complex is the TIM23-associated PAM
+      motor.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/PAM16/PAM16-deep-research-falcon.md
+    reason: Use PAM complex rather than the generic protein-containing complex term.
+    supported_by:
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: The literature and database evidence summarized here consistently refers to **human
+        PAM16** as **MAGMAS/TIM16/TIMM16**, a small mitochondrial protein (~125 aa; ~13 kDa) that is part of
+        the **TIM23-associated presequence import motor (PAM complex)**. This matches the UniProt description
+        for Q9Y3D7 (mitochondrial import inner membrane translocase subunit TIM16 / PAM16 family), including
+        the hallmark **J-like domain** and functional role in mitochondrial protein import.
+        (riva2018ajourneythrough pages 11-15, riva2018ajourneythrough pages 8-11, sinha2017thecomplexitiesofa
+        pages 4-5)
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: PAM16 (MAGMAS/TIM16/TIMM16) is an essential subunit of the **TIM23-associated PAM
+        motor**. Mechanistically, it forms a stable subcomplex with Pam18/Tim14 and is described as (i)
+        **recruiting Pam18** to the import channel and (ii) **controlling Pam18 activity**, thereby indirectly
+        regulating mtHsp70’s ATP-driven pulling activity during translocation into the matrix.
+        (sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5)
+- term:
+    id: GO:0030674
+    label: protein-macromolecule adaptor activity
+  evidence_type: NAS
+  original_reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+  review:
+    summary: New annotation. PAM16 functions as a regulatory adaptor/cochaperone that recruits and controls
+      Pam18 at the import channel rather than acting as an enzyme or transporter.
+    action: NEW
+    reason: PAM16 has a specific adaptor/cochaperone role in the PAM motor that is more informative than
+      generic protein binding and is not present in GOA.
+    supported_by:
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: '**PAM16 is not an enzyme catalyzing a metabolic reaction nor a transporter substrate-binding
+        channel.** Instead, it functions as a **regulatory cochaperone/adaptor** within the import motor. It is
+        described as a **J-like** protein (Hsp40/J-domain superfamily-like) that regulates the activity and positioning
+        of the true J-domain cochaperone **Pam18/Tim14** (metazoan functional ortholog often discussed as DNAJC19/Pam18
+        in the PAM motor context) which stimulates mtHsp70 ATPase activity. (sinha2017thecomplexitiesofa pages 4-5,
+        sinha2017thecomplexitiesof pages 4-5, riva2018ajourneythrough pages 11-15)'
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: PAM16 (MAGMAS/TIM16/TIMM16) is an essential subunit of the **TIM23-associated PAM
+        motor**. Mechanistically, it forms a stable subcomplex with Pam18/Tim14 and is described as (i)
+        **recruiting Pam18** to the import channel and (ii) **controlling Pam18 activity**, thereby indirectly
+        regulating mtHsp70’s ATP-driven pulling activity during translocation into the matrix.
+        (sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5)
+    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+      supporting_text: '| Mechanistic role | PAM16 is primarily a **regulatory cochaperone/adaptor**, not an enzyme
+        or transporter substrate-binding transporter itself. It forms a stable subcomplex with Pam18 and **recruits/controls
+        Pam18 at the import channel**, thereby **modulating Pam18-driven stimulation of mtHsp70 ATPase activity**
+        and fine-tuning the ATP-dependent import motor. It is described as a **negative regulator/antagonist** of
+        Pam18’s stimulatory effect on mtHsp70. | (riva2018ajourneythrough pages 11-15, sinha2017thecomplexitiesofa
+        pages 4-5, jain2025investigatingmitochondrialpresequence pages 15-17, sinha2017thecomplexitiesof pages 4-5)
+        | Riva 2018; Sinha 2017; Jain 2025 thesis, https://doi.org/10.53846/goediss-11596 |'
 references:
 - id: GO_REF:0000002
-  title: Gene Ontology annotation through association of InterPro records with GO
-    terms
+  title: Gene Ontology annotation through association of InterPro records with GO terms
   findings: []
 - id: GO_REF:0000024
-  title: Manual transfer of experimentally-verified manual GO annotation data to orthologs
-    by curator judgment of sequence similarity
+  title: Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment
+    of sequence similarity
   findings: []
 - id: GO_REF:0000033
   title: Annotation inferences using phylogenetic trees
   findings: []
 - id: GO_REF:0000044
-  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
-    vocabulary mapping, accompanied by conservative changes to GO terms applied by
-    UniProt
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping,
+    accompanied by conservative changes to GO terms applied by UniProt
   findings: []
 - id: GO_REF:0000052
   title: Gene Ontology annotation based on curation of immunofluorescence data
@@ -247,23 +771,20 @@ references:
   title: Electronic Gene Ontology annotations created by ARBA machine learning models
   findings: []
 - id: PMID:10339406
-  title: Genetic and structural characterization of the human mitochondrial inner
-    membrane translocase.
+  title: Genetic and structural characterization of the human mitochondrial inner membrane translocase.
   findings: []
 - id: PMID:19564938
-  title: 'The mitochondrial protein translocation motor: structural conservation between
-    the human and yeast Tim14/Pam18-Tim16/Pam16 co-chaperones.'
+  title: 'The mitochondrial protein translocation motor: structural conservation between the human and yeast Tim14/Pam18-Tim16/Pam16
+    co-chaperones.'
   findings: []
 - id: PMID:20053669
   title: Role of Magmas in protein transport and human mitochondria biogenesis.
   findings: []
 - id: PMID:23263864
-  title: Methylation-controlled J-protein MCJ acts in the import of proteins into
-    human mitochondria.
+  title: Methylation-controlled J-protein MCJ acts in the import of proteins into human mitochondria.
   findings: []
 - id: PMID:24786642
-  title: The impairment of MAGMAS function in human is responsible for a severe skeletal
-    dysplasia.
+  title: The impairment of MAGMAS function in human is responsible for a severe skeletal dysplasia.
   findings: []
 - id: PMID:25416956
   title: A proteome-scale map of the human interactome network.
@@ -272,10 +793,75 @@ references:
   title: A reference map of the human binary protein interactome.
   findings: []
 - id: PMID:33961781
-  title: Dual proteome-scale networks reveal cell-specific remodeling of the human
-    interactome.
+  title: Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.
   findings: []
 - id: PMID:34800366
-  title: Quantitative high-confidence human mitochondrial proteome and its dynamics
-    in cellular context.
+  title: Quantitative high-confidence human mitochondrial proteome and its dynamics in cellular context.
   findings: []
+- id: file:human/PAM16/PAM16-deep-research-falcon.md
+  title: Falcon deep research report for human PAM16
+  findings: []
+core_functions:
+- description: PAM16 is the matrix-facing regulatory J-like cochaperone/adaptor subunit of the PAM complex
+    that forms a subcomplex with Pam18/Tim14, recruits and restrains Pam18 activity, and tunes mtHsp70-powered
+    import of presequence-containing proteins into the mitochondrial matrix.
+  supported_by:
+  - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+    supporting_text: Most mitochondrial matrix proteins are encoded in the nucleus, translated in the cytosol,
+      and imported into mitochondria. The **TIM23 complex** (inner membrane presequence translocase) mediates
+      import of presequence-containing proteins; for matrix translocation, TIM23 couples to the **PAM
+      (presequence translocase-associated motor)**, which uses an **mtHsp70 ATPase cycle** to pull precursor
+      polypeptides into the matrix. (sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages
+      4-5)
+  - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+    supporting_text: PAM16 (MAGMAS/TIM16/TIMM16) is an essential subunit of the **TIM23-associated PAM
+      motor**. Mechanistically, it forms a stable subcomplex with Pam18/Tim14 and is described as (i)
+      **recruiting Pam18** to the import channel and (ii) **controlling Pam18 activity**, thereby indirectly
+      regulating mtHsp70’s ATP-driven pulling activity during translocation into the matrix.
+      (sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5)
+  - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+    supporting_text: 'A recurring mechanistic interpretation is that Pam16/MAGMAS functions antagonistically to
+      Pam18: it is required for correct association of the motor with the translocon and **inhibits Pam18-mediated
+      stimulation of mtHsp70 ATPase activity**, thus tuning the import motor’s activity. (riva2018ajourneythrough
+      pages 11-15, jain2025investigatingmitochondrialpresequence pages 15-17)'
+  - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+    supporting_text: '**PAM16 (Q9Y3D7; MAGMAS/TIM16/TIMM16)** is a mitochondrial, inner-membrane-associated (matrix-facing)
+      **regulatory subunit of the TIM23 presequence import motor (PAM complex)**. Its defining molecular feature
+      is a **degenerate J-like domain lacking the HPD motif**, consistent with a function in **forming a heterodimer
+      with Pam18 and modulating Pam18’s stimulation of mtHsp70 ATPase activity**, thereby tuning ATP-dependent protein
+      translocation into the mitochondrial matrix. Disease relevance includes database-supported association with
+      **autosomal recessive spondylometaphyseal dysplasia (Megarbane type)** and literature-supported roles in tumor
+      cell survival/chemoresistance with reported overexpression frequencies in prostate cancer and pituitary adenomas.
+      (riva2018ajourneythrough pages 11-15, sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages
+      4-5, OpenTargets Search: -PAM16,TIMM16,MAGMAS)'
+  molecular_function:
+    id: GO:0030674
+    label: protein-macromolecule adaptor activity
+  directly_involved_in:
+  - id: GO:0030150
+    label: protein import into mitochondrial matrix
+  locations:
+  - id: GO:0099617
+    label: matrix side of mitochondrial inner membrane
+  - id: GO:0005743
+    label: mitochondrial inner membrane
+  in_complex:
+    id: GO:0001405
+    label: PAM complex, Tim23 associated import motor
+proposed_new_terms: []
+suggested_questions:
+- question: Which human PAM16 surfaces are required for Pam18 recruitment versus inhibition of
+    Pam18-stimulated mtHsp70 ATPase activity?
+  experts: []
+- question: How do skeletal dysplasia variants alter PAM16 stability, Pam18 binding, and matrix import flux in
+    patient-relevant cells?
+  experts: []
+suggested_experiments:
+- hypothesis: PAM16 disease variants impair matrix import by destabilizing the Pam16-Pam18 regulatory
+    subcomplex.
+  description: Measure Pam18 binding, PAM/TIM23 association, mtHsp70 ATPase regulation, and matrix-import
+    reporter flux after rescue of PAM16-null human cells with wild-type and disease-variant PAM16.
+- hypothesis: PAM16 overexpression phenotypes in cancer models derive from altered PAM motor activity rather
+    than a separate enzymatic function.
+  description: Compare acute PAM16 knockdown or overexpression with Pam18-interface mutants for precursor
+    import, mitochondrial proteostasis, apoptosis sensitivity, and respiratory function.

--- a/genes/human/PAM16/PAM16-ai-review.yaml
+++ b/genes/human/PAM16/PAM16-ai-review.yaml
@@ -719,36 +719,37 @@ existing_annotations:
 - term:
     id: GO:0030674
     label: protein-macromolecule adaptor activity
-  evidence_type: NAS
-  original_reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
+  evidence_type: IDA
+  original_reference_id: PMID:20053669
   review:
-    summary: New annotation. PAM16 functions as a regulatory adaptor/cochaperone that recruits and controls
-      Pam18 at the import channel rather than acting as an enzyme or transporter.
+    summary: New annotation. PAM16 functions as a regulatory adaptor/cochaperone that forms a
+      Magmas-DnaJC19/Pam18 subcomplex, tethers the J-protein component to the translocon, and restrains
+      Pam18-stimulated mtHsp70 ATPase activity.
     action: NEW
     reason: PAM16 has a specific adaptor/cochaperone role in the PAM motor that is more informative than
       generic protein binding and is not present in GOA.
     supported_by:
-    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
-      supporting_text: '**PAM16 is not an enzyme catalyzing a metabolic reaction nor a transporter substrate-binding
-        channel.** Instead, it functions as a **regulatory cochaperone/adaptor** within the import motor. It is
-        described as a **J-like** protein (Hsp40/J-domain superfamily-like) that regulates the activity and positioning
-        of the true J-domain cochaperone **Pam18/Tim14** (metazoan functional ortholog often discussed as DNAJC19/Pam18
-        in the PAM motor context) which stimulates mtHsp70 ATPase activity. (sinha2017thecomplexitiesofa pages 4-5,
-        sinha2017thecomplexitiesof pages 4-5, riva2018ajourneythrough pages 11-15)'
+    - reference_id: PMID:20053669
+      supporting_text: Moreover, Magmas interacts with yeast Pam18 as well as human DnaJC19 (ortholog of yeast
+        Pam18) both in vivo and in vitro conditions to form a heterodimeric subcomplex.
+    - reference_id: PMID:20053669
+      supporting_text: Our results are consistent with the existence of stable interaction between Magmas and
+        DnaJC19 that plays a crucial role in tethering of DnaJC19 at the translocon and perhaps regulating
+        human import motor activity.
+    - reference_id: PMID:19564938
+      supporting_text: A similar effect was observed using human Tim16/Pam16s, which inhibited the increase in
+        the ATPase activity of mtHsp70 (obtained due to the presence of yTim14/Pam18) by almost 50%. The
+        latter result indicates that hTim16/Pam16s can replace its yeast Tim16/Pam18s homologue, in vitro, and
+        can act as a negative regulator of yTim14/Pam18.
     - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
       supporting_text: PAM16 (MAGMAS/TIM16/TIMM16) is an essential subunit of the **TIM23-associated PAM
         motor**. Mechanistically, it forms a stable subcomplex with Pam18/Tim14 and is described as (i)
         **recruiting Pam18** to the import channel and (ii) **controlling Pam18 activity**, thereby indirectly
         regulating mtHsp70’s ATP-driven pulling activity during translocation into the matrix.
         (sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5)
-    - reference_id: file:human/PAM16/PAM16-deep-research-falcon.md
-      supporting_text: '| Mechanistic role | PAM16 is primarily a **regulatory cochaperone/adaptor**, not an enzyme
-        or transporter substrate-binding transporter itself. It forms a stable subcomplex with Pam18 and **recruits/controls
-        Pam18 at the import channel**, thereby **modulating Pam18-driven stimulation of mtHsp70 ATPase activity**
-        and fine-tuning the ATP-dependent import motor. It is described as a **negative regulator/antagonist** of
-        Pam18’s stimulatory effect on mtHsp70. | (riva2018ajourneythrough pages 11-15, sinha2017thecomplexitiesofa
-        pages 4-5, jain2025investigatingmitochondrialpresequence pages 15-17, sinha2017thecomplexitiesof pages 4-5)
-        | Riva 2018; Sinha 2017; Jain 2025 thesis, https://doi.org/10.53846/goediss-11596 |'
+    additional_reference_ids:
+    - file:human/PAM16/PAM16-deep-research-falcon.md
+    - PMID:19564938
 references:
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO terms

--- a/genes/human/PAM16/PAM16-deep-research-falcon.md
+++ b/genes/human/PAM16/PAM16-deep-research-falcon.md
@@ -1,0 +1,295 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-11T18:16:43.304197'
+end_time: '2026-05-11T18:24:57.634760'
+duration_seconds: 494.33
+template_file: templates/gene_research_go_focused.md
+template_variables:
+  organism: human
+  gene_id: PAM16
+  gene_symbol: PAM16
+  uniprot_accession: Q9Y3D7
+  protein_description: 'RecName: Full=Mitochondrial import inner membrane translocase
+    subunit TIM16; AltName: Full=Mitochondria-associated granulocyte macrophage CSF-signaling
+    molecule; AltName: Full=Presequence translocated-associated motor subunit PAM16;'
+  gene_info: Name=PAM16; Synonyms=MAGMAS, TIM16, TIMM16; ORFNames=CGI-136;
+  organism_full: Homo sapiens (Human).
+  protein_family: Belongs to the TIM16/PAM16 family. .
+  protein_domains: J_dom_sf. (IPR036869); Tim16. (IPR005341); Pam16 (PF03656)
+provider_config:
+  timeout: 600
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 18
+---
+
+## Question
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** Q9Y3D7
+- **Protein Description:** RecName: Full=Mitochondrial import inner membrane translocase subunit TIM16; AltName: Full=Mitochondria-associated granulocyte macrophage CSF-signaling molecule; AltName: Full=Presequence translocated-associated motor subunit PAM16;
+- **Gene Information:** Name=PAM16; Synonyms=MAGMAS, TIM16, TIMM16; ORFNames=CGI-136;
+- **Organism (full):** Homo sapiens (Human).
+- **Protein Family:** Belongs to the TIM16/PAM16 family. .
+- **Key Domains:** J_dom_sf. (IPR036869); Tim16. (IPR005341); Pam16 (PF03656)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "PAM16" matches the protein description above**
+2. **Verify the organism is correct:** Homo sapiens (Human).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'PAM16' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **PAM16** (gene ID: PAM16, UniProt: Q9Y3D7) in human.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** Q9Y3D7
+- **Protein Description:** RecName: Full=Mitochondrial import inner membrane translocase subunit TIM16; AltName: Full=Mitochondria-associated granulocyte macrophage CSF-signaling molecule; AltName: Full=Presequence translocated-associated motor subunit PAM16;
+- **Gene Information:** Name=PAM16; Synonyms=MAGMAS, TIM16, TIMM16; ORFNames=CGI-136;
+- **Organism (full):** Homo sapiens (Human).
+- **Protein Family:** Belongs to the TIM16/PAM16 family. .
+- **Key Domains:** J_dom_sf. (IPR036869); Tim16. (IPR005341); Pam16 (PF03656)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "PAM16" matches the protein description above**
+2. **Verify the organism is correct:** Homo sapiens (Human).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'PAM16' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **PAM16** (gene ID: PAM16, UniProt: Q9Y3D7) in human.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+# Comprehensive Research Report: Human **PAM16** (UniProt **Q9Y3D7**; synonyms **MAGMAS/TIM16/TIMM16**)
+
+## 0) Scope and gene/protein verification (mandatory)
+The literature and database evidence summarized here consistently refers to **human PAM16** as **MAGMAS/TIM16/TIMM16**, a small mitochondrial protein (~125 aa; ~13 kDa) that is part of the **TIM23-associated presequence import motor (PAM complex)**. This matches the UniProt description for Q9Y3D7 (mitochondrial import inner membrane translocase subunit TIM16 / PAM16 family), including the hallmark **J-like domain** and functional role in mitochondrial protein import. (riva2018ajourneythrough pages 11-15, riva2018ajourneythrough pages 8-11, sinha2017thecomplexitiesofa pages 4-5)
+
+## 1) Key concepts and definitions (current understanding)
+
+### 1.1 Mitochondrial presequence import (TIM23) and the PAM motor
+Most mitochondrial matrix proteins are encoded in the nucleus, translated in the cytosol, and imported into mitochondria. The **TIM23 complex** (inner membrane presequence translocase) mediates import of presequence-containing proteins; for matrix translocation, TIM23 couples to the **PAM (presequence translocase-associated motor)**, which uses an **mtHsp70 ATPase cycle** to pull precursor polypeptides into the matrix. (sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5)
+
+### 1.2 What PAM16 is (and is not)
+**PAM16 is not an enzyme catalyzing a metabolic reaction nor a transporter substrate-binding channel.** Instead, it functions as a **regulatory cochaperone/adaptor** within the import motor. It is described as a **J-like** protein (Hsp40/J-domain superfamily-like) that regulates the activity and positioning of the true J-domain cochaperone **Pam18/Tim14** (metazoan functional ortholog often discussed as DNAJC19/Pam18 in the PAM motor context) which stimulates mtHsp70 ATPase activity. (sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5, riva2018ajourneythrough pages 11-15)
+
+### 1.3 Domain architecture: J-like domain lacking the canonical HPD motif
+A key defining concept for PAM16 family proteins is that they contain a **degenerate J-like domain** that resembles a J-domain fold but lacks the invariant **HPD** tripeptide required for canonical J-domain stimulation of Hsp70 ATPase activity. In the retrieved human MAGMAS/PAM16-focused review, the J-like domain is placed at **aa 54–117** and is reported to contain **DKE** in place of HPD, consistent with an **inhibitory/regulatory** (rather than stimulatory) role. (riva2018ajourneythrough pages 11-15, jain2025investigatingmitochondrialpresequence pages 15-17, riva2018ajourneythrough pages 79-82)
+
+## 2) Core biological function and mechanism (functional annotation)
+
+### 2.1 Primary function: regulation of the TIM23-PAM import motor
+PAM16 (MAGMAS/TIM16/TIMM16) is an essential subunit of the **TIM23-associated PAM motor**. Mechanistically, it forms a stable subcomplex with Pam18/Tim14 and is described as (i) **recruiting Pam18** to the import channel and (ii) **controlling Pam18 activity**, thereby indirectly regulating mtHsp70’s ATP-driven pulling activity during translocation into the matrix. (sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5)
+
+### 2.2 Antagonism/negative regulation of Pam18-stimulated mtHsp70 ATPase
+A recurring mechanistic interpretation is that Pam16/MAGMAS functions antagonistically to Pam18: it is required for correct association of the motor with the translocon and **inhibits Pam18-mediated stimulation of mtHsp70 ATPase activity**, thus tuning the import motor’s activity. (riva2018ajourneythrough pages 11-15, jain2025investigatingmitochondrialpresequence pages 15-17)
+
+### 2.3 Interacting partners and complex membership
+Across the retrieved reviews, PAM16 is placed within the PAM motor with the following canonical partners:
+- **Pam18/Tim14** (J-domain protein that stimulates mtHsp70 ATPase; PAM16 forms a stable complex with it)
+- **Tim44** (inner membrane-associated scaffold/adaptor that recruits mtHsp70 at the channel outlet)
+- **mtHsp70** (central ATP-driven motor/chaperone)
+- **Mge1/GrpE-like nucleotide exchange factor** (facilitates ADP/ATP exchange on mtHsp70; metazoan homologs include GRPEL family)
+- **Pam17** (organization factor; deletion disrupts association of Pam16/Pam18 with translocase in yeast-centric mechanistic discussions)
+These interactions are discussed as part of the motor architecture that couples the TIM23 channel to mtHsp70-driven translocation. (sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 5-6, sinha2017thecomplexitiesof pages 4-5, riva2018ajourneythrough pages 11-15)
+
+A specific interaction detail reported in the MAGMAS review is the Pam16–Pam18 heterodimer interface involving **L97 of Pam16** and **L150 of Pam18**. (riva2018ajourneythrough pages 11-15)
+
+## 3) Cellular and sub-mitochondrial localization
+PAM16/MAGMAS is localized to **mitochondria** and described as a **peripheral membrane protein** associated with the TIM23/PAM machinery at the **inner membrane, matrix-facing side**. One source explicitly notes that it does **not extend into the intermembrane space (IMS)**, consistent with a matrix-side role in regulating the mtHsp70 motor. (riva2018ajourneythrough pages 11-15, sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5)
+
+## 4) Disease relevance and phenotypic associations
+
+### 4.1 Mendelian disease association (database-level evidence)
+Open Targets returns PAM16 disease associations including **autosomal recessive spondylometaphyseal dysplasia, Megarbane type**, with a reported association score around **0.58** and **evidence size = 5** in the displayed summary, alongside other weaker associations (e.g., neurodegenerative disease, Parkinson disease, nephronophthisis) with evidence size = 5 in this snapshot. (OpenTargets Search: -PAM16,TIMM16,MAGMAS)
+
+### 4.2 PAM16/MAGMAS in cancer biology (quantitative observations)
+A MAGMAS-focused review summarizing experimental literature reports overexpression of MAGMAS in malignancy contexts, including:
+- **~50% of prostate cancers** with MAGMAS overexpression
+- **~72% of human pituitary adenomas** with MAGMAS overexpression
+The same source summarizes functional phenotypes: MAGMAS overexpression is associated with **reduced apoptosis** (e.g., reduced cytochrome c release; altered BAX/Bcl2 balance; reduced ROS), whereas silencing reduces DNA synthesis and causes **G0/G1 accumulation**, consistent with a pro-survival/proliferative role in some tumor models. (riva2018ajourneythrough pages 11-15, sinha2017thecomplexitiesof pages 5-6)
+
+## 5) Recent developments and latest research (prioritize 2023–2024)
+
+### 5.1 2023: reinforcement of TIM23/PAM module connectivity around mtHsp70
+Although not centered on PAM16 specifically, **Song et al. (Nature Communications, publication year 2023; DOI URL below)** reports biochemical association/co-purification behavior in yeast mitochondria in which **TIM23 and PAM subunits** are discussed together, and explicitly lists **Tim17, Tim44, Pam16 and Pam18** as co-associated components in the mtHsp70-centered context (TIM23/PAM module). This supports the continued relevance of the canonical import-motor composition and connectivity in contemporary mitochondrial protein biogenesis research.
+- URL: https://doi.org/10.1038/s41467-022-35720-5 (published in 2023; article metadata in the retrieved text) (song2023themitochondrialhsp70 pages 6-7, song2023themitochondrialhsp70 pages 7-9)
+
+### 5.2 2024: evolutionary repurposing of Pam16/Pam18 outside canonical import
+**von Känel et al. (PLOS Biology; Aug 2024)** shows that in *Trypanosoma brucei* the Pam16/Pam18 module has been evolutionarily repurposed away from canonical TIM23-mediated import toward regulation of **mitochondrial DNA (maxicircle) replication**, while still retaining features such as essentiality and apparent Pam16–Pam18 functional linkage (TbPam16 stability depending on TbPam18). Although this is not human biology, it is a high-quality 2024 study reinforcing that Pam16/Pam18 are ancient and adaptable regulatory modules normally tied to mitochondrial biogenesis.
+- Publication date: Aug 2024
+- URL: https://doi.org/10.1371/journal.pbio.3002449 (kanel2024pam16andpam18 pages 1-2, kanel2024pam16andpam18 pages 2-3)
+
+### 5.3 Evidence limitations for 2023–2024 human-specific PAM16 mechanistic advances
+Within the retrieved and accessible full text in this run, **direct 2023–2024 human-specific PAM16 mechanistic/structural studies were limited**; therefore, the “latest research” section relies on (i) 2023–2024 peer-reviewed work that contextualizes the PAM module and (ii) database-level disease association evidence, while the most explicit molecular mechanism statements come from earlier but focused reviews. (sinha2017thecomplexitiesofa pages 4-5, riva2018ajourneythrough pages 11-15, OpenTargets Search: -PAM16,TIMM16,MAGMAS)
+
+## 6) Current applications and real-world implementations
+
+### 6.1 Functional annotation use-cases
+In practice, PAM16 is used as a **marker/component** of the TIM23 presequence import motor in studies of:
+- mitochondrial protein import capacity and proteostasis
+- mtHsp70 cochaperone regulation
+- mitochondrial stress phenotypes linked to import machinery perturbation
+These applications follow directly from its described role as a regulator of Pam18/mtHsp70 at the TIM23 outlet. (sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5, riva2018ajourneythrough pages 11-15)
+
+### 6.2 Translational relevance
+The strongest “real-world” relevance in the retrieved corpus is twofold:
+- **Rare disease genetics**: association to Megarbane-type spondylometaphyseal dysplasia in disease-target resources (OpenTargets Search: -PAM16,TIMM16,MAGMAS).
+- **Cancer biology**: summarized overexpression frequencies and anti-apoptotic phenotypes in prostate cancer and pituitary adenomas, suggesting potential biomarker or vulnerability hypotheses. (riva2018ajourneythrough pages 11-15)
+
+## 7) Expert opinions / authoritative synthesis
+Two review-style sources in this evidence set frame PAM16 as a **regulatory, membrane-associated J-like cochaperone** whose main purpose is to **position and restrain Pam18**, thereby tuning mtHsp70-driven import:
+- A review on human inner membrane translocases emphasizes Pam16’s role in recruiting and controlling Pam18, and placing Pam16 within the TIM23-associated Hsp70-based motor. (sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5)
+- A MAGMAS-focused review integrates the import-motor role with disease/cancer phenotypes, emphasizing the degenerate J-like domain and antagonism of Pam18 stimulation of mtHsp70. (riva2018ajourneythrough pages 11-15)
+
+## 8) Summary table (evidence map)
+| Category | Key points | Best supporting citations (by context IDs) | Key sources with year/URL when available |
+|---|---|---|---|
+| Identity/synonyms | Human **PAM16** matches UniProt **Q9Y3D7** and is also referred to as **MAGMAS**, **TIM16**, and **TIMM16**; it encodes a small mitochondrial protein (~125 aa, ~13 kDa) that is part of the presequence translocase-associated motor linked to TIM23. | (riva2018ajourneythrough pages 11-15, riva2018ajourneythrough pages 8-11, sinha2017thecomplexitiesofa pages 4-5) | Riva 2018, *A journey through in vitro and in vivo models to understand the role of Magmas in cancer chemoresistance*; Sinha 2017, *The complexities of human mitochondrial inner-membrane protein translocases in maintenance of organeller function* |
+| Domain features | PAM16/MAGMAS contains a **degenerate J-like domain** (reported aa 54-117) related to Hsp40/J-domains but lacking the canonical **HPD** motif required for ATPase stimulation; reported substitution is **DKE** instead. This fits UniProt/InterPro family assignment to TIM16/PAM16 and a J-domain superfamily-like fold. | (riva2018ajourneythrough pages 11-15, riva2018ajourneythrough pages 79-82, jain2025investigatingmitochondrialpresequence pages 15-17) | Riva 2018; Jain 2025 thesis, https://doi.org/10.53846/goediss-11596 |
+| Complex/pathway | PAM16 is a component of the **mitochondrial TIM23 presequence import pathway**, specifically the **PAM (presequence translocase-associated motor)** that acts on matrix-destined precursor proteins after passage through TOM/TIM23. PAM motor subunits described with PAM16 include **Pam18/Tim14 (human ortholog DNAJC19/Pam18)**, **Tim44**, **mtHsp70**, and **Mge1/GRPEL1-like nucleotide exchange factor**. | (riva2018ajourneythrough pages 11-15, sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 5-6, sinha2017thecomplexitiesof pages 4-5) | Sinha 2017; Zhao & Zou 2021, *Front Cardiovasc Med*, https://doi.org/10.3389/fcvm.2021.749756 |
+| Mechanistic role | PAM16 is primarily a **regulatory cochaperone/adaptor**, not an enzyme or transporter substrate-binding transporter itself. It forms a stable subcomplex with Pam18 and **recruits/controls Pam18 at the import channel**, thereby **modulating Pam18-driven stimulation of mtHsp70 ATPase activity** and fine-tuning the ATP-dependent import motor. It is described as a **negative regulator/antagonist** of Pam18’s stimulatory effect on mtHsp70. | (riva2018ajourneythrough pages 11-15, sinha2017thecomplexitiesofa pages 4-5, jain2025investigatingmitochondrialpresequence pages 15-17, sinha2017thecomplexitiesof pages 4-5) | Riva 2018; Sinha 2017; Jain 2025 thesis, https://doi.org/10.53846/goediss-11596 |
+| Interacting partners | Best-supported partners are **Pam18/Tim14 (DNAJC19 orthologous role in metazoan TIM23 motor)**, **Tim44**, **mtHsp70**, **Mge1**, and the **TIM23 core translocase**. Reported interaction details include a tight Pam16-Pam18 heterodimer and cited residue contacts such as **L97 of Pam16** with **L150 of Pam18**. Pam17 is reported to help maintain the Pam16-Pam18 module at the translocase. | (riva2018ajourneythrough pages 11-15, sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 5-6, sinha2017thecomplexitiesof pages 4-5) | Riva 2018; Sinha 2017; Song et al. 2023, *Nat Commun*, https://doi.org/10.1038/s41467-022-35720-5 |
+| Localization | PAM16/MAGMAS is a **mitochondrial** protein associated with the **inner membrane on the matrix side** as a **peripheral membrane-associated** component of the TIM23/PAM machinery; reports note it does **not extend into the IMS**. Function is therefore carried out at the **matrix-facing exit of the TIM23 channel** where precursor pulling/folding occurs. | (riva2018ajourneythrough pages 11-15, sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5) | Riva 2018; Sinha 2017 |
+| Disease/phenotype links | PAM16 has recognized disease links, including **autosomal recessive spondylometaphyseal dysplasia, Megarbane type** in disease databases. Literature summarized in retrieved sources also links **MAGMAS overexpression** to neoplasia, including **prostate cancer**, **pituitary adenomas**, and anti-apoptotic/chemoresistance phenotypes. Open Targets also lists associations to neurodegenerative disease/Parkinson disease, but these are weaker database associations than the skeletal dysplasia link. | (riva2018ajourneythrough pages 11-15, sinha2017thecomplexitiesof pages 12-14, zhao2023mitochondrialskeletaldisorders pages 8-11, OpenTargets Search: -PAM16,TIMM16,MAGMAS) | Open Targets platform search context; Zhao 2023 dissertation; Riva 2018 |
+| Quantitative data | Reported quantitative observations include **overexpression in ~50% of prostate cancers** and **~72% of human pituitary adenomas**; MAGMAS silencing reduced DNA synthesis and caused **G0/G1 accumulation** in cited cancer models. Open Targets evidence summaries show disease-association evidence counts of **5** for several PAM16-linked diseases and highest listed score here for **autosomal recessive spondylometaphyseal dysplasia, Megarbane type** (**0.5824**). | (riva2018ajourneythrough pages 11-15, OpenTargets Search: -PAM16,TIMM16,MAGMAS) | Riva 2018; Open Targets platform context |
+| Recent (2023-2024) updates/related work | Direct human PAM16-specific 2023-2024 mechanistic advances were limited in retrieved material, but related recent work reinforces the **mtHsp70-centered PAM/TIM23 framework**. **Song et al. 2023** showed mtHsp70 remains physically associated with **Tim17, Tim44, Pam16, and Pam18** in mitochondrial interactome/co-purification analyses, supporting persistent linkage of PAM16 to mtHsp70-centered protein biogenesis networks. **von Känel et al. 2024** provided evolutionary evidence that Pam16/Pam18 are ancient regulatory modules normally tied to import, though repurposed in *T. brucei* for mitochondrial DNA replication rather than canonical import. | (kanel2024pam16andpam18 pages 2-3, kanel2024pam16andpam18 pages 1-2, song2023themitochondrialhsp70 pages 6-7, song2023themitochondrialhsp70 pages 9-11, song2023themitochondrialhsp70 pages 7-9) | Song et al. 2023, *Nature Communications*, 2023-01, https://doi.org/10.1038/s41467-022-35720-5; von Känel et al. 2024, *PLOS Biology*, 2024-08, https://doi.org/10.1371/journal.pbio.3002449 |
+
+
+*Table: This table summarizes verified identity, domain architecture, TIM23/PAM role, localization, disease relevance, quantitative findings, and recent literature context for human PAM16 (UniProt Q9Y3D7). It is useful as a concise evidence map for functional annotation with direct context-ID citations.*
+
+## 9) Key URLs (from retrieved sources)
+- Song J et al. *Nature Communications* (2023). “The mitochondrial Hsp70 controls the assembly of the F1FO-ATP synthase.” https://doi.org/10.1038/s41467-022-35720-5 (song2023themitochondrialhsp70 pages 6-7, song2023themitochondrialhsp70 pages 7-9)
+- von Känel C et al. *PLOS Biology* (Aug 2024). “Pam16 and Pam18 were repurposed during Trypanosoma brucei evolution to regulate the replication of mitochondrial DNA.” https://doi.org/10.1371/journal.pbio.3002449 (kanel2024pam16andpam18 pages 1-2)
+- Zhao F, Zou M-H. *Frontiers in Cardiovascular Medicine* (Sep 2021). “Role of the Mitochondrial Protein Import Machinery and Protein Processing in Heart Disease.” https://doi.org/10.3389/fcvm.2021.749756 (sinha2017thecomplexitiesofa pages 4-5)
+
+## 10) Conclusion (functional annotation statement)
+**PAM16 (Q9Y3D7; MAGMAS/TIM16/TIMM16)** is a mitochondrial, inner-membrane-associated (matrix-facing) **regulatory subunit of the TIM23 presequence import motor (PAM complex)**. Its defining molecular feature is a **degenerate J-like domain lacking the HPD motif**, consistent with a function in **forming a heterodimer with Pam18 and modulating Pam18’s stimulation of mtHsp70 ATPase activity**, thereby tuning ATP-dependent protein translocation into the mitochondrial matrix. Disease relevance includes database-supported association with **autosomal recessive spondylometaphyseal dysplasia (Megarbane type)** and literature-supported roles in tumor cell survival/chemoresistance with reported overexpression frequencies in prostate cancer and pituitary adenomas. (riva2018ajourneythrough pages 11-15, sinha2017thecomplexitiesofa pages 4-5, sinha2017thecomplexitiesof pages 4-5, OpenTargets Search: -PAM16,TIMM16,MAGMAS)
+
+References
+
+1. (riva2018ajourneythrough pages 11-15): E Riva. A journey through in vitro and in vivo models to understand the role of magmas in cancer chemoresistance. Unknown journal, 2018.
+
+2. (riva2018ajourneythrough pages 8-11): E Riva. A journey through in vitro and in vivo models to understand the role of magmas in cancer chemoresistance. Unknown journal, 2018.
+
+3. (sinha2017thecomplexitiesofa pages 4-5): D Sinha. The complexities of human mitochondrial inner-membrane protein translocases in maintenance of organeller function. Unknown journal, 2017.
+
+4. (sinha2017thecomplexitiesof pages 4-5): D Sinha. The complexities of human mitochondrial inner-membrane protein translocases in maintenance of organeller function. Unknown journal, 2017.
+
+5. (jain2025investigatingmitochondrialpresequence pages 15-17): Naintara Jain. Investigating Mitochondrial Presequence Import. PhD thesis, University Goettingen, 2025. URL: https://doi.org/10.53846/goediss-11596, doi:10.53846/goediss-11596.
+
+6. (riva2018ajourneythrough pages 79-82): E Riva. A journey through in vitro and in vivo models to understand the role of magmas in cancer chemoresistance. Unknown journal, 2018.
+
+7. (sinha2017thecomplexitiesof pages 5-6): D Sinha. The complexities of human mitochondrial inner-membrane protein translocases in maintenance of organeller function. Unknown journal, 2017.
+
+8. (OpenTargets Search: -PAM16,TIMM16,MAGMAS): Open Targets Query (-PAM16,TIMM16,MAGMAS, 5 results). Buniello, A. et al. (2025). Open Targets Platform: facilitating therapeutic hypotheses building in drug discovery. Nucleic Acids Research.
+
+9. (song2023themitochondrialhsp70 pages 6-7): Jiyao Song, Liesa Steidle, Isabelle Steymans, Jasjot Singh, Anne Sanner, Lena Böttinger, Dominic Winter, and Thomas Becker. The mitochondrial hsp70 controls the assembly of the f1fo-atp synthase. Nature Communications, Jan 2023. URL: https://doi.org/10.1038/s41467-022-35720-5, doi:10.1038/s41467-022-35720-5. This article has 25 citations and is from a highest quality peer-reviewed journal.
+
+10. (song2023themitochondrialhsp70 pages 7-9): Jiyao Song, Liesa Steidle, Isabelle Steymans, Jasjot Singh, Anne Sanner, Lena Böttinger, Dominic Winter, and Thomas Becker. The mitochondrial hsp70 controls the assembly of the f1fo-atp synthase. Nature Communications, Jan 2023. URL: https://doi.org/10.1038/s41467-022-35720-5, doi:10.1038/s41467-022-35720-5. This article has 25 citations and is from a highest quality peer-reviewed journal.
+
+11. (kanel2024pam16andpam18 pages 1-2): Corinne von Känel, Philip Stettler, Carmela Esposito, Stephan Berger, Simona Amodeo, Silke Oeljeklaus, Salvatore Calderaro, Ignacio M. Durante, Vendula Rašková, Bettina Warscheid, and André Schneider. Pam16 and pam18 were repurposed during trypanosoma brucei evolution to regulate the replication of mitochondrial dna. PLOS Biology, 22:e3002449, Aug 2024. URL: https://doi.org/10.1371/journal.pbio.3002449, doi:10.1371/journal.pbio.3002449. This article has 3 citations and is from a highest quality peer-reviewed journal.
+
+12. (kanel2024pam16andpam18 pages 2-3): Corinne von Känel, Philip Stettler, Carmela Esposito, Stephan Berger, Simona Amodeo, Silke Oeljeklaus, Salvatore Calderaro, Ignacio M. Durante, Vendula Rašková, Bettina Warscheid, and André Schneider. Pam16 and pam18 were repurposed during trypanosoma brucei evolution to regulate the replication of mitochondrial dna. PLOS Biology, 22:e3002449, Aug 2024. URL: https://doi.org/10.1371/journal.pbio.3002449, doi:10.1371/journal.pbio.3002449. This article has 3 citations and is from a highest quality peer-reviewed journal.
+
+13. (sinha2017thecomplexitiesof pages 12-14): D Sinha. The complexities of human mitochondrial inner-membrane protein translocases in maintenance of organeller function. Unknown journal, 2017.
+
+14. (zhao2023mitochondrialskeletaldisorders pages 8-11): Tian Rui Zhao. Mitochondrial skeletal disorders provide insight into the effect of mitochondrial proteostatic stress on steroidogenesis. Other, Sep 2023. URL: https://doi.org/10.11575/prism/42113, doi:10.11575/prism/42113. This article has 0 citations.
+
+15. (song2023themitochondrialhsp70 pages 9-11): Jiyao Song, Liesa Steidle, Isabelle Steymans, Jasjot Singh, Anne Sanner, Lena Böttinger, Dominic Winter, and Thomas Becker. The mitochondrial hsp70 controls the assembly of the f1fo-atp synthase. Nature Communications, Jan 2023. URL: https://doi.org/10.1038/s41467-022-35720-5, doi:10.1038/s41467-022-35720-5. This article has 25 citations and is from a highest quality peer-reviewed journal.
+
+## Citations
+
+1. riva2018ajourneythrough pages 11-15
+2. sinha2017thecomplexitiesofa pages 4-5
+3. riva2018ajourneythrough pages 8-11
+4. sinha2017thecomplexitiesof pages 4-5
+5. jain2025investigatingmitochondrialpresequence pages 15-17
+6. riva2018ajourneythrough pages 79-82
+7. sinha2017thecomplexitiesof pages 5-6
+8. sinha2017thecomplexitiesof pages 12-14
+9. zhao2023mitochondrialskeletaldisorders pages 8-11
+10. https://doi.org/10.1038/s41467-022-35720-5
+11. https://doi.org/10.1371/journal.pbio.3002449
+12. https://doi.org/10.53846/goediss-11596
+13. https://doi.org/10.3389/fcvm.2021.749756
+14. https://doi.org/10.1038/s41467-022-35720-5;
+15. https://doi.org/10.53846/goediss-11596,
+16. https://doi.org/10.1038/s41467-022-35720-5,
+17. https://doi.org/10.1371/journal.pbio.3002449,
+18. https://doi.org/10.11575/prism/42113,

--- a/genes/human/PMPCB/PMPCB-ai-review.html
+++ b/genes/human/PMPCB/PMPCB-ai-review.html
@@ -1,0 +1,4273 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>PMPCB - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>PMPCB</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/O75439" target="_blank" class="term-link">
+                        O75439
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "PMPCB";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="O75439" data-a="DESCRIPTION: PMPCB encodes the catalytic beta subunit of the mi..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>PMPCB encodes the catalytic beta subunit of the mitochondrial processing peptidase (MPP), a Zn2+-dependent metalloendopeptidase in the mitochondrial matrix that cleaves N-terminal targeting presequences from newly imported mitochondrial precursor proteins.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004222" target="_blank" class="term-link">
+                                    GO:0004222
+                                </a>
+                            </span>
+                            <span class="term-label">metalloendopeptidase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O75439" data-a="GO:0004222" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct and core. PMPCB is the catalytic Zn2+-dependent metalloendopeptidase subunit of MPP.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCB/PMPCB-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The UniProt accession **O75439** corresponds to **human PMPCB** (gene name **PMPCB**, synonym **MPPB**) annotated as **mitochondrial-processing peptidase subunit beta** (MPPβ), a member of the **peptidase M16 family** and the **catalytic β subunit** of the heterodimeric mitochondrial processing peptidase (MPP). This mapping (human PMPCB ↔ UniProt O75439) is explicitly supported by a review of mitochondrial processing peptidases that lists **Homo sapiens O75439** as the MPP subunit containing the characteristic inverted Zn-binding motif HxxEH…E required for activity, as well as by authoritative reviews describing human MPP as PMPCA (α) + PMPCB (β) with PMPCB harboring the catalytic site. (gakh2002mitochondrialprocessingpeptidases. pages 4-6, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, gala2021mitochondrialproteasesin pages 2-5, kunova2022mitochondrialprocessingpeptidases—structure pages 4-6)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCB/PMPCB-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">MPP is a **Zn2+-dependent metalloendopeptidase**. PMPCB contains the conserved inverted Zn-binding/catalytic motif **HxxEH…E** (with the distal glutamate contributing to Zn coordination). Mutation of residues in this motif abolishes Zn binding and peptidase activity, supporting that PMPCB is the catalytic subunit. (gakh2002mitochondrialprocessingpeptidases. pages 4-6, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCB/PMPCB-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Authoritative reviews converge on a model in which **PMPCB is the catalytic Zn metalloprotease** and **PMPCA contributes substrate recognition**, together enabling cleavage of a large fraction of imported mitochondrial proteins. This division of labor is supported by conserved motifs (active-site Zn-binding in β subunit), structural evidence (peptide binding in a negatively charged cavity, glycine-rich loop gating/positioning), and disease genetics demonstrating that partial disruption causes severe neurological phenotypes. (gala2021mitochondrialproteasesin pages 2-5, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, gakh2002mitochondrialprocessingpeptidases. pages 4-6)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0017087" target="_blank" class="term-link">
+                                    GO:0017087
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial processing peptidase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O75439" data-a="GO:0017087" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct and core. PMPCB forms the mitochondrial processing peptidase heterodimer with PMPCA.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCB/PMPCB-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The UniProt accession **O75439** corresponds to **human PMPCB** (gene name **PMPCB**, synonym **MPPB**) annotated as **mitochondrial-processing peptidase subunit beta** (MPPβ), a member of the **peptidase M16 family** and the **catalytic β subunit** of the heterodimeric mitochondrial processing peptidase (MPP). This mapping (human PMPCB ↔ UniProt O75439) is explicitly supported by a review of mitochondrial processing peptidases that lists **Homo sapiens O75439** as the MPP subunit containing the characteristic inverted Zn-binding motif HxxEH…E required for activity, as well as by authoritative reviews describing human MPP as PMPCA (α) + PMPCB (β) with PMPCB harboring the catalytic site. (gakh2002mitochondrialprocessingpeptidases. pages 4-6, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, gala2021mitochondrialproteasesin pages 2-5, kunova2022mitochondrialprocessingpeptidases—structure pages 4-6)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCB/PMPCB-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">| Complex membership | PMPCB forms the **MPP heterodimer** with **PMPCA (α-MPP)**; PMPCB provides catalysis, whereas PMPCA contributes substrate recognition/positioning via a glycine-rich loop and helps shape the substrate-binding cavity (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, gala2021mitochondrialproteasesin pages 2-5, kunova2022mitochondrialprocessingpeptidases—structure media e22ffe68). |</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004222" target="_blank" class="term-link">
+                                    GO:0004222
+                                </a>
+                            </span>
+                            <span class="term-label">metalloendopeptidase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O75439" data-a="GO:0004222" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct and core. PMPCB is the catalytic Zn2+-dependent metalloendopeptidase subunit of MPP.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCB/PMPCB-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The UniProt accession **O75439** corresponds to **human PMPCB** (gene name **PMPCB**, synonym **MPPB**) annotated as **mitochondrial-processing peptidase subunit beta** (MPPβ), a member of the **peptidase M16 family** and the **catalytic β subunit** of the heterodimeric mitochondrial processing peptidase (MPP). This mapping (human PMPCB ↔ UniProt O75439) is explicitly supported by a review of mitochondrial processing peptidases that lists **Homo sapiens O75439** as the MPP subunit containing the characteristic inverted Zn-binding motif HxxEH…E required for activity, as well as by authoritative reviews describing human MPP as PMPCA (α) + PMPCB (β) with PMPCB harboring the catalytic site. (gakh2002mitochondrialprocessingpeptidases. pages 4-6, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, gala2021mitochondrialproteasesin pages 2-5, kunova2022mitochondrialprocessingpeptidases—structure pages 4-6)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCB/PMPCB-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">MPP is a **Zn2+-dependent metalloendopeptidase**. PMPCB contains the conserved inverted Zn-binding/catalytic motif **HxxEH…E** (with the distal glutamate contributing to Zn coordination). Mutation of residues in this motif abolishes Zn binding and peptidase activity, supporting that PMPCB is the catalytic subunit. (gakh2002mitochondrialprocessingpeptidases. pages 4-6, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCB/PMPCB-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Authoritative reviews converge on a model in which **PMPCB is the catalytic Zn metalloprotease** and **PMPCA contributes substrate recognition**, together enabling cleavage of a large fraction of imported mitochondrial proteins. This division of labor is supported by conserved motifs (active-site Zn-binding in β subunit), structural evidence (peptide binding in a negatively charged cavity, glycine-rich loop gating/positioning), and disease genetics demonstrating that partial disruption causes severe neurological phenotypes. (gala2021mitochondrialproteasesin pages 2-5, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, gakh2002mitochondrialprocessingpeptidases. pages 4-6)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O75439" data-a="GO:0005759" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct. MPP/PMPCB acts in the mitochondrial matrix after precursor import through TOM/TIM.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCB/PMPCB-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">PMPCB functions in the **mitochondrial matrix** as part of MPP, acting on precursors after import via TOM/TIM pathways. (gala2021mitochondrialproteasesin pages 2-5, baker2025qualitycontrolat pages 4-5)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCB/PMPCB-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">In the canonical pathway, precursors are recognized and translocated through TOM and TIM machineries, then MPP removes the N-terminal targeting presequence in the matrix. Cleaved presequences are subsequently degraded by downstream peptidases (e.g., PreP), preventing accumulation of potentially disruptive targeting peptides. (baker2025qualitycontrolat pages 4-5, gala2021mitochondrialproteasesin pages 2-5)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006508" target="_blank" class="term-link">
+                                    GO:0006508
+                                </a>
+                            </span>
+                            <span class="term-label">proteolysis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O75439" data-a="GO:0006508" data-r="GO_REF:0000002" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct process family but too broad. PMPCB specifically performs mitochondrial presequence processing as the catalytic MPP subunit.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Prefer metalloendopeptidase activity and protein processing/presequence-cleavage terms over generic proteolysis.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCB/PMPCB-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">PMPCB provides the catalytic activity of MPP, which cleaves the **N-terminal mitochondrial targeting presequence** from mitochondrial precursor proteins after their translocation into mitochondria, yielding the mature protein N-terminus (or an intermediate for further processing by other peptidases). (gala2021mitochondrialproteasesin pages 2-5, taylor2001crystalstructuresof pages 1-2, baker2025qualitycontrolat pages 5-5)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCB/PMPCB-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Authoritative reviews converge on a model in which **PMPCB is the catalytic Zn metalloprotease** and **PMPCA contributes substrate recognition**, together enabling cleavage of a large fraction of imported mitochondrial proteins. This division of labor is supported by conserved motifs (active-site Zn-binding in β subunit), structural evidence (peptide binding in a negatively charged cavity, glycine-rich loop gating/positioning), and disease genetics demonstrating that partial disruption causes severe neurological phenotypes. (gala2021mitochondrialproteasesin pages 2-5, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, gakh2002mitochondrialprocessingpeptidases. pages 4-6)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009003" target="_blank" class="term-link">
+                                    GO:0009003
+                                </a>
+                            </span>
+                            <span class="term-label">signal peptidase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000003
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O75439" data-a="GO:0009003" data-r="GO_REF:0000003" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct. PMPCB cleaves mitochondrial targeting presequences; metalloendopeptidase activity captures the catalytic class more precisely.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCB/PMPCB-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Most mitochondrial proteins are nuclear-encoded, synthesized in the cytosol, and imported into mitochondria using N-terminal **mitochondrial targeting presequences** (often amphipathic, positively charged α-helices). These presequences generally must be cleaved after import for proper maturation and assembly of mitochondrial proteins. The central enzyme executing this step is the **mitochondrial processing peptidase (MPP)**. (gala2021mitochondrialproteasesin pages 2-5, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, taylor2001crystalstructuresof pages 1-2)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCB/PMPCB-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">PMPCB provides the catalytic activity of MPP, which cleaves the **N-terminal mitochondrial targeting presequence** from mitochondrial precursor proteins after their translocation into mitochondria, yielding the mature protein N-terminus (or an intermediate for further processing by other peptidases). (gala2021mitochondrialproteasesin pages 2-5, taylor2001crystalstructuresof pages 1-2, baker2025qualitycontrolat pages 5-5)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016485" target="_blank" class="term-link">
+                                    GO:0016485
+                                </a>
+                            </span>
+                            <span class="term-label">protein processing</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O75439" data-a="GO:0016485" data-r="GO_REF:0000117" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct and core. PMPCB processes newly imported mitochondrial precursor proteins by removing N-terminal targeting presequences.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCB/PMPCB-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Most mitochondrial proteins are nuclear-encoded, synthesized in the cytosol, and imported into mitochondria using N-terminal **mitochondrial targeting presequences** (often amphipathic, positively charged α-helices). These presequences generally must be cleaved after import for proper maturation and assembly of mitochondrial proteins. The central enzyme executing this step is the **mitochondrial processing peptidase (MPP)**. (gala2021mitochondrialproteasesin pages 2-5, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, taylor2001crystalstructuresof pages 1-2)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCB/PMPCB-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">PMPCB provides the catalytic activity of MPP, which cleaves the **N-terminal mitochondrial targeting presequence** from mitochondrial precursor proteins after their translocation into mitochondria, yielding the mature protein N-terminus (or an intermediate for further processing by other peptidases). (gala2021mitochondrialproteasesin pages 2-5, taylor2001crystalstructuresof pages 1-2, baker2025qualitycontrolat pages 5-5)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCB/PMPCB-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">In the canonical pathway, precursors are recognized and translocated through TOM and TIM machineries, then MPP removes the N-terminal targeting presequence in the matrix. Cleaved presequences are subsequently degraded by downstream peptidases (e.g., PreP), preventing accumulation of potentially disruptive targeting peptides. (baker2025qualitycontrolat pages 4-5, gala2021mitochondrialproteasesin pages 2-5)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046872" target="_blank" class="term-link">
+                                    GO:0046872
+                                </a>
+                            </span>
+                            <span class="term-label">metal ion binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O75439" data-a="GO:0046872" data-r="GO_REF:0000002" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct mechanistic feature but too generic. Zinc binding is integral to the metalloendopeptidase active site, so the enzyme activity term is more informative.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Prefer metalloendopeptidase activity over generic metal ion binding.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCB/PMPCB-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">MPP is a **Zn2+-dependent metalloendopeptidase**. PMPCB contains the conserved inverted Zn-binding/catalytic motif **HxxEH…E** (with the distal glutamate contributing to Zn coordination). Mutation of residues in this motif abolishes Zn binding and peptidase activity, supporting that PMPCB is the catalytic subunit. (gakh2002mitochondrialprocessingpeptidases. pages 4-6, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/32443488" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:32443488
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mitochondrial Protein Quality Control Mechanisms.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O75439" data-a="GO:0005739" data-r="PMID:32443488" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct but broad. PMPCB is specifically a mitochondrial matrix MPP complex subunit.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Prefer mitochondrial matrix and mitochondrial processing peptidase complex over generic mitochondrion.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCB/PMPCB-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">PMPCB functions in the **mitochondrial matrix** as part of MPP, acting on precursors after import via TOM/TIM pathways. (gala2021mitochondrialproteasesin pages 2-5, baker2025qualitycontrolat pages 4-5)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCB/PMPCB-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">| Complex membership | PMPCB forms the **MPP heterodimer** with **PMPCA (α-MPP)**; PMPCB provides catalysis, whereas PMPCA contributes substrate recognition/positioning via a glycine-rich loop and helps shape the substrate-binding cavity (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, gala2021mitochondrialproteasesin pages 2-5, kunova2022mitochondrialprocessingpeptidases—structure media e22ffe68). |</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0017087" target="_blank" class="term-link">
+                                    GO:0017087
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial processing peptidase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/32443488" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:32443488
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mitochondrial Protein Quality Control Mechanisms.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O75439" data-a="GO:0017087" data-r="PMID:32443488" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct and core. PMPCB forms the mitochondrial processing peptidase heterodimer with PMPCA.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCB/PMPCB-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The UniProt accession **O75439** corresponds to **human PMPCB** (gene name **PMPCB**, synonym **MPPB**) annotated as **mitochondrial-processing peptidase subunit beta** (MPPβ), a member of the **peptidase M16 family** and the **catalytic β subunit** of the heterodimeric mitochondrial processing peptidase (MPP). This mapping (human PMPCB ↔ UniProt O75439) is explicitly supported by a review of mitochondrial processing peptidases that lists **Homo sapiens O75439** as the MPP subunit containing the characteristic inverted Zn-binding motif HxxEH…E required for activity, as well as by authoritative reviews describing human MPP as PMPCA (α) + PMPCB (β) with PMPCB harboring the catalytic site. (gakh2002mitochondrialprocessingpeptidases. pages 4-6, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, gala2021mitochondrialproteasesin pages 2-5, kunova2022mitochondrialprocessingpeptidases—structure pages 4-6)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCB/PMPCB-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">| Complex membership | PMPCB forms the **MPP heterodimer** with **PMPCA (α-MPP)**; PMPCB provides catalysis, whereas PMPCA contributes substrate recognition/positioning via a glycine-rich loop and helps shape the substrate-binding cavity (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, gala2021mitochondrialproteasesin pages 2-5, kunova2022mitochondrialprocessingpeptidases—structure media e22ffe68). |</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070585" target="_blank" class="term-link">
+                                    GO:0070585
+                                </a>
+                            </span>
+                            <span class="term-label">protein localization to mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/32443488" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:32443488
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mitochondrial Protein Quality Control Mechanisms.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O75439" data-a="GO:0070585" data-r="PMID:32443488" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Over-annotated. PMPCB acts after protein import by cleaving targeting presequences; it is not itself the import/localization machinery.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Use protein processing and metalloendopeptidase activity rather than protein localization to mitochondrion.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCB/PMPCB-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">In the canonical pathway, precursors are recognized and translocated through TOM and TIM machineries, then MPP removes the N-terminal targeting presequence in the matrix. Cleaved presequences are subsequently degraded by downstream peptidases (e.g., PreP), preventing accumulation of potentially disruptive targeting peptides. (baker2025qualitycontrolat pages 4-5, gala2021mitochondrialproteasesin pages 2-5)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCB/PMPCB-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">PMPCB provides the catalytic activity of MPP, which cleaves the **N-terminal mitochondrial targeting presequence** from mitochondrial precursor proteins after their translocation into mitochondria, yielding the mature protein N-terminus (or an intermediate for further processing by other peptidases). (gala2021mitochondrialproteasesin pages 2-5, taylor2001crystalstructuresof pages 1-2, baker2025qualitycontrolat pages 5-5)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000052
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O75439" data-a="GO:0005739" data-r="GO_REF:0000052" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct but broad. PMPCB is specifically a mitochondrial matrix MPP complex subunit.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Prefer mitochondrial matrix and mitochondrial processing peptidase complex over generic mitochondrion.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCB/PMPCB-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">PMPCB functions in the **mitochondrial matrix** as part of MPP, acting on precursors after import via TOM/TIM pathways. (gala2021mitochondrialproteasesin pages 2-5, baker2025qualitycontrolat pages 4-5)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCB/PMPCB-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">| Complex membership | PMPCB forms the **MPP heterodimer** with **PMPCA (α-MPP)**; PMPCB provides catalysis, whereas PMPCA contributes substrate recognition/positioning via a glycine-rich loop and helps shape the substrate-binding cavity (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, gala2021mitochondrialproteasesin pages 2-5, kunova2022mitochondrialprocessingpeptidases—structure media e22ffe68). |</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006851" target="_blank" class="term-link">
+                                    GO:0006851
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial calcium ion transmembrane transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-8949215
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O75439" data-a="GO:0006851" data-r="Reactome:R-HSA-8949215" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Over-annotated. PMPCB can process proSMDT1/proEMRE, a component needed for MCU complex function, but PMPCB does not catalyze calcium transmembrane transport.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The Reactome event reflects MPP cleavage of an MCU-complex subunit precursor, not direct calcium ion transport by PMPCB.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-8949649
+
+                                </span>
+
+                                <div class="support-text">The mitochondrial endopeptidase PMPCA:PMPCB cleaves the transit peptide of proSMDT1 (proEMRE) yielding SMDT1 (Konig et al. 2016). Mature SMDT1 is assembled into the MCU complex where it serves to bridge the MCU pore and the MCU regulators MICU1 and MICU2 (or MICU3 in neurons).</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCB/PMPCB-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">PMPCB provides the catalytic activity of MPP, which cleaves the **N-terminal mitochondrial targeting presequence** from mitochondrial precursor proteins after their translocation into mitochondria, yielding the mature protein N-terminus (or an intermediate for further processing by other peptidases). (gala2021mitochondrialproteasesin pages 2-5, taylor2001crystalstructuresof pages 1-2, baker2025qualitycontrolat pages 5-5)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004222" target="_blank" class="term-link">
+                                    GO:0004222
+                                </a>
+                            </span>
+                            <span class="term-label">metalloendopeptidase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-8949649
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O75439" data-a="GO:0004222" data-r="Reactome:R-HSA-8949649" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct and core. PMPCB is the catalytic Zn2+-dependent metalloendopeptidase subunit of MPP.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCB/PMPCB-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The UniProt accession **O75439** corresponds to **human PMPCB** (gene name **PMPCB**, synonym **MPPB**) annotated as **mitochondrial-processing peptidase subunit beta** (MPPβ), a member of the **peptidase M16 family** and the **catalytic β subunit** of the heterodimeric mitochondrial processing peptidase (MPP). This mapping (human PMPCB ↔ UniProt O75439) is explicitly supported by a review of mitochondrial processing peptidases that lists **Homo sapiens O75439** as the MPP subunit containing the characteristic inverted Zn-binding motif HxxEH…E required for activity, as well as by authoritative reviews describing human MPP as PMPCA (α) + PMPCB (β) with PMPCB harboring the catalytic site. (gakh2002mitochondrialprocessingpeptidases. pages 4-6, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, gala2021mitochondrialproteasesin pages 2-5, kunova2022mitochondrialprocessingpeptidases—structure pages 4-6)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCB/PMPCB-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">MPP is a **Zn2+-dependent metalloendopeptidase**. PMPCB contains the conserved inverted Zn-binding/catalytic motif **HxxEH…E** (with the distal glutamate contributing to Zn coordination). Mutation of residues in this motif abolishes Zn binding and peptidase activity, supporting that PMPCB is the catalytic subunit. (gakh2002mitochondrialprocessingpeptidases. pages 4-6, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCB/PMPCB-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Authoritative reviews converge on a model in which **PMPCB is the catalytic Zn metalloprotease** and **PMPCA contributes substrate recognition**, together enabling cleavage of a large fraction of imported mitochondrial proteins. This division of labor is supported by conserved motifs (active-site Zn-binding in β subunit), structural evidence (peptide binding in a negatively charged cavity, glycine-rich loop gating/positioning), and disease genetics demonstrating that partial disruption causes severe neurological phenotypes. (gala2021mitochondrialproteasesin pages 2-5, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, gakh2002mitochondrialprocessingpeptidases. pages 4-6)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009003" target="_blank" class="term-link">
+                                    GO:0009003
+                                </a>
+                            </span>
+                            <span class="term-label">signal peptidase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O75439" data-a="GO:0009003" data-r="GO_REF:0000024" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct. PMPCB cleaves mitochondrial targeting presequences; metalloendopeptidase activity captures the catalytic class more precisely.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCB/PMPCB-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Most mitochondrial proteins are nuclear-encoded, synthesized in the cytosol, and imported into mitochondria using N-terminal **mitochondrial targeting presequences** (often amphipathic, positively charged α-helices). These presequences generally must be cleaved after import for proper maturation and assembly of mitochondrial proteins. The central enzyme executing this step is the **mitochondrial processing peptidase (MPP)**. (gala2021mitochondrialproteasesin pages 2-5, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, taylor2001crystalstructuresof pages 1-2)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCB/PMPCB-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">PMPCB provides the catalytic activity of MPP, which cleaves the **N-terminal mitochondrial targeting presequence** from mitochondrial precursor proteins after their translocation into mitochondria, yielding the mature protein N-terminus (or an intermediate for further processing by other peptidases). (gala2021mitochondrialproteasesin pages 2-5, taylor2001crystalstructuresof pages 1-2, baker2025qualitycontrolat pages 5-5)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016485" target="_blank" class="term-link">
+                                    GO:0016485
+                                </a>
+                            </span>
+                            <span class="term-label">protein processing</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/22354088" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:22354088
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mitochondrial processing peptidase regulates PINK1 processin...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O75439" data-a="GO:0016485" data-r="PMID:22354088" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct and core. PMPCB processes newly imported mitochondrial precursor proteins by removing N-terminal targeting presequences.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCB/PMPCB-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Most mitochondrial proteins are nuclear-encoded, synthesized in the cytosol, and imported into mitochondria using N-terminal **mitochondrial targeting presequences** (often amphipathic, positively charged α-helices). These presequences generally must be cleaved after import for proper maturation and assembly of mitochondrial proteins. The central enzyme executing this step is the **mitochondrial processing peptidase (MPP)**. (gala2021mitochondrialproteasesin pages 2-5, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, taylor2001crystalstructuresof pages 1-2)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCB/PMPCB-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">PMPCB provides the catalytic activity of MPP, which cleaves the **N-terminal mitochondrial targeting presequence** from mitochondrial precursor proteins after their translocation into mitochondria, yielding the mature protein N-terminus (or an intermediate for further processing by other peptidases). (gala2021mitochondrialproteasesin pages 2-5, taylor2001crystalstructuresof pages 1-2, baker2025qualitycontrolat pages 5-5)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCB/PMPCB-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">In the canonical pathway, precursors are recognized and translocated through TOM and TIM machineries, then MPP removes the N-terminal targeting presequence in the matrix. Cleaved presequences are subsequently degraded by downstream peptidases (e.g., PreP), preventing accumulation of potentially disruptive targeting peptides. (baker2025qualitycontrolat pages 4-5, gala2021mitochondrialproteasesin pages 2-5)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HTP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:34800366
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Quantitative high-confidence human mitochondrial proteome an...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O75439" data-a="GO:0005739" data-r="PMID:34800366" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct but broad. PMPCB is specifically a mitochondrial matrix MPP complex subunit.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Prefer mitochondrial matrix and mitochondrial processing peptidase complex over generic mitochondrion.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCB/PMPCB-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">PMPCB functions in the **mitochondrial matrix** as part of MPP, acting on precursors after import via TOM/TIM pathways. (gala2021mitochondrialproteasesin pages 2-5, baker2025qualitycontrolat pages 4-5)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCB/PMPCB-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">| Complex membership | PMPCB forms the **MPP heterodimer** with **PMPCA (α-MPP)**; PMPCB provides catalysis, whereas PMPCA contributes substrate recognition/positioning via a glycine-rich loop and helps shape the substrate-binding cavity (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, gala2021mitochondrialproteasesin pages 2-5, kunova2022mitochondrialprocessingpeptidases—structure media e22ffe68). |</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/22354088" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:22354088
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mitochondrial processing peptidase regulates PINK1 processin...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O75439" data-a="GO:0005759" data-r="PMID:22354088" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct. MPP/PMPCB acts in the mitochondrial matrix after precursor import through TOM/TIM.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCB/PMPCB-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">PMPCB functions in the **mitochondrial matrix** as part of MPP, acting on precursors after import via TOM/TIM pathways. (gala2021mitochondrialproteasesin pages 2-5, baker2025qualitycontrolat pages 4-5)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCB/PMPCB-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">In the canonical pathway, precursors are recognized and translocated through TOM and TIM machineries, then MPP removes the N-terminal targeting presequence in the matrix. Cleaved presequences are subsequently degraded by downstream peptidases (e.g., PreP), preventing accumulation of potentially disruptive targeting peptides. (baker2025qualitycontrolat pages 4-5, gala2021mitochondrialproteasesin pages 2-5)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-8949649
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O75439" data-a="GO:0005759" data-r="Reactome:R-HSA-8949649" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct. MPP/PMPCB acts in the mitochondrial matrix after precursor import through TOM/TIM.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCB/PMPCB-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">PMPCB functions in the **mitochondrial matrix** as part of MPP, acting on precursors after import via TOM/TIM pathways. (gala2021mitochondrialproteasesin pages 2-5, baker2025qualitycontrolat pages 4-5)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCB/PMPCB-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">In the canonical pathway, precursors are recognized and translocated through TOM and TIM machineries, then MPP removes the N-terminal targeting presequence in the matrix. Cleaved presequences are subsequently degraded by downstream peptidases (e.g., PreP), preventing accumulation of potentially disruptive targeting peptides. (baker2025qualitycontrolat pages 4-5, gala2021mitochondrialproteasesin pages 2-5)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004222" target="_blank" class="term-link">
+                                    GO:0004222
+                                </a>
+                            </span>
+                            <span class="term-label">metalloendopeptidase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/22354088" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:22354088
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mitochondrial processing peptidase regulates PINK1 processin...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="O75439" data-a="GO:0004222" data-r="PMID:22354088" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct and core. PMPCB is the catalytic Zn2+-dependent metalloendopeptidase subunit of MPP.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCB/PMPCB-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The UniProt accession **O75439** corresponds to **human PMPCB** (gene name **PMPCB**, synonym **MPPB**) annotated as **mitochondrial-processing peptidase subunit beta** (MPPβ), a member of the **peptidase M16 family** and the **catalytic β subunit** of the heterodimeric mitochondrial processing peptidase (MPP). This mapping (human PMPCB ↔ UniProt O75439) is explicitly supported by a review of mitochondrial processing peptidases that lists **Homo sapiens O75439** as the MPP subunit containing the characteristic inverted Zn-binding motif HxxEH…E required for activity, as well as by authoritative reviews describing human MPP as PMPCA (α) + PMPCB (β) with PMPCB harboring the catalytic site. (gakh2002mitochondrialprocessingpeptidases. pages 4-6, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, gala2021mitochondrialproteasesin pages 2-5, kunova2022mitochondrialprocessingpeptidases—structure pages 4-6)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCB/PMPCB-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">MPP is a **Zn2+-dependent metalloendopeptidase**. PMPCB contains the conserved inverted Zn-binding/catalytic motif **HxxEH…E** (with the distal glutamate contributing to Zn coordination). Mutation of residues in this motif abolishes Zn binding and peptidase activity, supporting that PMPCB is the catalytic subunit. (gakh2002mitochondrialprocessingpeptidases. pages 4-6, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCB/PMPCB-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Authoritative reviews converge on a model in which **PMPCB is the catalytic Zn metalloprotease** and **PMPCA contributes substrate recognition**, together enabling cleavage of a large fraction of imported mitochondrial proteins. This division of labor is supported by conserved motifs (active-site Zn-binding in β subunit), structural evidence (peptide binding in a negatively charged cavity, glycine-rich loop gating/positioning), and disease genetics demonstrating that partial disruption causes severe neurological phenotypes. (gala2021mitochondrialproteasesin pages 2-5, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, gakh2002mitochondrialprocessingpeptidases. pages 4-6)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/22354088" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:22354088
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mitochondrial processing peptidase regulates PINK1 processin...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="O75439" data-a="GO:0005739" data-r="PMID:22354088" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct but broad. PMPCB is specifically a mitochondrial matrix MPP complex subunit.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Prefer mitochondrial matrix and mitochondrial processing peptidase complex over generic mitochondrion.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCB/PMPCB-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">PMPCB functions in the **mitochondrial matrix** as part of MPP, acting on precursors after import via TOM/TIM pathways. (gala2021mitochondrialproteasesin pages 2-5, baker2025qualitycontrolat pages 4-5)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCB/PMPCB-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">| Complex membership | PMPCB forms the **MPP heterodimer** with **PMPCA (α-MPP)**; PMPCB provides catalysis, whereas PMPCA contributes substrate recognition/positioning via a glycine-rich loop and helps shape the substrate-binding cavity (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, gala2021mitochondrialproteasesin pages 2-5, kunova2022mitochondrialprocessingpeptidases—structure media e22ffe68). |</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>PMPCB is the catalytic beta subunit of the mitochondrial processing peptidase heterodimer. In the mitochondrial matrix, it performs Zn2+-dependent metalloendopeptidase cleavage of N-terminal mitochondrial targeting presequences from imported precursor proteins.</h3>
+                <span class="vote-buttons" data-g="O75439" data-a="FUNCTION: PMPCB is the catalytic beta subunit of the mitocho..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004222" target="_blank" class="term-link">
+                            metalloendopeptidase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016485" target="_blank" class="term-link">
+                                protein processing
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                mitochondrial matrix
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0017087" target="_blank" class="term-link">
+                            mitochondrial processing peptidase complex
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/PMPCB/PMPCB-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">The UniProt accession **O75439** corresponds to **human PMPCB** (gene name **PMPCB**, synonym **MPPB**) annotated as **mitochondrial-processing peptidase subunit beta** (MPPβ), a member of the **peptidase M16 family** and the **catalytic β subunit** of the heterodimeric mitochondrial processing peptidase (MPP). This mapping (human PMPCB ↔ UniProt O75439) is explicitly supported by a review of mitochondrial processing peptidases that lists **Homo sapiens O75439** as the MPP subunit containing the characteristic inverted Zn-binding motif HxxEH…E required for activity, as well as by authoritative reviews describing human MPP as PMPCA (α) + PMPCB (β) with PMPCB harboring the catalytic site. (gakh2002mitochondrialprocessingpeptidases. pages 4-6, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, gala2021mitochondrialproteasesin pages 2-5, kunova2022mitochondrialprocessingpeptidases—structure pages 4-6)</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/PMPCB/PMPCB-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">PMPCB provides the catalytic activity of MPP, which cleaves the **N-terminal mitochondrial targeting presequence** from mitochondrial precursor proteins after their translocation into mitochondria, yielding the mature protein N-terminus (or an intermediate for further processing by other peptidases). (gala2021mitochondrialproteasesin pages 2-5, taylor2001crystalstructuresof pages 1-2, baker2025qualitycontrolat pages 5-5)</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/PMPCB/PMPCB-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">MPP is a **Zn2+-dependent metalloendopeptidase**. PMPCB contains the conserved inverted Zn-binding/catalytic motif **HxxEH…E** (with the distal glutamate contributing to Zn coordination). Mutation of residues in this motif abolishes Zn binding and peptidase activity, supporting that PMPCB is the catalytic subunit. (gakh2002mitochondrialprocessingpeptidases. pages 4-6, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4)</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/PMPCB/PMPCB-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">PMPCB functions in the **mitochondrial matrix** as part of MPP, acting on precursors after import via TOM/TIM pathways. (gala2021mitochondrialproteasesin pages 2-5, baker2025qualitycontrolat pages 4-5)</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/PMPCB/PMPCB-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">Authoritative reviews converge on a model in which **PMPCB is the catalytic Zn metalloprotease** and **PMPCA contributes substrate recognition**, together enabling cleavage of a large fraction of imported mitochondrial proteins. This division of labor is supported by conserved motifs (active-site Zn-binding in β subunit), structural evidence (peptide binding in a negatively charged cavity, glycine-rich loop gating/positioning), and disease genetics demonstrating that partial disruption causes severe neurological phenotypes. (gala2021mitochondrialproteasesin pages 2-5, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, gakh2002mitochondrialprocessingpeptidases. pages 4-6)</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000003.md" target="_blank" class="term-link">
+                            GO_REF:0000003
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on Enzyme Commission mapping</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000024.md" target="_blank" class="term-link">
+                            GO_REF:0000024
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment of sequence similarity</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000052.md" target="_blank" class="term-link">
+                            GO_REF:0000052
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on curation of immunofluorescence data</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
+                            GO_REF:0000117
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/22354088" target="_blank" class="term-link">
+                            PMID:22354088
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Mitochondrial processing peptidase regulates PINK1 processing, import and Parkin recruitment.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/32443488" target="_blank" class="term-link">
+                            PMID:32443488
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Mitochondrial Protein Quality Control Mechanisms.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link">
+                            PMID:34800366
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Quantitative high-confidence human mitochondrial proteome and its dynamics in cellular context.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-8949215
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Mitochondrial calcium ion transport</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-8949649
+
+                    </span>
+                </div>
+
+                <div class="reference-title">PMPCA:PMPCB cleaves the transit peptide of proSMDT1 (proEMRE)</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/PMPCB/PMPCB-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research report for human PMPCB</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Which PMPCB disease variants primarily reduce catalytic activity versus MPP complex stability or substrate recognition?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="O75439" data-a="Q: Which PMPCB disease variants primarily reduce cata..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Which human MPP substrates are most sensitive to partial PMPCB impairment in neuronal cells?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="O75439" data-a="Q: Which human MPP substrates are most sensitive to p..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Perform quantitative N-terminomics and targeted substrate immunoblots in PMPCB-variant rescue cells to compare cleavage efficiency across mitochondrial precursors.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: PMPCB disease variants cause selective substrate-processing defects rather than uniform loss of all MPP cleavage.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="O75439" data-a="EXPERIMENT: Perform quantitative N-terminomics and targeted su..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Separate acute PMPCB catalytic inhibition from mature EMRE rescue and measure proSMDT1 processing, MCU complex assembly, and mitochondrial calcium uptake.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: The PMPCB contribution to mitochondrial calcium uptake is indirect through proSMDT1/proEMRE maturation.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="O75439" data-a="EXPERIMENT: Separate acute PMPCB catalytic inhibition from mat..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Deep Research Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(PMPCB-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="O75439" data-a="DOC: Deep Research Falcon" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <hr />
+<p>provider: falcon<br />
+model: Edison Scientific Literature<br />
+cached: false<br />
+start_time: '2026-05-11T18:05:55.546917'<br />
+end_time: '2026-05-11T18:15:13.574652'<br />
+duration_seconds: 558.03<br />
+template_file: templates/gene_research_go_focused.md<br />
+template_variables:<br />
+  organism: human<br />
+  gene_id: PMPCB<br />
+  gene_symbol: PMPCB<br />
+  uniprot_accession: O75439<br />
+  protein_description: 'RecName: Full=Mitochondrial-processing peptidase subunit beta;<br />
+    EC=3.4.24.64 {ECO:0000305|PubMed:22354088}; AltName: Full=Beta-MPP; AltName: Full=P-52;<br />
+    Flags: Precursor;'<br />
+  gene_info: Name=PMPCB; Synonyms=MPPB;<br />
+  organism_full: Homo sapiens (Human).<br />
+  protein_family: Belongs to the peptidase M16 family. .<br />
+  protein_domains: Metalloenz_LuxS/M16. (IPR011249); MPP/UQCRC_Complex. (IPR050361);<br />
+    Pept_M16_N. (IPR011765); Pept_M16_Zn_BS. (IPR001431); Peptidase_M16_C. (IPR007863)<br />
+provider_config:<br />
+  timeout: 600<br />
+  max_retries: 3<br />
+  parameters:<br />
+    allowed_domains: []<br />
+    temperature: 0.1<br />
+citation_count: 22</p>
+<hr />
+<h2 id="question">Question</h2>
+<h1 id="gene-research-for-functional-annotation">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> O75439</li>
+<li><strong>Protein Description:</strong> RecName: Full=Mitochondrial-processing peptidase subunit beta; EC=3.4.24.64 {ECO:0000305|PubMed:22354088}; AltName: Full=Beta-MPP; AltName: Full=P-52; Flags: Precursor;</li>
+<li><strong>Gene Information:</strong> Name=PMPCB; Synonyms=MPPB;</li>
+<li><strong>Organism (full):</strong> Homo sapiens (Human).</li>
+<li><strong>Protein Family:</strong> Belongs to the peptidase M16 family. .</li>
+<li><strong>Key Domains:</strong> Metalloenz_LuxS/M16. (IPR011249); MPP/UQCRC_Complex. (IPR050361); Pept_M16_N. (IPR011765); Pept_M16_Zn_BS. (IPR001431); Peptidase_M16_C. (IPR007863)</li>
+</ul>
+<h3 id="mandatory-verification-steps">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "PMPCB" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Homo sapiens (Human).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'PMPCB' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>PMPCB</strong> (gene ID: PMPCB, UniProt: O75439) in human.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="output">Output</h2>
+<p>Question: You are an expert researcher providing comprehensive, well-cited information.</p>
+<p>Provide detailed information focusing on:<br />
+1. Key concepts and definitions with current understanding<br />
+2. Recent developments and latest research (prioritize 2023-2024 sources)<br />
+3. Current applications and real-world implementations<br />
+4. Expert opinions and analysis from authoritative sources<br />
+5. Relevant statistics and data from recent studies</p>
+<p>Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.<br />
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.</p>
+<h1 id="gene-research-for-functional-annotation_1">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context_1">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot_1">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> O75439</li>
+<li><strong>Protein Description:</strong> RecName: Full=Mitochondrial-processing peptidase subunit beta; EC=3.4.24.64 {ECO:0000305|PubMed:22354088}; AltName: Full=Beta-MPP; AltName: Full=P-52; Flags: Precursor;</li>
+<li><strong>Gene Information:</strong> Name=PMPCB; Synonyms=MPPB;</li>
+<li><strong>Organism (full):</strong> Homo sapiens (Human).</li>
+<li><strong>Protein Family:</strong> Belongs to the peptidase M16 family. .</li>
+<li><strong>Key Domains:</strong> Metalloenz_LuxS/M16. (IPR011249); MPP/UQCRC_Complex. (IPR050361); Pept_M16_N. (IPR011765); Pept_M16_Zn_BS. (IPR001431); Peptidase_M16_C. (IPR007863)</li>
+</ul>
+<h3 id="mandatory-verification-steps_1">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "PMPCB" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Homo sapiens (Human).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature_1">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'PMPCB' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target_1">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>PMPCB</strong> (gene ID: PMPCB, UniProt: O75439) in human.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="comprehensive-research-report-pmpcb-uniprot-o75439-human-mitochondrial-processing-peptidase-subunit-mpp">Comprehensive Research Report: <strong>PMPCB (UniProt O75439)</strong> — Human Mitochondrial-Processing Peptidase Subunit β (MPPβ)</h1>
+<h2 id="1-identity-verification-mandatory">1) Identity verification (mandatory)</h2>
+<p>The UniProt accession <strong>O75439</strong> corresponds to <strong>human PMPCB</strong> (gene name <strong>PMPCB</strong>, synonym <strong>MPPB</strong>) annotated as <strong>mitochondrial-processing peptidase subunit beta</strong> (MPPβ), a member of the <strong>peptidase M16 family</strong> and the <strong>catalytic β subunit</strong> of the heterodimeric mitochondrial processing peptidase (MPP). This mapping (human PMPCB ↔ UniProt O75439) is explicitly supported by a review of mitochondrial processing peptidases that lists <strong>Homo sapiens O75439</strong> as the MPP subunit containing the characteristic inverted Zn-binding motif HxxEH…E required for activity, as well as by authoritative reviews describing human MPP as PMPCA (α) + PMPCB (β) with PMPCB harboring the catalytic site. (gakh2002mitochondrialprocessingpeptidases. pages 4-6, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, gala2021mitochondrialproteasesin pages 2-5, kunova2022mitochondrialprocessingpeptidases—structure pages 4-6)</p>
+<h2 id="2-key-concepts-and-definitions-current-understanding">2) Key concepts and definitions (current understanding)</h2>
+<h3 id="21-mitochondrial-targeting-presequences-and-presequence-processing">2.1 Mitochondrial targeting presequences and presequence processing</h3>
+<p>Most mitochondrial proteins are nuclear-encoded, synthesized in the cytosol, and imported into mitochondria using N-terminal <strong>mitochondrial targeting presequences</strong> (often amphipathic, positively charged α-helices). These presequences generally must be cleaved after import for proper maturation and assembly of mitochondrial proteins. The central enzyme executing this step is the <strong>mitochondrial processing peptidase (MPP)</strong>. (gala2021mitochondrialproteasesin pages 2-5, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, taylor2001crystalstructuresof pages 1-2)</p>
+<h3 id="22-mpp-composition-and-division-of-labor">2.2 MPP composition and division of labor</h3>
+<p>Human MPP is a <strong>heterodimeric</strong> enzyme complex consisting of:<br />
+- <strong>PMPCA (α-MPP)</strong>: primarily contributes to <strong>substrate recognition/positioning</strong>, including a <strong>glycine-rich loop</strong> implicated in engaging presequences and facilitating productive presentation to the active site.<br />
+- <strong>PMPCB (β-MPP)</strong>: the <strong>catalytic</strong> Zn2+-dependent metallopeptidase subunit containing the functional active site.<br />
+These subunits form a substrate-binding cavity; both are required for efficient processing in vivo. (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, gala2021mitochondrialproteasesin pages 2-5, gakh2002mitochondrialprocessingpeptidases. pages 4-6, kunova2022mitochondrialprocessingpeptidases—structure media e22ffe68)</p>
+<h2 id="3-molecular-function-of-pmpcb-reaction-catalytic-mechanism-and-substrate-specificity">3) Molecular function of PMPCB: reaction, catalytic mechanism, and substrate specificity</h2>
+<h3 id="31-reaction-catalyzed-ec-342464">3.1 Reaction catalyzed (EC 3.4.24.64)</h3>
+<p>PMPCB provides the catalytic activity of MPP, which cleaves the <strong>N-terminal mitochondrial targeting presequence</strong> from mitochondrial precursor proteins after their translocation into mitochondria, yielding the mature protein N-terminus (or an intermediate for further processing by other peptidases). (gala2021mitochondrialproteasesin pages 2-5, taylor2001crystalstructuresof pages 1-2, baker2025qualitycontrolat pages 5-5)</p>
+<h3 id="32-catalytic-class-and-essential-motifs">3.2 Catalytic class and essential motifs</h3>
+<p>MPP is a <strong>Zn2+-dependent metalloendopeptidase</strong>. PMPCB contains the conserved inverted Zn-binding/catalytic motif <strong>HxxEH…E</strong> (with the distal glutamate contributing to Zn coordination). Mutation of residues in this motif abolishes Zn binding and peptidase activity, supporting that PMPCB is the catalytic subunit. (gakh2002mitochondrialprocessingpeptidases. pages 4-6, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4)</p>
+<h3 id="33-catalytic-mechanism-thermolysin-like">3.3 Catalytic mechanism (thermolysin-like)</h3>
+<p>Structural and mechanistic evidence indicates a <strong>thermolysin-like</strong> mechanism: a water molecule coordinated to Zn2+ is activated (polarized/deprotonated) by a nearby glutamate acting as a general base, enabling nucleophilic attack on the scissile peptide bond carbonyl to hydrolyze the peptide bond. This architecture and mechanism are supported by crystal structures and by functional evidence that mutation of the catalytic glutamate abolishes activity. (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, taylor2001crystalstructuresof pages 3-4)</p>
+<h3 id="34-substrate-specificity-cleavage-motif-and-determinants">3.4 Substrate specificity: cleavage motif and determinants</h3>
+<p>MPP recognizes diverse mitochondrial presequences but exhibits characteristic preferences:<br />
+- A frequent <strong>arginine at the −2 position</strong> relative to the cleavage site (the “R−2 motif”; also described as an arginine at position 2 of the cleavage-site motif depending on indexing conventions), supported by N-terminome analyses and structural studies.<br />
+- Additional features can include upstream basic residues and a bulky hydrophobic/aromatic residue at P1, with presequences binding in an extended conformation within a large, negatively charged cavity that favors positively charged peptides. (gala2021mitochondrialproteasesin pages 2-5, taylor2001crystalstructuresof pages 1-2, taylor2001crystalstructuresof pages 3-4, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4)</p>
+<h3 id="35-key-substratesexamples">3.5 Key substrates/examples</h3>
+<p>Although MPP processes a large fraction of imported mitochondrial proteins, <strong>frataxin (FXN)</strong> is a well-studied substrate relevant to PMPCB biology. A yeast two-hybrid assay found FXN as a direct partner of human PMPCB; and patient-derived systems with PMPCB variants show accumulation of a frataxin processing intermediate, linking PMPCB activity to FXN maturation and downstream iron–sulfur (Fe–S) biology. (kunova2022mitochondrialprocessingpeptidases—structure pages 4-6, vogtle2018mutationsinpmpcb pages 1-2)</p>
+<h2 id="4-subcellular-localization-and-pathway-context">4) Subcellular localization and pathway context</h2>
+<h3 id="41-subcellular-localization">4.1 Subcellular localization</h3>
+<p>PMPCB functions in the <strong>mitochondrial matrix</strong> as part of MPP, acting on precursors after import via TOM/TIM pathways. (gala2021mitochondrialproteasesin pages 2-5, baker2025qualitycontrolat pages 4-5)</p>
+<h3 id="42-biological-pathway-mitochondrial-protein-import-presequence-cleavage-maturation">4.2 Biological pathway: mitochondrial protein import → presequence cleavage → maturation</h3>
+<p>In the canonical pathway, precursors are recognized and translocated through TOM and TIM machineries, then MPP removes the N-terminal targeting presequence in the matrix. Cleaved presequences are subsequently degraded by downstream peptidases (e.g., PreP), preventing accumulation of potentially disruptive targeting peptides. (baker2025qualitycontrolat pages 4-5, gala2021mitochondrialproteasesin pages 2-5)</p>
+<h2 id="5-recent-developments-and-latest-research-emphasis-on-20232024">5) Recent developments and latest research (emphasis on 2023–2024)</h2>
+<h3 id="51-2024-clinical-expansion-first-splice-site-variant-and-adult-survival">5.1 2024 clinical expansion: first splice-site variant and adult survival</h3>
+<p>A 2024 report identified the <strong>first splice-site PMPCB variant</strong> causing disease and expanded the phenotypic spectrum to an individual surviving to <strong>age 39</strong>. The study used an <strong>exon-trapping (minigene) assay</strong> to demonstrate that the splice variant causes <strong>exon 12 skipping</strong>, supporting pathogenic loss-of-function via aberrant splicing. (Matthews et al., 2024-02; URL https://doi.org/10.1038/s10038-024-01226-9) (matthews2024leighsyndromewith pages 1-2, matthews2024leighsyndromewith pages 2-3)</p>
+<h3 id="52-quantitative-update-from-2024-paper-statistics">5.2 Quantitative update from 2024 paper (statistics)</h3>
+<p>The 2024 report summarized prior literature, stating that before their publication only <strong>five</strong> affected individuals had been reported (all missense variants), with <strong>onset by 12 months</strong> in each pediatric case, <strong>none</strong> achieving ambulation or speech, and <strong>3/5</strong> dying by <strong>age 6</strong>; dystonia/epilepsy/ataxia occurred in <strong>4/5</strong>. These numbers provide currently available coarse epidemiologic statistics for this ultra-rare disorder. (matthews2024leighsyndromewith pages 1-2)</p>
+<h3 id="53-20232024-mechanistic-context-mitochondrial-proteostasisprocessing-machinery-as-druggable-biology">5.3 2023–2024 mechanistic context: mitochondrial proteostasis/processing machinery as druggable biology</h3>
+<p>While not centered on PMPCB variants, recent mitochondrial proteostasis studies emphasize that impaired turnover of targeting peptides and feedback inhibition of MPP can broadly disrupt mitochondrial function, reinforcing the importance of efficient presequence processing as a systems-level node (e.g., interaction with downstream peptide-degradation machinery). (gala2021mitochondrialproteasesin pages 2-5)</p>
+<h2 id="6-disease-associations-clinical-phenotypes-and-mechanistic-evidence">6) Disease associations, clinical phenotypes, and mechanistic evidence</h2>
+<h3 id="61-disease-entity">6.1 Disease entity</h3>
+<p>Biallelic pathogenic variants in <strong>PMPCB</strong> cause a mitochondrial disease often described as a <strong>Leigh-like neurodegenerative disorder</strong> and classified as <strong>multiple mitochondrial dysfunctions syndrome 6 (MMDS6)</strong>. (matthews2024leighsyndromewith pages 1-2, baker2025qualitycontrolat pages 5-5)</p>
+<h3 id="62-2018-primary-evidence-genotype-mechanism-phenotype">6.2 2018 primary evidence: genotype → mechanism → phenotype</h3>
+<p>A 2018 American Journal of Human Genetics study reported <strong>biallelic PMPCB variants in 4 families (5 affected individuals)</strong> with early-childhood onset neurodegeneration featuring episodic regression (often illness-triggered), basal ganglia lesions, and cerebellar atrophy. The study provided multi-level mechanistic evidence linking PMPCB dysfunction to impaired mitochondrial presequence processing and mitochondrial metabolism:<br />
+- <strong>Patient cells</strong>: reduced PMPCB levels and <strong>accumulation of a frataxin processing intermediate</strong>.<br />
+- <strong>Yeast modeling</strong> (Mas1, PMPCB homolog): disease-variant modeling caused growth defects and impaired MPP processing with accumulation of precursor proteins.<br />
+- <strong>Downstream mitochondrial consequences</strong>: impairment of Fe–S cluster biogenesis and decreased activity in Fe–S-dependent respiratory-chain components and enzymes; evidence of complex I assembly perturbations and complex II activity reduction in some tissues. (Vögtle et al., 2018-04; URL https://doi.org/10.1016/j.ajhg.2018.02.014) (vogtle2018mutationsinpmpcb pages 1-2, vogtle2018mutationsinpmpcb pages 11-12)</p>
+<h3 id="63-database-level-disease-association-contextual">6.3 Database-level disease association (contextual)</h3>
+<p>Open Targets links PMPCB to <strong>MMDS6</strong> and broader categories including genetic and neurodegenerative disease, reflecting curated associations and literature evidence; this supports clinical relevance but is secondary to primary patient and mechanistic studies. (OpenTargets Search: -PMPCB)</p>
+<h2 id="7-current-applications-and-real-world-implementations">7) Current applications and real-world implementations</h2>
+<h3 id="71-clinical-geneticsdiagnostics">7.1 Clinical genetics/diagnostics</h3>
+<p>PMPCB is now an established candidate gene in <strong>mitochondrial disease and Leigh(-like) syndrome gene panels</strong> and in <strong>whole-exome/whole-genome sequencing</strong> diagnostic pipelines for neurodevelopmental regression with basal ganglia/cerebellar imaging findings, given the strong causal evidence from biallelic pathogenic variants and functional validation. The 2024 splice-variant case demonstrates direct clinical utility of combining sequencing with functional splicing assays (minigene) to interpret variants. (matthews2024leighsyndromewith pages 1-2, vogtle2018mutationsinpmpcb pages 1-2)</p>
+<h3 id="72-research-implementation-mitochondrial-import-and-proteostasis-assays">7.2 Research implementation: mitochondrial import and proteostasis assays</h3>
+<p>PMPCB/MPP activity is routinely assessed indirectly by monitoring processing states of known MPP substrates (e.g., frataxin intermediates) and by proteomics/N-terminomics strategies that infer MPP cleavage motif preferences across the mitochondrial proteome. Such applications are highlighted in reviews discussing MPP specificity and downstream degradation of presequences. (gala2021mitochondrialproteasesin pages 2-5, vogtle2018mutationsinpmpcb pages 1-2)</p>
+<h2 id="8-expert-opinions-and-analysis-authoritative-synthesis">8) Expert opinions and analysis (authoritative synthesis)</h2>
+<h3 id="81-consensus-model-for-mpp-function-in-humans">8.1 Consensus model for MPP function in humans</h3>
+<p>Authoritative reviews converge on a model in which <strong>PMPCB is the catalytic Zn metalloprotease</strong> and <strong>PMPCA contributes substrate recognition</strong>, together enabling cleavage of a large fraction of imported mitochondrial proteins. This division of labor is supported by conserved motifs (active-site Zn-binding in β subunit), structural evidence (peptide binding in a negatively charged cavity, glycine-rich loop gating/positioning), and disease genetics demonstrating that partial disruption causes severe neurological phenotypes. (gala2021mitochondrialproteasesin pages 2-5, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, gakh2002mitochondrialprocessingpeptidases. pages 4-6)</p>
+<h3 id="82-disease-mechanism-inference">8.2 Disease mechanism inference</h3>
+<p>Clinical and experimental evidence suggests that disease-causing PMPCB variants can lead to <strong>selective or stress-sensitive processing defects</strong>, rather than uniform failure of all MPP substrates, which may help explain tissue specificity (neurological vulnerability) and triggers (febrile illness). The yeast model’s temperature sensitivity and the observation of pathway-specific downstream defects (notably Fe–S cluster biogenesis and respiratory chain effects) support this interpretation. (vogtle2018mutationsinpmpcb pages 11-12, vogtle2018mutationsinpmpcb pages 1-2)</p>
+<h2 id="9-visual-evidence-from-recent-review-figures">9) Visual evidence from recent review figures</h2>
+<p>A 2022 review provides figures depicting MPP architecture and sequence conservation, including the <strong>Zn2+-binding catalytic site in PMPCB</strong> and the <strong>glycine-rich loop in PMPCA</strong>, along with alignments highlighting conserved motifs and disease-associated residues. These visuals are useful for functional inference and variant interpretation. (kunova2022mitochondrialprocessingpeptidases—structure media e22ffe68, kunova2022mitochondrialprocessingpeptidases—structure media bbb4e0aa)</p>
+<h2 id="summary-table-evidence-backed">Summary table (evidence-backed)</h2>
+<p>The following table consolidates key annotation elements—identity, function, mechanism, localization, pathway role, and disease statistics.</p>
+<table>
+<thead>
+<tr>
+<th>Aspect</th>
+<th>Summary</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Identity</td>
+<td><strong>PMPCB</strong> is the human gene encoding <strong>mitochondrial-processing peptidase subunit beta (MPPβ)</strong>, the <strong>catalytic β subunit</strong> of the heterodimeric mitochondrial processing peptidase; this matches <strong>UniProt O75439</strong> and the peptidase M16 metalloprotease family assignment (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, gala2021mitochondrialproteasesin pages 2-5, gakh2002mitochondrialprocessingpeptidases. pages 4-6, kunova2022mitochondrialprocessingpeptidases—structure pages 4-6).</td>
+</tr>
+<tr>
+<td>Localization</td>
+<td>PMPCB functions in the <strong>mitochondrial matrix</strong>, where MPP cleaves N-terminal targeting presequences from newly imported nuclear-encoded mitochondrial proteins after translocation through TOM/TIM import pathways (gala2021mitochondrialproteasesin pages 2-5, baker2025qualitycontrolat pages 4-5, taylor2001crystalstructuresof pages 1-2).</td>
+</tr>
+<tr>
+<td>Complex membership</td>
+<td>PMPCB forms the <strong>MPP heterodimer</strong> with <strong>PMPCA (α-MPP)</strong>; PMPCB provides catalysis, whereas PMPCA contributes substrate recognition/positioning via a glycine-rich loop and helps shape the substrate-binding cavity (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, gala2021mitochondrialproteasesin pages 2-5, kunova2022mitochondrialprocessingpeptidases—structure media e22ffe68).</td>
+</tr>
+<tr>
+<td>Catalytic class &amp; EC</td>
+<td>MPP is a <strong>Zn²⁺-dependent metallopeptidase / metalloendopeptidase</strong>; UniProt assigns <strong>EC 3.4.24.64</strong>. Reviews explicitly identify PMPCB as the zinc metalloprotease catalytic subunit of MPP (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, gala2021mitochondrialproteasesin pages 2-5, taylor2001crystalstructuresof pages 1-2, gakh2002mitochondrialprocessingpeptidases. pages 4-6).</td>
+</tr>
+<tr>
+<td>Active-site motif</td>
+<td>PMPCB contains the conserved <strong>HxxEH…E</strong> zinc-binding/catalytic motif typical of M16 peptidases; mutating residues in this motif abolishes Zn²⁺ binding and MPP activity (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, gakh2002mitochondrialprocessingpeptidases. pages 4-6, kunova2022mitochondrialprocessingpeptidases—structure pages 4-6, kunova2022mitochondrialprocessingpeptidases—structure media e22ffe68).</td>
+</tr>
+<tr>
+<td>Mechanism</td>
+<td>Structural/mechanistic work supports a <strong>thermolysin-like hydrolytic mechanism</strong>: Zn²⁺ is coordinated by active-site residues, while a nearby glutamate activates a bound water molecule for nucleophilic attack on the scissile peptide bond; the substrate binds in an extended conformation in a negatively charged cavity (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, taylor2001crystalstructuresof pages 1-2, taylor2001crystalstructuresof pages 3-4).</td>
+</tr>
+<tr>
+<td>Substrate specificity / cleavage motif</td>
+<td>PMPCB/MPP cleaves <strong>N-terminal mitochondrial targeting presequences</strong> of imported precursor proteins. Preferred features include positively charged, amphipathic presequences and frequent <strong>Arg at the −2 position</strong> relative to the cleavage site (with related recognition patterns also involving upstream basic residues and often a bulky hydrophobic/aromatic P1 residue) (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, gala2021mitochondrialproteasesin pages 2-5, taylor2001crystalstructuresof pages 1-2, taylor2001crystalstructuresof pages 3-4).</td>
+</tr>
+<tr>
+<td>Key substrates / examples</td>
+<td>MPP processes a broad range of nuclear-encoded mitochondrial precursors; <strong>frataxin (FXN)</strong> is a well-studied example whose maturation depends on PMPCB, and impaired PMPCB function leads to accumulation of frataxin processing intermediates in patient-derived cells (kunova2022mitochondrialprocessingpeptidases—structure pages 4-6, vogtle2018mutationsinpmpcb pages 1-2).</td>
+</tr>
+<tr>
+<td>Pathway context</td>
+<td>PMPCB acts in the <strong>mitochondrial protein import and presequence-processing pathway</strong>, a core mitochondrial proteostasis step required for maturation of many matrix and inner-membrane proteins; cleaved presequences are subsequently degraded by downstream peptidases such as <strong>PreP/PITRM1</strong> (gala2021mitochondrialproteasesin pages 2-5, baker2025qualitycontrolat pages 4-5).</td>
+</tr>
+<tr>
+<td>Disease association &amp; key stats</td>
+<td>Biallelic <strong>PMPCB</strong> variants cause <strong>multiple mitochondrial dysfunctions syndrome 6 (MMDS6)</strong> / a Leigh-like early-childhood neurodegenerative disorder. The 2018 AJHG study reported <strong>4 families / 5 affected individuals</strong> with episodic developmental regression, basal ganglia lesions, cerebellar atrophy, and biochemical evidence of defective presequence processing, impaired frataxin maturation, Fe–S cluster defects, and complex I/II abnormalities (vogtle2018mutationsinpmpcb pages 1-2, vogtle2018mutationsinpmpcb pages 11-12, baker2025qualitycontrolat pages 5-5, OpenTargets Search: -PMPCB).</td>
+</tr>
+<tr>
+<td>Recent developments 2024</td>
+<td>A <strong>2024 Journal of Human Genetics</strong> case report described the <strong>first splice-site PMPCB variant</strong> and expanded the phenotype to an adult survivor: a <strong>39-year-old</strong> compound-heterozygous individual with childhood regression/ataxia. The paper notes that before this report only <strong>5 individuals</strong> had been described, all with onset by <strong>12 months</strong>, <strong>none</strong> having achieved ambulation or speech, and <strong>3/5</strong> dying by age <strong>6</strong>; a minigene assay showed exon 12 skipping from the splice variant (matthews2024leighsyndromewith pages 1-2, matthews2024leighsyndromewith pages 2-3).</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes verified identity, molecular function, mechanism, localization, pathway role, and disease relevance for human PMPCB/MPPβ (UniProt O75439). It condenses foundational and recent evidence, including key 2018 mechanistic disease data and the 2024 splice-variant update.</em></p>
+<h2 id="key-references-with-urls-and-dates-as-available-in-retrieved-sources">Key references (with URLs and dates as available in retrieved sources)</h2>
+<ul>
+<li><strong>Matthews E, Whittle EF, Khan F, McEntagart M, Carroll CJ.</strong> <em>Leigh syndrome with developmental regression and ataxia due to a novel splicing variant in the PMPCB gene.</em> <strong>Journal of Human Genetics</strong> (Feb <strong>2024</strong>). https://doi.org/10.1038/s10038-024-01226-9 (matthews2024leighsyndromewith pages 1-2, matthews2024leighsyndromewith pages 2-3)</li>
+<li><strong>Vögtle F-N et al.</strong> <em>Mutations in PMPCB Encoding the Catalytic Subunit of the Mitochondrial Presequence Protease Cause Neurodegeneration in Early Childhood.</em> <strong>American Journal of Human Genetics</strong> (Apr <strong>2018</strong>). https://doi.org/10.1016/j.ajhg.2018.02.014 (vogtle2018mutationsinpmpcb pages 1-2, vogtle2018mutationsinpmpcb pages 11-12)</li>
+<li><strong>Kunová N et al.</strong> <em>Mitochondrial Processing Peptidases—Structure, Function and the Role in Human Diseases.</em> <strong>International Journal of Molecular Sciences</strong> (Jan <strong>2022</strong>). https://doi.org/10.3390/ijms23031297 (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, kunova2022mitochondrialprocessingpeptidases—structure pages 4-6, kunova2022mitochondrialprocessingpeptidases—structure media e22ffe68)</li>
+<li><strong>Gala MGF, Vögtle F-N.</strong> <em>Mitochondrial proteases in human diseases.</em> <strong>FEBS Letters</strong> (Feb <strong>2021</strong>). https://doi.org/10.1002/1873-3468.14039 (gala2021mitochondrialproteasesin pages 2-5)</li>
+<li><strong>Gakh O, Cavadini P, Isaya G.</strong> <em>Mitochondrial processing peptidases.</em> <strong>Biochimica et Biophysica Acta</strong> (Sep <strong>2002</strong>). https://doi.org/10.1016/S0167-4889(02)00265-3 (gakh2002mitochondrialprocessingpeptidases. pages 4-6)</li>
+<li><strong>Taylor AB et al.</strong> <em>Crystal structures of mitochondrial processing peptidase reveal the mode for specific cleavage of import signal sequences.</em> <strong>Structure</strong> (Jul <strong>2001</strong>). https://doi.org/10.1016/S0969-2126(01)00621-9 (taylor2001crystalstructuresof pages 1-2, taylor2001crystalstructuresof pages 3-4)</li>
+</ul>
+<p>References</p>
+<ol>
+<li>
+<p>(gakh2002mitochondrialprocessingpeptidases. pages 4-6): Oleksandr Gakh, Patrizia Cavadini, and Grazia Isaya. Mitochondrial processing peptidases. Biochimica et biophysica acta, 1592 1:63-77, Sep 2002. URL: https://doi.org/10.1016/s0167-4889(02)00265-3, doi:10.1016/s0167-4889(02)00265-3. This article has 583 citations.</p>
+</li>
+<li>
+<p>(kunova2022mitochondrialprocessingpeptidases—structure pages 2-4): Nina Kunová, Henrieta Havalová, Gabriela Ondrovičová, Barbora Stojkovičová, Jacob A. Bauer, Vladena Bauerová-Hlinková, Vladimir Pevala, and Eva Kutejová. Mitochondrial processing peptidases—structure, function and the role in human diseases. International Journal of Molecular Sciences, 23:1297, Jan 2022. URL: https://doi.org/10.3390/ijms23031297, doi:10.3390/ijms23031297. This article has 39 citations.</p>
+</li>
+<li>
+<p>(gala2021mitochondrialproteasesin pages 2-5): Maria Gomez‐Fabra Gala and Friederike‐Nora Vögtle. Mitochondrial proteases in human diseases. FEBS Letters, 595:1205-1222, Feb 2021. URL: https://doi.org/10.1002/1873-3468.14039, doi:10.1002/1873-3468.14039. This article has 51 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(kunova2022mitochondrialprocessingpeptidases—structure pages 4-6): Nina Kunová, Henrieta Havalová, Gabriela Ondrovičová, Barbora Stojkovičová, Jacob A. Bauer, Vladena Bauerová-Hlinková, Vladimir Pevala, and Eva Kutejová. Mitochondrial processing peptidases—structure, function and the role in human diseases. International Journal of Molecular Sciences, 23:1297, Jan 2022. URL: https://doi.org/10.3390/ijms23031297, doi:10.3390/ijms23031297. This article has 39 citations.</p>
+</li>
+<li>
+<p>(taylor2001crystalstructuresof pages 1-2): Alexander B. Taylor, Barbara S. Smith, Sakae Kitada, Katsuhiko Kojima, Hideki Miyaura, Zbyszek Otwinowski, Akio Ito, and Johann Deisenhofer. Crystal structures of mitochondrial processing peptidase reveal the mode for specific cleavage of import signal sequences. Structure, 9 7:615-25, Jul 2001. URL: https://doi.org/10.1016/s0969-2126(01)00621-9, doi:10.1016/s0969-2126(01)00621-9. This article has 320 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(kunova2022mitochondrialprocessingpeptidases—structure media e22ffe68): Nina Kunová, Henrieta Havalová, Gabriela Ondrovičová, Barbora Stojkovičová, Jacob A. Bauer, Vladena Bauerová-Hlinková, Vladimir Pevala, and Eva Kutejová. Mitochondrial processing peptidases—structure, function and the role in human diseases. International Journal of Molecular Sciences, 23:1297, Jan 2022. URL: https://doi.org/10.3390/ijms23031297, doi:10.3390/ijms23031297. This article has 39 citations.</p>
+</li>
+<li>
+<p>(baker2025qualitycontrolat pages 5-5): Megan J. Baker, Kai Qi Yek, and Diana Stojanovski. Quality control at the powerhouse: mitochondrial proteostasis dysfunction and disease. Biochemical Society Transactions, 53:1105-1117, Aug 2025. URL: https://doi.org/10.1042/bst20253044, doi:10.1042/bst20253044. This article has 3 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(taylor2001crystalstructuresof pages 3-4): Alexander B. Taylor, Barbara S. Smith, Sakae Kitada, Katsuhiko Kojima, Hideki Miyaura, Zbyszek Otwinowski, Akio Ito, and Johann Deisenhofer. Crystal structures of mitochondrial processing peptidase reveal the mode for specific cleavage of import signal sequences. Structure, 9 7:615-25, Jul 2001. URL: https://doi.org/10.1016/s0969-2126(01)00621-9, doi:10.1016/s0969-2126(01)00621-9. This article has 320 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(vogtle2018mutationsinpmpcb pages 1-2): F.-Nora Vögtle, Björn Brändl, Austin Larson, Manuela Pendziwiat, Marisa W. Friederich, Susan M. White, Alice Basinger, Cansu Kücükköse, Hiltrud Muhle, Johanna A. Jähn, Oliver Keminer, Katherine L. Helbig, Carolyn F. Delto, Lisa Myketin, Dirk Mossmann, Nils Burger, Noriko Miyake, Audrey Burnett, Andreas van Baalen, Mark A. Lovell, Naomichi Matsumoto, Maie Walsh, Hung-Chun Yu, Deepali N. Shinde, Ulrich Stephani, Johan L.K. Van Hove, Franz-Josef Müller, and Ingo Helbig. Mutations in pmpcb encoding the catalytic subunit of the mitochondrial presequence protease cause neurodegeneration in early childhood. American journal of human genetics, 102 4:557-573, Apr 2018. URL: https://doi.org/10.1016/j.ajhg.2018.02.014, doi:10.1016/j.ajhg.2018.02.014. This article has 111 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(baker2025qualitycontrolat pages 4-5): Megan J. Baker, Kai Qi Yek, and Diana Stojanovski. Quality control at the powerhouse: mitochondrial proteostasis dysfunction and disease. Biochemical Society Transactions, 53:1105-1117, Aug 2025. URL: https://doi.org/10.1042/bst20253044, doi:10.1042/bst20253044. This article has 3 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(matthews2024leighsyndromewith pages 1-2): Emma Matthews, Ella F. Whittle, Faraan Khan, Meriel McEntagart, and Christopher J. Carroll. Leigh syndrome with developmental regression and ataxia due to a novel splicing variant in the pmpcb gene. Journal of Human Genetics, 69:283-285, Feb 2024. URL: https://doi.org/10.1038/s10038-024-01226-9, doi:10.1038/s10038-024-01226-9. This article has 6 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(matthews2024leighsyndromewith pages 2-3): Emma Matthews, Ella F. Whittle, Faraan Khan, Meriel McEntagart, and Christopher J. Carroll. Leigh syndrome with developmental regression and ataxia due to a novel splicing variant in the pmpcb gene. Journal of Human Genetics, 69:283-285, Feb 2024. URL: https://doi.org/10.1038/s10038-024-01226-9, doi:10.1038/s10038-024-01226-9. This article has 6 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(vogtle2018mutationsinpmpcb pages 11-12): F.-Nora Vögtle, Björn Brändl, Austin Larson, Manuela Pendziwiat, Marisa W. Friederich, Susan M. White, Alice Basinger, Cansu Kücükköse, Hiltrud Muhle, Johanna A. Jähn, Oliver Keminer, Katherine L. Helbig, Carolyn F. Delto, Lisa Myketin, Dirk Mossmann, Nils Burger, Noriko Miyake, Audrey Burnett, Andreas van Baalen, Mark A. Lovell, Naomichi Matsumoto, Maie Walsh, Hung-Chun Yu, Deepali N. Shinde, Ulrich Stephani, Johan L.K. Van Hove, Franz-Josef Müller, and Ingo Helbig. Mutations in pmpcb encoding the catalytic subunit of the mitochondrial presequence protease cause neurodegeneration in early childhood. American journal of human genetics, 102 4:557-573, Apr 2018. URL: https://doi.org/10.1016/j.ajhg.2018.02.014, doi:10.1016/j.ajhg.2018.02.014. This article has 111 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(OpenTargets Search: -PMPCB): Open Targets Query (-PMPCB, 5 results). Buniello, A. et al. (2025). Open Targets Platform: facilitating therapeutic hypotheses building in drug discovery. Nucleic Acids Research.</p>
+</li>
+<li>
+<p>(kunova2022mitochondrialprocessingpeptidases—structure media bbb4e0aa): Nina Kunová, Henrieta Havalová, Gabriela Ondrovičová, Barbora Stojkovičová, Jacob A. Bauer, Vladena Bauerová-Hlinková, Vladimir Pevala, and Eva Kutejová. Mitochondrial processing peptidases—structure, function and the role in human diseases. International Journal of Molecular Sciences, 23:1297, Jan 2022. URL: https://doi.org/10.3390/ijms23031297, doi:10.3390/ijms23031297. This article has 39 citations.</p>
+</li>
+</ol>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>matthews2024leighsyndromewith pages 1-2</li>
+<li>gala2021mitochondrialproteasesin pages 2-5</li>
+<li>taylor2001crystalstructuresof pages 1-2</li>
+<li>baker2025qualitycontrolat pages 5-5</li>
+<li>taylor2001crystalstructuresof pages 3-4</li>
+<li>vogtle2018mutationsinpmpcb pages 1-2</li>
+<li>baker2025qualitycontrolat pages 4-5</li>
+<li>matthews2024leighsyndromewith pages 2-3</li>
+<li>vogtle2018mutationsinpmpcb pages 11-12</li>
+<li>https://doi.org/10.1038/s10038-024-01226-9</li>
+<li>https://doi.org/10.1016/j.ajhg.2018.02.014</li>
+<li>https://doi.org/10.3390/ijms23031297</li>
+<li>https://doi.org/10.1002/1873-3468.14039</li>
+<li>https://doi.org/10.1016/S0167-4889(02</li>
+<li>https://doi.org/10.1016/S0969-2126(01</li>
+<li>https://doi.org/10.1016/s0167-4889(02</li>
+<li>https://doi.org/10.3390/ijms23031297,</li>
+<li>https://doi.org/10.1002/1873-3468.14039,</li>
+<li>https://doi.org/10.1016/s0969-2126(01</li>
+<li>https://doi.org/10.1042/bst20253044,</li>
+<li>https://doi.org/10.1016/j.ajhg.2018.02.014,</li>
+<li>https://doi.org/10.1038/s10038-024-01226-9,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: O75439
+gene_symbol: PMPCB
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: &#39;PMPCB encodes the catalytic beta subunit of the mitochondrial processing peptidase (MPP), a Zn2+-dependent
+  metalloendopeptidase in the mitochondrial matrix that cleaves N-terminal targeting presequences from newly imported
+  mitochondrial precursor proteins.&#39;
+existing_annotations:
+- term:
+    id: GO:0004222
+    label: metalloendopeptidase activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: Correct and core. PMPCB is the catalytic Zn2+-dependent metalloendopeptidase subunit of MPP.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/PMPCB/PMPCB-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: The UniProt accession **O75439** corresponds to **human PMPCB** (gene name **PMPCB**,
+        synonym **MPPB**) annotated as **mitochondrial-processing peptidase subunit beta** (MPPβ), a member of
+        the **peptidase M16 family** and the **catalytic β subunit** of the heterodimeric mitochondrial
+        processing peptidase (MPP). This mapping (human PMPCB ↔ UniProt O75439) is explicitly supported by a
+        review of mitochondrial processing peptidases that lists **Homo sapiens O75439** as the MPP subunit
+        containing the characteristic inverted Zn-binding motif HxxEH…E required for activity, as well as by
+        authoritative reviews describing human MPP as PMPCA (α) + PMPCB (β) with PMPCB harboring the catalytic
+        site. (gakh2002mitochondrialprocessingpeptidases. pages 4-6,
+        kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, gala2021mitochondrialproteasesin
+        pages 2-5, kunova2022mitochondrialprocessingpeptidases—structure pages 4-6)
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: MPP is a **Zn2+-dependent metalloendopeptidase**. PMPCB contains the conserved inverted
+        Zn-binding/catalytic motif **HxxEH…E** (with the distal glutamate contributing to Zn coordination).
+        Mutation of residues in this motif abolishes Zn binding and peptidase activity, supporting that PMPCB
+        is the catalytic subunit. (gakh2002mitochondrialprocessingpeptidases. pages 4-6,
+        kunova2022mitochondrialprocessingpeptidases—structure pages 2-4)
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: Authoritative reviews converge on a model in which **PMPCB is the catalytic Zn
+        metalloprotease** and **PMPCA contributes substrate recognition**, together enabling cleavage of a
+        large fraction of imported mitochondrial proteins. This division of labor is supported by conserved
+        motifs (active-site Zn-binding in β subunit), structural evidence (peptide binding in a negatively
+        charged cavity, glycine-rich loop gating/positioning), and disease genetics demonstrating that partial
+        disruption causes severe neurological phenotypes. (gala2021mitochondrialproteasesin pages 2-5,
+        kunova2022mitochondrialprocessingpeptidases—structure pages 2-4,
+        gakh2002mitochondrialprocessingpeptidases. pages 4-6)
+- term:
+    id: GO:0017087
+    label: mitochondrial processing peptidase complex
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: Correct and core. PMPCB forms the mitochondrial processing peptidase heterodimer with PMPCA.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/PMPCB/PMPCB-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: The UniProt accession **O75439** corresponds to **human PMPCB** (gene name **PMPCB**,
+        synonym **MPPB**) annotated as **mitochondrial-processing peptidase subunit beta** (MPPβ), a member of
+        the **peptidase M16 family** and the **catalytic β subunit** of the heterodimeric mitochondrial
+        processing peptidase (MPP). This mapping (human PMPCB ↔ UniProt O75439) is explicitly supported by a
+        review of mitochondrial processing peptidases that lists **Homo sapiens O75439** as the MPP subunit
+        containing the characteristic inverted Zn-binding motif HxxEH…E required for activity, as well as by
+        authoritative reviews describing human MPP as PMPCA (α) + PMPCB (β) with PMPCB harboring the catalytic
+        site. (gakh2002mitochondrialprocessingpeptidases. pages 4-6,
+        kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, gala2021mitochondrialproteasesin
+        pages 2-5, kunova2022mitochondrialprocessingpeptidases—structure pages 4-6)
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: &#39;| Complex membership | PMPCB forms the **MPP heterodimer** with **PMPCA (α-MPP)**; PMPCB
+        provides catalysis, whereas PMPCA contributes substrate recognition/positioning via a glycine-rich loop
+        and helps shape the substrate-binding cavity (kunova2022mitochondrialprocessingpeptidases—structure pages
+        2-4, gala2021mitochondrialproteasesin pages 2-5, kunova2022mitochondrialprocessingpeptidases—structure media
+        e22ffe68). |&#39;
+- term:
+    id: GO:0004222
+    label: metalloendopeptidase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  review:
+    summary: Correct and core. PMPCB is the catalytic Zn2+-dependent metalloendopeptidase subunit of MPP.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/PMPCB/PMPCB-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: The UniProt accession **O75439** corresponds to **human PMPCB** (gene name **PMPCB**,
+        synonym **MPPB**) annotated as **mitochondrial-processing peptidase subunit beta** (MPPβ), a member of
+        the **peptidase M16 family** and the **catalytic β subunit** of the heterodimeric mitochondrial
+        processing peptidase (MPP). This mapping (human PMPCB ↔ UniProt O75439) is explicitly supported by a
+        review of mitochondrial processing peptidases that lists **Homo sapiens O75439** as the MPP subunit
+        containing the characteristic inverted Zn-binding motif HxxEH…E required for activity, as well as by
+        authoritative reviews describing human MPP as PMPCA (α) + PMPCB (β) with PMPCB harboring the catalytic
+        site. (gakh2002mitochondrialprocessingpeptidases. pages 4-6,
+        kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, gala2021mitochondrialproteasesin
+        pages 2-5, kunova2022mitochondrialprocessingpeptidases—structure pages 4-6)
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: MPP is a **Zn2+-dependent metalloendopeptidase**. PMPCB contains the conserved inverted
+        Zn-binding/catalytic motif **HxxEH…E** (with the distal glutamate contributing to Zn coordination).
+        Mutation of residues in this motif abolishes Zn binding and peptidase activity, supporting that PMPCB
+        is the catalytic subunit. (gakh2002mitochondrialprocessingpeptidases. pages 4-6,
+        kunova2022mitochondrialprocessingpeptidases—structure pages 2-4)
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: Authoritative reviews converge on a model in which **PMPCB is the catalytic Zn
+        metalloprotease** and **PMPCA contributes substrate recognition**, together enabling cleavage of a
+        large fraction of imported mitochondrial proteins. This division of labor is supported by conserved
+        motifs (active-site Zn-binding in β subunit), structural evidence (peptide binding in a negatively
+        charged cavity, glycine-rich loop gating/positioning), and disease genetics demonstrating that partial
+        disruption causes severe neurological phenotypes. (gala2021mitochondrialproteasesin pages 2-5,
+        kunova2022mitochondrialprocessingpeptidases—structure pages 2-4,
+        gakh2002mitochondrialprocessingpeptidases. pages 4-6)
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  review:
+    summary: Correct. MPP/PMPCB acts in the mitochondrial matrix after precursor import through TOM/TIM.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/PMPCB/PMPCB-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: PMPCB functions in the **mitochondrial matrix** as part of MPP, acting on precursors
+        after import via TOM/TIM pathways. (gala2021mitochondrialproteasesin pages 2-5,
+        baker2025qualitycontrolat pages 4-5)
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: In the canonical pathway, precursors are recognized and translocated through TOM and
+        TIM machineries, then MPP removes the N-terminal targeting presequence in the matrix. Cleaved
+        presequences are subsequently degraded by downstream peptidases (e.g., PreP), preventing accumulation
+        of potentially disruptive targeting peptides. (baker2025qualitycontrolat pages 4-5,
+        gala2021mitochondrialproteasesin pages 2-5)
+- term:
+    id: GO:0006508
+    label: proteolysis
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  review:
+    summary: Correct process family but too broad. PMPCB specifically performs mitochondrial presequence
+      processing as the catalytic MPP subunit.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/PMPCB/PMPCB-deep-research-falcon.md
+    reason: Prefer metalloendopeptidase activity and protein processing/presequence-cleavage terms over
+      generic proteolysis.
+    supported_by:
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: PMPCB provides the catalytic activity of MPP, which cleaves the **N-terminal
+        mitochondrial targeting presequence** from mitochondrial precursor proteins after their translocation
+        into mitochondria, yielding the mature protein N-terminus (or an intermediate for further processing
+        by other peptidases). (gala2021mitochondrialproteasesin pages 2-5, taylor2001crystalstructuresof pages
+        1-2, baker2025qualitycontrolat pages 5-5)
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: Authoritative reviews converge on a model in which **PMPCB is the catalytic Zn
+        metalloprotease** and **PMPCA contributes substrate recognition**, together enabling cleavage of a
+        large fraction of imported mitochondrial proteins. This division of labor is supported by conserved
+        motifs (active-site Zn-binding in β subunit), structural evidence (peptide binding in a negatively
+        charged cavity, glycine-rich loop gating/positioning), and disease genetics demonstrating that partial
+        disruption causes severe neurological phenotypes. (gala2021mitochondrialproteasesin pages 2-5,
+        kunova2022mitochondrialprocessingpeptidases—structure pages 2-4,
+        gakh2002mitochondrialprocessingpeptidases. pages 4-6)
+- term:
+    id: GO:0009003
+    label: signal peptidase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000003
+  review:
+    summary: Correct. PMPCB cleaves mitochondrial targeting presequences; metalloendopeptidase activity
+      captures the catalytic class more precisely.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/PMPCB/PMPCB-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: Most mitochondrial proteins are nuclear-encoded, synthesized in the cytosol, and
+        imported into mitochondria using N-terminal **mitochondrial targeting presequences** (often
+        amphipathic, positively charged α-helices). These presequences generally must be cleaved after import
+        for proper maturation and assembly of mitochondrial proteins. The central enzyme executing this step
+        is the **mitochondrial processing peptidase (MPP)**. (gala2021mitochondrialproteasesin pages 2-5,
+        kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, taylor2001crystalstructuresof pages
+        1-2)
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: PMPCB provides the catalytic activity of MPP, which cleaves the **N-terminal
+        mitochondrial targeting presequence** from mitochondrial precursor proteins after their translocation
+        into mitochondria, yielding the mature protein N-terminus (or an intermediate for further processing
+        by other peptidases). (gala2021mitochondrialproteasesin pages 2-5, taylor2001crystalstructuresof pages
+        1-2, baker2025qualitycontrolat pages 5-5)
+- term:
+    id: GO:0016485
+    label: protein processing
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  review:
+    summary: Correct and core. PMPCB processes newly imported mitochondrial precursor proteins by removing
+      N-terminal targeting presequences.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/PMPCB/PMPCB-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: Most mitochondrial proteins are nuclear-encoded, synthesized in the cytosol, and
+        imported into mitochondria using N-terminal **mitochondrial targeting presequences** (often
+        amphipathic, positively charged α-helices). These presequences generally must be cleaved after import
+        for proper maturation and assembly of mitochondrial proteins. The central enzyme executing this step
+        is the **mitochondrial processing peptidase (MPP)**. (gala2021mitochondrialproteasesin pages 2-5,
+        kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, taylor2001crystalstructuresof pages
+        1-2)
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: PMPCB provides the catalytic activity of MPP, which cleaves the **N-terminal
+        mitochondrial targeting presequence** from mitochondrial precursor proteins after their translocation
+        into mitochondria, yielding the mature protein N-terminus (or an intermediate for further processing
+        by other peptidases). (gala2021mitochondrialproteasesin pages 2-5, taylor2001crystalstructuresof pages
+        1-2, baker2025qualitycontrolat pages 5-5)
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: In the canonical pathway, precursors are recognized and translocated through TOM and
+        TIM machineries, then MPP removes the N-terminal targeting presequence in the matrix. Cleaved
+        presequences are subsequently degraded by downstream peptidases (e.g., PreP), preventing accumulation
+        of potentially disruptive targeting peptides. (baker2025qualitycontrolat pages 4-5,
+        gala2021mitochondrialproteasesin pages 2-5)
+- term:
+    id: GO:0046872
+    label: metal ion binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  review:
+    summary: Correct mechanistic feature but too generic. Zinc binding is integral to the metalloendopeptidase
+      active site, so the enzyme activity term is more informative.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/PMPCB/PMPCB-deep-research-falcon.md
+    reason: Prefer metalloendopeptidase activity over generic metal ion binding.
+    supported_by:
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: MPP is a **Zn2+-dependent metalloendopeptidase**. PMPCB contains the conserved inverted
+        Zn-binding/catalytic motif **HxxEH…E** (with the distal glutamate contributing to Zn coordination).
+        Mutation of residues in this motif abolishes Zn binding and peptidase activity, supporting that PMPCB
+        is the catalytic subunit. (gakh2002mitochondrialprocessingpeptidases. pages 4-6,
+        kunova2022mitochondrialprocessingpeptidases—structure pages 2-4)
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: NAS
+  original_reference_id: PMID:32443488
+  review:
+    summary: Correct but broad. PMPCB is specifically a mitochondrial matrix MPP complex subunit.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/PMPCB/PMPCB-deep-research-falcon.md
+    reason: Prefer mitochondrial matrix and mitochondrial processing peptidase complex over generic
+      mitochondrion.
+    supported_by:
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: PMPCB functions in the **mitochondrial matrix** as part of MPP, acting on precursors
+        after import via TOM/TIM pathways. (gala2021mitochondrialproteasesin pages 2-5,
+        baker2025qualitycontrolat pages 4-5)
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: &#39;| Complex membership | PMPCB forms the **MPP heterodimer** with **PMPCA (α-MPP)**; PMPCB
+        provides catalysis, whereas PMPCA contributes substrate recognition/positioning via a glycine-rich loop
+        and helps shape the substrate-binding cavity (kunova2022mitochondrialprocessingpeptidases—structure pages
+        2-4, gala2021mitochondrialproteasesin pages 2-5, kunova2022mitochondrialprocessingpeptidases—structure media
+        e22ffe68). |&#39;
+- term:
+    id: GO:0017087
+    label: mitochondrial processing peptidase complex
+  evidence_type: NAS
+  original_reference_id: PMID:32443488
+  review:
+    summary: Correct and core. PMPCB forms the mitochondrial processing peptidase heterodimer with PMPCA.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/PMPCB/PMPCB-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: The UniProt accession **O75439** corresponds to **human PMPCB** (gene name **PMPCB**,
+        synonym **MPPB**) annotated as **mitochondrial-processing peptidase subunit beta** (MPPβ), a member of
+        the **peptidase M16 family** and the **catalytic β subunit** of the heterodimeric mitochondrial
+        processing peptidase (MPP). This mapping (human PMPCB ↔ UniProt O75439) is explicitly supported by a
+        review of mitochondrial processing peptidases that lists **Homo sapiens O75439** as the MPP subunit
+        containing the characteristic inverted Zn-binding motif HxxEH…E required for activity, as well as by
+        authoritative reviews describing human MPP as PMPCA (α) + PMPCB (β) with PMPCB harboring the catalytic
+        site. (gakh2002mitochondrialprocessingpeptidases. pages 4-6,
+        kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, gala2021mitochondrialproteasesin
+        pages 2-5, kunova2022mitochondrialprocessingpeptidases—structure pages 4-6)
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: &#39;| Complex membership | PMPCB forms the **MPP heterodimer** with **PMPCA (α-MPP)**; PMPCB
+        provides catalysis, whereas PMPCA contributes substrate recognition/positioning via a glycine-rich loop
+        and helps shape the substrate-binding cavity (kunova2022mitochondrialprocessingpeptidases—structure pages
+        2-4, gala2021mitochondrialproteasesin pages 2-5, kunova2022mitochondrialprocessingpeptidases—structure media
+        e22ffe68). |&#39;
+- term:
+    id: GO:0070585
+    label: protein localization to mitochondrion
+  evidence_type: NAS
+  original_reference_id: PMID:32443488
+  review:
+    summary: Over-annotated. PMPCB acts after protein import by cleaving targeting presequences; it is not
+      itself the import/localization machinery.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/PMPCB/PMPCB-deep-research-falcon.md
+    reason: Use protein processing and metalloendopeptidase activity rather than protein localization to
+      mitochondrion.
+    supported_by:
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: In the canonical pathway, precursors are recognized and translocated through TOM and
+        TIM machineries, then MPP removes the N-terminal targeting presequence in the matrix. Cleaved
+        presequences are subsequently degraded by downstream peptidases (e.g., PreP), preventing accumulation
+        of potentially disruptive targeting peptides. (baker2025qualitycontrolat pages 4-5,
+        gala2021mitochondrialproteasesin pages 2-5)
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: PMPCB provides the catalytic activity of MPP, which cleaves the **N-terminal
+        mitochondrial targeting presequence** from mitochondrial precursor proteins after their translocation
+        into mitochondria, yielding the mature protein N-terminus (or an intermediate for further processing
+        by other peptidases). (gala2021mitochondrialproteasesin pages 2-5, taylor2001crystalstructuresof pages
+        1-2, baker2025qualitycontrolat pages 5-5)
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IDA
+  original_reference_id: GO_REF:0000052
+  review:
+    summary: Correct but broad. PMPCB is specifically a mitochondrial matrix MPP complex subunit.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/PMPCB/PMPCB-deep-research-falcon.md
+    reason: Prefer mitochondrial matrix and mitochondrial processing peptidase complex over generic
+      mitochondrion.
+    supported_by:
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: PMPCB functions in the **mitochondrial matrix** as part of MPP, acting on precursors
+        after import via TOM/TIM pathways. (gala2021mitochondrialproteasesin pages 2-5,
+        baker2025qualitycontrolat pages 4-5)
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: &#39;| Complex membership | PMPCB forms the **MPP heterodimer** with **PMPCA (α-MPP)**; PMPCB
+        provides catalysis, whereas PMPCA contributes substrate recognition/positioning via a glycine-rich loop
+        and helps shape the substrate-binding cavity (kunova2022mitochondrialprocessingpeptidases—structure pages
+        2-4, gala2021mitochondrialproteasesin pages 2-5, kunova2022mitochondrialprocessingpeptidases—structure media
+        e22ffe68). |&#39;
+- term:
+    id: GO:0006851
+    label: mitochondrial calcium ion transmembrane transport
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-8949215
+  review:
+    summary: Over-annotated. PMPCB can process proSMDT1/proEMRE, a component needed for MCU complex function,
+      but PMPCB does not catalyze calcium transmembrane transport.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/PMPCB/PMPCB-deep-research-falcon.md
+    - Reactome:R-HSA-8949649
+    reason: The Reactome event reflects MPP cleavage of an MCU-complex subunit precursor, not direct calcium
+      ion transport by PMPCB.
+    supported_by:
+    - reference_id: Reactome:R-HSA-8949649
+      supporting_text: The mitochondrial endopeptidase PMPCA:PMPCB cleaves the transit peptide of proSMDT1
+        (proEMRE) yielding SMDT1 (Konig et al. 2016). Mature SMDT1 is assembled into the MCU complex where it
+        serves to bridge the MCU pore and the MCU regulators MICU1 and MICU2 (or MICU3 in neurons).
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: PMPCB provides the catalytic activity of MPP, which cleaves the **N-terminal
+        mitochondrial targeting presequence** from mitochondrial precursor proteins after their translocation
+        into mitochondria, yielding the mature protein N-terminus (or an intermediate for further processing
+        by other peptidases). (gala2021mitochondrialproteasesin pages 2-5, taylor2001crystalstructuresof pages
+        1-2, baker2025qualitycontrolat pages 5-5)
+- term:
+    id: GO:0004222
+    label: metalloendopeptidase activity
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-8949649
+  review:
+    summary: Correct and core. PMPCB is the catalytic Zn2+-dependent metalloendopeptidase subunit of MPP.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/PMPCB/PMPCB-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: The UniProt accession **O75439** corresponds to **human PMPCB** (gene name **PMPCB**,
+        synonym **MPPB**) annotated as **mitochondrial-processing peptidase subunit beta** (MPPβ), a member of
+        the **peptidase M16 family** and the **catalytic β subunit** of the heterodimeric mitochondrial
+        processing peptidase (MPP). This mapping (human PMPCB ↔ UniProt O75439) is explicitly supported by a
+        review of mitochondrial processing peptidases that lists **Homo sapiens O75439** as the MPP subunit
+        containing the characteristic inverted Zn-binding motif HxxEH…E required for activity, as well as by
+        authoritative reviews describing human MPP as PMPCA (α) + PMPCB (β) with PMPCB harboring the catalytic
+        site. (gakh2002mitochondrialprocessingpeptidases. pages 4-6,
+        kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, gala2021mitochondrialproteasesin
+        pages 2-5, kunova2022mitochondrialprocessingpeptidases—structure pages 4-6)
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: MPP is a **Zn2+-dependent metalloendopeptidase**. PMPCB contains the conserved inverted
+        Zn-binding/catalytic motif **HxxEH…E** (with the distal glutamate contributing to Zn coordination).
+        Mutation of residues in this motif abolishes Zn binding and peptidase activity, supporting that PMPCB
+        is the catalytic subunit. (gakh2002mitochondrialprocessingpeptidases. pages 4-6,
+        kunova2022mitochondrialprocessingpeptidases—structure pages 2-4)
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: Authoritative reviews converge on a model in which **PMPCB is the catalytic Zn
+        metalloprotease** and **PMPCA contributes substrate recognition**, together enabling cleavage of a
+        large fraction of imported mitochondrial proteins. This division of labor is supported by conserved
+        motifs (active-site Zn-binding in β subunit), structural evidence (peptide binding in a negatively
+        charged cavity, glycine-rich loop gating/positioning), and disease genetics demonstrating that partial
+        disruption causes severe neurological phenotypes. (gala2021mitochondrialproteasesin pages 2-5,
+        kunova2022mitochondrialprocessingpeptidases—structure pages 2-4,
+        gakh2002mitochondrialprocessingpeptidases. pages 4-6)
+- term:
+    id: GO:0009003
+    label: signal peptidase activity
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  review:
+    summary: Correct. PMPCB cleaves mitochondrial targeting presequences; metalloendopeptidase activity
+      captures the catalytic class more precisely.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/PMPCB/PMPCB-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: Most mitochondrial proteins are nuclear-encoded, synthesized in the cytosol, and
+        imported into mitochondria using N-terminal **mitochondrial targeting presequences** (often
+        amphipathic, positively charged α-helices). These presequences generally must be cleaved after import
+        for proper maturation and assembly of mitochondrial proteins. The central enzyme executing this step
+        is the **mitochondrial processing peptidase (MPP)**. (gala2021mitochondrialproteasesin pages 2-5,
+        kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, taylor2001crystalstructuresof pages
+        1-2)
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: PMPCB provides the catalytic activity of MPP, which cleaves the **N-terminal
+        mitochondrial targeting presequence** from mitochondrial precursor proteins after their translocation
+        into mitochondria, yielding the mature protein N-terminus (or an intermediate for further processing
+        by other peptidases). (gala2021mitochondrialproteasesin pages 2-5, taylor2001crystalstructuresof pages
+        1-2, baker2025qualitycontrolat pages 5-5)
+- term:
+    id: GO:0016485
+    label: protein processing
+  evidence_type: IDA
+  original_reference_id: PMID:22354088
+  review:
+    summary: Correct and core. PMPCB processes newly imported mitochondrial precursor proteins by removing
+      N-terminal targeting presequences.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/PMPCB/PMPCB-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: Most mitochondrial proteins are nuclear-encoded, synthesized in the cytosol, and
+        imported into mitochondria using N-terminal **mitochondrial targeting presequences** (often
+        amphipathic, positively charged α-helices). These presequences generally must be cleaved after import
+        for proper maturation and assembly of mitochondrial proteins. The central enzyme executing this step
+        is the **mitochondrial processing peptidase (MPP)**. (gala2021mitochondrialproteasesin pages 2-5,
+        kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, taylor2001crystalstructuresof pages
+        1-2)
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: PMPCB provides the catalytic activity of MPP, which cleaves the **N-terminal
+        mitochondrial targeting presequence** from mitochondrial precursor proteins after their translocation
+        into mitochondria, yielding the mature protein N-terminus (or an intermediate for further processing
+        by other peptidases). (gala2021mitochondrialproteasesin pages 2-5, taylor2001crystalstructuresof pages
+        1-2, baker2025qualitycontrolat pages 5-5)
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: In the canonical pathway, precursors are recognized and translocated through TOM and
+        TIM machineries, then MPP removes the N-terminal targeting presequence in the matrix. Cleaved
+        presequences are subsequently degraded by downstream peptidases (e.g., PreP), preventing accumulation
+        of potentially disruptive targeting peptides. (baker2025qualitycontrolat pages 4-5,
+        gala2021mitochondrialproteasesin pages 2-5)
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: HTP
+  original_reference_id: PMID:34800366
+  review:
+    summary: Correct but broad. PMPCB is specifically a mitochondrial matrix MPP complex subunit.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/PMPCB/PMPCB-deep-research-falcon.md
+    reason: Prefer mitochondrial matrix and mitochondrial processing peptidase complex over generic
+      mitochondrion.
+    supported_by:
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: PMPCB functions in the **mitochondrial matrix** as part of MPP, acting on precursors
+        after import via TOM/TIM pathways. (gala2021mitochondrialproteasesin pages 2-5,
+        baker2025qualitycontrolat pages 4-5)
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: &#39;| Complex membership | PMPCB forms the **MPP heterodimer** with **PMPCA (α-MPP)**; PMPCB
+        provides catalysis, whereas PMPCA contributes substrate recognition/positioning via a glycine-rich loop
+        and helps shape the substrate-binding cavity (kunova2022mitochondrialprocessingpeptidases—structure pages
+        2-4, gala2021mitochondrialproteasesin pages 2-5, kunova2022mitochondrialprocessingpeptidases—structure media
+        e22ffe68). |&#39;
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: EXP
+  original_reference_id: PMID:22354088
+  review:
+    summary: Correct. MPP/PMPCB acts in the mitochondrial matrix after precursor import through TOM/TIM.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/PMPCB/PMPCB-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: PMPCB functions in the **mitochondrial matrix** as part of MPP, acting on precursors
+        after import via TOM/TIM pathways. (gala2021mitochondrialproteasesin pages 2-5,
+        baker2025qualitycontrolat pages 4-5)
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: In the canonical pathway, precursors are recognized and translocated through TOM and
+        TIM machineries, then MPP removes the N-terminal targeting presequence in the matrix. Cleaved
+        presequences are subsequently degraded by downstream peptidases (e.g., PreP), preventing accumulation
+        of potentially disruptive targeting peptides. (baker2025qualitycontrolat pages 4-5,
+        gala2021mitochondrialproteasesin pages 2-5)
+- term:
+    id: GO:0005759
+    label: mitochondrial matrix
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-8949649
+  review:
+    summary: Correct. MPP/PMPCB acts in the mitochondrial matrix after precursor import through TOM/TIM.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/PMPCB/PMPCB-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: PMPCB functions in the **mitochondrial matrix** as part of MPP, acting on precursors
+        after import via TOM/TIM pathways. (gala2021mitochondrialproteasesin pages 2-5,
+        baker2025qualitycontrolat pages 4-5)
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: In the canonical pathway, precursors are recognized and translocated through TOM and
+        TIM machineries, then MPP removes the N-terminal targeting presequence in the matrix. Cleaved
+        presequences are subsequently degraded by downstream peptidases (e.g., PreP), preventing accumulation
+        of potentially disruptive targeting peptides. (baker2025qualitycontrolat pages 4-5,
+        gala2021mitochondrialproteasesin pages 2-5)
+- term:
+    id: GO:0004222
+    label: metalloendopeptidase activity
+  evidence_type: IDA
+  original_reference_id: PMID:22354088
+  review:
+    summary: Correct and core. PMPCB is the catalytic Zn2+-dependent metalloendopeptidase subunit of MPP.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/PMPCB/PMPCB-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: The UniProt accession **O75439** corresponds to **human PMPCB** (gene name **PMPCB**,
+        synonym **MPPB**) annotated as **mitochondrial-processing peptidase subunit beta** (MPPβ), a member of
+        the **peptidase M16 family** and the **catalytic β subunit** of the heterodimeric mitochondrial
+        processing peptidase (MPP). This mapping (human PMPCB ↔ UniProt O75439) is explicitly supported by a
+        review of mitochondrial processing peptidases that lists **Homo sapiens O75439** as the MPP subunit
+        containing the characteristic inverted Zn-binding motif HxxEH…E required for activity, as well as by
+        authoritative reviews describing human MPP as PMPCA (α) + PMPCB (β) with PMPCB harboring the catalytic
+        site. (gakh2002mitochondrialprocessingpeptidases. pages 4-6,
+        kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, gala2021mitochondrialproteasesin
+        pages 2-5, kunova2022mitochondrialprocessingpeptidases—structure pages 4-6)
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: MPP is a **Zn2+-dependent metalloendopeptidase**. PMPCB contains the conserved inverted
+        Zn-binding/catalytic motif **HxxEH…E** (with the distal glutamate contributing to Zn coordination).
+        Mutation of residues in this motif abolishes Zn binding and peptidase activity, supporting that PMPCB
+        is the catalytic subunit. (gakh2002mitochondrialprocessingpeptidases. pages 4-6,
+        kunova2022mitochondrialprocessingpeptidases—structure pages 2-4)
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: Authoritative reviews converge on a model in which **PMPCB is the catalytic Zn
+        metalloprotease** and **PMPCA contributes substrate recognition**, together enabling cleavage of a
+        large fraction of imported mitochondrial proteins. This division of labor is supported by conserved
+        motifs (active-site Zn-binding in β subunit), structural evidence (peptide binding in a negatively
+        charged cavity, glycine-rich loop gating/positioning), and disease genetics demonstrating that partial
+        disruption causes severe neurological phenotypes. (gala2021mitochondrialproteasesin pages 2-5,
+        kunova2022mitochondrialprocessingpeptidases—structure pages 2-4,
+        gakh2002mitochondrialprocessingpeptidases. pages 4-6)
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IDA
+  original_reference_id: PMID:22354088
+  review:
+    summary: Correct but broad. PMPCB is specifically a mitochondrial matrix MPP complex subunit.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/PMPCB/PMPCB-deep-research-falcon.md
+    reason: Prefer mitochondrial matrix and mitochondrial processing peptidase complex over generic
+      mitochondrion.
+    supported_by:
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: PMPCB functions in the **mitochondrial matrix** as part of MPP, acting on precursors
+        after import via TOM/TIM pathways. (gala2021mitochondrialproteasesin pages 2-5,
+        baker2025qualitycontrolat pages 4-5)
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: &#39;| Complex membership | PMPCB forms the **MPP heterodimer** with **PMPCA (α-MPP)**; PMPCB
+        provides catalysis, whereas PMPCA contributes substrate recognition/positioning via a glycine-rich loop
+        and helps shape the substrate-binding cavity (kunova2022mitochondrialprocessingpeptidases—structure pages
+        2-4, gala2021mitochondrialproteasesin pages 2-5, kunova2022mitochondrialprocessingpeptidases—structure media
+        e22ffe68). |&#39;
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO terms
+  findings: []
+- id: GO_REF:0000003
+  title: Gene Ontology annotation based on Enzyme Commission mapping
+  findings: []
+- id: GO_REF:0000024
+  title: Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment
+    of sequence similarity
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000052
+  title: Gene Ontology annotation based on curation of immunofluorescence data
+  findings: []
+- id: GO_REF:0000117
+  title: Electronic Gene Ontology annotations created by ARBA machine learning models
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: PMID:22354088
+  title: Mitochondrial processing peptidase regulates PINK1 processing, import and Parkin recruitment.
+  findings: []
+- id: PMID:32443488
+  title: Mitochondrial Protein Quality Control Mechanisms.
+  findings: []
+- id: PMID:34800366
+  title: Quantitative high-confidence human mitochondrial proteome and its dynamics in cellular context.
+  findings: []
+- id: Reactome:R-HSA-8949215
+  title: Mitochondrial calcium ion transport
+  findings: []
+- id: Reactome:R-HSA-8949649
+  title: PMPCA:PMPCB cleaves the transit peptide of proSMDT1 (proEMRE)
+  findings: []
+- id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+  title: Falcon deep research report for human PMPCB
+  findings: []
+core_functions:
+- description: PMPCB is the catalytic beta subunit of the mitochondrial processing peptidase heterodimer. In
+    the mitochondrial matrix, it performs Zn2+-dependent metalloendopeptidase cleavage of N-terminal
+    mitochondrial targeting presequences from imported precursor proteins.
+  supported_by:
+  - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+    supporting_text: The UniProt accession **O75439** corresponds to **human PMPCB** (gene name **PMPCB**,
+      synonym **MPPB**) annotated as **mitochondrial-processing peptidase subunit beta** (MPPβ), a member of
+      the **peptidase M16 family** and the **catalytic β subunit** of the heterodimeric mitochondrial
+      processing peptidase (MPP). This mapping (human PMPCB ↔ UniProt O75439) is explicitly supported by a
+      review of mitochondrial processing peptidases that lists **Homo sapiens O75439** as the MPP subunit
+      containing the characteristic inverted Zn-binding motif HxxEH…E required for activity, as well as by
+      authoritative reviews describing human MPP as PMPCA (α) + PMPCB (β) with PMPCB harboring the catalytic
+      site. (gakh2002mitochondrialprocessingpeptidases. pages 4-6,
+      kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, gala2021mitochondrialproteasesin pages
+      2-5, kunova2022mitochondrialprocessingpeptidases—structure pages 4-6)
+  - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+    supporting_text: PMPCB provides the catalytic activity of MPP, which cleaves the **N-terminal
+      mitochondrial targeting presequence** from mitochondrial precursor proteins after their translocation
+      into mitochondria, yielding the mature protein N-terminus (or an intermediate for further processing by
+      other peptidases). (gala2021mitochondrialproteasesin pages 2-5, taylor2001crystalstructuresof pages 1-2,
+      baker2025qualitycontrolat pages 5-5)
+  - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+    supporting_text: MPP is a **Zn2+-dependent metalloendopeptidase**. PMPCB contains the conserved inverted
+      Zn-binding/catalytic motif **HxxEH…E** (with the distal glutamate contributing to Zn coordination).
+      Mutation of residues in this motif abolishes Zn binding and peptidase activity, supporting that PMPCB is
+      the catalytic subunit. (gakh2002mitochondrialprocessingpeptidases. pages 4-6,
+      kunova2022mitochondrialprocessingpeptidases—structure pages 2-4)
+  - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+    supporting_text: PMPCB functions in the **mitochondrial matrix** as part of MPP, acting on precursors
+      after import via TOM/TIM pathways. (gala2021mitochondrialproteasesin pages 2-5,
+      baker2025qualitycontrolat pages 4-5)
+  - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+    supporting_text: Authoritative reviews converge on a model in which **PMPCB is the catalytic Zn
+      metalloprotease** and **PMPCA contributes substrate recognition**, together enabling cleavage of a large
+      fraction of imported mitochondrial proteins. This division of labor is supported by conserved motifs
+      (active-site Zn-binding in β subunit), structural evidence (peptide binding in a negatively charged
+      cavity, glycine-rich loop gating/positioning), and disease genetics demonstrating that partial
+      disruption causes severe neurological phenotypes. (gala2021mitochondrialproteasesin pages 2-5,
+      kunova2022mitochondrialprocessingpeptidases—structure pages 2-4,
+      gakh2002mitochondrialprocessingpeptidases. pages 4-6)
+  molecular_function:
+    id: GO:0004222
+    label: metalloendopeptidase activity
+  directly_involved_in:
+  - id: GO:0016485
+    label: protein processing
+  locations:
+  - id: GO:0005759
+    label: mitochondrial matrix
+  in_complex:
+    id: GO:0017087
+    label: mitochondrial processing peptidase complex
+proposed_new_terms: []
+suggested_questions:
+- question: Which PMPCB disease variants primarily reduce catalytic activity versus MPP complex stability or
+    substrate recognition?
+  experts: []
+- question: Which human MPP substrates are most sensitive to partial PMPCB impairment in neuronal cells?
+  experts: []
+suggested_experiments:
+- hypothesis: PMPCB disease variants cause selective substrate-processing defects rather than uniform loss of
+    all MPP cleavage.
+  description: Perform quantitative N-terminomics and targeted substrate immunoblots in PMPCB-variant rescue
+    cells to compare cleavage efficiency across mitochondrial precursors.
+- hypothesis: The PMPCB contribution to mitochondrial calcium uptake is indirect through proSMDT1/proEMRE
+    maturation.
+  description: Separate acute PMPCB catalytic inhibition from mature EMRE rescue and measure proSMDT1
+    processing, MCU complex assembly, and mitochondrial calcium uptake.
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/human/PMPCB/PMPCB-ai-review.yaml
+++ b/genes/human/PMPCB/PMPCB-ai-review.yaml
@@ -1,11 +1,13 @@
 id: O75439
 gene_symbol: PMPCB
 product_type: PROTEIN
-status: INITIALIZED
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
-description: 'TODO: Add description for PMPCB'
+description: 'PMPCB encodes the catalytic beta subunit of the mitochondrial processing peptidase (MPP), a Zn2+-dependent
+  metalloendopeptidase in the mitochondrial matrix that cleaves N-terminal targeting presequences from newly imported
+  mitochondrial precursor proteins.'
 existing_annotations:
 - term:
     id: GO:0004222
@@ -13,179 +15,584 @@ existing_annotations:
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct and core. PMPCB is the catalytic Zn2+-dependent metalloendopeptidase subunit of MPP.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/PMPCB/PMPCB-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: The UniProt accession **O75439** corresponds to **human PMPCB** (gene name **PMPCB**,
+        synonym **MPPB**) annotated as **mitochondrial-processing peptidase subunit beta** (MPPβ), a member of
+        the **peptidase M16 family** and the **catalytic β subunit** of the heterodimeric mitochondrial
+        processing peptidase (MPP). This mapping (human PMPCB ↔ UniProt O75439) is explicitly supported by a
+        review of mitochondrial processing peptidases that lists **Homo sapiens O75439** as the MPP subunit
+        containing the characteristic inverted Zn-binding motif HxxEH…E required for activity, as well as by
+        authoritative reviews describing human MPP as PMPCA (α) + PMPCB (β) with PMPCB harboring the catalytic
+        site. (gakh2002mitochondrialprocessingpeptidases. pages 4-6,
+        kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, gala2021mitochondrialproteasesin
+        pages 2-5, kunova2022mitochondrialprocessingpeptidases—structure pages 4-6)
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: MPP is a **Zn2+-dependent metalloendopeptidase**. PMPCB contains the conserved inverted
+        Zn-binding/catalytic motif **HxxEH…E** (with the distal glutamate contributing to Zn coordination).
+        Mutation of residues in this motif abolishes Zn binding and peptidase activity, supporting that PMPCB
+        is the catalytic subunit. (gakh2002mitochondrialprocessingpeptidases. pages 4-6,
+        kunova2022mitochondrialprocessingpeptidases—structure pages 2-4)
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: Authoritative reviews converge on a model in which **PMPCB is the catalytic Zn
+        metalloprotease** and **PMPCA contributes substrate recognition**, together enabling cleavage of a
+        large fraction of imported mitochondrial proteins. This division of labor is supported by conserved
+        motifs (active-site Zn-binding in β subunit), structural evidence (peptide binding in a negatively
+        charged cavity, glycine-rich loop gating/positioning), and disease genetics demonstrating that partial
+        disruption causes severe neurological phenotypes. (gala2021mitochondrialproteasesin pages 2-5,
+        kunova2022mitochondrialprocessingpeptidases—structure pages 2-4,
+        gakh2002mitochondrialprocessingpeptidases. pages 4-6)
 - term:
     id: GO:0017087
     label: mitochondrial processing peptidase complex
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct and core. PMPCB forms the mitochondrial processing peptidase heterodimer with PMPCA.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/PMPCB/PMPCB-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: The UniProt accession **O75439** corresponds to **human PMPCB** (gene name **PMPCB**,
+        synonym **MPPB**) annotated as **mitochondrial-processing peptidase subunit beta** (MPPβ), a member of
+        the **peptidase M16 family** and the **catalytic β subunit** of the heterodimeric mitochondrial
+        processing peptidase (MPP). This mapping (human PMPCB ↔ UniProt O75439) is explicitly supported by a
+        review of mitochondrial processing peptidases that lists **Homo sapiens O75439** as the MPP subunit
+        containing the characteristic inverted Zn-binding motif HxxEH…E required for activity, as well as by
+        authoritative reviews describing human MPP as PMPCA (α) + PMPCB (β) with PMPCB harboring the catalytic
+        site. (gakh2002mitochondrialprocessingpeptidases. pages 4-6,
+        kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, gala2021mitochondrialproteasesin
+        pages 2-5, kunova2022mitochondrialprocessingpeptidases—structure pages 4-6)
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: '| Complex membership | PMPCB forms the **MPP heterodimer** with **PMPCA (α-MPP)**; PMPCB
+        provides catalysis, whereas PMPCA contributes substrate recognition/positioning via a glycine-rich loop
+        and helps shape the substrate-binding cavity (kunova2022mitochondrialprocessingpeptidases—structure pages
+        2-4, gala2021mitochondrialproteasesin pages 2-5, kunova2022mitochondrialprocessingpeptidases—structure media
+        e22ffe68). |'
 - term:
     id: GO:0004222
     label: metalloendopeptidase activity
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct and core. PMPCB is the catalytic Zn2+-dependent metalloendopeptidase subunit of MPP.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/PMPCB/PMPCB-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: The UniProt accession **O75439** corresponds to **human PMPCB** (gene name **PMPCB**,
+        synonym **MPPB**) annotated as **mitochondrial-processing peptidase subunit beta** (MPPβ), a member of
+        the **peptidase M16 family** and the **catalytic β subunit** of the heterodimeric mitochondrial
+        processing peptidase (MPP). This mapping (human PMPCB ↔ UniProt O75439) is explicitly supported by a
+        review of mitochondrial processing peptidases that lists **Homo sapiens O75439** as the MPP subunit
+        containing the characteristic inverted Zn-binding motif HxxEH…E required for activity, as well as by
+        authoritative reviews describing human MPP as PMPCA (α) + PMPCB (β) with PMPCB harboring the catalytic
+        site. (gakh2002mitochondrialprocessingpeptidases. pages 4-6,
+        kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, gala2021mitochondrialproteasesin
+        pages 2-5, kunova2022mitochondrialprocessingpeptidases—structure pages 4-6)
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: MPP is a **Zn2+-dependent metalloendopeptidase**. PMPCB contains the conserved inverted
+        Zn-binding/catalytic motif **HxxEH…E** (with the distal glutamate contributing to Zn coordination).
+        Mutation of residues in this motif abolishes Zn binding and peptidase activity, supporting that PMPCB
+        is the catalytic subunit. (gakh2002mitochondrialprocessingpeptidases. pages 4-6,
+        kunova2022mitochondrialprocessingpeptidases—structure pages 2-4)
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: Authoritative reviews converge on a model in which **PMPCB is the catalytic Zn
+        metalloprotease** and **PMPCA contributes substrate recognition**, together enabling cleavage of a
+        large fraction of imported mitochondrial proteins. This division of labor is supported by conserved
+        motifs (active-site Zn-binding in β subunit), structural evidence (peptide binding in a negatively
+        charged cavity, glycine-rich loop gating/positioning), and disease genetics demonstrating that partial
+        disruption causes severe neurological phenotypes. (gala2021mitochondrialproteasesin pages 2-5,
+        kunova2022mitochondrialprocessingpeptidases—structure pages 2-4,
+        gakh2002mitochondrialprocessingpeptidases. pages 4-6)
 - term:
     id: GO:0005759
     label: mitochondrial matrix
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct. MPP/PMPCB acts in the mitochondrial matrix after precursor import through TOM/TIM.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/PMPCB/PMPCB-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: PMPCB functions in the **mitochondrial matrix** as part of MPP, acting on precursors
+        after import via TOM/TIM pathways. (gala2021mitochondrialproteasesin pages 2-5,
+        baker2025qualitycontrolat pages 4-5)
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: In the canonical pathway, precursors are recognized and translocated through TOM and
+        TIM machineries, then MPP removes the N-terminal targeting presequence in the matrix. Cleaved
+        presequences are subsequently degraded by downstream peptidases (e.g., PreP), preventing accumulation
+        of potentially disruptive targeting peptides. (baker2025qualitycontrolat pages 4-5,
+        gala2021mitochondrialproteasesin pages 2-5)
 - term:
     id: GO:0006508
     label: proteolysis
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct process family but too broad. PMPCB specifically performs mitochondrial presequence
+      processing as the catalytic MPP subunit.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/PMPCB/PMPCB-deep-research-falcon.md
+    reason: Prefer metalloendopeptidase activity and protein processing/presequence-cleavage terms over
+      generic proteolysis.
+    supported_by:
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: PMPCB provides the catalytic activity of MPP, which cleaves the **N-terminal
+        mitochondrial targeting presequence** from mitochondrial precursor proteins after their translocation
+        into mitochondria, yielding the mature protein N-terminus (or an intermediate for further processing
+        by other peptidases). (gala2021mitochondrialproteasesin pages 2-5, taylor2001crystalstructuresof pages
+        1-2, baker2025qualitycontrolat pages 5-5)
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: Authoritative reviews converge on a model in which **PMPCB is the catalytic Zn
+        metalloprotease** and **PMPCA contributes substrate recognition**, together enabling cleavage of a
+        large fraction of imported mitochondrial proteins. This division of labor is supported by conserved
+        motifs (active-site Zn-binding in β subunit), structural evidence (peptide binding in a negatively
+        charged cavity, glycine-rich loop gating/positioning), and disease genetics demonstrating that partial
+        disruption causes severe neurological phenotypes. (gala2021mitochondrialproteasesin pages 2-5,
+        kunova2022mitochondrialprocessingpeptidases—structure pages 2-4,
+        gakh2002mitochondrialprocessingpeptidases. pages 4-6)
 - term:
     id: GO:0009003
     label: signal peptidase activity
   evidence_type: IEA
   original_reference_id: GO_REF:0000003
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct. PMPCB cleaves mitochondrial targeting presequences; metalloendopeptidase activity
+      captures the catalytic class more precisely.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/PMPCB/PMPCB-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: Most mitochondrial proteins are nuclear-encoded, synthesized in the cytosol, and
+        imported into mitochondria using N-terminal **mitochondrial targeting presequences** (often
+        amphipathic, positively charged α-helices). These presequences generally must be cleaved after import
+        for proper maturation and assembly of mitochondrial proteins. The central enzyme executing this step
+        is the **mitochondrial processing peptidase (MPP)**. (gala2021mitochondrialproteasesin pages 2-5,
+        kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, taylor2001crystalstructuresof pages
+        1-2)
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: PMPCB provides the catalytic activity of MPP, which cleaves the **N-terminal
+        mitochondrial targeting presequence** from mitochondrial precursor proteins after their translocation
+        into mitochondria, yielding the mature protein N-terminus (or an intermediate for further processing
+        by other peptidases). (gala2021mitochondrialproteasesin pages 2-5, taylor2001crystalstructuresof pages
+        1-2, baker2025qualitycontrolat pages 5-5)
 - term:
     id: GO:0016485
     label: protein processing
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct and core. PMPCB processes newly imported mitochondrial precursor proteins by removing
+      N-terminal targeting presequences.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/PMPCB/PMPCB-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: Most mitochondrial proteins are nuclear-encoded, synthesized in the cytosol, and
+        imported into mitochondria using N-terminal **mitochondrial targeting presequences** (often
+        amphipathic, positively charged α-helices). These presequences generally must be cleaved after import
+        for proper maturation and assembly of mitochondrial proteins. The central enzyme executing this step
+        is the **mitochondrial processing peptidase (MPP)**. (gala2021mitochondrialproteasesin pages 2-5,
+        kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, taylor2001crystalstructuresof pages
+        1-2)
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: PMPCB provides the catalytic activity of MPP, which cleaves the **N-terminal
+        mitochondrial targeting presequence** from mitochondrial precursor proteins after their translocation
+        into mitochondria, yielding the mature protein N-terminus (or an intermediate for further processing
+        by other peptidases). (gala2021mitochondrialproteasesin pages 2-5, taylor2001crystalstructuresof pages
+        1-2, baker2025qualitycontrolat pages 5-5)
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: In the canonical pathway, precursors are recognized and translocated through TOM and
+        TIM machineries, then MPP removes the N-terminal targeting presequence in the matrix. Cleaved
+        presequences are subsequently degraded by downstream peptidases (e.g., PreP), preventing accumulation
+        of potentially disruptive targeting peptides. (baker2025qualitycontrolat pages 4-5,
+        gala2021mitochondrialproteasesin pages 2-5)
 - term:
     id: GO:0046872
     label: metal ion binding
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct mechanistic feature but too generic. Zinc binding is integral to the metalloendopeptidase
+      active site, so the enzyme activity term is more informative.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/PMPCB/PMPCB-deep-research-falcon.md
+    reason: Prefer metalloendopeptidase activity over generic metal ion binding.
+    supported_by:
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: MPP is a **Zn2+-dependent metalloendopeptidase**. PMPCB contains the conserved inverted
+        Zn-binding/catalytic motif **HxxEH…E** (with the distal glutamate contributing to Zn coordination).
+        Mutation of residues in this motif abolishes Zn binding and peptidase activity, supporting that PMPCB
+        is the catalytic subunit. (gakh2002mitochondrialprocessingpeptidases. pages 4-6,
+        kunova2022mitochondrialprocessingpeptidases—structure pages 2-4)
 - term:
     id: GO:0005739
     label: mitochondrion
   evidence_type: NAS
   original_reference_id: PMID:32443488
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct but broad. PMPCB is specifically a mitochondrial matrix MPP complex subunit.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/PMPCB/PMPCB-deep-research-falcon.md
+    reason: Prefer mitochondrial matrix and mitochondrial processing peptidase complex over generic
+      mitochondrion.
+    supported_by:
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: PMPCB functions in the **mitochondrial matrix** as part of MPP, acting on precursors
+        after import via TOM/TIM pathways. (gala2021mitochondrialproteasesin pages 2-5,
+        baker2025qualitycontrolat pages 4-5)
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: '| Complex membership | PMPCB forms the **MPP heterodimer** with **PMPCA (α-MPP)**; PMPCB
+        provides catalysis, whereas PMPCA contributes substrate recognition/positioning via a glycine-rich loop
+        and helps shape the substrate-binding cavity (kunova2022mitochondrialprocessingpeptidases—structure pages
+        2-4, gala2021mitochondrialproteasesin pages 2-5, kunova2022mitochondrialprocessingpeptidases—structure media
+        e22ffe68). |'
 - term:
     id: GO:0017087
     label: mitochondrial processing peptidase complex
   evidence_type: NAS
   original_reference_id: PMID:32443488
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct and core. PMPCB forms the mitochondrial processing peptidase heterodimer with PMPCA.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/PMPCB/PMPCB-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: The UniProt accession **O75439** corresponds to **human PMPCB** (gene name **PMPCB**,
+        synonym **MPPB**) annotated as **mitochondrial-processing peptidase subunit beta** (MPPβ), a member of
+        the **peptidase M16 family** and the **catalytic β subunit** of the heterodimeric mitochondrial
+        processing peptidase (MPP). This mapping (human PMPCB ↔ UniProt O75439) is explicitly supported by a
+        review of mitochondrial processing peptidases that lists **Homo sapiens O75439** as the MPP subunit
+        containing the characteristic inverted Zn-binding motif HxxEH…E required for activity, as well as by
+        authoritative reviews describing human MPP as PMPCA (α) + PMPCB (β) with PMPCB harboring the catalytic
+        site. (gakh2002mitochondrialprocessingpeptidases. pages 4-6,
+        kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, gala2021mitochondrialproteasesin
+        pages 2-5, kunova2022mitochondrialprocessingpeptidases—structure pages 4-6)
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: '| Complex membership | PMPCB forms the **MPP heterodimer** with **PMPCA (α-MPP)**; PMPCB
+        provides catalysis, whereas PMPCA contributes substrate recognition/positioning via a glycine-rich loop
+        and helps shape the substrate-binding cavity (kunova2022mitochondrialprocessingpeptidases—structure pages
+        2-4, gala2021mitochondrialproteasesin pages 2-5, kunova2022mitochondrialprocessingpeptidases—structure media
+        e22ffe68). |'
 - term:
     id: GO:0070585
     label: protein localization to mitochondrion
   evidence_type: NAS
   original_reference_id: PMID:32443488
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Over-annotated. PMPCB acts after protein import by cleaving targeting presequences; it is not
+      itself the import/localization machinery.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/PMPCB/PMPCB-deep-research-falcon.md
+    reason: Use protein processing and metalloendopeptidase activity rather than protein localization to
+      mitochondrion.
+    supported_by:
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: In the canonical pathway, precursors are recognized and translocated through TOM and
+        TIM machineries, then MPP removes the N-terminal targeting presequence in the matrix. Cleaved
+        presequences are subsequently degraded by downstream peptidases (e.g., PreP), preventing accumulation
+        of potentially disruptive targeting peptides. (baker2025qualitycontrolat pages 4-5,
+        gala2021mitochondrialproteasesin pages 2-5)
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: PMPCB provides the catalytic activity of MPP, which cleaves the **N-terminal
+        mitochondrial targeting presequence** from mitochondrial precursor proteins after their translocation
+        into mitochondria, yielding the mature protein N-terminus (or an intermediate for further processing
+        by other peptidases). (gala2021mitochondrialproteasesin pages 2-5, taylor2001crystalstructuresof pages
+        1-2, baker2025qualitycontrolat pages 5-5)
 - term:
     id: GO:0005739
     label: mitochondrion
   evidence_type: IDA
   original_reference_id: GO_REF:0000052
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct but broad. PMPCB is specifically a mitochondrial matrix MPP complex subunit.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/PMPCB/PMPCB-deep-research-falcon.md
+    reason: Prefer mitochondrial matrix and mitochondrial processing peptidase complex over generic
+      mitochondrion.
+    supported_by:
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: PMPCB functions in the **mitochondrial matrix** as part of MPP, acting on precursors
+        after import via TOM/TIM pathways. (gala2021mitochondrialproteasesin pages 2-5,
+        baker2025qualitycontrolat pages 4-5)
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: '| Complex membership | PMPCB forms the **MPP heterodimer** with **PMPCA (α-MPP)**; PMPCB
+        provides catalysis, whereas PMPCA contributes substrate recognition/positioning via a glycine-rich loop
+        and helps shape the substrate-binding cavity (kunova2022mitochondrialprocessingpeptidases—structure pages
+        2-4, gala2021mitochondrialproteasesin pages 2-5, kunova2022mitochondrialprocessingpeptidases—structure media
+        e22ffe68). |'
 - term:
     id: GO:0006851
     label: mitochondrial calcium ion transmembrane transport
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-8949215
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Over-annotated. PMPCB can process proSMDT1/proEMRE, a component needed for MCU complex function,
+      but PMPCB does not catalyze calcium transmembrane transport.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/PMPCB/PMPCB-deep-research-falcon.md
+    - Reactome:R-HSA-8949649
+    reason: The Reactome event reflects MPP cleavage of an MCU-complex subunit precursor, not direct calcium
+      ion transport by PMPCB.
+    supported_by:
+    - reference_id: Reactome:R-HSA-8949649
+      supporting_text: The mitochondrial endopeptidase PMPCA:PMPCB cleaves the transit peptide of proSMDT1
+        (proEMRE) yielding SMDT1 (Konig et al. 2016). Mature SMDT1 is assembled into the MCU complex where it
+        serves to bridge the MCU pore and the MCU regulators MICU1 and MICU2 (or MICU3 in neurons).
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: PMPCB provides the catalytic activity of MPP, which cleaves the **N-terminal
+        mitochondrial targeting presequence** from mitochondrial precursor proteins after their translocation
+        into mitochondria, yielding the mature protein N-terminus (or an intermediate for further processing
+        by other peptidases). (gala2021mitochondrialproteasesin pages 2-5, taylor2001crystalstructuresof pages
+        1-2, baker2025qualitycontrolat pages 5-5)
 - term:
     id: GO:0004222
     label: metalloendopeptidase activity
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-8949649
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct and core. PMPCB is the catalytic Zn2+-dependent metalloendopeptidase subunit of MPP.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/PMPCB/PMPCB-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: The UniProt accession **O75439** corresponds to **human PMPCB** (gene name **PMPCB**,
+        synonym **MPPB**) annotated as **mitochondrial-processing peptidase subunit beta** (MPPβ), a member of
+        the **peptidase M16 family** and the **catalytic β subunit** of the heterodimeric mitochondrial
+        processing peptidase (MPP). This mapping (human PMPCB ↔ UniProt O75439) is explicitly supported by a
+        review of mitochondrial processing peptidases that lists **Homo sapiens O75439** as the MPP subunit
+        containing the characteristic inverted Zn-binding motif HxxEH…E required for activity, as well as by
+        authoritative reviews describing human MPP as PMPCA (α) + PMPCB (β) with PMPCB harboring the catalytic
+        site. (gakh2002mitochondrialprocessingpeptidases. pages 4-6,
+        kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, gala2021mitochondrialproteasesin
+        pages 2-5, kunova2022mitochondrialprocessingpeptidases—structure pages 4-6)
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: MPP is a **Zn2+-dependent metalloendopeptidase**. PMPCB contains the conserved inverted
+        Zn-binding/catalytic motif **HxxEH…E** (with the distal glutamate contributing to Zn coordination).
+        Mutation of residues in this motif abolishes Zn binding and peptidase activity, supporting that PMPCB
+        is the catalytic subunit. (gakh2002mitochondrialprocessingpeptidases. pages 4-6,
+        kunova2022mitochondrialprocessingpeptidases—structure pages 2-4)
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: Authoritative reviews converge on a model in which **PMPCB is the catalytic Zn
+        metalloprotease** and **PMPCA contributes substrate recognition**, together enabling cleavage of a
+        large fraction of imported mitochondrial proteins. This division of labor is supported by conserved
+        motifs (active-site Zn-binding in β subunit), structural evidence (peptide binding in a negatively
+        charged cavity, glycine-rich loop gating/positioning), and disease genetics demonstrating that partial
+        disruption causes severe neurological phenotypes. (gala2021mitochondrialproteasesin pages 2-5,
+        kunova2022mitochondrialprocessingpeptidases—structure pages 2-4,
+        gakh2002mitochondrialprocessingpeptidases. pages 4-6)
 - term:
     id: GO:0009003
     label: signal peptidase activity
   evidence_type: ISS
   original_reference_id: GO_REF:0000024
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct. PMPCB cleaves mitochondrial targeting presequences; metalloendopeptidase activity
+      captures the catalytic class more precisely.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/PMPCB/PMPCB-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: Most mitochondrial proteins are nuclear-encoded, synthesized in the cytosol, and
+        imported into mitochondria using N-terminal **mitochondrial targeting presequences** (often
+        amphipathic, positively charged α-helices). These presequences generally must be cleaved after import
+        for proper maturation and assembly of mitochondrial proteins. The central enzyme executing this step
+        is the **mitochondrial processing peptidase (MPP)**. (gala2021mitochondrialproteasesin pages 2-5,
+        kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, taylor2001crystalstructuresof pages
+        1-2)
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: PMPCB provides the catalytic activity of MPP, which cleaves the **N-terminal
+        mitochondrial targeting presequence** from mitochondrial precursor proteins after their translocation
+        into mitochondria, yielding the mature protein N-terminus (or an intermediate for further processing
+        by other peptidases). (gala2021mitochondrialproteasesin pages 2-5, taylor2001crystalstructuresof pages
+        1-2, baker2025qualitycontrolat pages 5-5)
 - term:
     id: GO:0016485
     label: protein processing
   evidence_type: IDA
   original_reference_id: PMID:22354088
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct and core. PMPCB processes newly imported mitochondrial precursor proteins by removing
+      N-terminal targeting presequences.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/PMPCB/PMPCB-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: Most mitochondrial proteins are nuclear-encoded, synthesized in the cytosol, and
+        imported into mitochondria using N-terminal **mitochondrial targeting presequences** (often
+        amphipathic, positively charged α-helices). These presequences generally must be cleaved after import
+        for proper maturation and assembly of mitochondrial proteins. The central enzyme executing this step
+        is the **mitochondrial processing peptidase (MPP)**. (gala2021mitochondrialproteasesin pages 2-5,
+        kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, taylor2001crystalstructuresof pages
+        1-2)
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: PMPCB provides the catalytic activity of MPP, which cleaves the **N-terminal
+        mitochondrial targeting presequence** from mitochondrial precursor proteins after their translocation
+        into mitochondria, yielding the mature protein N-terminus (or an intermediate for further processing
+        by other peptidases). (gala2021mitochondrialproteasesin pages 2-5, taylor2001crystalstructuresof pages
+        1-2, baker2025qualitycontrolat pages 5-5)
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: In the canonical pathway, precursors are recognized and translocated through TOM and
+        TIM machineries, then MPP removes the N-terminal targeting presequence in the matrix. Cleaved
+        presequences are subsequently degraded by downstream peptidases (e.g., PreP), preventing accumulation
+        of potentially disruptive targeting peptides. (baker2025qualitycontrolat pages 4-5,
+        gala2021mitochondrialproteasesin pages 2-5)
 - term:
     id: GO:0005739
     label: mitochondrion
   evidence_type: HTP
   original_reference_id: PMID:34800366
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct but broad. PMPCB is specifically a mitochondrial matrix MPP complex subunit.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/PMPCB/PMPCB-deep-research-falcon.md
+    reason: Prefer mitochondrial matrix and mitochondrial processing peptidase complex over generic
+      mitochondrion.
+    supported_by:
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: PMPCB functions in the **mitochondrial matrix** as part of MPP, acting on precursors
+        after import via TOM/TIM pathways. (gala2021mitochondrialproteasesin pages 2-5,
+        baker2025qualitycontrolat pages 4-5)
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: '| Complex membership | PMPCB forms the **MPP heterodimer** with **PMPCA (α-MPP)**; PMPCB
+        provides catalysis, whereas PMPCA contributes substrate recognition/positioning via a glycine-rich loop
+        and helps shape the substrate-binding cavity (kunova2022mitochondrialprocessingpeptidases—structure pages
+        2-4, gala2021mitochondrialproteasesin pages 2-5, kunova2022mitochondrialprocessingpeptidases—structure media
+        e22ffe68). |'
 - term:
     id: GO:0005759
     label: mitochondrial matrix
   evidence_type: EXP
   original_reference_id: PMID:22354088
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct. MPP/PMPCB acts in the mitochondrial matrix after precursor import through TOM/TIM.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/PMPCB/PMPCB-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: PMPCB functions in the **mitochondrial matrix** as part of MPP, acting on precursors
+        after import via TOM/TIM pathways. (gala2021mitochondrialproteasesin pages 2-5,
+        baker2025qualitycontrolat pages 4-5)
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: In the canonical pathway, precursors are recognized and translocated through TOM and
+        TIM machineries, then MPP removes the N-terminal targeting presequence in the matrix. Cleaved
+        presequences are subsequently degraded by downstream peptidases (e.g., PreP), preventing accumulation
+        of potentially disruptive targeting peptides. (baker2025qualitycontrolat pages 4-5,
+        gala2021mitochondrialproteasesin pages 2-5)
 - term:
     id: GO:0005759
     label: mitochondrial matrix
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-8949649
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct. MPP/PMPCB acts in the mitochondrial matrix after precursor import through TOM/TIM.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/PMPCB/PMPCB-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: PMPCB functions in the **mitochondrial matrix** as part of MPP, acting on precursors
+        after import via TOM/TIM pathways. (gala2021mitochondrialproteasesin pages 2-5,
+        baker2025qualitycontrolat pages 4-5)
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: In the canonical pathway, precursors are recognized and translocated through TOM and
+        TIM machineries, then MPP removes the N-terminal targeting presequence in the matrix. Cleaved
+        presequences are subsequently degraded by downstream peptidases (e.g., PreP), preventing accumulation
+        of potentially disruptive targeting peptides. (baker2025qualitycontrolat pages 4-5,
+        gala2021mitochondrialproteasesin pages 2-5)
 - term:
     id: GO:0004222
     label: metalloendopeptidase activity
   evidence_type: IDA
   original_reference_id: PMID:22354088
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct and core. PMPCB is the catalytic Zn2+-dependent metalloendopeptidase subunit of MPP.
+    action: ACCEPT
+    additional_reference_ids:
+    - file:human/PMPCB/PMPCB-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: The UniProt accession **O75439** corresponds to **human PMPCB** (gene name **PMPCB**,
+        synonym **MPPB**) annotated as **mitochondrial-processing peptidase subunit beta** (MPPβ), a member of
+        the **peptidase M16 family** and the **catalytic β subunit** of the heterodimeric mitochondrial
+        processing peptidase (MPP). This mapping (human PMPCB ↔ UniProt O75439) is explicitly supported by a
+        review of mitochondrial processing peptidases that lists **Homo sapiens O75439** as the MPP subunit
+        containing the characteristic inverted Zn-binding motif HxxEH…E required for activity, as well as by
+        authoritative reviews describing human MPP as PMPCA (α) + PMPCB (β) with PMPCB harboring the catalytic
+        site. (gakh2002mitochondrialprocessingpeptidases. pages 4-6,
+        kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, gala2021mitochondrialproteasesin
+        pages 2-5, kunova2022mitochondrialprocessingpeptidases—structure pages 4-6)
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: MPP is a **Zn2+-dependent metalloendopeptidase**. PMPCB contains the conserved inverted
+        Zn-binding/catalytic motif **HxxEH…E** (with the distal glutamate contributing to Zn coordination).
+        Mutation of residues in this motif abolishes Zn binding and peptidase activity, supporting that PMPCB
+        is the catalytic subunit. (gakh2002mitochondrialprocessingpeptidases. pages 4-6,
+        kunova2022mitochondrialprocessingpeptidases—structure pages 2-4)
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: Authoritative reviews converge on a model in which **PMPCB is the catalytic Zn
+        metalloprotease** and **PMPCA contributes substrate recognition**, together enabling cleavage of a
+        large fraction of imported mitochondrial proteins. This division of labor is supported by conserved
+        motifs (active-site Zn-binding in β subunit), structural evidence (peptide binding in a negatively
+        charged cavity, glycine-rich loop gating/positioning), and disease genetics demonstrating that partial
+        disruption causes severe neurological phenotypes. (gala2021mitochondrialproteasesin pages 2-5,
+        kunova2022mitochondrialprocessingpeptidases—structure pages 2-4,
+        gakh2002mitochondrialprocessingpeptidases. pages 4-6)
 - term:
     id: GO:0005739
     label: mitochondrion
   evidence_type: IDA
   original_reference_id: PMID:22354088
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Correct but broad. PMPCB is specifically a mitochondrial matrix MPP complex subunit.
+    action: MARK_AS_OVER_ANNOTATED
+    additional_reference_ids:
+    - file:human/PMPCB/PMPCB-deep-research-falcon.md
+    reason: Prefer mitochondrial matrix and mitochondrial processing peptidase complex over generic
+      mitochondrion.
+    supported_by:
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: PMPCB functions in the **mitochondrial matrix** as part of MPP, acting on precursors
+        after import via TOM/TIM pathways. (gala2021mitochondrialproteasesin pages 2-5,
+        baker2025qualitycontrolat pages 4-5)
+    - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+      supporting_text: '| Complex membership | PMPCB forms the **MPP heterodimer** with **PMPCA (α-MPP)**; PMPCB
+        provides catalysis, whereas PMPCA contributes substrate recognition/positioning via a glycine-rich loop
+        and helps shape the substrate-binding cavity (kunova2022mitochondrialprocessingpeptidases—structure pages
+        2-4, gala2021mitochondrialproteasesin pages 2-5, kunova2022mitochondrialprocessingpeptidases—structure media
+        e22ffe68). |'
 references:
 - id: GO_REF:0000002
-  title: Gene Ontology annotation through association of InterPro records with GO
-    terms
+  title: Gene Ontology annotation through association of InterPro records with GO terms
   findings: []
 - id: GO_REF:0000003
   title: Gene Ontology annotation based on Enzyme Commission mapping
   findings: []
 - id: GO_REF:0000024
-  title: Manual transfer of experimentally-verified manual GO annotation data to orthologs
-    by curator judgment of sequence similarity
+  title: Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment
+    of sequence similarity
   findings: []
 - id: GO_REF:0000033
   title: Annotation inferences using phylogenetic trees
@@ -200,15 +607,13 @@ references:
   title: Combined Automated Annotation using Multiple IEA Methods
   findings: []
 - id: PMID:22354088
-  title: Mitochondrial processing peptidase regulates PINK1 processing, import and
-    Parkin recruitment.
+  title: Mitochondrial processing peptidase regulates PINK1 processing, import and Parkin recruitment.
   findings: []
 - id: PMID:32443488
   title: Mitochondrial Protein Quality Control Mechanisms.
   findings: []
 - id: PMID:34800366
-  title: Quantitative high-confidence human mitochondrial proteome and its dynamics
-    in cellular context.
+  title: Quantitative high-confidence human mitochondrial proteome and its dynamics in cellular context.
   findings: []
 - id: Reactome:R-HSA-8949215
   title: Mitochondrial calcium ion transport
@@ -216,3 +621,75 @@ references:
 - id: Reactome:R-HSA-8949649
   title: PMPCA:PMPCB cleaves the transit peptide of proSMDT1 (proEMRE)
   findings: []
+- id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+  title: Falcon deep research report for human PMPCB
+  findings: []
+core_functions:
+- description: PMPCB is the catalytic beta subunit of the mitochondrial processing peptidase heterodimer. In
+    the mitochondrial matrix, it performs Zn2+-dependent metalloendopeptidase cleavage of N-terminal
+    mitochondrial targeting presequences from imported precursor proteins.
+  supported_by:
+  - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+    supporting_text: The UniProt accession **O75439** corresponds to **human PMPCB** (gene name **PMPCB**,
+      synonym **MPPB**) annotated as **mitochondrial-processing peptidase subunit beta** (MPPβ), a member of
+      the **peptidase M16 family** and the **catalytic β subunit** of the heterodimeric mitochondrial
+      processing peptidase (MPP). This mapping (human PMPCB ↔ UniProt O75439) is explicitly supported by a
+      review of mitochondrial processing peptidases that lists **Homo sapiens O75439** as the MPP subunit
+      containing the characteristic inverted Zn-binding motif HxxEH…E required for activity, as well as by
+      authoritative reviews describing human MPP as PMPCA (α) + PMPCB (β) with PMPCB harboring the catalytic
+      site. (gakh2002mitochondrialprocessingpeptidases. pages 4-6,
+      kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, gala2021mitochondrialproteasesin pages
+      2-5, kunova2022mitochondrialprocessingpeptidases—structure pages 4-6)
+  - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+    supporting_text: PMPCB provides the catalytic activity of MPP, which cleaves the **N-terminal
+      mitochondrial targeting presequence** from mitochondrial precursor proteins after their translocation
+      into mitochondria, yielding the mature protein N-terminus (or an intermediate for further processing by
+      other peptidases). (gala2021mitochondrialproteasesin pages 2-5, taylor2001crystalstructuresof pages 1-2,
+      baker2025qualitycontrolat pages 5-5)
+  - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+    supporting_text: MPP is a **Zn2+-dependent metalloendopeptidase**. PMPCB contains the conserved inverted
+      Zn-binding/catalytic motif **HxxEH…E** (with the distal glutamate contributing to Zn coordination).
+      Mutation of residues in this motif abolishes Zn binding and peptidase activity, supporting that PMPCB is
+      the catalytic subunit. (gakh2002mitochondrialprocessingpeptidases. pages 4-6,
+      kunova2022mitochondrialprocessingpeptidases—structure pages 2-4)
+  - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+    supporting_text: PMPCB functions in the **mitochondrial matrix** as part of MPP, acting on precursors
+      after import via TOM/TIM pathways. (gala2021mitochondrialproteasesin pages 2-5,
+      baker2025qualitycontrolat pages 4-5)
+  - reference_id: file:human/PMPCB/PMPCB-deep-research-falcon.md
+    supporting_text: Authoritative reviews converge on a model in which **PMPCB is the catalytic Zn
+      metalloprotease** and **PMPCA contributes substrate recognition**, together enabling cleavage of a large
+      fraction of imported mitochondrial proteins. This division of labor is supported by conserved motifs
+      (active-site Zn-binding in β subunit), structural evidence (peptide binding in a negatively charged
+      cavity, glycine-rich loop gating/positioning), and disease genetics demonstrating that partial
+      disruption causes severe neurological phenotypes. (gala2021mitochondrialproteasesin pages 2-5,
+      kunova2022mitochondrialprocessingpeptidases—structure pages 2-4,
+      gakh2002mitochondrialprocessingpeptidases. pages 4-6)
+  molecular_function:
+    id: GO:0004222
+    label: metalloendopeptidase activity
+  directly_involved_in:
+  - id: GO:0016485
+    label: protein processing
+  locations:
+  - id: GO:0005759
+    label: mitochondrial matrix
+  in_complex:
+    id: GO:0017087
+    label: mitochondrial processing peptidase complex
+proposed_new_terms: []
+suggested_questions:
+- question: Which PMPCB disease variants primarily reduce catalytic activity versus MPP complex stability or
+    substrate recognition?
+  experts: []
+- question: Which human MPP substrates are most sensitive to partial PMPCB impairment in neuronal cells?
+  experts: []
+suggested_experiments:
+- hypothesis: PMPCB disease variants cause selective substrate-processing defects rather than uniform loss of
+    all MPP cleavage.
+  description: Perform quantitative N-terminomics and targeted substrate immunoblots in PMPCB-variant rescue
+    cells to compare cleavage efficiency across mitochondrial precursors.
+- hypothesis: The PMPCB contribution to mitochondrial calcium uptake is indirect through proSMDT1/proEMRE
+    maturation.
+  description: Separate acute PMPCB catalytic inhibition from mature EMRE rescue and measure proSMDT1
+    processing, MCU complex assembly, and mitochondrial calcium uptake.

--- a/genes/human/PMPCB/PMPCB-deep-research-falcon.md
+++ b/genes/human/PMPCB/PMPCB-deep-research-falcon.md
@@ -1,0 +1,303 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-11T18:05:55.546917'
+end_time: '2026-05-11T18:15:13.574652'
+duration_seconds: 558.03
+template_file: templates/gene_research_go_focused.md
+template_variables:
+  organism: human
+  gene_id: PMPCB
+  gene_symbol: PMPCB
+  uniprot_accession: O75439
+  protein_description: 'RecName: Full=Mitochondrial-processing peptidase subunit beta;
+    EC=3.4.24.64 {ECO:0000305|PubMed:22354088}; AltName: Full=Beta-MPP; AltName: Full=P-52;
+    Flags: Precursor;'
+  gene_info: Name=PMPCB; Synonyms=MPPB;
+  organism_full: Homo sapiens (Human).
+  protein_family: Belongs to the peptidase M16 family. .
+  protein_domains: Metalloenz_LuxS/M16. (IPR011249); MPP/UQCRC_Complex. (IPR050361);
+    Pept_M16_N. (IPR011765); Pept_M16_Zn_BS. (IPR001431); Peptidase_M16_C. (IPR007863)
+provider_config:
+  timeout: 600
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 22
+---
+
+## Question
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** O75439
+- **Protein Description:** RecName: Full=Mitochondrial-processing peptidase subunit beta; EC=3.4.24.64 {ECO:0000305|PubMed:22354088}; AltName: Full=Beta-MPP; AltName: Full=P-52; Flags: Precursor;
+- **Gene Information:** Name=PMPCB; Synonyms=MPPB;
+- **Organism (full):** Homo sapiens (Human).
+- **Protein Family:** Belongs to the peptidase M16 family. .
+- **Key Domains:** Metalloenz_LuxS/M16. (IPR011249); MPP/UQCRC_Complex. (IPR050361); Pept_M16_N. (IPR011765); Pept_M16_Zn_BS. (IPR001431); Peptidase_M16_C. (IPR007863)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "PMPCB" matches the protein description above**
+2. **Verify the organism is correct:** Homo sapiens (Human).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'PMPCB' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **PMPCB** (gene ID: PMPCB, UniProt: O75439) in human.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** O75439
+- **Protein Description:** RecName: Full=Mitochondrial-processing peptidase subunit beta; EC=3.4.24.64 {ECO:0000305|PubMed:22354088}; AltName: Full=Beta-MPP; AltName: Full=P-52; Flags: Precursor;
+- **Gene Information:** Name=PMPCB; Synonyms=MPPB;
+- **Organism (full):** Homo sapiens (Human).
+- **Protein Family:** Belongs to the peptidase M16 family. .
+- **Key Domains:** Metalloenz_LuxS/M16. (IPR011249); MPP/UQCRC_Complex. (IPR050361); Pept_M16_N. (IPR011765); Pept_M16_Zn_BS. (IPR001431); Peptidase_M16_C. (IPR007863)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "PMPCB" matches the protein description above**
+2. **Verify the organism is correct:** Homo sapiens (Human).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'PMPCB' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **PMPCB** (gene ID: PMPCB, UniProt: O75439) in human.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+# Comprehensive Research Report: **PMPCB (UniProt O75439)** — Human Mitochondrial-Processing Peptidase Subunit β (MPPβ)
+
+## 1) Identity verification (mandatory)
+The UniProt accession **O75439** corresponds to **human PMPCB** (gene name **PMPCB**, synonym **MPPB**) annotated as **mitochondrial-processing peptidase subunit beta** (MPPβ), a member of the **peptidase M16 family** and the **catalytic β subunit** of the heterodimeric mitochondrial processing peptidase (MPP). This mapping (human PMPCB ↔ UniProt O75439) is explicitly supported by a review of mitochondrial processing peptidases that lists **Homo sapiens O75439** as the MPP subunit containing the characteristic inverted Zn-binding motif HxxEH…E required for activity, as well as by authoritative reviews describing human MPP as PMPCA (α) + PMPCB (β) with PMPCB harboring the catalytic site. (gakh2002mitochondrialprocessingpeptidases. pages 4-6, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, gala2021mitochondrialproteasesin pages 2-5, kunova2022mitochondrialprocessingpeptidases—structure pages 4-6)
+
+## 2) Key concepts and definitions (current understanding)
+### 2.1 Mitochondrial targeting presequences and presequence processing
+Most mitochondrial proteins are nuclear-encoded, synthesized in the cytosol, and imported into mitochondria using N-terminal **mitochondrial targeting presequences** (often amphipathic, positively charged α-helices). These presequences generally must be cleaved after import for proper maturation and assembly of mitochondrial proteins. The central enzyme executing this step is the **mitochondrial processing peptidase (MPP)**. (gala2021mitochondrialproteasesin pages 2-5, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, taylor2001crystalstructuresof pages 1-2)
+
+### 2.2 MPP composition and division of labor
+Human MPP is a **heterodimeric** enzyme complex consisting of:
+- **PMPCA (α-MPP)**: primarily contributes to **substrate recognition/positioning**, including a **glycine-rich loop** implicated in engaging presequences and facilitating productive presentation to the active site.
+- **PMPCB (β-MPP)**: the **catalytic** Zn2+-dependent metallopeptidase subunit containing the functional active site.
+These subunits form a substrate-binding cavity; both are required for efficient processing in vivo. (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, gala2021mitochondrialproteasesin pages 2-5, gakh2002mitochondrialprocessingpeptidases. pages 4-6, kunova2022mitochondrialprocessingpeptidases—structure media e22ffe68)
+
+## 3) Molecular function of PMPCB: reaction, catalytic mechanism, and substrate specificity
+### 3.1 Reaction catalyzed (EC 3.4.24.64)
+PMPCB provides the catalytic activity of MPP, which cleaves the **N-terminal mitochondrial targeting presequence** from mitochondrial precursor proteins after their translocation into mitochondria, yielding the mature protein N-terminus (or an intermediate for further processing by other peptidases). (gala2021mitochondrialproteasesin pages 2-5, taylor2001crystalstructuresof pages 1-2, baker2025qualitycontrolat pages 5-5)
+
+### 3.2 Catalytic class and essential motifs
+MPP is a **Zn2+-dependent metalloendopeptidase**. PMPCB contains the conserved inverted Zn-binding/catalytic motif **HxxEH…E** (with the distal glutamate contributing to Zn coordination). Mutation of residues in this motif abolishes Zn binding and peptidase activity, supporting that PMPCB is the catalytic subunit. (gakh2002mitochondrialprocessingpeptidases. pages 4-6, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4)
+
+### 3.3 Catalytic mechanism (thermolysin-like)
+Structural and mechanistic evidence indicates a **thermolysin-like** mechanism: a water molecule coordinated to Zn2+ is activated (polarized/deprotonated) by a nearby glutamate acting as a general base, enabling nucleophilic attack on the scissile peptide bond carbonyl to hydrolyze the peptide bond. This architecture and mechanism are supported by crystal structures and by functional evidence that mutation of the catalytic glutamate abolishes activity. (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, taylor2001crystalstructuresof pages 3-4)
+
+### 3.4 Substrate specificity: cleavage motif and determinants
+MPP recognizes diverse mitochondrial presequences but exhibits characteristic preferences:
+- A frequent **arginine at the −2 position** relative to the cleavage site (the “R−2 motif”; also described as an arginine at position 2 of the cleavage-site motif depending on indexing conventions), supported by N-terminome analyses and structural studies.
+- Additional features can include upstream basic residues and a bulky hydrophobic/aromatic residue at P1, with presequences binding in an extended conformation within a large, negatively charged cavity that favors positively charged peptides. (gala2021mitochondrialproteasesin pages 2-5, taylor2001crystalstructuresof pages 1-2, taylor2001crystalstructuresof pages 3-4, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4)
+
+### 3.5 Key substrates/examples
+Although MPP processes a large fraction of imported mitochondrial proteins, **frataxin (FXN)** is a well-studied substrate relevant to PMPCB biology. A yeast two-hybrid assay found FXN as a direct partner of human PMPCB; and patient-derived systems with PMPCB variants show accumulation of a frataxin processing intermediate, linking PMPCB activity to FXN maturation and downstream iron–sulfur (Fe–S) biology. (kunova2022mitochondrialprocessingpeptidases—structure pages 4-6, vogtle2018mutationsinpmpcb pages 1-2)
+
+## 4) Subcellular localization and pathway context
+### 4.1 Subcellular localization
+PMPCB functions in the **mitochondrial matrix** as part of MPP, acting on precursors after import via TOM/TIM pathways. (gala2021mitochondrialproteasesin pages 2-5, baker2025qualitycontrolat pages 4-5)
+
+### 4.2 Biological pathway: mitochondrial protein import → presequence cleavage → maturation
+In the canonical pathway, precursors are recognized and translocated through TOM and TIM machineries, then MPP removes the N-terminal targeting presequence in the matrix. Cleaved presequences are subsequently degraded by downstream peptidases (e.g., PreP), preventing accumulation of potentially disruptive targeting peptides. (baker2025qualitycontrolat pages 4-5, gala2021mitochondrialproteasesin pages 2-5)
+
+## 5) Recent developments and latest research (emphasis on 2023–2024)
+### 5.1 2024 clinical expansion: first splice-site variant and adult survival
+A 2024 report identified the **first splice-site PMPCB variant** causing disease and expanded the phenotypic spectrum to an individual surviving to **age 39**. The study used an **exon-trapping (minigene) assay** to demonstrate that the splice variant causes **exon 12 skipping**, supporting pathogenic loss-of-function via aberrant splicing. (Matthews et al., 2024-02; URL https://doi.org/10.1038/s10038-024-01226-9) (matthews2024leighsyndromewith pages 1-2, matthews2024leighsyndromewith pages 2-3)
+
+### 5.2 Quantitative update from 2024 paper (statistics)
+The 2024 report summarized prior literature, stating that before their publication only **five** affected individuals had been reported (all missense variants), with **onset by 12 months** in each pediatric case, **none** achieving ambulation or speech, and **3/5** dying by **age 6**; dystonia/epilepsy/ataxia occurred in **4/5**. These numbers provide currently available coarse epidemiologic statistics for this ultra-rare disorder. (matthews2024leighsyndromewith pages 1-2)
+
+### 5.3 2023–2024 mechanistic context: mitochondrial proteostasis/processing machinery as druggable biology
+While not centered on PMPCB variants, recent mitochondrial proteostasis studies emphasize that impaired turnover of targeting peptides and feedback inhibition of MPP can broadly disrupt mitochondrial function, reinforcing the importance of efficient presequence processing as a systems-level node (e.g., interaction with downstream peptide-degradation machinery). (gala2021mitochondrialproteasesin pages 2-5)
+
+## 6) Disease associations, clinical phenotypes, and mechanistic evidence
+### 6.1 Disease entity
+Biallelic pathogenic variants in **PMPCB** cause a mitochondrial disease often described as a **Leigh-like neurodegenerative disorder** and classified as **multiple mitochondrial dysfunctions syndrome 6 (MMDS6)**. (matthews2024leighsyndromewith pages 1-2, baker2025qualitycontrolat pages 5-5)
+
+### 6.2 2018 primary evidence: genotype → mechanism → phenotype
+A 2018 American Journal of Human Genetics study reported **biallelic PMPCB variants in 4 families (5 affected individuals)** with early-childhood onset neurodegeneration featuring episodic regression (often illness-triggered), basal ganglia lesions, and cerebellar atrophy. The study provided multi-level mechanistic evidence linking PMPCB dysfunction to impaired mitochondrial presequence processing and mitochondrial metabolism:
+- **Patient cells**: reduced PMPCB levels and **accumulation of a frataxin processing intermediate**.
+- **Yeast modeling** (Mas1, PMPCB homolog): disease-variant modeling caused growth defects and impaired MPP processing with accumulation of precursor proteins.
+- **Downstream mitochondrial consequences**: impairment of Fe–S cluster biogenesis and decreased activity in Fe–S-dependent respiratory-chain components and enzymes; evidence of complex I assembly perturbations and complex II activity reduction in some tissues. (Vögtle et al., 2018-04; URL https://doi.org/10.1016/j.ajhg.2018.02.014) (vogtle2018mutationsinpmpcb pages 1-2, vogtle2018mutationsinpmpcb pages 11-12)
+
+### 6.3 Database-level disease association (contextual)
+Open Targets links PMPCB to **MMDS6** and broader categories including genetic and neurodegenerative disease, reflecting curated associations and literature evidence; this supports clinical relevance but is secondary to primary patient and mechanistic studies. (OpenTargets Search: -PMPCB)
+
+## 7) Current applications and real-world implementations
+### 7.1 Clinical genetics/diagnostics
+PMPCB is now an established candidate gene in **mitochondrial disease and Leigh(-like) syndrome gene panels** and in **whole-exome/whole-genome sequencing** diagnostic pipelines for neurodevelopmental regression with basal ganglia/cerebellar imaging findings, given the strong causal evidence from biallelic pathogenic variants and functional validation. The 2024 splice-variant case demonstrates direct clinical utility of combining sequencing with functional splicing assays (minigene) to interpret variants. (matthews2024leighsyndromewith pages 1-2, vogtle2018mutationsinpmpcb pages 1-2)
+
+### 7.2 Research implementation: mitochondrial import and proteostasis assays
+PMPCB/MPP activity is routinely assessed indirectly by monitoring processing states of known MPP substrates (e.g., frataxin intermediates) and by proteomics/N-terminomics strategies that infer MPP cleavage motif preferences across the mitochondrial proteome. Such applications are highlighted in reviews discussing MPP specificity and downstream degradation of presequences. (gala2021mitochondrialproteasesin pages 2-5, vogtle2018mutationsinpmpcb pages 1-2)
+
+## 8) Expert opinions and analysis (authoritative synthesis)
+### 8.1 Consensus model for MPP function in humans
+Authoritative reviews converge on a model in which **PMPCB is the catalytic Zn metalloprotease** and **PMPCA contributes substrate recognition**, together enabling cleavage of a large fraction of imported mitochondrial proteins. This division of labor is supported by conserved motifs (active-site Zn-binding in β subunit), structural evidence (peptide binding in a negatively charged cavity, glycine-rich loop gating/positioning), and disease genetics demonstrating that partial disruption causes severe neurological phenotypes. (gala2021mitochondrialproteasesin pages 2-5, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, gakh2002mitochondrialprocessingpeptidases. pages 4-6)
+
+### 8.2 Disease mechanism inference
+Clinical and experimental evidence suggests that disease-causing PMPCB variants can lead to **selective or stress-sensitive processing defects**, rather than uniform failure of all MPP substrates, which may help explain tissue specificity (neurological vulnerability) and triggers (febrile illness). The yeast model’s temperature sensitivity and the observation of pathway-specific downstream defects (notably Fe–S cluster biogenesis and respiratory chain effects) support this interpretation. (vogtle2018mutationsinpmpcb pages 11-12, vogtle2018mutationsinpmpcb pages 1-2)
+
+## 9) Visual evidence from recent review figures
+A 2022 review provides figures depicting MPP architecture and sequence conservation, including the **Zn2+-binding catalytic site in PMPCB** and the **glycine-rich loop in PMPCA**, along with alignments highlighting conserved motifs and disease-associated residues. These visuals are useful for functional inference and variant interpretation. (kunova2022mitochondrialprocessingpeptidases—structure media e22ffe68, kunova2022mitochondrialprocessingpeptidases—structure media bbb4e0aa)
+
+## Summary table (evidence-backed)
+The following table consolidates key annotation elements—identity, function, mechanism, localization, pathway role, and disease statistics.
+
+| Aspect | Summary |
+|---|---|
+| Identity | **PMPCB** is the human gene encoding **mitochondrial-processing peptidase subunit beta (MPPβ)**, the **catalytic β subunit** of the heterodimeric mitochondrial processing peptidase; this matches **UniProt O75439** and the peptidase M16 metalloprotease family assignment (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, gala2021mitochondrialproteasesin pages 2-5, gakh2002mitochondrialprocessingpeptidases. pages 4-6, kunova2022mitochondrialprocessingpeptidases—structure pages 4-6). |
+| Localization | PMPCB functions in the **mitochondrial matrix**, where MPP cleaves N-terminal targeting presequences from newly imported nuclear-encoded mitochondrial proteins after translocation through TOM/TIM import pathways (gala2021mitochondrialproteasesin pages 2-5, baker2025qualitycontrolat pages 4-5, taylor2001crystalstructuresof pages 1-2). |
+| Complex membership | PMPCB forms the **MPP heterodimer** with **PMPCA (α-MPP)**; PMPCB provides catalysis, whereas PMPCA contributes substrate recognition/positioning via a glycine-rich loop and helps shape the substrate-binding cavity (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, gala2021mitochondrialproteasesin pages 2-5, kunova2022mitochondrialprocessingpeptidases—structure media e22ffe68). |
+| Catalytic class & EC | MPP is a **Zn²⁺-dependent metallopeptidase / metalloendopeptidase**; UniProt assigns **EC 3.4.24.64**. Reviews explicitly identify PMPCB as the zinc metalloprotease catalytic subunit of MPP (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, gala2021mitochondrialproteasesin pages 2-5, taylor2001crystalstructuresof pages 1-2, gakh2002mitochondrialprocessingpeptidases. pages 4-6). |
+| Active-site motif | PMPCB contains the conserved **HxxEH…E** zinc-binding/catalytic motif typical of M16 peptidases; mutating residues in this motif abolishes Zn²⁺ binding and MPP activity (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, gakh2002mitochondrialprocessingpeptidases. pages 4-6, kunova2022mitochondrialprocessingpeptidases—structure pages 4-6, kunova2022mitochondrialprocessingpeptidases—structure media e22ffe68). |
+| Mechanism | Structural/mechanistic work supports a **thermolysin-like hydrolytic mechanism**: Zn²⁺ is coordinated by active-site residues, while a nearby glutamate activates a bound water molecule for nucleophilic attack on the scissile peptide bond; the substrate binds in an extended conformation in a negatively charged cavity (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, taylor2001crystalstructuresof pages 1-2, taylor2001crystalstructuresof pages 3-4). |
+| Substrate specificity / cleavage motif | PMPCB/MPP cleaves **N-terminal mitochondrial targeting presequences** of imported precursor proteins. Preferred features include positively charged, amphipathic presequences and frequent **Arg at the −2 position** relative to the cleavage site (with related recognition patterns also involving upstream basic residues and often a bulky hydrophobic/aromatic P1 residue) (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, gala2021mitochondrialproteasesin pages 2-5, taylor2001crystalstructuresof pages 1-2, taylor2001crystalstructuresof pages 3-4). |
+| Key substrates / examples | MPP processes a broad range of nuclear-encoded mitochondrial precursors; **frataxin (FXN)** is a well-studied example whose maturation depends on PMPCB, and impaired PMPCB function leads to accumulation of frataxin processing intermediates in patient-derived cells (kunova2022mitochondrialprocessingpeptidases—structure pages 4-6, vogtle2018mutationsinpmpcb pages 1-2). |
+| Pathway context | PMPCB acts in the **mitochondrial protein import and presequence-processing pathway**, a core mitochondrial proteostasis step required for maturation of many matrix and inner-membrane proteins; cleaved presequences are subsequently degraded by downstream peptidases such as **PreP/PITRM1** (gala2021mitochondrialproteasesin pages 2-5, baker2025qualitycontrolat pages 4-5). |
+| Disease association & key stats | Biallelic **PMPCB** variants cause **multiple mitochondrial dysfunctions syndrome 6 (MMDS6)** / a Leigh-like early-childhood neurodegenerative disorder. The 2018 AJHG study reported **4 families / 5 affected individuals** with episodic developmental regression, basal ganglia lesions, cerebellar atrophy, and biochemical evidence of defective presequence processing, impaired frataxin maturation, Fe–S cluster defects, and complex I/II abnormalities (vogtle2018mutationsinpmpcb pages 1-2, vogtle2018mutationsinpmpcb pages 11-12, baker2025qualitycontrolat pages 5-5, OpenTargets Search: -PMPCB). |
+| Recent developments 2024 | A **2024 Journal of Human Genetics** case report described the **first splice-site PMPCB variant** and expanded the phenotype to an adult survivor: a **39-year-old** compound-heterozygous individual with childhood regression/ataxia. The paper notes that before this report only **5 individuals** had been described, all with onset by **12 months**, **none** having achieved ambulation or speech, and **3/5** dying by age **6**; a minigene assay showed exon 12 skipping from the splice variant (matthews2024leighsyndromewith pages 1-2, matthews2024leighsyndromewith pages 2-3). |
+
+
+*Table: This table summarizes verified identity, molecular function, mechanism, localization, pathway role, and disease relevance for human PMPCB/MPPβ (UniProt O75439). It condenses foundational and recent evidence, including key 2018 mechanistic disease data and the 2024 splice-variant update.*
+
+## Key references (with URLs and dates as available in retrieved sources)
+- **Matthews E, Whittle EF, Khan F, McEntagart M, Carroll CJ.** *Leigh syndrome with developmental regression and ataxia due to a novel splicing variant in the PMPCB gene.* **Journal of Human Genetics** (Feb **2024**). https://doi.org/10.1038/s10038-024-01226-9 (matthews2024leighsyndromewith pages 1-2, matthews2024leighsyndromewith pages 2-3)
+- **Vögtle F-N et al.** *Mutations in PMPCB Encoding the Catalytic Subunit of the Mitochondrial Presequence Protease Cause Neurodegeneration in Early Childhood.* **American Journal of Human Genetics** (Apr **2018**). https://doi.org/10.1016/j.ajhg.2018.02.014 (vogtle2018mutationsinpmpcb pages 1-2, vogtle2018mutationsinpmpcb pages 11-12)
+- **Kunová N et al.** *Mitochondrial Processing Peptidases—Structure, Function and the Role in Human Diseases.* **International Journal of Molecular Sciences** (Jan **2022**). https://doi.org/10.3390/ijms23031297 (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, kunova2022mitochondrialprocessingpeptidases—structure pages 4-6, kunova2022mitochondrialprocessingpeptidases—structure media e22ffe68)
+- **Gala MGF, Vögtle F-N.** *Mitochondrial proteases in human diseases.* **FEBS Letters** (Feb **2021**). https://doi.org/10.1002/1873-3468.14039 (gala2021mitochondrialproteasesin pages 2-5)
+- **Gakh O, Cavadini P, Isaya G.** *Mitochondrial processing peptidases.* **Biochimica et Biophysica Acta** (Sep **2002**). https://doi.org/10.1016/S0167-4889(02)00265-3 (gakh2002mitochondrialprocessingpeptidases. pages 4-6)
+- **Taylor AB et al.** *Crystal structures of mitochondrial processing peptidase reveal the mode for specific cleavage of import signal sequences.* **Structure** (Jul **2001**). https://doi.org/10.1016/S0969-2126(01)00621-9 (taylor2001crystalstructuresof pages 1-2, taylor2001crystalstructuresof pages 3-4)
+
+
+References
+
+1. (gakh2002mitochondrialprocessingpeptidases. pages 4-6): Oleksandr Gakh, Patrizia Cavadini, and Grazia Isaya. Mitochondrial processing peptidases. Biochimica et biophysica acta, 1592 1:63-77, Sep 2002. URL: https://doi.org/10.1016/s0167-4889(02)00265-3, doi:10.1016/s0167-4889(02)00265-3. This article has 583 citations.
+
+2. (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4): Nina Kunová, Henrieta Havalová, Gabriela Ondrovičová, Barbora Stojkovičová, Jacob A. Bauer, Vladena Bauerová-Hlinková, Vladimir Pevala, and Eva Kutejová. Mitochondrial processing peptidases—structure, function and the role in human diseases. International Journal of Molecular Sciences, 23:1297, Jan 2022. URL: https://doi.org/10.3390/ijms23031297, doi:10.3390/ijms23031297. This article has 39 citations.
+
+3. (gala2021mitochondrialproteasesin pages 2-5): Maria Gomez‐Fabra Gala and Friederike‐Nora Vögtle. Mitochondrial proteases in human diseases. FEBS Letters, 595:1205-1222, Feb 2021. URL: https://doi.org/10.1002/1873-3468.14039, doi:10.1002/1873-3468.14039. This article has 51 citations and is from a peer-reviewed journal.
+
+4. (kunova2022mitochondrialprocessingpeptidases—structure pages 4-6): Nina Kunová, Henrieta Havalová, Gabriela Ondrovičová, Barbora Stojkovičová, Jacob A. Bauer, Vladena Bauerová-Hlinková, Vladimir Pevala, and Eva Kutejová. Mitochondrial processing peptidases—structure, function and the role in human diseases. International Journal of Molecular Sciences, 23:1297, Jan 2022. URL: https://doi.org/10.3390/ijms23031297, doi:10.3390/ijms23031297. This article has 39 citations.
+
+5. (taylor2001crystalstructuresof pages 1-2): Alexander B. Taylor, Barbara S. Smith, Sakae Kitada, Katsuhiko Kojima, Hideki Miyaura, Zbyszek Otwinowski, Akio Ito, and Johann Deisenhofer. Crystal structures of mitochondrial processing peptidase reveal the mode for specific cleavage of import signal sequences. Structure, 9 7:615-25, Jul 2001. URL: https://doi.org/10.1016/s0969-2126(01)00621-9, doi:10.1016/s0969-2126(01)00621-9. This article has 320 citations and is from a domain leading peer-reviewed journal.
+
+6. (kunova2022mitochondrialprocessingpeptidases—structure media e22ffe68): Nina Kunová, Henrieta Havalová, Gabriela Ondrovičová, Barbora Stojkovičová, Jacob A. Bauer, Vladena Bauerová-Hlinková, Vladimir Pevala, and Eva Kutejová. Mitochondrial processing peptidases—structure, function and the role in human diseases. International Journal of Molecular Sciences, 23:1297, Jan 2022. URL: https://doi.org/10.3390/ijms23031297, doi:10.3390/ijms23031297. This article has 39 citations.
+
+7. (baker2025qualitycontrolat pages 5-5): Megan J. Baker, Kai Qi Yek, and Diana Stojanovski. Quality control at the powerhouse: mitochondrial proteostasis dysfunction and disease. Biochemical Society Transactions, 53:1105-1117, Aug 2025. URL: https://doi.org/10.1042/bst20253044, doi:10.1042/bst20253044. This article has 3 citations and is from a peer-reviewed journal.
+
+8. (taylor2001crystalstructuresof pages 3-4): Alexander B. Taylor, Barbara S. Smith, Sakae Kitada, Katsuhiko Kojima, Hideki Miyaura, Zbyszek Otwinowski, Akio Ito, and Johann Deisenhofer. Crystal structures of mitochondrial processing peptidase reveal the mode for specific cleavage of import signal sequences. Structure, 9 7:615-25, Jul 2001. URL: https://doi.org/10.1016/s0969-2126(01)00621-9, doi:10.1016/s0969-2126(01)00621-9. This article has 320 citations and is from a domain leading peer-reviewed journal.
+
+9. (vogtle2018mutationsinpmpcb pages 1-2): F.-Nora Vögtle, Björn Brändl, Austin Larson, Manuela Pendziwiat, Marisa W. Friederich, Susan M. White, Alice Basinger, Cansu Kücükköse, Hiltrud Muhle, Johanna A. Jähn, Oliver Keminer, Katherine L. Helbig, Carolyn F. Delto, Lisa Myketin, Dirk Mossmann, Nils Burger, Noriko Miyake, Audrey Burnett, Andreas van Baalen, Mark A. Lovell, Naomichi Matsumoto, Maie Walsh, Hung-Chun Yu, Deepali N. Shinde, Ulrich Stephani, Johan L.K. Van Hove, Franz-Josef Müller, and Ingo Helbig. Mutations in pmpcb encoding the catalytic subunit of the mitochondrial presequence protease cause neurodegeneration in early childhood. American journal of human genetics, 102 4:557-573, Apr 2018. URL: https://doi.org/10.1016/j.ajhg.2018.02.014, doi:10.1016/j.ajhg.2018.02.014. This article has 111 citations and is from a highest quality peer-reviewed journal.
+
+10. (baker2025qualitycontrolat pages 4-5): Megan J. Baker, Kai Qi Yek, and Diana Stojanovski. Quality control at the powerhouse: mitochondrial proteostasis dysfunction and disease. Biochemical Society Transactions, 53:1105-1117, Aug 2025. URL: https://doi.org/10.1042/bst20253044, doi:10.1042/bst20253044. This article has 3 citations and is from a peer-reviewed journal.
+
+11. (matthews2024leighsyndromewith pages 1-2): Emma Matthews, Ella F. Whittle, Faraan Khan, Meriel McEntagart, and Christopher J. Carroll. Leigh syndrome with developmental regression and ataxia due to a novel splicing variant in the pmpcb gene. Journal of Human Genetics, 69:283-285, Feb 2024. URL: https://doi.org/10.1038/s10038-024-01226-9, doi:10.1038/s10038-024-01226-9. This article has 6 citations and is from a peer-reviewed journal.
+
+12. (matthews2024leighsyndromewith pages 2-3): Emma Matthews, Ella F. Whittle, Faraan Khan, Meriel McEntagart, and Christopher J. Carroll. Leigh syndrome with developmental regression and ataxia due to a novel splicing variant in the pmpcb gene. Journal of Human Genetics, 69:283-285, Feb 2024. URL: https://doi.org/10.1038/s10038-024-01226-9, doi:10.1038/s10038-024-01226-9. This article has 6 citations and is from a peer-reviewed journal.
+
+13. (vogtle2018mutationsinpmpcb pages 11-12): F.-Nora Vögtle, Björn Brändl, Austin Larson, Manuela Pendziwiat, Marisa W. Friederich, Susan M. White, Alice Basinger, Cansu Kücükköse, Hiltrud Muhle, Johanna A. Jähn, Oliver Keminer, Katherine L. Helbig, Carolyn F. Delto, Lisa Myketin, Dirk Mossmann, Nils Burger, Noriko Miyake, Audrey Burnett, Andreas van Baalen, Mark A. Lovell, Naomichi Matsumoto, Maie Walsh, Hung-Chun Yu, Deepali N. Shinde, Ulrich Stephani, Johan L.K. Van Hove, Franz-Josef Müller, and Ingo Helbig. Mutations in pmpcb encoding the catalytic subunit of the mitochondrial presequence protease cause neurodegeneration in early childhood. American journal of human genetics, 102 4:557-573, Apr 2018. URL: https://doi.org/10.1016/j.ajhg.2018.02.014, doi:10.1016/j.ajhg.2018.02.014. This article has 111 citations and is from a highest quality peer-reviewed journal.
+
+14. (OpenTargets Search: -PMPCB): Open Targets Query (-PMPCB, 5 results). Buniello, A. et al. (2025). Open Targets Platform: facilitating therapeutic hypotheses building in drug discovery. Nucleic Acids Research.
+
+15. (kunova2022mitochondrialprocessingpeptidases—structure media bbb4e0aa): Nina Kunová, Henrieta Havalová, Gabriela Ondrovičová, Barbora Stojkovičová, Jacob A. Bauer, Vladena Bauerová-Hlinková, Vladimir Pevala, and Eva Kutejová. Mitochondrial processing peptidases—structure, function and the role in human diseases. International Journal of Molecular Sciences, 23:1297, Jan 2022. URL: https://doi.org/10.3390/ijms23031297, doi:10.3390/ijms23031297. This article has 39 citations.
+
+## Citations
+
+1. matthews2024leighsyndromewith pages 1-2
+2. gala2021mitochondrialproteasesin pages 2-5
+3. taylor2001crystalstructuresof pages 1-2
+4. baker2025qualitycontrolat pages 5-5
+5. taylor2001crystalstructuresof pages 3-4
+6. vogtle2018mutationsinpmpcb pages 1-2
+7. baker2025qualitycontrolat pages 4-5
+8. matthews2024leighsyndromewith pages 2-3
+9. vogtle2018mutationsinpmpcb pages 11-12
+10. https://doi.org/10.1038/s10038-024-01226-9
+11. https://doi.org/10.1016/j.ajhg.2018.02.014
+12. https://doi.org/10.3390/ijms23031297
+13. https://doi.org/10.1002/1873-3468.14039
+14. https://doi.org/10.1016/S0167-4889(02
+15. https://doi.org/10.1016/S0969-2126(01
+16. https://doi.org/10.1016/s0167-4889(02
+17. https://doi.org/10.3390/ijms23031297,
+18. https://doi.org/10.1002/1873-3468.14039,
+19. https://doi.org/10.1016/s0969-2126(01
+20. https://doi.org/10.1042/bst20253044,
+21. https://doi.org/10.1016/j.ajhg.2018.02.014,
+22. https://doi.org/10.1038/s10038-024-01226-9,


### PR DESCRIPTION
## Summary

Adds Falcon deep-research reports, curated GO annotation reviews, core function summaries, and rendered HTML for three human mitochondrial genes:

- `PAM16`: TIM23-associated PAM import motor regulatory cochaperone/adaptor; adds a new `GO:0030674` adaptor-activity annotation and refines TIM23-complex annotations to PAM complex membership.
- `PMPCB`: catalytic beta subunit of mitochondrial processing peptidase; reviews presequence-cleavage, MPP complex, matrix localization, and indirect calcium-transport pathway annotations.
- `GFER`: ALR/Erv1 FAD-linked sulfhydryl oxidase in the mitochondrial IMS disulfide relay; modifies reductase annotations to sulfhydryl/thiol oxidase terms and keeps non-mitochondrial ALR reports as non-core.

## Validation

- `uv run python scripts/validate_deep_research.py genes/human/PAM16/PAM16-deep-research-falcon.md genes/human/PMPCB/PMPCB-deep-research-falcon.md genes/human/GFER/GFER-deep-research-falcon.md`
- `just validate human PAM16`
- `just validate human PMPCB`
- `just validate human GFER`
- `just render human PAM16`
- `just render human PMPCB`
- `just render human GFER`
- custom exact supporting-text check: 170 entries matched local source files
- `git diff --check`